### PR TITLE
frida-asan: Un-inline report funclet to reduce code bloat

### DIFF
--- a/fuzzers/frida_libpng/Cargo.toml
+++ b/fuzzers/frida_libpng/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2018"
 build = "build.rs"
 
 [features]
-default = ["std", "frida"]
+default = ["std"]
 std = []
-frida = ["frida-gum", "frida-gum-sys"]
 
 [profile.release]
 lto = true
@@ -22,10 +21,10 @@ num_cpus = "1.0"
 which = "4.1"
 
 [target.'cfg(unix)'.dependencies]
-libafl = { path = "../../libafl/", features = [ "std" ] } #,  "llmp_small_maps", "llmp_debug"]}
+libafl = { path = "../../libafl/", features = [ "std", "llmp_compression" ] } #,  "llmp_small_maps", "llmp_debug"]}
 capstone = "0.8.0"
-frida-gum = { version = "0.4", optional = true, features = [ "auto-download", "event-sink", "invocation-listener"] }
-frida-gum-sys = { version = "0.2.4", optional = true, features = [ "auto-download", "event-sink", "invocation-listener"] }
+frida-gum = { version = "0.4", git = "https://github.com/s1341/frida-rust", features = [ "auto-download", "event-sink", "invocation-listener"] }
+#frida-gum = { version = "0.4", path = "../../../frida-rust/frida-gum", features = [ "auto-download", "event-sink", "invocation-listener"] }
 libafl_frida = { path = "../../libafl_frida", version = "0.1.0" }
 lazy_static = "1.4.0"
 libc = "0.2"

--- a/fuzzers/frida_libpng/harness.cc
+++ b/fuzzers/frida_libpng/harness.cc
@@ -89,7 +89,8 @@ __attribute__((noinline))
 void func3( char * alloc) {
   printf("func3\n");
   if (random() == 0) {
-    alloc[0xff] = 0xde;
+    alloc[0x1ff] = 0xde;
+    printf("alloc[0x200]: %d\n", alloc[0x200]);
   }
 }
 __attribute__((noinline))

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -17,8 +17,10 @@ libc = "0.2.92"
 hashbrown = "0.11"
 libloading = "0.7.0"
 rangemap = "0.1.10"
-frida-gum = { version = "0.4.0", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
-frida-gum-sys = { version = "0.2.4", features = [ "auto-download", "event-sink", "invocation-listener"] }
+frida-gum = { version = "0.4.0", git = "https://github.com/s1341/frida-rust", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
+frida-gum-sys = { version = "0.2.4", git = "https://github.com/s1341/frida-rust", features = [ "auto-download", "event-sink", "invocation-listener"] }
+#frida-gum = { version = "0.4.0",  path = "../../frida-rust/frida-gum", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
+#frida-gum-sys = { version = "0.2.4", path = "../../frida-rust/frida-gum-sys", features = [ "auto-download", "event-sink", "invocation-listener"] }
 regex = "1.4"
 dynasmrt = "1.0.1"
 capstone = "0.8.0"

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -24,7 +24,7 @@ use color_backtrace::{default_output_stream, BacktracePrinter, Verbosity};
 use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 #[cfg(unix)]
 use gothook::GotHookLibrary;
-use libc::{_SC_PAGESIZE, getrlimit64, rlimit64, sysconf};
+use libc::{getrlimit64, rlimit64, sysconf, _SC_PAGESIZE};
 use rangemap::RangeSet;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -90,7 +90,10 @@ impl Allocator {
                     addr as *mut c_void,
                     page_size,
                     ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                    MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS | MapFlags::MAP_FIXED | MapFlags::MAP_NORESERVE,
+                    MapFlags::MAP_PRIVATE
+                        | MapFlags::MAP_ANONYMOUS
+                        | MapFlags::MAP_FIXED
+                        | MapFlags::MAP_NORESERVE,
                     -1,
                     0,
                 )
@@ -110,7 +113,10 @@ impl Allocator {
                 addr as *mut c_void,
                 addr + addr,
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                MapFlags::MAP_ANONYMOUS | MapFlags::MAP_FIXED | MapFlags::MAP_PRIVATE | MapFlags::MAP_NORESERVE,
+                MapFlags::MAP_ANONYMOUS
+                    | MapFlags::MAP_FIXED
+                    | MapFlags::MAP_PRIVATE
+                    | MapFlags::MAP_NORESERVE,
                 -1,
                 0,
             )
@@ -161,7 +167,8 @@ impl Allocator {
         let mut current_size = size;
         while current_size <= self.largest_allocation {
             if self.allocation_queue.contains_key(&current_size) {
-                if let Some(metadata) = self.allocation_queue.entry(current_size).or_default().pop() {
+                if let Some(metadata) = self.allocation_queue.entry(current_size).or_default().pop()
+                {
                     return Some(metadata);
                 }
             }
@@ -184,8 +191,7 @@ impl Allocator {
         }
         let rounded_up_size = self.round_up_to_page(size);
 
-        let metadata = if let Some(mut metadata) = self.find_smallest_fit(rounded_up_size)
-        {
+        let metadata = if let Some(mut metadata) = self.find_smallest_fit(rounded_up_size) {
             //println!("reusing allocation at {:x}, (actual mapping starts at {:x}) size {:x}", metadata.address, metadata.address - self.page_size, size);
             metadata.is_malloc_zero = is_malloc_zero;
             metadata.size = size;
@@ -214,11 +220,7 @@ impl Allocator {
                 }
             };
 
-            self.map_shadow_for_region(
-                mapping,
-                mapping + rounded_up_size,
-                false,
-            );
+            self.map_shadow_for_region(mapping, mapping + rounded_up_size, false);
 
             let mut metadata = AllocationMetadata {
                 address: mapping,
@@ -805,8 +807,11 @@ impl AsanRuntime {
         let stack_address = &stack_var as *const _ as *const c_void as usize;
         let (start, end, _, _) = find_mapping_for_address(stack_address).unwrap();
 
-        let mut stack_rlimit = rlimit64 { rlim_cur: 0, rlim_max: 0 };
-        assert!(unsafe { getrlimit64(3, &mut stack_rlimit as *mut rlimit64 ) } == 0);
+        let mut stack_rlimit = rlimit64 {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        assert!(unsafe { getrlimit64(3, &mut stack_rlimit as *mut rlimit64) } == 0);
 
         println!("stack_rlimit: {:?}", stack_rlimit);
 
@@ -818,7 +823,10 @@ impl AsanRuntime {
                     max_start as *mut c_void,
                     start - max_start,
                     ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                    MapFlags::MAP_ANONYMOUS | MapFlags::MAP_FIXED | MapFlags::MAP_PRIVATE | MapFlags::MAP_STACK,
+                    MapFlags::MAP_ANONYMOUS
+                        | MapFlags::MAP_FIXED
+                        | MapFlags::MAP_PRIVATE
+                        | MapFlags::MAP_STACK,
                     -1,
                     0,
                 )
@@ -833,7 +841,7 @@ impl AsanRuntime {
         let tls_address = unsafe { get_tls_ptr() } as usize;
         // we need to mask off the highest byte, due to 'High Byte Ignore"
         #[cfg(target_os = "android")]
-        let tls_address = tls_address  & 0xffffffffffffff;
+        let tls_address = tls_address & 0xffffffffffffff;
 
         let (start, end, _, _) = find_mapping_for_address(tls_address).unwrap();
         (start, end)
@@ -1439,8 +1447,7 @@ impl AsanRuntime {
             );};
         }
 
-        let mut ops =
-            dynasmrt::VecAssembler::<dynasmrt::aarch64::Aarch64Relocation>::new(0);
+        let mut ops = dynasmrt::VecAssembler::<dynasmrt::aarch64::Aarch64Relocation>::new(0);
         shadow_check!(ops, bit);
         let ops_vec = ops.finalize().unwrap();
         ops_vec[..ops_vec.len() - 4].to_vec().into_boxed_slice()
@@ -1473,8 +1480,7 @@ impl AsanRuntime {
             );};
         }
 
-        let mut ops =
-            dynasmrt::VecAssembler::<dynasmrt::aarch64::Aarch64Relocation>::new(0);
+        let mut ops = dynasmrt::VecAssembler::<dynasmrt::aarch64::Aarch64Relocation>::new(0);
         shadow_check_exact!(ops, val);
         let ops_vec = ops.finalize().unwrap();
         ops_vec[..ops_vec.len() - 4].to_vec().into_boxed_slice()
@@ -1590,7 +1596,6 @@ impl AsanRuntime {
             ; .dword 0x0
         );
         self.blob_report = Some(ops_report.finalize().unwrap().into_boxed_slice());
-
 
         self.blob_check_mem_byte = Some(self.generate_shadow_check_blob(0));
         self.blob_check_mem_halfword = Some(self.generate_shadow_check_blob(1));

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -9,7 +9,10 @@ use libafl::utils::find_mapping_for_path;
 use libafl_targets::drcov::{DrCovBasicBlock, DrCovWriter};
 
 #[cfg(target_arch = "aarch64")]
-use capstone::arch::{arm64::{Arm64OperandType, Arm64Extender, Arm64Shift}, ArchOperand::Arm64Operand};
+use capstone::arch::{
+    arm64::{Arm64Extender, Arm64OperandType, Arm64Shift},
+    ArchOperand::Arm64Operand,
+};
 use capstone::{
     arch::{self, BuildsCapstone},
     Capstone, Insn,
@@ -89,10 +92,7 @@ impl<'a> FridaHelper<'a> for FridaInstrumentationHelper<'a> {
             let mut hasher = AHasher::new_with_keys(0, 0);
             hasher.write(input.target_bytes().as_slice());
 
-            let filename = format!(
-                "./coverage/{:016x}.drcov",
-                hasher.finish(),
-            );
+            let filename = format!("./coverage/{:016x}.drcov", hasher.finish(),);
             DrCovWriter::new(&filename, &self.ranges, &mut self.drcov_basic_blocks).write();
         }
 
@@ -223,10 +223,14 @@ impl<'a> FridaInstrumentationHelper<'a> {
         if options.stalker_enabled() {
             for (id, module_name) in modules_to_instrument.iter().enumerate() {
                 let (lib_start, lib_end) = find_mapping_for_path(module_name.to_str().unwrap());
-                println!("including range {:x}-{:x} for {:?}", lib_start, lib_end, module_name);
-                helper
-                    .ranges
-                    .insert(lib_start..lib_end, (id as u16, module_name.to_str().unwrap()));
+                println!(
+                    "including range {:x}-{:x} for {:?}",
+                    lib_start, lib_end, module_name
+                );
+                helper.ranges.insert(
+                    lib_start..lib_end,
+                    (id as u16, module_name.to_str().unwrap()),
+                );
             }
 
             if helper.options.drcov_enabled() {
@@ -419,14 +423,18 @@ impl<'a> FridaInstrumentationHelper<'a> {
 
                 if extender_encoding != -1 && shift_amount < 0b1000 {
                     // emit add extended register: https://developer.arm.com/documentation/ddi0602/latest/Base-Instructions/ADD--extended-register---Add--extended-register--
-                    writer.put_bytes(&(0x8b210000 | ((extender_encoding as u32) << 13) | (shift_amount << 10)).to_le_bytes());
+                    writer.put_bytes(
+                        &(0x8b210000 | ((extender_encoding as u32) << 13) | (shift_amount << 10))
+                            .to_le_bytes(),
+                    );
                 } else if shift_encoding != -1 {
-                    writer.put_bytes(&(0x8b010000 | ((shift_encoding as u32) << 22) | (shift_amount << 10)).to_le_bytes());
+                    writer.put_bytes(
+                        &(0x8b010000 | ((shift_encoding as u32) << 22) | (shift_amount << 10))
+                            .to_le_bytes(),
+                    );
                 } else {
                     panic!("extender: {:?}, shift: {:?}", extender, shift);
                 }
-
-
             };
         }
 
@@ -500,8 +508,8 @@ impl<'a> FridaInstrumentationHelper<'a> {
             3 | 6 | 12 | 24 | 32 | 48 | 64 => {
                 let msr_nvcz_x0: u32 = 0xd51b4200;
                 writer.put_bytes(&msr_nvcz_x0.to_le_bytes());
-            },
-            _ => ()
+            }
+            _ => (),
         }
 
         // Restore x0, x1
@@ -586,7 +594,17 @@ impl<'a> FridaInstrumentationHelper<'a> {
         &self,
         _address: u64,
         instr: &Insn,
-    ) -> Result<(capstone::RegId, capstone::RegId, i32, u32, Arm64Shift, Arm64Extender), ()> {
+    ) -> Result<
+        (
+            capstone::RegId,
+            capstone::RegId,
+            i32,
+            u32,
+            Arm64Shift,
+            Arm64Extender,
+        ),
+        (),
+    > {
         // We have to ignore these instructions. Simulating them with their side effects is
         // complex, to say the least.
         match instr.mnemonic().unwrap() {


### PR DESCRIPTION
This should fix #73.

We now only emit the report funclet when we absolutely need to. This should significantly reduce the code bloat, and may improve performance.