### PR TITLE
Observers refactor

### DIFF
--- a/fuzzers/baby_fuzzer/src/main.rs
+++ b/fuzzers/baby_fuzzer/src/main.rs
@@ -77,7 +77,6 @@ pub fn main() {
 
     // Create the executor for an in-process function with just one observer
     let mut executor = InProcessExecutor::new(
-        "in-process(signals)",
         &mut harness,
         tuple_list!(observer),
         &mut state,

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -2,14 +2,15 @@
 //! The example harness is built for libpng.
 
 use libafl::{
-    bolts::tuples::{tuple_list, Named},
+    bolts::tuples::tuple_list,
     corpus::{
         ondisk::OnDiskMetadataFormat, Corpus, InMemoryCorpus,
         IndexesLenTimeMinimizerCorpusScheduler, OnDiskCorpus, QueueCorpusScheduler,
     },
-    events::{setup_restarting_mgr_std, EventManager},
+    events::setup_restarting_mgr_std,
     executors::{
-        inprocess::InProcessExecutor, timeout::TimeoutExecutor, Executor, ExitKind, HasObservers,
+        inprocess::InProcessExecutor, timeout::TimeoutExecutor, Executor, ExitKind, HasExecHooks,
+        HasExecHooksTuple, HasObservers, HasObserversHooks,
     },
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeoutFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
@@ -37,14 +38,14 @@ use libafl_frida::{
     FridaOptions,
 };
 
-struct FridaInProcessExecutor<'a, 'b, 'c, FH, H, I, OT>
+struct FridaInProcessExecutor<'a, 'b, 'c, EM, FH, H, I, OT, S>
 where
     FH: FridaHelper<'b>,
     H: FnMut(&[u8]) -> ExitKind,
     I: Input + HasTargetBytes,
     OT: ObserversTuple,
 {
-    base: TimeoutExecutor<InProcessExecutor<'a, H, I, OT>, I, OT>,
+    base: TimeoutExecutor<InProcessExecutor<'a, EM, H, I, OT, S>, I>,
     /// Frida's dynamic rewriting engine
     stalker: Stalker<'a>,
     /// User provided callback for instrumentation
@@ -53,19 +54,17 @@ where
     _phantom: PhantomData<&'b u8>,
 }
 
-impl<'a, 'b, 'c, FH, H, I, OT> Executor<I> for FridaInProcessExecutor<'a, 'b, 'c, FH, H, I, OT>
+impl<'a, 'b, 'c, EM, FH, H, I, OT, S> Executor<I>
+    for FridaInProcessExecutor<'a, 'b, 'c, EM, FH, H, I, OT, S>
 where
     FH: FridaHelper<'b>,
     H: FnMut(&[u8]) -> ExitKind,
     I: Input + HasTargetBytes,
     OT: ObserversTuple,
 {
-    /// Called right before exexution starts
+    /// Instruct the target about the input and run
     #[inline]
-    fn pre_exec<EM, S>(&mut self, state: &mut S, event_mgr: &mut EM, input: &I) -> Result<(), Error>
-    where
-        EM: EventManager<I, S>,
-    {
+    fn run_target(&mut self, input: &I) -> Result<ExitKind, Error> {
         if self.helper.stalker_enabled() {
             if !self.followed {
                 self.followed = true;
@@ -77,15 +76,6 @@ where
                 ))
             }
         }
-
-        self.helper.pre_exec(input);
-
-        self.base.pre_exec(state, event_mgr, input)
-    }
-
-    /// Instruct the target about the input and run
-    #[inline]
-    fn run_target(&mut self, input: &I) -> Result<ExitKind, Error> {
         let res = self.base.run_target(input);
         if unsafe { ASAN_ERRORS.is_some() && !ASAN_ERRORS.as_ref().unwrap().is_empty() } {
             println!("Crashing target as it had ASAN errors");
@@ -93,29 +83,38 @@ where
                 libc::raise(libc::SIGABRT);
             }
         }
+        if self.helper.stalker_enabled() {
+            self.stalker.deactivate();
+        }
         res
+    }
+}
+
+impl<'a, 'b, 'c, EM, FH, H, I, OT, S> HasExecHooks<EM, I, S>
+    for FridaInProcessExecutor<'a, 'b, 'c, EM, FH, H, I, OT, S>
+where
+    FH: FridaHelper<'b>,
+    H: FnMut(&[u8]) -> ExitKind,
+    I: Input + HasTargetBytes,
+    OT: ObserversTuple,
+{
+    /// Called right before exexution starts
+    #[inline]
+    fn pre_exec(&mut self, state: &mut S, event_mgr: &mut EM, input: &I) -> Result<(), Error> {
+        self.helper.pre_exec(input);
+        self.base.pre_exec(state, event_mgr, input)
     }
 
     /// Called right after execution finished.
     #[inline]
-    fn post_exec<EM, S>(
-        &mut self,
-        state: &mut S,
-        event_mgr: &mut EM,
-        input: &I,
-    ) -> Result<(), Error>
-    where
-        EM: EventManager<I, S>,
-    {
-        if self.helper.stalker_enabled() {
-            self.stalker.deactivate();
-        }
+    fn post_exec(&mut self, state: &mut S, event_mgr: &mut EM, input: &I) -> Result<(), Error> {
         self.helper.post_exec(input);
         self.base.post_exec(state, event_mgr, input)
     }
 }
 
-impl<'a, 'b, 'c, FH, H, I, OT> HasObservers<OT> for FridaInProcessExecutor<'a, 'b, 'c, FH, H, I, OT>
+impl<'a, 'b, 'c, EM, FH, H, I, OT, S> HasObservers<OT>
+    for FridaInProcessExecutor<'a, 'b, 'c, EM, FH, H, I, OT, S>
 where
     FH: FridaHelper<'b>,
     H: FnMut(&[u8]) -> ExitKind,
@@ -133,19 +132,17 @@ where
     }
 }
 
-impl<'a, 'b, 'c, FH, H, I, OT> Named for FridaInProcessExecutor<'a, 'b, 'c, FH, H, I, OT>
+impl<'a, 'b, 'c, EM, FH, H, I, OT, S> HasObserversHooks<EM, I, OT, S>
+    for FridaInProcessExecutor<'a, 'b, 'c, EM, FH, H, I, OT, S>
 where
     FH: FridaHelper<'b>,
     H: FnMut(&[u8]) -> ExitKind,
     I: Input + HasTargetBytes,
-    OT: ObserversTuple,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
 {
-    fn name(&self) -> &str {
-        self.base.name()
-    }
 }
 
-impl<'a, 'b, 'c, FH, H, I, OT> FridaInProcessExecutor<'a, 'b, 'c, FH, H, I, OT>
+impl<'a, 'b, 'c, EM, FH, H, I, OT, S> FridaInProcessExecutor<'a, 'b, 'c, EM, FH, H, I, OT, S>
 where
     FH: FridaHelper<'b>,
     H: FnMut(&[u8]) -> ExitKind,
@@ -154,7 +151,7 @@ where
 {
     pub fn new(
         gum: &'a Gum,
-        base: InProcessExecutor<'a, H, I, OT>,
+        base: InProcessExecutor<'a, EM, H, I, OT, S>,
         helper: &'c mut FH,
         timeout: Duration,
     ) -> Self {
@@ -324,7 +321,6 @@ unsafe fn fuzz(
     let mut executor = FridaInProcessExecutor::new(
         &gum,
         InProcessExecutor::new(
-            "in-process(edges)",
             &mut frida_harness,
             tuple_list!(edges_observer, AsanErrorsObserver::new(&ASAN_ERRORS)),
             &mut state,

--- a/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
@@ -113,7 +113,6 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
 
     // Create the executor for an in-process function with observers for edge coverage, value-profile and allocations sizes
     let mut executor = InProcessExecutor::new(
-        "in-process(edges,cmp,alloc)",
         &mut harness,
         tuple_list!(edges_observer, cmps_observer, allocs_observer),
         &mut state,

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -120,7 +120,6 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
     let mut executor = TimeoutExecutor::new(
         InProcessExecutor::new(
-            "in-process(edges,time)",
             &mut harness,
             tuple_list!(edges_observer, TimeObserver::new("time")),
             &mut state,

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -116,7 +116,6 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
 
     // Create the executor for an in-process function with just one observer for edge coverage
     let mut executor = InProcessExecutor::new(
-        "in-process(edges,time)",
         &mut harness,
         tuple_list!(edges_observer, TimeObserver::new("time")),
         &mut state,

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -43,7 +43,7 @@ pub trait HasExecHooks<EM, I, S> {
     }
 }
 
-/// A haskell-style tuple of observers
+/// A haskell-style tuple of objects that have pre and post exec hooks
 pub trait HasExecHooksTuple<EM, I, S> {
     /// This is called right before the next execution.
     fn pre_exec_all(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error>;
@@ -90,6 +90,7 @@ where
     fn observers_mut(&mut self) -> &mut OT;
 }
 
+/// Execute the exec hooks of the observers if they all implement HasExecHooks
 pub trait HasObserversHooks<EM, I, OT, S>: HasObservers<OT>
 where
     OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -8,8 +8,7 @@ pub use timeout::TimeoutExecutor;
 use core::marker::PhantomData;
 
 use crate::{
-    bolts::{serdeany::SerdeAny, tuples::Named},
-    events::EventManager,
+    bolts::serdeany::SerdeAny,
     inputs::{HasTargetBytes, Input},
     observers::ObserversTuple,
     Error,
@@ -29,6 +28,57 @@ pub enum ExitKind {
     Custom(Box<dyn CustomExitKind>),
 }
 
+/// Pre and post exec hooks
+pub trait HasExecHooks<EM, I, S> {
+    /// Called right before exexution starts
+    #[inline]
+    fn pre_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Called right after execution finished.
+    #[inline]
+    fn post_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// A haskell-style tuple of observers
+pub trait HasExecHooksTuple<EM, I, S> {
+    /// This is called right before the next execution.
+    fn pre_exec_all(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error>;
+
+    /// This is called right after the last execution
+    fn post_exec_all(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error>;
+}
+
+impl<EM, I, S> HasExecHooksTuple<EM, I, S> for () {
+    fn pre_exec_all(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn post_exec_all(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl<EM, I, S, Head, Tail> HasExecHooksTuple<EM, I, S> for (Head, Tail)
+where
+    Head: HasExecHooks<EM, I, S>,
+    Tail: HasExecHooksTuple<EM, I, S>,
+{
+    fn pre_exec_all(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+        self.0.pre_exec(state, mgr, input)?;
+        self.1.pre_exec_all(state, mgr, input)
+    }
+
+    fn post_exec_all(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+        self.0.post_exec(state, mgr, input)?;
+        self.1.post_exec_all(state, mgr, input)
+    }
+}
+
+/// Holds a tuple of Observers
 pub trait HasObservers<OT>
 where
     OT: ObserversTuple,
@@ -38,27 +88,40 @@ where
 
     /// Get the linked observers
     fn observers_mut(&mut self) -> &mut OT;
+}
 
-    /// Reset the state of all the observes linked to this executor
+pub trait HasObserversHooks<EM, I, OT, S>: HasObservers<OT>
+where
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+{
     #[inline]
-    fn pre_exec_observers(&mut self) -> Result<(), Error> {
-        self.observers_mut().pre_exec_all()
+    fn pre_exec_observers(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+        self.observers_mut().pre_exec_all(state, mgr, input)
     }
 
     /// Run the post exec hook for all the observes linked to this executor
     #[inline]
-    fn post_exec_observers(&mut self) -> Result<(), Error> {
-        self.observers_mut().post_exec_all()
+    fn post_exec_observers(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+        self.observers_mut().post_exec_all(state, mgr, input)
     }
+}
+
+/// An executor takes the given inputs, and runs the harness/target.
+pub trait Executor<I>
+where
+    I: Input,
+{
+    /// Instruct the target about the input and run
+    fn run_target(&mut self, input: &I) -> Result<ExitKind, Error>;
 }
 
 /// A simple executor that does nothing.
 /// If intput len is 0, `run_target` will return Err
-struct NopExecutor<I> {
-    phantom: PhantomData<I>,
+struct NopExecutor<EM, I, S> {
+    phantom: PhantomData<(EM, I, S)>,
 }
 
-impl<I> Executor<I> for NopExecutor<I>
+impl<EM, I, S> Executor<I> for NopExecutor<EM, I, S>
 where
     I: Input + HasTargetBytes,
 {
@@ -71,48 +134,7 @@ where
     }
 }
 
-impl<I> Named for NopExecutor<I> {
-    fn name(&self) -> &str {
-        &"NopExecutor"
-    }
-}
-
-/// An executor takes the given inputs, and runs the harness/target.
-pub trait Executor<I>: Named
-where
-    I: Input,
-{
-    /// Called right before exexution starts
-    #[inline]
-    fn pre_exec<EM, S>(
-        &mut self,
-        _state: &mut S,
-        _event_mgr: &mut EM,
-        _input: &I,
-    ) -> Result<(), Error>
-    where
-        EM: EventManager<I, S>,
-    {
-        Ok(())
-    }
-
-    /// Called right after execution finished.
-    #[inline]
-    fn post_exec<EM, S>(
-        &mut self,
-        _state: &mut S,
-        _event_mgr: &mut EM,
-        _input: &I,
-    ) -> Result<(), Error>
-    where
-        EM: EventManager<I, S>,
-    {
-        Ok(())
-    }
-
-    /// Instruct the target about the input and run
-    fn run_target(&mut self, input: &I) -> Result<ExitKind, Error>;
-}
+impl<EM, I, S> HasExecHooks<EM, I, S> for NopExecutor<EM, I, S> where I: Input + HasTargetBytes {}
 
 #[cfg(test)]
 mod test {
@@ -125,7 +147,7 @@ mod test {
     fn nop_executor() {
         let empty_input = BytesInput::new(vec![]);
         let nonempty_input = BytesInput::new(vec![1u8]);
-        let mut executor = NopExecutor {
+        let mut executor = NopExecutor::<(), _, ()> {
             phantom: PhantomData,
         };
         assert!(executor.run_target(&empty_input).is_err());

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -25,12 +25,14 @@ where
     I: Input,
 {
     /// `is_interesting ` should return the "Interestingness" from 0 to 255 (percent times 2.55)
-    fn is_interesting<OT: ObserversTuple>(
+    fn is_interesting<OT>(
         &mut self,
         input: &I,
         observers: &OT,
         exit_kind: &ExitKind,
-    ) -> Result<u32, Error>;
+    ) -> Result<u32, Error>
+    where
+        OT: ObserversTuple;
 
     /// Append to the testcase the generated metadata in case of a new corpus item
     #[inline]
@@ -50,12 +52,14 @@ where
     I: Input,
 {
     /// Get the total interestingness value from all feedbacks
-    fn is_interesting_all<OT: ObserversTuple>(
+    fn is_interesting_all<OT>(
         &mut self,
         input: &I,
         observers: &OT,
         exit_kind: &ExitKind,
-    ) -> Result<u32, Error>;
+    ) -> Result<u32, Error>
+    where
+        OT: ObserversTuple;
 
     /// Write metadata for this testcase
     fn append_metadata_all(&mut self, testcase: &mut Testcase<I>) -> Result<(), Error>;
@@ -69,12 +73,10 @@ where
     I: Input,
 {
     #[inline]
-    fn is_interesting_all<OT: ObserversTuple>(
-        &mut self,
-        _: &I,
-        _: &OT,
-        _: &ExitKind,
-    ) -> Result<u32, Error> {
+    fn is_interesting_all<OT>(&mut self, _: &I, _: &OT, _: &ExitKind) -> Result<u32, Error>
+    where
+        OT: ObserversTuple,
+    {
         Ok(0)
     }
 
@@ -95,12 +97,15 @@ where
     Tail: FeedbacksTuple<I>,
     I: Input,
 {
-    fn is_interesting_all<OT: ObserversTuple>(
+    fn is_interesting_all<OT>(
         &mut self,
         input: &I,
         observers: &OT,
         exit_kind: &ExitKind,
-    ) -> Result<u32, Error> {
+    ) -> Result<u32, Error>
+    where
+        OT: ObserversTuple,
+    {
         Ok(self.0.is_interesting(input, observers, exit_kind)?
             + self.1.is_interesting_all(input, observers, exit_kind)?)
     }
@@ -124,12 +129,15 @@ impl<I> Feedback<I> for CrashFeedback
 where
     I: Input,
 {
-    fn is_interesting<OT: ObserversTuple>(
+    fn is_interesting<OT>(
         &mut self,
         _input: &I,
         _observers: &OT,
         exit_kind: &ExitKind,
-    ) -> Result<u32, Error> {
+    ) -> Result<u32, Error>
+    where
+        OT: ObserversTuple,
+    {
         if let ExitKind::Crash = exit_kind {
             Ok(1)
         } else {
@@ -164,12 +172,15 @@ impl<I> Feedback<I> for TimeoutFeedback
 where
     I: Input,
 {
-    fn is_interesting<OT: ObserversTuple>(
+    fn is_interesting<OT>(
         &mut self,
         _input: &I,
         _observers: &OT,
         exit_kind: &ExitKind,
-    ) -> Result<u32, Error> {
+    ) -> Result<u32, Error>
+    where
+        OT: ObserversTuple,
+    {
         if let ExitKind::Timeout = exit_kind {
             Ok(1)
         } else {
@@ -207,12 +218,15 @@ impl<I> Feedback<I> for TimeFeedback
 where
     I: Input,
 {
-    fn is_interesting<OT: ObserversTuple>(
+    fn is_interesting<OT>(
         &mut self,
         _input: &I,
         observers: &OT,
         _exit_kind: &ExitKind,
-    ) -> Result<u32, Error> {
+    ) -> Result<u32, Error>
+    where
+        OT: ObserversTuple,
+    {
         let observer = observers.match_first_type::<TimeObserver>().unwrap();
         self.exec_time = *observer.last_runtime();
         Ok(0)

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -194,7 +194,6 @@ mod tests {
 
         let mut harness = |_buf: &[u8]| ExitKind::Ok;
         let mut executor = InProcessExecutor::new(
-            "main",
             &mut harness,
             tuple_list!(),
             //Box::new(|_, _, _, _, _| ()),

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use crate::{
     corpus::{Corpus, CorpusScheduler},
     events::EventManager,
-    executors::{Executor, HasObservers},
+    executors::{Executor, HasExecHooks, HasExecHooksTuple, HasObservers, HasObserversHooks},
     inputs::Input,
     mutators::Mutator,
     observers::ObserversTuple,
@@ -25,8 +25,8 @@ where
     S: HasCorpus<C, I> + Evaluator<I>,
     C: Corpus<I>,
     EM: EventManager<I, S>,
-    E: Executor<I> + HasObservers<OT>,
-    OT: ObserversTuple,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
     CS: CorpusScheduler<I, S>,
 {
     /// The mutator registered for this stage
@@ -76,8 +76,8 @@ where
     S: HasCorpus<C, I> + Evaluator<I> + HasRand<R>,
     C: Corpus<I>,
     EM: EventManager<I, S>,
-    E: Executor<I> + HasObservers<OT>,
-    OT: ObserversTuple,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
     CS: CorpusScheduler<I, S>,
     R: Rand,
 {
@@ -94,8 +94,8 @@ where
     S: HasCorpus<C, I> + Evaluator<I> + HasRand<R>,
     C: Corpus<I>,
     EM: EventManager<I, S>,
-    E: Executor<I> + HasObservers<OT>,
-    OT: ObserversTuple,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
     CS: CorpusScheduler<I, S>,
     R: Rand,
 {
@@ -125,8 +125,8 @@ where
     S: HasCorpus<C, I> + Evaluator<I> + HasRand<R>,
     C: Corpus<I>,
     EM: EventManager<I, S>,
-    E: Executor<I> + HasObservers<OT>,
-    OT: ObserversTuple,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
     CS: CorpusScheduler<I, S>,
     R: Rand,
 {
@@ -150,8 +150,8 @@ where
     S: HasCorpus<C, I> + Evaluator<I> + HasRand<R>,
     C: Corpus<I>,
     EM: EventManager<I, S>,
-    E: Executor<I> + HasObservers<OT>,
-    OT: ObserversTuple,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
     CS: CorpusScheduler<I, S>,
     R: Rand,
 {

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -2,7 +2,7 @@ use hashbrown::HashMap;
 use libafl::{
     bolts::{ownedref::OwnedPtr, tuples::Named},
     corpus::Testcase,
-    executors::{CustomExitKind, ExitKind},
+    executors::{CustomExitKind, ExitKind, HasExecHooks},
     feedbacks::Feedback,
     inputs::{HasTargetBytes, Input},
     observers::{Observer, ObserversTuple},
@@ -1625,8 +1625,10 @@ pub struct AsanErrorsObserver {
     errors: OwnedPtr<Option<AsanErrors>>,
 }
 
-impl Observer for AsanErrorsObserver {
-    fn pre_exec(&mut self) -> Result<(), Error> {
+impl Observer for AsanErrorsObserver {}
+
+impl<EM, I, S> HasExecHooks<EM, I, S> for AsanErrorsObserver {
+    fn pre_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
         unsafe {
             if ASAN_ERRORS.is_some() {
                 ASAN_ERRORS.as_mut().unwrap().clear();


### PR DESCRIPTION
This PR introduces the HasExecHooks trait for pre_exec and post_exec hooks.
These hooks take the state, the manager and the input as parameters.
Now the hooks are separated from the definition of the Observer trait, otherwise we need to introduce EM, S and I as generics to observers and then feedbacks.
Executors should implement HasExecHooks too, that is now a common interface.