### PR TITLE
Tcp Broker to Broker Communication

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -61,7 +61,7 @@ libafl_derive = { version = "*", optional = true, path = "../libafl_derive" }
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] } # an easy way to debug print SerdeAnyMap
 compression = { version = "0.1.5" }
 num_enum = "0.5.1"
-spin = "0.9.0"
+hostname = "^0.3" # Is there really no gethostname in the stdlib?
 
 [target.'cfg(target_os = "android")'.dependencies]
 backtrace = { version = "0.3", optional = true, default-features = false, features = ["std", "libbacktrace"] } # for llmp_debug

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -40,7 +40,8 @@ anymap_debug = ["serde_json"] # uses serde_json to Debug the anymap trait. Disab
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
 llmp_small_maps = [] # reduces initial map size for llmp
 llmp_debug = ["backtrace"] # Enables debug output for LLMP
-llmp_compression = [] #llmp compression using GZip
+llmp_compression = [] # llmp compression using GZip
+llmp_bind_public = [] # If set, llmp will bind to 0.0.0.0, allowing cross-device communication. Binds to localhost by default.
 
 [[example]]
 name = "llmp_test"

--- a/libafl/examples/llmp_test/main.rs
+++ b/libafl/examples/llmp_test/main.rs
@@ -83,7 +83,7 @@ fn large_msg_loop(port: u16) -> ! {
 fn broker_message_hook(
     client_id: u32,
     tag: llmp::Tag,
-    _flags: llmp::Flag,
+    _flags: llmp::Flags,
     message: &[u8],
 ) -> Result<llmp::LlmpMsgHookResult, Error> {
     match tag {

--- a/libafl/examples/llmp_test/main.rs
+++ b/libafl/examples/llmp_test/main.rs
@@ -137,22 +137,14 @@ fn main() {
     match mode.as_str() {
         "broker" => {
             let mut broker = llmp::LlmpBroker::new(StdShMemProvider::new().unwrap()).unwrap();
-            broker
-                .launch_listener(llmp::Listener::Tcp(
-                    std::net::TcpListener::bind(format!("127.0.0.1:{}", port)).unwrap(),
-                ))
-                .unwrap();
+            broker.launch_tcp_listener_on(port).unwrap();
             broker.loop_forever(&mut broker_message_hook, Some(Duration::from_millis(5)))
         }
         "b2b" => {
             let mut broker = llmp::LlmpBroker::new(StdShMemProvider::new().unwrap()).unwrap();
-            broker
-                .launch_listener(llmp::Listener::Tcp(
-                    std::net::TcpListener::bind(("127.0.0.1", b2b_port)).unwrap(),
-                ))
-                .unwrap();
-            // connect to the main broker.
-            broker.connect_b2b(("127.0.0.1", b2b_port)).unwrap();
+            broker.launch_tcp_listener_on(b2b_port).unwrap();
+            // connect back to the main broker.
+            broker.connect_b2b(("127.0.0.1", port)).unwrap();
             broker.loop_forever(&mut broker_message_hook, Some(Duration::from_millis(5)))
         }
         "ctr" => {

--- a/libafl/src/bolts/compress.rs
+++ b/libafl/src/bolts/compress.rs
@@ -42,6 +42,7 @@ impl GzipCompressor {
 
     /// Decompression.
     /// Flag is used to indicate if it's compressed or not
+    #[allow(clippy::unused_self)]
     pub fn decompress(&self, buf: &[u8]) -> Result<Vec<u8>, Error> {
         Ok(buf
             .iter()

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -1754,7 +1754,7 @@ where
         self.launch_listener(Listener::Tcp(listener))
     }
 
-    /// Anncounes a new client on the given shared map.
+    /// Announces a new client on the given shared map.
     /// Called from a background thread, typically.
     /// Upon receiving this message, the broker should map the announced page and start trckang it for new messages.
     #[allow(dead_code)]

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -328,7 +328,7 @@ where
     stream.write_all(&msg)?;
 
     #[cfg(feature = "llmp_debug")]
-    println!("LLMP TCP: Send finished", msg.len());
+    println!("LLMP TCP: Sending {} bytes finished.", msg.len());
 
     Ok(())
 }

--- a/libafl/src/bolts/shmem.rs
+++ b/libafl/src/bolts/shmem.rs
@@ -171,8 +171,8 @@ pub trait ShMemProvider: Send + Clone + Default + Debug {
         ))
     }
 
-    /// This method should be called after a fork or thread creation event, allowing the ShMem to
-    /// reset thread specific info.
+    /// This method should be called after a fork or after cloning/a thread creation event, allowing the ShMem to
+    /// reset thread specific info, and potentially reconnect.
     fn post_fork(&mut self) {
         // do nothing
     }
@@ -183,6 +183,9 @@ pub trait ShMemProvider: Send + Clone + Default + Debug {
     }
 }
 
+/// A Refernce Counted shared map,
+/// that can use internal mutability.
+/// Useful if the `ShMemProvider` needs to keep local state.
 #[derive(Debug, Clone)]
 pub struct RcShMem<T: ShMemProvider> {
     internal: ManuallyDrop<T::Mem>,
@@ -216,6 +219,9 @@ impl<T: ShMemProvider> Drop for RcShMem<T> {
     }
 }
 
+/// A Refernce Counted `ShMemProvider`,
+/// that can use internal mutability.
+/// Useful if the `ShMemProvider` needs to keep local state.
 #[derive(Debug, Clone)]
 pub struct RcShMemProvider<T: ShMemProvider> {
     internal: Rc<RefCell<T>>,
@@ -274,6 +280,11 @@ where
     }
 }
 
+/// A Unix sharedmem implementation.
+///
+/// On Android, this is partially reused to wrap `Ashmem`,
+/// Although for an `AshmemShMemProvider using a unix domain socket
+/// Is needed on top.
 #[cfg(all(unix, feature = "std"))]
 pub mod unix_shmem {
 

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -15,7 +15,7 @@ use crate::bolts::{
 
 use crate::{
     bolts::{
-        llmp::{self, Flag, LlmpClientDescription, LlmpSender, Tag},
+        llmp::{self, Flags, LlmpClientDescription, LlmpSender, Tag},
         shmem::ShMemProvider,
     },
     corpus::CorpusScheduler,
@@ -173,7 +173,7 @@ where
                 #[cfg(feature = "llmp_compression")]
                 let compressor = &self.compressor;
                 broker.loop_forever(
-                    &mut |sender_id: u32, tag: Tag, _flags: Flag, msg: &[u8]| {
+                    &mut |sender_id: u32, tag: Tag, _flags: Flags, msg: &[u8]| {
                         if tag == LLMP_TAG_EVENT_TO_BOTH {
                             #[cfg(not(feature = "llmp_compression"))]
                             let event_bytes = msg;
@@ -376,7 +376,7 @@ where
     #[cfg(feature = "llmp_compression")]
     fn fire(&mut self, _state: &mut S, event: Event<I>) -> Result<(), Error> {
         let serialized = postcard::to_allocvec(&event)?;
-        let flags: Flag = LLMP_FLAG_INITIALIZED;
+        let flags: Flags = LLMP_FLAG_INITIALIZED;
 
         match self.compressor.compress(&serialized)? {
             Some(comp_buf) => {


### PR DESCRIPTION
This PR will add Broker 2 Broker communication to LLMP.
In first tests, forwarding didn't seem to work yet (`cargo build --example llmp_test`)