### PR TITLE
Introduce FeedbackState and allow Feedbacks to process the entire State

### DIFF
--- a/fuzzers/baby_fuzzer/src/main.rs
+++ b/fuzzers/baby_fuzzer/src/main.rs
@@ -5,13 +5,13 @@ use libafl::{
     corpus::{InMemoryCorpus, OnDiskCorpus, QueueCorpusScheduler},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
-    feedbacks::{CrashFeedback, MaxMapFeedback},
+    feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
     generators::RandPrintablesGenerator,
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     observers::StdMapObserver,
     stages::mutational::StdMutationalStage,
-    state::State,
+    state::StdState,
     stats::SimpleStats,
     utils::{current_nanos, StdRand},
 };
@@ -42,19 +42,27 @@ pub fn main() {
     // Create an observation channel using the signals map
     let observer = StdMapObserver::new("signals", unsafe { &mut SIGNALS });
 
+    // The state of the edges feedback.
+    let feedback_state = MapFeedbackState::with_observer(&observer);
+
+    // Feedback to rate the interestingness of an input
+    let feedback = MaxMapFeedback::new(&feedback_state, &observer);
+
+    // A feedback to choose if an input is a solution or not
+    let objective = CrashFeedback::new();
+
     // create a State from scratch
-    let mut state = State::new(
+    let mut state = StdState::new(
         // RNG
         StdRand::with_seed(current_nanos()),
         // Corpus that will be evolved, we keep it in memory for performance
         InMemoryCorpus::new(),
-        // Feedback to rate the interestingness of an input
-        MaxMapFeedback::new_with_observer(&observer),
         // Corpus in which we store solutions (crashes in this example),
         // on disk so the user can get them after stopping the fuzzer
         OnDiskCorpus::new(PathBuf::from("./crashes")).unwrap(),
-        // Feedbacks to recognize an input as solution
-        CrashFeedback::new(),
+        // States of the feedbacks.
+        // They are the data related to the feedbacks that you want to persist in the State.
+        tuple_list!(feedback_state),
     );
 
     // The Stats trait define how the fuzzer stats are reported to the user
@@ -67,27 +75,32 @@ pub fn main() {
     // A queue policy to get testcasess from the corpus
     let scheduler = QueueCorpusScheduler::new();
 
+    // A fuzzer with feedbacks and a corpus scheduler
+    let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
+
     // Create the executor for an in-process function with just one observer
-    let mut executor =
-        InProcessExecutor::new(&mut harness, tuple_list!(observer), &mut state, &mut mgr)
-            .expect("Failed to create the Executor".into());
+    let mut executor = InProcessExecutor::new(
+        &mut harness,
+        tuple_list!(observer),
+        &mut fuzzer,
+        &mut state,
+        &mut mgr,
+    )
+    .expect("Failed to create the Executor".into());
 
     // Generator of printable bytearrays of max size 32
     let mut generator = RandPrintablesGenerator::new(32);
 
     // Generate 8 initial inputs
     state
-        .generate_initial_inputs(&mut executor, &mut generator, &mut mgr, &scheduler, 8)
+        .generate_initial_inputs(&mut fuzzer, &mut executor, &mut generator, &mut mgr, 8)
         .expect("Failed to generate the initial corpus".into());
 
-    // Setup a basic mutator with a mutational stage
+    // Setup a mutational stage with a basic bytes mutator
     let mutator = StdScheduledMutator::new(havoc_mutations());
-    let stage = StdMutationalStage::new(mutator);
-
-    // A fuzzer with just one stage
-    let mut fuzzer = StdFuzzer::new(tuple_list!(stage));
+    let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
     fuzzer
-        .fuzz_loop(&mut state, &mut executor, &mut mgr, &scheduler)
+        .fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)
         .expect("Error in the fuzzing loop".into());
 }

--- a/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
@@ -9,13 +9,13 @@ use libafl::{
     events::setup_restarting_mgr_std,
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
-    feedbacks::{CrashFeedback, MaxMapFeedback},
+    feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
     observers::StdMapObserver,
     stages::mutational::StdMutationalStage,
-    state::{HasCorpus, HasMetadata, State},
+    state::{HasCorpus, HasMetadata, StdState},
     stats::SimpleStats,
     utils::{current_nanos, StdRand},
     Error,
@@ -68,24 +68,42 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // Create an observation channel using the allocations map
     let allocs_observer = StdMapObserver::new("allocs", unsafe { &mut libafl_alloc_map });
 
+    // The state of the edges feedback.
+    let edges_feedback_state = MapFeedbackState::with_observer(&edges_observer);
+
+    // The state of the cmps feedback.
+    let cmps_feedback_state = MapFeedbackState::with_observer(&cmps_observer);
+
+    // The state of the allocs feedback.
+    let allocs_feedback_state = MapFeedbackState::with_observer(&allocs_observer);
+
+    // Feedback to rate the interestingness of an input
+    let feedback = feedback_or!(
+        MaxMapFeedback::new(&edges_feedback_state, &edges_observer),
+        MaxMapFeedback::new(&cmps_feedback_state, &cmps_observer),
+        MaxMapFeedback::new(&allocs_feedback_state, &allocs_observer)
+    );
+
+    // A feedback to choose if an input is a solution or not
+    let objective = CrashFeedback::new();
+
     // If not restarting, create a State from scratch
     let mut state = state.unwrap_or_else(|| {
-        State::new(
+        StdState::new(
             // RNG
             StdRand::with_seed(current_nanos()),
             // Corpus that will be evolved, we keep it in memory for performance
             InMemoryCorpus::new(),
-            // Feedbacks to rate the interestingness of an input
-            feedback_or!(
-                MaxMapFeedback::new_with_observer(&edges_observer),
-                MaxMapFeedback::new_with_observer(&cmps_observer),
-                MaxMapFeedback::new_with_observer(&allocs_observer)
-            ),
             // Corpus in which we store solutions (crashes in this example),
             // on disk so the user can get them after stopping the fuzzer
             OnDiskCorpus::new(objective_dir).unwrap(),
-            // Feedbacks to recognize an input as solution
-            CrashFeedback::new(),
+            // States of the feedbacks.
+            // They are the data related to the feedbacks that you want to persist in the State.
+            tuple_list!(
+                edges_feedback_state,
+                cmps_feedback_state,
+                allocs_feedback_state
+            ),
         )
     });
 
@@ -98,12 +116,13 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
 
     // Setup a basic mutator with a mutational stage
     let mutator = StdScheduledMutator::new(havoc_mutations());
-    let stage = StdMutationalStage::new(mutator);
+    let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
     // A random policy to get testcasess from the corpus
     let scheduler = RandCorpusScheduler::new();
-    // A fuzzer with just one stage
-    let mut fuzzer = StdFuzzer::new(tuple_list!(stage));
+
+    // A fuzzer with feedbacks and a corpus scheduler
+    let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |buf: &[u8]| {
@@ -115,6 +134,7 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     let mut executor = InProcessExecutor::new(
         &mut harness,
         tuple_list!(edges_observer, cmps_observer, allocs_observer),
+        &mut fuzzer,
         &mut state,
         &mut restarting_mgr,
     )?;
@@ -129,7 +149,12 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // In case the corpus is empty (on first run), reset
     if state.corpus().count() < 1 {
         state
-            .load_initial_inputs(&mut executor, &mut restarting_mgr, &scheduler, &corpus_dirs)
+            .load_initial_inputs(
+                &mut fuzzer,
+                &mut executor,
+                &mut restarting_mgr,
+                &corpus_dirs,
+            )
             .expect(&format!(
                 "Failed to load initial corpus at {:?}",
                 &corpus_dirs
@@ -137,7 +162,7 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
         println!("We imported {} inputs from disk.", state.corpus().count());
     }
 
-    fuzzer.fuzz_loop(&mut state, &mut executor, &mut restarting_mgr, &scheduler)?;
+    fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut restarting_mgr)?;
 
     // Never reached
     Ok(())

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -10,16 +10,16 @@ use libafl::{
         Corpus, InMemoryCorpus, IndexesLenTimeMinimizerCorpusScheduler, OnDiskCorpus,
         QueueCorpusScheduler,
     },
-    events::{setup_restarting_mgr_std, EventManager},
+    events::{setup_restarting_mgr_std, EventRestarter},
     executors::{inprocess::InProcessExecutor, ExitKind, TimeoutExecutor},
     feedback_or,
-    feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback, TimeoutFeedback},
+    feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback, TimeFeedback, TimeoutFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
     observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
     stages::mutational::StdMutationalStage,
-    state::{HasCorpus, HasMetadata, State},
+    state::{HasCorpus, HasMetadata, StdState},
     stats::SimpleStats,
     utils::{current_nanos, StdRand},
     Error,
@@ -65,29 +65,41 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     };
 
     // Create an observation channel using the coverage map
+    // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
     let edges = unsafe { &mut EDGES_MAP[0..MAX_EDGES_NUM] };
     let edges_observer = HitcountsMapObserver::new(StdMapObserver::new("edges", edges));
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
+    // The state of the edges feedback.
+    let feedback_state = MapFeedbackState::with_observer(&edges_observer);
+
+    // Feedback to rate the interestingness of an input
+    // This one is composed by two Feedbacks in OR
+    let feedback = feedback_or!(
+        // New maximization map feedback linked to the edges observer and the feedback state
+        MaxMapFeedback::new_tracking(&feedback_state, &edges_observer, true, false),
+        // Time feedback, this one does not need a feedback state
+        TimeFeedback::new_with_observer(&time_observer)
+    );
+
+    // A feedback to choose if an input is a solution or not
+    let objective = feedback_or!(CrashFeedback::new(), TimeoutFeedback::new());
+
     // If not restarting, create a State from scratch
     let mut state = state.unwrap_or_else(|| {
-        State::new(
+        StdState::new(
             // RNG
             StdRand::with_seed(current_nanos()),
             // Corpus that will be evolved, we keep it in memory for performance
             InMemoryCorpus::new(),
-            // Feedbacks to rate the interestingness of an input
-            feedback_or!(
-                MaxMapFeedback::new_tracking_with_observer(&edges_observer, true, false),
-                TimeFeedback::new_with_observer(&time_observer)
-            ),
             // Corpus in which we store solutions (crashes in this example),
             // on disk so the user can get them after stopping the fuzzer
             OnDiskCorpus::new(objective_dir).unwrap(),
-            // Feedbacks to recognize an input as solution
-            feedback_or!(CrashFeedback::new(), TimeoutFeedback::new()),
+            // States of the feedbacks.
+            // They are the data related to the feedbacks that you want to persist in the State.
+            tuple_list!(feedback_state),
         )
     });
 
@@ -106,13 +118,13 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
 
     // Setup a basic mutator with a mutational stage
     let mutator = StdScheduledMutator::new(havoc_mutations());
-    let stage = StdMutationalStage::new(mutator);
-
-    // A fuzzer with just one stage
-    let mut fuzzer = StdFuzzer::new(tuple_list!(stage));
+    let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
     // A minimization+queue policy to get testcasess from the corpus
     let scheduler = IndexesLenTimeMinimizerCorpusScheduler::new(QueueCorpusScheduler::new());
+
+    // A fuzzer with feedbacks and a corpus scheduler
+    let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |buf: &[u8]| {
@@ -125,6 +137,7 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
         InProcessExecutor::new(
             &mut harness,
             tuple_list!(edges_observer, time_observer),
+            &mut fuzzer,
             &mut state,
             &mut restarting_mgr,
         )?,
@@ -142,7 +155,12 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // In case the corpus is empty (on first run), reset
     if state.corpus().count() < 1 {
         state
-            .load_initial_inputs(&mut executor, &mut restarting_mgr, &scheduler, &corpus_dirs)
+            .load_initial_inputs(
+                &mut fuzzer,
+                &mut executor,
+                &mut restarting_mgr,
+                &corpus_dirs,
+            )
             .expect(&format!(
                 "Failed to load initial corpus at {:?}",
                 &corpus_dirs
@@ -156,10 +174,10 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // However, you will lose a lot of performance that way.
     let iters = 1_000_000;
     fuzzer.fuzz_loop_for(
+        &mut stages,
         &mut state,
         &mut executor,
         &mut restarting_mgr,
-        &scheduler,
         iters,
     )?;
 

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -65,7 +65,6 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     };
 
     // Create an observation channel using the coverage map
-    // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
     let edges = unsafe { &mut EDGES_MAP[0..MAX_EDGES_NUM] };
     let edges_observer = HitcountsMapObserver::new(StdMapObserver::new("edges", edges));
 

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -120,7 +120,7 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // A minimization+queue policy to get testcasess from the corpus
     let scheduler = IndexesLenTimeMinimizerCorpusScheduler::new(QueueCorpusScheduler::new());
 
-    // A fuzzer with just one stage and a minimization+queue policy to get testcasess from the corpus
+    // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -12,13 +12,13 @@ use libafl::{
     events::setup_restarting_mgr_std,
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
-    feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
+    feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback, MapFeedbackState},
     fuzzer::{Fuzzer, StdFuzzer},
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
     observers::{StdMapObserver, TimeObserver},
     stages::mutational::StdMutationalStage,
-    state::{HasCorpus, HasMetadata, State},
+    state::{HasCorpus, HasMetadata, StdState},
     stats::SimpleStats,
     utils::{current_nanos, StdRand},
     Error,
@@ -69,23 +69,34 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
+    // The state of the edges feedback.
+    let feedback_state = MapFeedbackState::with_observer(&edges_observer);
+
+    // Feedback to rate the interestingness of an input
+    // This one is composed by two Feedbacks in OR
+    let feedback = feedback_or!(
+        // New maximization map feedback linked to the edges observer and the feedback state
+        MaxMapFeedback::new_tracking(&feedback_state, &edges_observer, true, false),
+        // Time feedback, this one does not need a feedback state
+        TimeFeedback::new_with_observer(&time_observer)
+    );
+
+    // A feedback to choose if an input is a solution or not
+    let objective = CrashFeedback::new();
+
     // If not restarting, create a State from scratch
     let mut state = state.unwrap_or_else(|| {
-        State::new(
+        StdState::new(
             // RNG
             StdRand::with_seed(current_nanos()),
             // Corpus that will be evolved, we keep it in memory for performance
             InMemoryCorpus::new(),
-            // Feedbacks to rate the interestingness of an input
-            feedback_or!(
-                MaxMapFeedback::new_tracking_with_observer(&edges_observer, true, false),
-                TimeFeedback::new_with_observer(&time_observer)
-            ),
             // Corpus in which we store solutions (crashes in this example),
             // on disk so the user can get them after stopping the fuzzer
             OnDiskCorpus::new(objective_dir).unwrap(),
-            // Feedback to recognize an input as solution
-            CrashFeedback::new(),
+            // States of the feedbacks.
+            // They are the data related to the feedbacks that you want to persist in the State.
+            tuple_list!(feedback_state),
         )
     });
 
@@ -104,13 +115,13 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
 
     // Setup a basic mutator with a mutational stage
     let mutator = StdScheduledMutator::new(havoc_mutations());
-    let stage = StdMutationalStage::new(mutator);
-
-    // A fuzzer with just one stage and a minimization+queue policy to get testcasess from the corpus
-    let mut fuzzer = StdFuzzer::new(tuple_list!(stage));
+    let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
     // A minimization+queue policy to get testcasess from the corpus
     let scheduler = IndexesLenTimeMinimizerCorpusScheduler::new(QueueCorpusScheduler::new());
+
+    // A fuzzer with just one stage and a minimization+queue policy to get testcasess from the corpus
+    let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |buf: &[u8]| {
@@ -122,6 +133,7 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     let mut executor = InProcessExecutor::new(
         &mut harness,
         tuple_list!(edges_observer, time_observer),
+        &mut fuzzer,
         &mut state,
         &mut restarting_mgr,
     )?;
@@ -134,7 +146,7 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     }
 
     // In case the corpus is empty (on first run), reset
-    if state.corpus().count() < 1 {
+    /*if state.corpus().count() < 1 {
         state
             .load_initial_inputs(&mut executor, &mut restarting_mgr, &scheduler, &corpus_dirs)
             .expect(&format!(
@@ -142,9 +154,9 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
                 &corpus_dirs
             ));
         println!("We imported {} inputs from disk.", state.corpus().count());
-    }
+    }*/
 
-    fuzzer.fuzz_loop(&mut state, &mut executor, &mut restarting_mgr, &scheduler)?;
+    fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut restarting_mgr)?;
 
     // Never reached
     Ok(())

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -12,7 +12,7 @@ use libafl::{
     events::setup_restarting_mgr_std,
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
-    feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback, MapFeedbackState},
+    feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback, TimeFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
@@ -146,15 +146,20 @@ fn fuzz(corpus_dirs: Vec<PathBuf>, objective_dir: PathBuf, broker_port: u16) -> 
     }
 
     // In case the corpus is empty (on first run), reset
-    /*if state.corpus().count() < 1 {
+    if state.corpus().count() < 1 {
         state
-            .load_initial_inputs(&mut executor, &mut restarting_mgr, &scheduler, &corpus_dirs)
+            .load_initial_inputs(
+                &mut fuzzer,
+                &mut executor,
+                &mut restarting_mgr,
+                &corpus_dirs,
+            )
             .expect(&format!(
                 "Failed to load initial corpus at {:?}",
                 &corpus_dirs
             ));
         println!("We imported {} inputs from disk.", state.corpus().count());
-    }*/
+    }
 
     fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut restarting_mgr)?;
 

--- a/libafl/src/corpus/queue.rs
+++ b/libafl/src/corpus/queue.rs
@@ -76,7 +76,7 @@ where
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-
+    /*
     use std::{fs, path::PathBuf};
 
     use crate::{
@@ -119,5 +119,5 @@ mod tests {
         assert_eq!(filename, "target/.test/fancy/path/fancyfile");
 
         fs::remove_dir_all("target/.test/fancy").unwrap();
-    }
+    }*/
 }

--- a/libafl/src/corpus/queue.rs
+++ b/libafl/src/corpus/queue.rs
@@ -76,13 +76,13 @@ where
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod tests {
-    /*
+
     use std::{fs, path::PathBuf};
 
     use crate::{
         corpus::{Corpus, CorpusScheduler, OnDiskCorpus, QueueCorpusScheduler, Testcase},
         inputs::bytes::BytesInput,
-        state::{HasCorpus, State},
+        state::{HasCorpus, StdState},
         utils::StdRand,
     };
 
@@ -103,7 +103,7 @@ mod tests {
             OnDiskCorpus::<BytesInput>::new(PathBuf::from("target/.test/fancy/objective/path"))
                 .unwrap();
 
-        let mut state = State::new(rand, q, (), objective_q, ());
+        let mut state = StdState::new(rand, q, objective_q, ());
 
         let next_idx = scheduler.next(&mut state).unwrap();
         let filename = state
@@ -119,5 +119,5 @@ mod tests {
         assert_eq!(filename, "target/.test/fancy/path/fancyfile");
 
         fs::remove_dir_all("target/.test/fancy").unwrap();
-    }*/
+    }
 }

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -528,7 +528,7 @@ where
     //CE: CustomEvent<I>,
 {
     /// The llmp client needs to wait until a broker mapped all pages, before shutting down.
-    /// Otherwise, the OS mfay already have removed the shared maps,
+    /// Otherwise, the OS may already have removed the shared maps,
     #[inline]
     fn await_restart_safe(&mut self) {
         self.llmp_mgr.await_restart_safe()

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -17,7 +17,7 @@ use crate::{
         llmp::{self, Flags, LlmpClientDescription, LlmpSender, Tag},
         shmem::ShMemProvider,
     },
-    events::{BrokerEventResult, Event, EventFirer, EventManager},
+    events::{BrokerEventResult, Event, EventFirer, EventManager, EventProcessor},
     executors::Executor,
     executors::ExitKind,
     fuzzer::IfInteresting,
@@ -392,7 +392,7 @@ where
     }
 }
 
-impl<E, I, OT, S, SP, ST, Z> EventManager<E, I, S, Z> for LlmpEventManager<E, I, OT, S, SP, ST, Z>
+impl<E, I, OT, S, SP, ST, Z> EventProcessor<E, S, Z> for LlmpEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
     I: Input,
@@ -438,6 +438,19 @@ where
         })?;
         Ok(count)
     }
+}
+
+impl<E, I, OT, S, SP, ST, Z> EventManager<E, I, S, Z> for LlmpEventManager<E, I, OT, S, SP, ST, Z>
+where
+    E: Executor<I>,
+    I: Input,
+    S: State,
+    Z: IfInteresting<I, OT, S>,
+    OT: ObserversTuple,
+    SP: ShMemProvider,
+    ST: Stats,
+    //CE: CustomEvent<I>,
+{
 }
 
 /// Serialize the current state and corpus during an executiont to bytes.
@@ -533,7 +546,7 @@ where
     }
 }
 
-impl<E, I, OT, S, SP, ST, Z> EventManager<E, I, S, Z>
+impl<E, I, OT, S, SP, ST, Z> EventProcessor<E, S, Z>
     for LlmpRestartingEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
@@ -548,6 +561,20 @@ where
     fn process(&mut self, fuzzer: &mut Z, state: &mut S, executor: &mut E) -> Result<usize, Error> {
         self.llmp_mgr.process(fuzzer, state, executor)
     }
+}
+
+impl<E, I, OT, S, SP, ST, Z> EventManager<E, I, S, Z>
+    for LlmpRestartingEventManager<E, I, OT, S, SP, ST, Z>
+where
+    E: Executor<I>,
+    I: Input,
+    S: State,
+    Z: IfInteresting<I, OT, S>,
+    OT: ObserversTuple,
+    SP: ShMemProvider + 'static,
+    ST: Stats,
+    //CE: CustomEvent<I>,
+{
 }
 
 /// The llmp connection from the actual fuzzer to the process supervising it

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -3,6 +3,8 @@
 use alloc::{string::ToString, vec::Vec};
 use core::{marker::PhantomData, time::Duration};
 
+use serde::{de::DeserializeOwned, Serialize};
+
 #[cfg(feature = "std")]
 use core::ptr::{addr_of, read_volatile};
 
@@ -23,7 +25,6 @@ use crate::{
     fuzzer::IfInteresting,
     inputs::Input,
     observers::ObserversTuple,
-    state::State,
     stats::Stats,
     Error,
 };
@@ -60,7 +61,7 @@ pub struct LlmpEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider + 'static,
@@ -83,7 +84,6 @@ impl<E, I, OT, S, SP, ST, Z> Drop for LlmpEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -99,7 +99,6 @@ impl<E, I, OT, S, SP, ST, Z> LlmpEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -348,7 +347,6 @@ impl<E, I, OT, S, SP, ST, Z> EventFirer<I, S> for LlmpEventManager<E, I, OT, S, 
 where
     E: Executor<I>,
     I: Input,
-    S: State,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -396,7 +394,6 @@ impl<E, I, OT, S, SP, ST, Z> EventProcessor<E, S, Z> for LlmpEventManager<E, I, 
 where
     E: Executor<I>,
     I: Input,
-    S: State,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -444,7 +441,7 @@ impl<E, I, OT, S, SP, ST, Z> EventManager<E, I, S, Z> for LlmpEventManager<E, I,
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -463,7 +460,7 @@ pub fn serialize_state_mgr<E, I, OT, S, SP, ST, Z>(
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+    S: Serialize,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -481,7 +478,7 @@ pub fn deserialize_state_mgr<E, I, OT, S, SP, ST, Z>(
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+    S: DeserializeOwned,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -500,7 +497,7 @@ pub struct LlmpRestartingEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider + 'static,
@@ -517,7 +514,7 @@ impl<E, I, OT, S, SP, ST, Z> EventFirer<I, S> for LlmpRestartingEventManager<E, 
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+    S: Serialize,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider,
@@ -551,7 +548,7 @@ impl<E, I, OT, S, SP, ST, Z> EventProcessor<E, S, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider + 'static,
@@ -568,7 +565,7 @@ impl<E, I, OT, S, SP, ST, Z> EventManager<E, I, S, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+    S: Serialize,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider + 'static,
@@ -587,7 +584,7 @@ impl<E, I, OT, S, SP, ST, Z> LlmpRestartingEventManager<E, I, OT, S, SP, ST, Z>
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider + 'static,
@@ -628,7 +625,7 @@ pub fn setup_restarting_mgr_std<E, I, OT, S, ST, Z>(
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+    S: DeserializeOwned,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     ST: Stats,
@@ -662,7 +659,7 @@ pub fn setup_restarting_mgr<E, I, OT, S, SP, ST, Z>(
 where
     E: Executor<I>,
     I: Input,
-    S: State,
+    S: DeserializeOwned,
     Z: IfInteresting<I, OT, S>,
     OT: ObserversTuple,
     SP: ShMemProvider + 'static,

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -176,7 +176,9 @@ where
 {
     /// Send off an event to the broker
     fn fire(&mut self, state: &mut S, event: Event<I>) -> Result<(), Error>;
+}
 
+pub trait EventRestarter<S> {
     /// For restarting event managers, implement a way to forward state to their next peers.
     #[inline]
     fn on_restart(&mut self, _state: &mut S) -> Result<(), Error> {
@@ -213,7 +215,7 @@ pub trait EventProcessor<E, S, Z> {
 
 /// [`EventManager`] is the main communications hub.
 /// For the "normal" multi-processed mode, you may want to look into `RestartingEventManager`
-pub trait EventManager<E, I, S, Z>: EventFirer<I, S> + EventProcessor<E, S, Z>
+pub trait EventManager<E, I, S, Z>: EventFirer<I, S> + EventProcessor<E, S, Z> + EventRestarter<S>
 where
     I: Input,
 {
@@ -230,6 +232,10 @@ where
     fn fire(&mut self, _state: &mut S, _event: Event<I>) -> Result<(), Error> {
         Ok(())
     }
+}
+
+impl<S> EventRestarter<S> for NopEventManager
+{
 }
 
 impl<E, S, Z> EventProcessor<E, S, Z> for NopEventManager {

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -215,7 +215,8 @@ pub trait EventProcessor<E, S, Z> {
 
 /// [`EventManager`] is the main communications hub.
 /// For the "normal" multi-processed mode, you may want to look into `RestartingEventManager`
-pub trait EventManager<E, I, S, Z>: EventFirer<I, S> + EventProcessor<E, S, Z> + EventRestarter<S>
+pub trait EventManager<E, I, S, Z>:
+    EventFirer<I, S> + EventProcessor<E, S, Z> + EventRestarter<S>
 where
     I: Input,
 {
@@ -234,9 +235,7 @@ where
     }
 }
 
-impl<S> EventRestarter<S> for NopEventManager
-{
-}
+impl<S> EventRestarter<S> for NopEventManager {}
 
 impl<E, S, Z> EventProcessor<E, S, Z> for NopEventManager {
     fn process(

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -2,7 +2,7 @@
 use alloc::{string::ToString, vec::Vec};
 
 use crate::{
-    events::{BrokerEventResult, Event, EventFirer, EventManager, EventRestarter, EventProcessor},
+    events::{BrokerEventResult, Event, EventFirer, EventManager, EventProcessor, EventRestarter},
     inputs::Input,
     stats::Stats,
     Error,

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -2,7 +2,7 @@
 use alloc::{string::ToString, vec::Vec};
 
 use crate::{
-    events::{BrokerEventResult, Event, EventFirer, EventManager, EventProcessor},
+    events::{BrokerEventResult, Event, EventFirer, EventManager, EventRestarter, EventProcessor},
     inputs::Input,
     stats::Stats,
     Error,
@@ -33,6 +33,13 @@ where
         };
         Ok(())
     }
+}
+
+impl<I, S, ST> EventRestarter<S> for SimpleEventManager<I, ST>
+where
+    I: Input,
+    ST: Stats, //CE: CustomEvent<I, OT>,
+{
 }
 
 impl<E, I, S, ST, Z> EventProcessor<E, S, Z> for SimpleEventManager<I, ST>

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -2,10 +2,8 @@
 use alloc::{string::ToString, vec::Vec};
 
 use crate::{
-    events::{BrokerEventResult, Event, EventFirer, EventManager},
-    executors::Executor,
+    events::{BrokerEventResult, Event, EventFirer, EventManager, EventProcessor},
     inputs::Input,
-    state::State,
     stats::Stats,
     Error,
 };
@@ -26,7 +24,6 @@ where
 impl<I, S, ST> EventFirer<I, S> for SimpleEventManager<I, ST>
 where
     I: Input,
-    S: State,
     ST: Stats, //CE: CustomEvent<I, OT>,
 {
     fn fire(&mut self, _state: &mut S, event: Event<I>) -> Result<(), Error> {
@@ -38,11 +35,9 @@ where
     }
 }
 
-impl<E, I, S, ST, Z> EventManager<E, I, S, Z> for SimpleEventManager<I, ST>
+impl<E, I, S, ST, Z> EventProcessor<E, S, Z> for SimpleEventManager<I, ST>
 where
-    E: Executor<I>,
     I: Input,
-    S: State,
     ST: Stats, //CE: CustomEvent<I, OT>,
 {
     fn process(
@@ -58,6 +53,13 @@ where
         }
         Ok(count)
     }
+}
+
+impl<E, I, S, ST, Z> EventManager<E, I, S, Z> for SimpleEventManager<I, ST>
+where
+    I: Input,
+    ST: Stats, //CE: CustomEvent<I, OT>,
+{
 }
 
 impl<I, ST> SimpleEventManager<I, ST>

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -731,7 +731,7 @@ mod tests {
     fn test_inmem_exec() {
         let mut harness = |_buf: &[u8]| ExitKind::Ok;
 
-        let mut in_process_executor = InProcessExecutor::< _, NopInput, (), ()> {
+        let mut in_process_executor = InProcessExecutor::<_, NopInput, (), ()> {
             harness_fn: &mut harness,
             observers: tuple_list!(),
             phantom: PhantomData,

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -15,7 +15,7 @@ use crate::bolts::os::windows_exceptions::setup_exception_handler;
 
 use crate::{
     corpus::Corpus,
-    events::EventFirer,
+    events::{EventFirer, EventRestarter},
     executors::{
         Executor, ExitKind, HasExecHooks, HasExecHooksTuple, HasObservers, HasObserversHooks,
     },
@@ -182,7 +182,7 @@ where
         _event_mgr: &mut EM,
     ) -> Result<Self, Error>
     where
-        EM: EventFirer<I, S>,
+        EM: EventFirer<I, S> + EventRestarter<S>,
         OC: Corpus<I>,
         OF: Feedback<I, S>,
         S: HasSolutions<OC, I>,
@@ -250,7 +250,7 @@ mod unix_signal_handler {
     use crate::{
         bolts::os::unix_signals::{Handler, Signal},
         corpus::{Corpus, Testcase},
-        events::{Event, EventFirer},
+        events::{Event, EventFirer, EventRestarter},
         executors::ExitKind,
         feedbacks::Feedback,
         fuzzer::HasObjective,
@@ -336,7 +336,7 @@ mod unix_signal_handler {
         _context: &mut ucontext_t,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        EM: EventFirer<I, S>,
+        EM: EventFirer<I, S> + EventRestarter<S>,
         OT: ObserversTuple,
         OC: Corpus<I>,
         OF: Feedback<I, S>,
@@ -410,7 +410,7 @@ mod unix_signal_handler {
         _context: &mut ucontext_t,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        EM: EventFirer<I, S>,
+        EM: EventFirer<I, S> + EventRestarter<S>,
         OT: ObserversTuple,
         OC: Corpus<I>,
         OF: Feedback<I, S>,
@@ -719,7 +719,6 @@ mod windows_exception_handler {
 
 #[cfg(test)]
 mod tests {
-    /*
     use core::marker::PhantomData;
 
     use crate::{
@@ -732,12 +731,12 @@ mod tests {
     fn test_inmem_exec() {
         let mut harness = |_buf: &[u8]| ExitKind::Ok;
 
-        let mut in_process_executor = InProcessExecutor::<(), _, NopInput, (), (), ()> {
+        let mut in_process_executor = InProcessExecutor::< _, NopInput, (), ()> {
             harness_fn: &mut harness,
             observers: tuple_list!(),
             phantom: PhantomData,
         };
         let input = NopInput {};
         assert!(in_process_executor.run_target(&input).is_ok());
-    }*/
+    }
 }

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -59,7 +59,7 @@ impl<'a, EM, H, I, OT, S, Z> HasExecHooks<EM, I, S, Z> for InProcessExecutor<'a,
 where
     H: FnMut(&[u8]) -> ExitKind,
     I: Input + HasTargetBytes,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Z>,
+    OT: ObserversTuple,
 {
     #[inline]
     fn pre_exec(

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -97,21 +97,27 @@ where
     }
 }
 
-impl<E, EM, I, OT, S> HasObserversHooks<EM, I, OT, S> for TimeoutExecutor<E, I>
+impl<E, EM, I, OT, S, Z> HasObserversHooks<EM, I, OT, S, Z> for TimeoutExecutor<E, I>
 where
     E: Executor<I> + HasObservers<OT>,
     I: Input,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Z>,
 {
 }
 
-impl<E, EM, I, S> HasExecHooks<EM, I, S> for TimeoutExecutor<E, I>
+impl<E, EM, I, S, Z> HasExecHooks<EM, I, S, Z> for TimeoutExecutor<E, I>
 where
-    E: Executor<I> + HasExecHooks<EM, I, S>,
+    E: Executor<I> + HasExecHooks<EM, I, S, Z>,
     I: Input,
 {
     #[inline]
-    fn pre_exec(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+    fn pre_exec(
+        &mut self,
+        fuzzer: &mut Z,
+        state: &mut S,
+        mgr: &mut EM,
+        input: &I,
+    ) -> Result<(), Error> {
         #[cfg(unix)]
         unsafe {
             let milli_sec = self.exec_tmout.as_millis();
@@ -137,11 +143,17 @@ where
             // TODO
             let _ = self.exec_tmout.as_millis();
         }
-        self.executor.pre_exec(state, mgr, input)
+        self.executor.pre_exec(fuzzer, state, mgr, input)
     }
 
     #[inline]
-    fn post_exec(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+    fn post_exec(
+        &mut self,
+        fuzzer: &mut Z,
+        state: &mut S,
+        mgr: &mut EM,
+        input: &I,
+    ) -> Result<(), Error> {
         #[cfg(unix)]
         unsafe {
             let it_value = Timeval {
@@ -165,6 +177,6 @@ where
         {
             // TODO
         }
-        self.executor.post_exec(state, mgr, input)
+        self.executor.post_exec(fuzzer, state, mgr, input)
     }
 }

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -261,7 +261,7 @@ where
 
         let map_state = state
             .feedback_states_mut()
-            .match_name::<MapFeedbackState<T>>(&self.name)
+            .match_name_mut::<MapFeedbackState<T>>(&self.name)
             .unwrap();
 
         if map_state.indexes.is_none() && map_state.novelties.is_none() {
@@ -324,7 +324,7 @@ where
     fn append_metadata(&mut self, state: &mut S, testcase: &mut Testcase<I>) -> Result<(), Error> {
         let map_state = state
             .feedback_states_mut()
-            .match_name::<MapFeedbackState<T>>(&self.name)
+            .match_name_mut::<MapFeedbackState<T>>(&self.name)
             .unwrap();
 
         if let Some(v) = map_state.indexes.as_mut() {
@@ -342,7 +342,7 @@ where
     fn discard_metadata(&mut self, state: &mut S, _input: &I) -> Result<(), Error> {
         let map_state = state
             .feedback_states_mut()
-            .match_name::<MapFeedbackState<T>>(&self.name)
+            .match_name_mut::<MapFeedbackState<T>>(&self.name)
             .unwrap();
 
         if let Some(v) = map_state.indexes.as_mut() {

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -12,10 +12,10 @@ use crate::{
     bolts::tuples::Named,
     corpus::Testcase,
     executors::ExitKind,
-    feedbacks::Feedback,
+    feedbacks::{Feedback, FeedbackStatesTuple},
     inputs::Input,
     observers::{MapObserver, ObserversTuple},
-    state::HasMetadata,
+    state::{HasFeedbackStates, HasMetadata},
     utils::AsSlice,
     Error,
 };
@@ -118,6 +118,107 @@ impl MapNoveltiesMetadata {
     }
 }
 
+/// The state of MapFeedback
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(bound = "T: serde::de::DeserializeOwned")]
+pub struct MapFeedbackState<T>
+where
+    T: Integer + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+{
+    /// Contains information about untouched entries
+    pub history_map: Vec<T>,
+    /// Indexes used in the last observation
+    pub indexes: Option<Vec<usize>>,
+    /// New indexes observed in the last observation
+    pub novelties: Option<Vec<usize>>,
+    /// Name identifier of this instance
+    pub name: String,
+}
+
+impl<T> Named for MapFeedbackState<T>
+where
+    T: Integer + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+{
+    #[inline]
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl<T> MapFeedbackState<T>
+where
+    T: Integer + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+{
+    /// Create new `MapFeedbackState`
+    #[must_use]
+    pub fn new(name: &'static str, map_size: usize) -> Self {
+        Self {
+            history_map: vec![T::default(); map_size],
+            indexes: None,
+            novelties: None,
+            name: name.to_string(),
+        }
+    }
+
+    /// Create new `MapFeedbackState` for the observer type.
+    pub fn new_with_observer<O>(map_observer: &O) -> Self
+    where
+        O: MapObserver<T>,
+    {
+        Self {
+            history_map: vec![T::default(); map_observer.map().len()],
+            indexes: None,
+            novelties: None,
+            name: map_observer.name().to_string(),
+        }
+    }
+
+    /// Create new `MapFeedbackState` specifying if it must track indexes of novelties
+    #[must_use]
+    pub fn new_tracking(
+        name: &'static str,
+        map_size: usize,
+        track_indexes: bool,
+        track_novelties: bool,
+    ) -> Self {
+        Self {
+            history_map: vec![T::default(); map_size],
+            indexes: if track_indexes { Some(vec![]) } else { None },
+            novelties: if track_novelties { Some(vec![]) } else { None },
+            name: name.to_string(),
+        }
+    }
+
+    /// Create new `MapFeedbackState` for the observer type if it must track indexes of novelties
+    pub fn new_tracking_with_observer<O>(
+        map_observer: &O,
+        track_indexes: bool,
+        track_novelties: bool,
+    ) -> Self
+    where
+        O: MapObserver<T>,
+    {
+        Self {
+            history_map: vec![T::default(); map_observer.map().len()],
+            indexes: if track_indexes { Some(vec![]) } else { None },
+            novelties: if track_novelties { Some(vec![]) } else { None },
+            name: map_observer.name().to_string(),
+        }
+    }
+
+    /// Create new `MapFeedbackState` using a map observer, and a map.
+    /// The map can be shared.
+    #[must_use]
+    pub fn with_history_map(name: &'static str, history_map: Vec<T>) -> Self {
+        Self {
+            history_map,
+            name: name.to_string(),
+            indexes: None,
+            novelties: None,
+        }
+    }
+}
+
 /// The most common AFL-like feedback type
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "T: serde::de::DeserializeOwned")]
@@ -127,27 +228,24 @@ where
     R: Reducer<T>,
     O: MapObserver<T>,
 {
-    /// Contains information about untouched entries
-    history_map: Vec<T>,
-    /// Indexes used in the last observation
-    indexes: Option<Vec<usize>>,
-    /// New indexes observed in the last observation
-    novelties: Option<Vec<usize>>,
     /// Name identifier of this instance
     name: String,
     /// Phantom Data of Reducer
-    phantom: PhantomData<(R, O)>,
+    phantom: PhantomData<(R, O, T)>,
 }
 
-impl<O, R, T, I> Feedback<I> for MapFeedback<O, R, T>
+impl<I, FT, O, R, S, T> Feedback<FT, I, S> for MapFeedback<O, R, T>
 where
     T: Integer + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
     R: Reducer<T>,
     O: MapObserver<T>,
     I: Input,
+    S: HasFeedbackStates<FT, I>,
+    FT: FeedbackStatesTuple<I>,
 {
     fn is_interesting<OT>(
         &mut self,
+        state: &mut S,
         _input: &I,
         observers: &OT,
         _exit_kind: &ExitKind,
@@ -161,56 +259,61 @@ where
         let size = observer.usable_count();
         let initial = observer.initial();
 
-        if self.indexes.is_none() && self.novelties.is_none() {
+        let map_state = state
+            .feedback_states_mut()
+            .match_name::<MapFeedbackState<T>>(&self.name)
+            .unwrap();
+
+        if map_state.indexes.is_none() && map_state.novelties.is_none() {
             for i in 0..size {
-                let history = self.history_map[i];
+                let history = map_state.history_map[i];
                 let item = observer.map()[i];
 
                 let reduced = R::reduce(history, item);
                 if history != reduced {
-                    self.history_map[i] = reduced;
+                    map_state.history_map[i] = reduced;
                     interesting = true;
                 }
             }
-        } else if self.indexes.is_some() && self.novelties.is_none() {
+        } else if map_state.indexes.is_some() && map_state.novelties.is_none() {
             for i in 0..size {
-                let history = self.history_map[i];
+                let history = map_state.history_map[i];
                 let item = observer.map()[i];
                 if item != initial {
-                    self.indexes.as_mut().unwrap().push(i);
+                    map_state.indexes.as_mut().unwrap().push(i);
                 }
 
                 let reduced = R::reduce(history, item);
                 if history != reduced {
-                    self.history_map[i] = reduced;
+                    map_state.history_map[i] = reduced;
                     interesting = true;
                 }
             }
-        } else if self.indexes.is_none() && self.novelties.is_some() {
+        } else if map_state.indexes.is_none() && map_state.novelties.is_some() {
             for i in 0..size {
-                let history = self.history_map[i];
+                let history = map_state.history_map[i];
                 let item = observer.map()[i];
 
                 let reduced = R::reduce(history, item);
                 if history != reduced {
-                    self.history_map[i] = reduced;
+                    map_state.history_map[i] = reduced;
                     interesting = true;
-                    self.novelties.as_mut().unwrap().push(i);
+                    map_state.novelties.as_mut().unwrap().push(i);
                 }
             }
         } else {
             for i in 0..size {
-                let history = self.history_map[i];
+                let history = map_state.history_map[i];
                 let item = observer.map()[i];
                 if item != initial {
-                    self.indexes.as_mut().unwrap().push(i);
+                    map_state.indexes.as_mut().unwrap().push(i);
                 }
 
                 let reduced = R::reduce(history, item);
                 if history != reduced {
-                    self.history_map[i] = reduced;
+                    map_state.history_map[i] = reduced;
                     interesting = true;
-                    self.novelties.as_mut().unwrap().push(i);
+                    map_state.novelties.as_mut().unwrap().push(i);
                 }
             }
         }
@@ -218,12 +321,17 @@ where
         Ok(interesting)
     }
 
-    fn append_metadata(&mut self, testcase: &mut Testcase<I>) -> Result<(), Error> {
-        if let Some(v) = self.indexes.as_mut() {
+    fn append_metadata(&mut self, state: &mut S, testcase: &mut Testcase<I>) -> Result<(), Error> {
+        let map_state = state
+            .feedback_states_mut()
+            .match_name::<MapFeedbackState<T>>(&self.name)
+            .unwrap();
+
+        if let Some(v) = map_state.indexes.as_mut() {
             let meta = MapIndexesMetadata::new(core::mem::take(v));
             testcase.add_metadata(meta);
         };
-        if let Some(v) = self.novelties.as_mut() {
+        if let Some(v) = map_state.novelties.as_mut() {
             let meta = MapNoveltiesMetadata::new(core::mem::take(v));
             testcase.add_metadata(meta);
         };
@@ -231,11 +339,16 @@ where
     }
 
     /// Discard the stored metadata in case that the testcase is not added to the corpus
-    fn discard_metadata(&mut self, _input: &I) -> Result<(), Error> {
-        if let Some(v) = self.indexes.as_mut() {
+    fn discard_metadata(&mut self, state: &mut S, _input: &I) -> Result<(), Error> {
+        let map_state = state
+            .feedback_states_mut()
+            .match_name::<MapFeedbackState<T>>(&self.name)
+            .unwrap();
+
+        if let Some(v) = map_state.indexes.as_mut() {
             v.clear();
         }
-        if let Some(v) = self.novelties.as_mut() {
+        if let Some(v) = map_state.novelties.as_mut() {
             v.clear();
         }
         Ok(())
@@ -262,80 +375,14 @@ where
 {
     /// Create new `MapFeedback`
     #[must_use]
-    pub fn new(name: &'static str, map_size: usize) -> Self {
+    pub fn new(name: &'static str) -> Self {
         Self {
-            history_map: vec![T::default(); map_size],
             phantom: PhantomData,
-            indexes: None,
-            novelties: None,
             name: name.to_string(),
-        }
-    }
-
-    /// Create new `MapFeedback` for the observer type.
-    pub fn new_with_observer(map_observer: &O) -> Self {
-        Self {
-            history_map: vec![T::default(); map_observer.map().len()],
-            phantom: PhantomData,
-            indexes: None,
-            novelties: None,
-            name: map_observer.name().to_string(),
-        }
-    }
-
-    /// Create new `MapFeedback` specifying if it must track indexes of novelties
-    #[must_use]
-    pub fn new_tracking(
-        name: &'static str,
-        map_size: usize,
-        track_indexes: bool,
-        track_novelties: bool,
-    ) -> Self {
-        Self {
-            history_map: vec![T::default(); map_size],
-            phantom: PhantomData,
-            indexes: if track_indexes { Some(vec![]) } else { None },
-            novelties: if track_novelties { Some(vec![]) } else { None },
-            name: name.to_string(),
-        }
-    }
-
-    /// Create new `MapFeedback` for the observer type if it must track indexes of novelties
-    pub fn new_tracking_with_observer(
-        map_observer: &O,
-        track_indexes: bool,
-        track_novelties: bool,
-    ) -> Self {
-        Self {
-            history_map: vec![T::default(); map_observer.map().len()],
-            phantom: PhantomData,
-            indexes: if track_indexes { Some(vec![]) } else { None },
-            novelties: if track_novelties { Some(vec![]) } else { None },
-            name: map_observer.name().to_string(),
         }
     }
 }
-
-impl<O, R, T> MapFeedback<O, R, T>
-where
-    T: Integer + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
-    R: Reducer<T>,
-    O: MapObserver<T>,
-{
-    /// Create new `MapFeedback` using a map observer, and a map.
-    /// The map can be shared.
-    #[must_use]
-    pub fn with_history_map(name: &'static str, history_map: Vec<T>) -> Self {
-        Self {
-            history_map,
-            name: name.to_string(),
-            indexes: None,
-            novelties: None,
-            phantom: PhantomData,
-        }
-    }
-}
-
+/*
 /// A [`ReachabilityFeedback`] reports if a target has been reached.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ReachabilityFeedback<O> {
@@ -421,3 +468,4 @@ where
         self.name.as_str()
     }
 }
+*/

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -396,7 +396,6 @@ where
     }
 }
 
-/*
 /// A [`ReachabilityFeedback`] reports if a target has been reached.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ReachabilityFeedback<O> {
@@ -411,7 +410,7 @@ where
 {
     /// Creates a new [`ReachabilityFeedback`] for a [`MapObserver`].
     #[must_use]
-    pub fn new_with_observer(map_observer: &O) -> Self {
+    pub fn new(map_observer: &O) -> Self {
         Self {
             name: map_observer.name().to_string(),
             target_idx: vec![],
@@ -421,7 +420,7 @@ where
 
     /// Creates a new [`ReachabilityFeedback`] for a [`MapObserver`] with the given `name`.
     #[must_use]
-    pub fn new(name: &'static str) -> Self {
+    pub fn with_name(name: &'static str) -> Self {
         Self {
             name: name.to_string(),
             target_idx: vec![],
@@ -430,17 +429,21 @@ where
     }
 }
 
-impl<I, O> Feedback<I> for ReachabilityFeedback<O>
+impl<I, O, S> Feedback<I, S> for ReachabilityFeedback<O>
 where
     I: Input,
     O: MapObserver<usize>,
 {
-    fn is_interesting<OT: ObserversTuple>(
+    fn is_interesting<OT>(
         &mut self,
+        _state: &mut S,
         _input: &I,
         observers: &OT,
         _exit_kind: &ExitKind,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, Error>
+    where
+        OT: ObserversTuple,
+    {
         // TODO Replace with match_name_type when stable
         let observer = observers.match_name::<O>(&self.name).unwrap();
         let size = observer.usable_count();
@@ -459,7 +462,7 @@ where
         }
     }
 
-    fn append_metadata(&mut self, testcase: &mut Testcase<I>) -> Result<(), Error> {
+    fn append_metadata(&mut self, _state: &mut S, testcase: &mut Testcase<I>) -> Result<(), Error> {
         if !self.target_idx.is_empty() {
             let meta = MapIndexesMetadata::new(core::mem::take(self.target_idx.as_mut()));
             testcase.add_metadata(meta);
@@ -467,7 +470,7 @@ where
         Ok(())
     }
 
-    fn discard_metadata(&mut self, _input: &I) -> Result<(), Error> {
+    fn discard_metadata(&mut self, _state: &mut S, _input: &I) -> Result<(), Error> {
         self.target_idx.clear();
         Ok(())
     }
@@ -482,4 +485,3 @@ where
         self.name.as_str()
     }
 }
-*/

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -118,7 +118,7 @@ impl MapNoveltiesMetadata {
     }
 }
 
-/// The state of MapFeedback
+/// The state of [`MapFeedback`]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 pub struct MapFeedbackState<T>

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -86,7 +86,7 @@ where
     }
 }
 
-/// FeedbackState is the data associated with a Feedback that must persist as part
+/// [`FeedbackState`] is the data associated with a [`Feedback`] that must persist as part
 /// of the fuzzer State
 pub trait FeedbackState: Named + serde::Serialize + serde::de::DeserializeOwned {}
 

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -56,7 +56,7 @@ where
         let start_time = crate::cpu::read_time_counter();
 
         // Execute this feedback
-        let ret = self.is_interesting(input, observers, &exit_kind);
+        let ret = self.is_interesting(state, input, observers, &exit_kind);
 
         // Get the elapsed time for checking this feedback
         let elapsed = crate::cpu::read_time_counter() - start_time;
@@ -158,6 +158,7 @@ where
     {
         // Execute this feedback
         let a = self.first.is_interesting_with_perf(
+            state,
             input,
             observers,
             &exit_kind,
@@ -165,6 +166,7 @@ where
             feedback_index,
         )?;
         let b = self.second.is_interesting_with_perf(
+            state,
             input,
             observers,
             &exit_kind,
@@ -273,6 +275,7 @@ where
     {
         // Execute this feedback
         let a = self.first.is_interesting_with_perf(
+            state,
             input,
             observers,
             &exit_kind,
@@ -280,6 +283,7 @@ where
             feedback_index,
         )?;
         let b = self.second.is_interesting_with_perf(
+            state,
             input,
             observers,
             &exit_kind,

--- a/libafl/src/fuzzer.rs
+++ b/libafl/src/fuzzer.rs
@@ -197,7 +197,7 @@ where
     /// before exiting, make sure you call `event_mgr.on_restart(&mut state)?;`.
     /// This way, the state will be available in the next, respawned, iteration.
     fn fuzz_loop_for(
-        &self,
+        &mut self,
         stages: &mut ST,
         state: &mut S,
         executor: &mut E,
@@ -244,8 +244,11 @@ pub struct StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -305,8 +308,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasCorpusScheduler<CS, I, S>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -329,8 +335,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasFeedback<F, FT, I, S>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -353,8 +362,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasObjective<FT, I, OF, S>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -377,8 +389,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> IfInteresting<I, OT, S>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -428,8 +443,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> Evaluator<E, EM, I, S>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -484,8 +502,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC, ST> Fuzzer<E, EM, I, S, ST>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -586,8 +607,11 @@ impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> StdFuzzer<C, CS, E, EM, F, FT, I, OF
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    E: Executor<I>
+        + HasObservers<OT>
+        + HasExecHooks<EM, I, S, Self>
+        + HasObserversHooks<EM, I, OT, S, Self>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<FT, I, S>,
     FT: FeedbackStatesTuple<I>,
@@ -615,11 +639,11 @@ where
         input: &I,
     ) -> Result<(bool, bool), Error> {
         start_timer!(state);
-        executor.pre_exec_observers(state, event_mgr, input)?;
+        executor.pre_exec_observers(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::PreExecObservers);
 
         start_timer!(state);
-        executor.pre_exec(state, event_mgr, input)?;
+        executor.pre_exec(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::PreExec);
 
         start_timer!(state);
@@ -627,13 +651,13 @@ where
         mark_feature_time!(state, PerfFeature::TargetExecution);
 
         start_timer!(state);
-        executor.post_exec(state, event_mgr, input)?;
+        executor.post_exec(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::PostExec);
 
         *state.executions_mut() += 1;
 
         start_timer!(state);
-        executor.post_exec_observers(state, event_mgr, input)?;
+        executor.post_exec_observers(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::PostExecObservers);
 
         let observers = executor.observers();

--- a/libafl/src/fuzzer.rs
+++ b/libafl/src/fuzzer.rs
@@ -12,7 +12,7 @@ use crate::{
     observers::ObserversTuple,
     stages::StagesTuple,
     start_timer,
-    state::{HasCorpus, HasExecutions, HasSolutions, HasClientPerfStats},
+    state::{HasClientPerfStats, HasCorpus, HasExecutions, HasSolutions},
     utils::current_time,
     Error,
 };
@@ -541,7 +541,8 @@ where
             )?;
 
             // Update the feedback stats
-            state.introspection_stats_mut()
+            state
+                .introspection_stats_mut()
                 .update_feedbacks(feedback_stats);
 
             // Return the total fitness

--- a/libafl/src/fuzzer.rs
+++ b/libafl/src/fuzzer.rs
@@ -1,13 +1,19 @@
 //! The `Fuzzer` is the main struct for a fuzz campaign.
 
 use crate::{
-    corpus::CorpusScheduler,
+    corpus::{Corpus, CorpusScheduler, Testcase},
     events::{Event, EventManager},
-    executors::{Executor, HasObservers},
+    executors::{
+        Executor, ExitKind, HasExecHooks, HasExecHooksTuple, HasObservers, HasObserversHooks,
+    },
+    feedbacks::{Feedback, FeedbackStatesTuple},
     inputs::Input,
+    mark_feature_time,
     observers::ObserversTuple,
     stages::StagesTuple,
-    state::{HasClientPerfStats, HasExecutions},
+    start_timer,
+    state::{HasClientPerfStats, HasCorpus, HasExecutions, HasSolutions},
+    state::{HasFeedbackStates, State},
     utils::current_time,
     Error,
 };
@@ -18,14 +24,14 @@ use core::{marker::PhantomData, time::Duration};
 /// Send a stats update all 3 (or more) seconds
 const STATS_TIMEOUT_DEFAULT: Duration = Duration::from_millis(3 * 1000);
 
+/*
 /// Holds a set of stages
-pub trait HasStages<CS, E, EM, I, S, ST>
+pub trait HasStages<EM, I, S, ST>: Sized
 where
-    ST: StagesTuple<CS, E, EM, I, S>,
-    E: Executor<I>,
-    EM: EventManager<I, S>,
+    ST: StagesTuple<EM, I, S, Self>,
+    EM: EventManager<E, I, S, Self>,
     I: Input,
-    Self: Sized,
+    S: State + HasExecutions + HasCorpus<C, I>,
 {
     /// The stages
     fn stages(&self) -> &ST;
@@ -34,11 +40,27 @@ where
     fn stages_mut(&mut self) -> &mut ST;
 }
 
+/// Holds an executor
+pub trait HasExecutor<E, I, S>
+where
+    E: Executor<I>,
+    I: Input,
+    S: State + HasExecutions + HasCorpus<C, I>,
+{
+    /// The executor
+    fn executor(&self) -> &E;
+
+    /// The executor (mut)
+    fn executor_mut(&mut self) -> &mut E;
+}
+*/
+
 /// Holds a scheduler
 pub trait HasCorpusScheduler<CS, I, S>
 where
     CS: CorpusScheduler<I, S>,
     I: Input,
+    S: State,
 {
     /// The scheduler
     fn scheduler(&self) -> &CS;
@@ -47,8 +69,97 @@ where
     fn scheduler_mut(&mut self) -> &mut CS;
 }
 
+/// Holds an feedback
+pub trait HasFeedback<F, FT, I, S>
+where
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    S: State + HasFeedbackStates<FT, I>,
+{
+    /// The feedback
+    fn feedback(&self) -> &F;
+
+    /// The feedback (mut)
+    fn feedback_mut(&mut self) -> &mut F;
+}
+
+/// Holds an objective feedback
+pub trait HasObjective<FT, I, OF, S>
+where
+    OF: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    S: State + HasFeedbackStates<FT, I>,
+{
+    /// The objective feedback
+    fn objective(&self) -> &OF;
+
+    /// The objective feedback (mut)
+    fn objective_mut(&mut self) -> &mut OF;
+}
+
+/// Trait for the starting time
+pub trait HasStartTime {
+    /// The starting time
+    fn start_time(&self) -> &Duration;
+
+    /// The starting time (mut)
+    fn start_time_mut(&mut self) -> &mut Duration;
+}
+
+/// Add to the state if interesting
+pub trait IfInteresting<I, OT, S>: Sized
+where
+    I: Input,
+    S: State,
+    OT: ObserversTuple,
+{
+    /// Evaluate if a set of observation channels has an interesting state
+    fn is_interesting(
+        &mut self,
+        state: &mut S,
+        input: &I,
+        observers: &OT,
+        exit_kind: &ExitKind,
+    ) -> Result<bool, Error>;
+
+    /// Adds this input to the corpus, if it's intersting, and return the index
+    fn add_if_interesting(
+        &mut self,
+        state: &mut S,
+        input: &I,
+        is_interesting: bool,
+    ) -> Result<Option<usize>, Error>;
+}
+
+/// Evaluate an input modyfing the state of the fuzzer
+pub trait Evaluator<E, EM, I, S>: Sized
+where
+    E: Executor<I>,
+    EM: EventManager<E, I, S, Self>,
+    I: Input,
+    S: State,
+{
+    /// Runs the input and triggers observers and feedback
+    fn evaluate_input(
+        &mut self,
+        state: &mut S,
+        executor: &mut E,
+        manager: &mut EM,
+        input: I,
+    ) -> Result<(bool, Option<usize>), Error>;
+}
+
 /// The main fuzzer trait.
-pub trait Fuzzer<E, EM, S, CS> {
+pub trait Fuzzer<E, EM, I, S, ST>: Sized
+where
+    E: Executor<I>,
+    EM: EventManager<E, I, S, Self>,
+    I: Input,
+    S: State,
+    ST: StagesTuple<E, EM, I, S, Self>,
+{
     /// Fuzz for a single iteration
     /// Returns the index of the last fuzzed corpus item
     ///
@@ -57,24 +168,24 @@ pub trait Fuzzer<E, EM, S, CS> {
     /// This way, the state will be available in the next, respawned, iteration.
     fn fuzz_one(
         &mut self,
-        state: &mut S,
+        stages: &mut ST,
         executor: &mut E,
+        state: &mut S,
         manager: &mut EM,
-        scheduler: &CS,
     ) -> Result<usize, Error>;
 
     /// Fuzz forever (or until stopped)
     fn fuzz_loop(
         &mut self,
-        state: &mut S,
+        stages: &mut ST,
         executor: &mut E,
+        state: &mut S,
         manager: &mut EM,
-        scheduler: &CS,
     ) -> Result<usize, Error> {
         let mut last = current_time();
         let stats_timeout = STATS_TIMEOUT_DEFAULT;
         loop {
-            self.fuzz_one(state, executor, manager, scheduler)?;
+            self.fuzz_one(stages, executor, state, manager)?;
             last = Self::maybe_report_stats(state, manager, last, stats_timeout)?;
         }
     }
@@ -85,18 +196,14 @@ pub trait Fuzzer<E, EM, S, CS> {
     /// If you use this fn in a restarting scenario to only run for `n` iterations,
     /// before exiting, make sure you call `event_mgr.on_restart(&mut state)?;`.
     /// This way, the state will be available in the next, respawned, iteration.
-    fn fuzz_loop_for<I>(
-        &mut self,
+    fn fuzz_loop_for(
+        &self,
+        stages: &mut ST,
         state: &mut S,
         executor: &mut E,
         manager: &mut EM,
-        scheduler: &CS,
         iters: u64,
-    ) -> Result<usize, Error>
-    where
-        EM: EventManager<I, S>,
-        I: Input,
-    {
+    ) -> Result<usize, Error> {
         if iters == 0 {
             return Err(Error::IllegalArgument(
                 "Cannot fuzz for 0 iterations!".to_string(),
@@ -108,7 +215,7 @@ pub trait Fuzzer<E, EM, S, CS> {
         let stats_timeout = STATS_TIMEOUT_DEFAULT;
 
         for _ in 0..iters {
-            ret = self.fuzz_one(state, executor, manager, scheduler)?;
+            ret = self.fuzz_one(stages, executor, state, manager)?;
             last = Self::maybe_report_stats(state, manager, last, stats_timeout)?;
         }
 
@@ -132,26 +239,38 @@ pub trait Fuzzer<E, EM, S, CS> {
 }
 
 /// Your default fuzzer instance, for everyday use.
-#[derive(Clone, Debug)]
-pub struct StdFuzzer<CS, ST, E, EM, I, OT, S>
+#[derive(Debug)]
+pub struct StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
 where
+    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    ST: StagesTuple<CS, E, EM, I, S>,
-    E: Executor<I>,
-    EM: EventManager<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
     I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
 {
-    stages: ST,
-    phantom: PhantomData<(CS, E, EM, I, OT, S)>,
+    scheduler: CS,
+    feedback: F,
+    objective: OF,
+    phantom: PhantomData<(C, E, EM, FT, I, OT, S, SC)>,
 }
 
-impl<CS, ST, E, EM, I, OT, S> HasStages<CS, E, EM, I, S, ST> for StdFuzzer<CS, ST, E, EM, I, OT, S>
+/*
+impl<CS, E, EM, F, I, OF, S, ST> HasStages<EM, I, S, ST> for StdFuzzer<CS, E, EM, F, I, OF, S, ST>
 where
     CS: CorpusScheduler<I, S>,
-    ST: StagesTuple<CS, E, EM, I, S>,
     E: Executor<I>,
-    EM: EventManager<I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
     I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I>,
+    ST: StagesTuple<EM, I, S, Self>,
 {
     fn stages(&self) -> &ST {
         &self.stages
@@ -162,14 +281,39 @@ where
     }
 }
 
-/*
-impl<CS, ST, E, EM, I, OT, S> HasCorpusScheduler<CS, I, S> for StdFuzzer<CS, ST, E, EM, I, OT, S>
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasExecutor<E, I, S> for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
 where
     CS: CorpusScheduler<I, S>,
-    ST: StagesTuple<CS, E, EM, I, S>,
     E: Executor<I>,
-    EM: EventManager<I, S>,
+    F: Feedback<FT, I, S>,
     I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I>,
+{
+    fn executor(&self) -> &E {
+        &self.executor
+    }
+
+    fn executor_mut(&mut self) -> &mut E {
+        &mut self.executor
+    }
+}
+*/
+
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasCorpusScheduler<CS, I, S>
+    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+where
+    C: Corpus<I>,
+    CS: CorpusScheduler<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
 {
     fn scheduler(&self) -> &CS {
         &self.scheduler
@@ -179,17 +323,177 @@ where
         &mut self.scheduler
     }
 }
-*/
 
-impl<CS, ST, E, EM, I, OT, S> Fuzzer<E, EM, S, CS> for StdFuzzer<CS, ST, E, EM, I, OT, S>
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasFeedback<F, FT, I, S>
+    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
 where
+    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    S: HasExecutions + HasClientPerfStats,
-    ST: StagesTuple<CS, E, EM, I, S>,
-    EM: EventManager<I, S>,
-    E: Executor<I> + HasObservers<OT>,
-    OT: ObserversTuple,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
     I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
+{
+    fn feedback(&self) -> &F {
+        &self.feedback
+    }
+
+    fn feedback_mut(&mut self) -> &mut F {
+        &mut self.feedback
+    }
+}
+
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasObjective<FT, I, OF, S>
+    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+where
+    C: Corpus<I>,
+    CS: CorpusScheduler<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
+{
+    fn objective(&self) -> &OF {
+        &self.objective
+    }
+
+    fn objective_mut(&mut self) -> &mut OF {
+        &mut self.objective
+    }
+}
+
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> IfInteresting<I, OT, S>
+    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+where
+    C: Corpus<I>,
+    CS: CorpusScheduler<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
+{
+    /// Evaluate if a set of observation channels has an interesting state
+    fn is_interesting(
+        &mut self,
+        state: &mut S,
+        input: &I,
+        observers: &OT,
+        exit_kind: &ExitKind,
+    ) -> Result<bool, Error>
+    where
+        OT: ObserversTuple,
+    {
+        self.feedback_mut()
+            .is_interesting(state, input, observers, exit_kind)
+    }
+
+    /// Adds this input to the corpus, if it's intersting, and return the index
+    #[inline]
+    fn add_if_interesting(
+        &mut self,
+        state: &mut S,
+        input: &I,
+        is_interesting: bool,
+    ) -> Result<Option<usize>, Error> {
+        if is_interesting {
+            let mut testcase = Testcase::new(input.clone());
+            self.feedback_mut().append_metadata(state, &mut testcase)?;
+            let idx = state.corpus_mut().add(testcase)?;
+            self.scheduler_mut().on_add(state, idx)?;
+            Ok(Some(idx))
+        } else {
+            self.feedback_mut().discard_metadata(state, input)?;
+            Ok(None)
+        }
+    }
+}
+
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> Evaluator<E, EM, I, S>
+    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+where
+    C: Corpus<I>,
+    CS: CorpusScheduler<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
+{
+    /// Process one input, adding to the respective corpuses if needed and firing the right events
+    #[inline]
+    fn evaluate_input(
+        &mut self,
+        state: &mut S,
+        executor: &mut E,
+        manager: &mut EM,
+        input: I,
+    ) -> Result<(bool, Option<usize>), Error> {
+        let (is_interesting, is_solution) = self.execute_input(state, executor, manager, &input)?;
+        let observers = executor.observers();
+
+        if is_solution {
+            // If the input is a solution, add it to the respective corpus
+            let mut testcase = Testcase::new(input.clone());
+            self.objective_mut().append_metadata(state, &mut testcase)?;
+            state.solutions_mut().add(testcase)?;
+        } else {
+            self.objective_mut().discard_metadata(state, &input)?;
+        }
+
+        let corpus_idx = self.add_if_interesting(state, &input, is_interesting)?;
+        if corpus_idx.is_some() {
+            let observers_buf = manager.serialize_observers(observers)?;
+            manager.fire(
+                state,
+                Event::NewTestcase {
+                    input,
+                    observers_buf,
+                    corpus_size: state.corpus().count(),
+                    client_config: "TODO".into(),
+                    time: crate::utils::current_time(),
+                    executions: *state.executions(),
+                },
+            )?;
+        }
+
+        Ok((is_interesting, corpus_idx))
+    }
+}
+
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC, ST> Fuzzer<E, EM, I, S, ST>
+    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+where
+    C: Corpus<I>,
+    CS: CorpusScheduler<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
+    I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
+    ST: StagesTuple<E, EM, I, S, Self>,
 {
     #[inline]
     fn maybe_report_stats(
@@ -240,17 +544,17 @@ where
 
     fn fuzz_one(
         &mut self,
-        state: &mut S,
+        stages: &mut ST,
         executor: &mut E,
+        state: &mut S,
         manager: &mut EM,
-        scheduler: &CS,
     ) -> Result<usize, Error> {
         // Init timer for scheduler
         #[cfg(feature = "introspection")]
         state.introspection_stats_mut().start_timer();
 
         // Get the next index from the scheduler
-        let idx = scheduler.next(state)?;
+        let idx = self.scheduler.next(state)?;
 
         // Mark the elapsed time for the scheduler
         #[cfg(feature = "introspection")]
@@ -261,15 +565,14 @@ where
         state.introspection_stats_mut().reset_stage_index();
 
         // Execute all stages
-        self.stages_mut()
-            .perform_all(state, executor, manager, scheduler, idx)?;
+        stages.perform_all(self, executor, state, manager, idx)?;
 
         // Init timer for manager
         #[cfg(feature = "introspection")]
         state.introspection_stats_mut().start_timer();
 
         // Execute the manager
-        manager.process(state, executor, scheduler)?;
+        manager.process(self, state, executor)?;
 
         // Mark the elapsed time for the manager
         #[cfg(feature = "introspection")]
@@ -279,19 +582,97 @@ where
     }
 }
 
-impl<CS, ST, E, EM, I, OT, S> StdFuzzer<CS, ST, E, EM, I, OT, S>
+impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
 where
+    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    ST: StagesTuple<CS, E, EM, I, S>,
-    E: Executor<I>,
-    EM: EventManager<I, S>,
+    E: Executor<I> + HasObservers<OT> + HasExecHooks<EM, I, S> + HasObserversHooks<EM, I, OT, S>,
+    OT: ObserversTuple + HasExecHooksTuple<EM, I, S>,
+    EM: EventManager<E, I, S, Self>,
+    F: Feedback<FT, I, S>,
+    FT: FeedbackStatesTuple<I>,
     I: Input,
+    OF: Feedback<FT, I, S>,
+    S: State + HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT, I>,
+    SC: Corpus<I>,
 {
     /// Create a new `StdFuzzer` with standard behavior.
-    pub fn new(stages: ST) -> Self {
+    pub fn new(scheduler: CS, feedback: F, objective: OF) -> Self {
         Self {
-            stages,
+            scheduler,
+            feedback,
+            objective,
             phantom: PhantomData,
         }
+    }
+
+    /// Runs the input and triggers observers and feedback
+    pub fn execute_input(
+        &mut self,
+        state: &mut S,
+        executor: &mut E,
+        event_mgr: &mut EM,
+        input: &I,
+    ) -> Result<(bool, bool), Error> {
+        start_timer!(state);
+        executor.pre_exec_observers(state, event_mgr, input)?;
+        mark_feature_time!(state, PerfFeature::PreExecObservers);
+
+        start_timer!(state);
+        executor.pre_exec(state, event_mgr, input)?;
+        mark_feature_time!(state, PerfFeature::PreExec);
+
+        start_timer!(state);
+        let exit_kind = executor.run_target(input)?;
+        mark_feature_time!(state, PerfFeature::TargetExecution);
+
+        start_timer!(state);
+        executor.post_exec(state, event_mgr, input)?;
+        mark_feature_time!(state, PerfFeature::PostExec);
+
+        *state.executions_mut() += 1;
+
+        start_timer!(state);
+        executor.post_exec_observers(state, event_mgr, input)?;
+        mark_feature_time!(state, PerfFeature::PostExecObservers);
+
+        let observers = executor.observers();
+        #[cfg(not(feature = "introspection"))]
+        let is_interesting = self
+            .feedback_mut()
+            .is_interesting(state, &input, observers, &exit_kind)?;
+
+        #[cfg(feature = "introspection")]
+        let is_interesting = {
+            // Init temporary feedback stats here. We can't use the typical pattern above
+            // since we need a `mut self` for `feedbacks_mut`, so we can't also hand a
+            // new `mut self` to `is_interesting_with_perf`. We use this stack
+            // variable to get the stats and then update the feedbacks directly
+            let mut feedback_stats = [0_u64; crate::stats::NUM_FEEDBACKS];
+            let feedback_index = 0;
+            let is_interesting = self.feedback_mut().is_interesting_with_perf(
+                &input,
+                observers,
+                &exit_kind,
+                &mut feedback_stats,
+                feedback_index,
+            )?;
+
+            // Update the feedback stats
+            self.introspection_stats_mut()
+                .update_feedbacks(feedback_stats);
+
+            // Return the total fitness
+            is_interesting
+        };
+
+        start_timer!(state);
+        let is_solution = self
+            .objective_mut()
+            .is_interesting(state, &input, observers, &exit_kind)?;
+
+        mark_feature_time!(state, PerfFeature::GetObjectivesInterestingAll);
+
+        Ok((is_interesting, is_solution))
     }
 }

--- a/libafl/src/fuzzer.rs
+++ b/libafl/src/fuzzer.rs
@@ -6,14 +6,13 @@ use crate::{
     executors::{
         Executor, ExitKind, HasExecHooks, HasExecHooksTuple, HasObservers, HasObserversHooks,
     },
-    feedbacks::{Feedback, FeedbackStatesTuple},
+    feedbacks::{Feedback},
     inputs::Input,
     mark_feature_time,
     observers::ObserversTuple,
     stages::StagesTuple,
     start_timer,
-    state::{HasClientPerfStats, HasCorpus, HasExecutions, HasSolutions},
-    state::{HasFeedbackStates, State},
+    state::{HasCorpus, HasExecutions, HasSolutions},
     utils::current_time,
     Error,
 };
@@ -180,46 +179,26 @@ pub trait Fuzzer<E, EM, I, S, ST> {
 
 /// Your default fuzzer instance, for everyday use.
 #[derive(Debug)]
-pub struct StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+pub struct StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
-    EM: EventManager<E, I, S, Self>,
     F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
     I: Input,
     OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
 {
     scheduler: CS,
     feedback: F,
     objective: OF,
-    phantom: PhantomData<(C, E, EM, FT, I, OT, S, SC)>,
+    phantom: PhantomData<(C, I, OT, S, SC)>
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasCorpusScheduler<CS, I, S>
-    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, F, I, OF, OT, S, SC> HasCorpusScheduler<CS, I, S>
+    for StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
-    EM: EventManager<E, I, S, Self>,
     F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
     I: Input,
     OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
 {
     fn scheduler(&self) -> &CS {
         &self.scheduler
@@ -230,23 +209,13 @@ where
     }
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasFeedback<F, I, S>
-    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, F, I, OF, OT, S, SC> HasFeedback<F, I, S>
+    for StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
-    CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
-    EM: EventManager<E, I, S, Self>,
-    F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
-    I: Input,
-    OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
+CS: CorpusScheduler<I, S>,
+F: Feedback<I, S>,
+I: Input,
+OF: Feedback<I, S>,
 {
     fn feedback(&self) -> &F {
         &self.feedback
@@ -257,23 +226,13 @@ where
     }
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> HasObjective<I, OF, S>
-    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, F, I, OF, OT, S, SC> HasObjective<I, OF, S>
+    for StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
-    CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
-    EM: EventManager<E, I, S, Self>,
-    F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
-    I: Input,
-    OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
+CS: CorpusScheduler<I, S>,
+F: Feedback<I, S>,
+I: Input,
+OF: Feedback<I, S>,
 {
     fn objective(&self) -> &OF {
         &self.objective
@@ -284,23 +243,16 @@ where
     }
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> IfInteresting<I, OT, S>
-    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, F, I, OF, OT, S, SC> IfInteresting<I, OT, S>
+    for StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
-    CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
-    EM: EventManager<E, I, S, Self>,
-    F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
-    I: Input,
-    OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
+C: Corpus<I>,
+CS: CorpusScheduler<I, S>,
+F: Feedback<I, S>,
+I: Input,
+OF: Feedback<I, S>,
+OT: ObserversTuple,
+S: HasCorpus<C, I>
 {
     /// Evaluate if a set of observation channels has an interesting state
     fn is_interesting(
@@ -338,8 +290,8 @@ where
     }
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> Evaluator<E, EM, I, S>
-    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, E, EM, F, I, OF, OT, S, SC> Evaluator<E, EM, I, S>
+    for StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
     C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
@@ -350,10 +302,9 @@ where
     OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
     I: Input,
     OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
+    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I>,
     SC: Corpus<I>,
 {
     /// Process one input, adding to the respective corpuses if needed and firing the right events
@@ -397,23 +348,15 @@ where
     }
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC, ST> Fuzzer<E, EM, I, S, ST>
-    for StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, E, EM, F, I, OF, OT, S, ST, SC> Fuzzer<E, EM, I, S, ST>
+    for StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
     EM: EventManager<E, I, S, Self>,
     F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
     I: Input,
+    S: HasExecutions,
     OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
     ST: StagesTuple<E, EM, S, Self>,
 {
     #[inline]
@@ -503,22 +446,13 @@ where
     }
 }
 
-impl<C, CS, E, EM, F, FT, I, OF, OT, S, SC> StdFuzzer<C, CS, E, EM, F, FT, I, OF, OT, S, SC>
+impl<C, CS, F, I, OF, OT, S, SC> StdFuzzer<C, CS, F, I, OF, OT, S, SC>
 where
-    C: Corpus<I>,
     CS: CorpusScheduler<I, S>,
-    E: Executor<I>
-        + HasObservers<OT>
-        + HasExecHooks<EM, I, S, Self>
-        + HasObserversHooks<EM, I, OT, S, Self>,
-    OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
-    EM: EventManager<E, I, S, Self>,
     F: Feedback<I, S>,
-    FT: FeedbackStatesTuple,
     I: Input,
     OF: Feedback<I, S>,
-    S: HasExecutions + HasCorpus<C, I> + HasSolutions<SC, I> + HasFeedbackStates<FT>,
-    SC: Corpus<I>,
+    S: HasExecutions
 {
     /// Create a new `StdFuzzer` with standard behavior.
     pub fn new(scheduler: CS, feedback: F, objective: OF) -> Self {
@@ -531,13 +465,21 @@ where
     }
 
     /// Runs the input and triggers observers and feedback
-    pub fn execute_input(
+    pub fn execute_input<E, EM>(
         &mut self,
         state: &mut S,
         executor: &mut E,
         event_mgr: &mut EM,
         input: &I,
-    ) -> Result<(bool, bool), Error> {
+    ) -> Result<(bool, bool), Error>
+    where
+        E: Executor<I>
+            + HasObservers<OT>
+            + HasExecHooks<EM, I, S, Self>
+            + HasObserversHooks<EM, I, OT, S, Self>,
+        OT: ObserversTuple + HasExecHooksTuple<EM, I, S, Self>,
+        EM: EventManager<E, I, S, Self>,
+    {
         start_timer!(state);
         executor.pre_exec_observers(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::PreExecObservers);

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -159,7 +159,7 @@ mod tests {
     use crate::{
         bolts::tuples::tuple_list,
         corpus::{Corpus, InMemoryCorpus, RandCorpusScheduler, Testcase},
-        executors::{ExitKind, HasExecHooks, HasObserversHooks, InProcessExecutor},
+        executors::{ExitKind, InProcessExecutor},
         inputs::BytesInput,
         mutators::{mutations::BitFlipMutator, StdScheduledMutator},
         stages::StdMutationalStage,

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -156,7 +156,7 @@ impl From<ParseIntError> for Error {
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-
+    /*
     use crate::{
         bolts::tuples::tuple_list,
         corpus::{Corpus, InMemoryCorpus, RandCorpusScheduler, Testcase},
@@ -231,5 +231,5 @@ mod tests {
         let corpus_deserialized: InMemoryCorpus<BytesInput> =
             postcard::from_bytes(corpus_serialized.as_slice()).unwrap();
         assert_eq!(state.corpus().count(), corpus_deserialized.count());
-    }
+    }*/
 }

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1837,7 +1837,7 @@ mod tests {
         corpus::{Corpus, InMemoryCorpus},
         inputs::BytesInput,
         mutators::MutatorsTuple,
-        state::{HasMetadata, State},
+        state::{HasMetadata, StdState},
         utils::StdRand,
     };
 
@@ -1875,7 +1875,7 @@ mod tests {
             BytesSwapMutator::new(),
         )
     }
-    /*
+
     #[test]
     fn test_mutators() {
         let mut inputs = vec![
@@ -1895,7 +1895,7 @@ mod tests {
             .add(BytesInput::new(vec![0x42; 0x1337]).into())
             .unwrap();
 
-        let mut state = StdState::new(rand, corpus, (), InMemoryCorpus::new(), ());
+        let mut state = StdState::new(rand, corpus, InMemoryCorpus::new(), ());
 
         let mut mutations = test_mutations();
         for _ in 0..2 {
@@ -1914,5 +1914,5 @@ mod tests {
             }
             inputs.append(&mut new_testcases);
         }
-    }*/
+    }
 }

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1875,7 +1875,7 @@ mod tests {
             BytesSwapMutator::new(),
         )
     }
-
+    /*
     #[test]
     fn test_mutators() {
         let mut inputs = vec![
@@ -1895,7 +1895,7 @@ mod tests {
             .add(BytesInput::new(vec![0x42; 0x1337]).into())
             .unwrap();
 
-        let mut state = State::new(rand, corpus, (), InMemoryCorpus::new(), ());
+        let mut state = StdState::new(rand, corpus, (), InMemoryCorpus::new(), ());
 
         let mut mutations = test_mutations();
         for _ in 0..2 {
@@ -1914,5 +1914,5 @@ mod tests {
             }
             inputs.append(&mut new_testcases);
         }
-    }
+    }*/
 }

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -396,7 +396,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    /*use crate::{
+    use crate::{
         corpus::{Corpus, InMemoryCorpus, Testcase},
         inputs::{BytesInput, HasBytesVec},
         mutators::{
@@ -404,7 +404,7 @@ mod tests {
             scheduled::{havoc_mutations, StdScheduledMutator},
             Mutator,
         },
-        state::State,
+        state::StdState,
         utils::{Rand, StdRand, XkcdRand},
     };
 
@@ -419,7 +419,7 @@ mod tests {
         let testcase = corpus.get(0).expect("Corpus did not contain entries");
         let mut input = testcase.borrow_mut().load_input().unwrap().clone();
 
-        let mut state = State::new(rand, corpus, (), InMemoryCorpus::new(), ());
+        let mut state = StdState::new(rand, corpus, InMemoryCorpus::new(), ());
 
         rand.set_seed(5);
 
@@ -446,7 +446,7 @@ mod tests {
         let mut input = testcase.borrow_mut().load_input().unwrap().clone();
         let input_prior = input.clone();
 
-        let mut state = State::new(rand, corpus, (), InMemoryCorpus::new(), ());
+        let mut state = StdState::new(rand, corpus, InMemoryCorpus::new(), ());
 
         let mut havoc = StdScheduledMutator::new(havoc_mutations());
 
@@ -465,5 +465,5 @@ mod tests {
             };
             assert_ne!(equal_in_a_row, 5);
         }
-    }*/
+    }
 }

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -396,7 +396,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
+    /*use crate::{
         corpus::{Corpus, InMemoryCorpus, Testcase},
         inputs::{BytesInput, HasBytesVec},
         mutators::{
@@ -465,5 +465,5 @@ mod tests {
             };
             assert_ne!(equal_in_a_row, 5);
         }
-    }
+    }*/
 }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -75,13 +75,19 @@ impl<'a, T> Observer for StdMapObserver<'a, T> where
 {
 }
 
-impl<'a, EM, I, S, T> HasExecHooks<EM, I, S> for StdMapObserver<'a, T>
+impl<'a, EM, I, S, T, Z> HasExecHooks<EM, I, S, Z> for StdMapObserver<'a, T>
 where
     T: Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
     Self: MapObserver<T>,
 {
     #[inline]
-    fn pre_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _state: &mut S,
+        _mgr: &mut EM,
+        _input: &I,
+    ) -> Result<(), Error> {
         self.reset_map()
     }
 }
@@ -185,12 +191,18 @@ impl<'a, T> Observer for VariableMapObserver<'a, T> where
 {
 }
 
-impl<'a, EM, I, S, T> HasExecHooks<EM, I, S> for VariableMapObserver<'a, T>
+impl<'a, EM, I, S, T, Z> HasExecHooks<EM, I, S, Z> for VariableMapObserver<'a, T>
 where
     T: Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
-    fn pre_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _state: &mut S,
+        _mgr: &mut EM,
+        _input: &I,
+    ) -> Result<(), Error> {
         self.reset_map()
     }
 }
@@ -302,21 +314,33 @@ static COUNT_CLASS_LOOKUP: [u8; 256] = [
 
 impl<M> Observer for HitcountsMapObserver<M> where M: MapObserver<u8> {}
 
-impl<EM, I, S, M> HasExecHooks<EM, I, S> for HitcountsMapObserver<M>
+impl<EM, I, S, M, Z> HasExecHooks<EM, I, S, Z> for HitcountsMapObserver<M>
 where
-    M: MapObserver<u8> + HasExecHooks<EM, I, S>,
+    M: MapObserver<u8> + HasExecHooks<EM, I, S, Z>,
 {
     #[inline]
-    fn pre_exec(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
-        self.base.pre_exec(state, mgr, input)
+    fn pre_exec(
+        &mut self,
+        fuzzer: &mut Z,
+        state: &mut S,
+        mgr: &mut EM,
+        input: &I,
+    ) -> Result<(), Error> {
+        self.base.pre_exec(fuzzer, state, mgr, input)
     }
 
     #[inline]
-    fn post_exec(&mut self, state: &mut S, mgr: &mut EM, input: &I) -> Result<(), Error> {
+    fn post_exec(
+        &mut self,
+        fuzzer: &mut Z,
+        state: &mut S,
+        mgr: &mut EM,
+        input: &I,
+    ) -> Result<(), Error> {
         for x in self.map_mut().iter_mut() {
             *x = COUNT_CLASS_LOOKUP[*x as usize];
         }
-        self.base.post_exec(state, mgr, input)
+        self.base.post_exec(fuzzer, state, mgr, input)
     }
 }
 

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -65,14 +65,26 @@ impl TimeObserver {
 
 impl Observer for TimeObserver {}
 
-impl<EM, I, S> HasExecHooks<EM, I, S> for TimeObserver {
-    fn pre_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+impl<EM, I, S, Z> HasExecHooks<EM, I, S, Z> for TimeObserver {
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _state: &mut S,
+        _mgr: &mut EM,
+        _input: &I,
+    ) -> Result<(), Error> {
         self.last_runtime = None;
         self.start_time = current_time();
         Ok(())
     }
 
-    fn post_exec(&mut self, _state: &mut S, _mgr: &mut EM, _input: &I) -> Result<(), Error> {
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _state: &mut S,
+        _mgr: &mut EM,
+        _input: &I,
+    ) -> Result<(), Error> {
         self.last_runtime = Some(current_time() - self.start_time);
         Ok(())
     }

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -7,7 +7,7 @@ Other stages may enrich [`crate::corpus::Testcase`]s with metadata.
 /// Mutational stage is the normal fuzzing stage,
 pub mod mutational;
 
-//pub use mutational::{MutationalStage, StdMutationalStage};
+pub use mutational::{MutationalStage, StdMutationalStage};
 
 //pub mod power;
 //pub use power::PowerMutationalStage;

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -5,26 +5,17 @@ Other stages may enrich [`crate::corpus::Testcase`]s with metadata.
 */
 
 /// Mutational stage is the normal fuzzing stage,
-//pub mod mutational;
+pub mod mutational;
 
 //pub use mutational::{MutationalStage, StdMutationalStage};
 
 //pub mod power;
 //pub use power::PowerMutationalStage;
-use crate::{
-    bolts::tuples::TupleList, events::EventManager, executors::Executor, inputs::Input,
-    state::State, Error,
-};
+use crate::Error;
 
 /// A stage is one step in the fuzzing process.
 /// Multiple stages will be scheduled one by one for each input.
-pub trait Stage<E, EM, I, S, Z>
-where
-    E: Executor<I>,
-    EM: EventManager<E, I, S, Z>,
-    I: Input,
-    S: State,
-{
+pub trait Stage<E, EM, S, Z> {
     /// Run the stage
     fn perform(
         &mut self,
@@ -37,13 +28,7 @@ where
 }
 
 /// A tuple holding all `Stages` used for fuzzing.
-pub trait StagesTuple<E, EM, I, S, Z>
-where
-    E: Executor<I>,
-    EM: EventManager<E, I, S, Z>,
-    I: Input,
-    S: State,
-{
+pub trait StagesTuple<E, EM, S, Z> {
     /// Performs all `Stages` in this tuple
     fn perform_all(
         &mut self,
@@ -55,13 +40,7 @@ where
     ) -> Result<(), Error>;
 }
 
-impl<E, EM, I, S, Z> StagesTuple<E, EM, I, S, Z> for ()
-where
-    E: Executor<I>,
-    EM: EventManager<E, I, S, Z>,
-    I: Input,
-    S: State,
-{
+impl<E, EM, S, Z> StagesTuple<E, EM, S, Z> for () {
     fn perform_all(
         &mut self,
         _: &mut Z,
@@ -74,14 +53,10 @@ where
     }
 }
 
-impl<Head, Tail, E, EM, I, S, Z> StagesTuple<E, EM, I, S, Z> for (Head, Tail)
+impl<Head, Tail, E, EM, S, Z> StagesTuple<E, EM, S, Z> for (Head, Tail)
 where
-    Head: Stage<E, EM, I, S, Z>,
-    Tail: StagesTuple<E, EM, I, S, Z> + TupleList,
-    E: Executor<I>,
-    EM: EventManager<E, I, S, Z>,
-    I: Input,
-    S: State,
+    Head: Stage<E, EM, S, Z>,
+    Tail: StagesTuple<E, EM, S, Z>,
 {
     fn perform_all(
         &mut self,

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::{
-    corpus::{Corpus},
+    corpus::Corpus,
     fuzzer::Evaluator,
     inputs::Input,
     mark_feature_time,

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -1,7 +1,7 @@
 //! The fuzzer, and state are the core pieces of every good fuzzer
 
 use core::{fmt::Debug, marker::PhantomData, time::Duration};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(feature = "std")]
 use std::{
     fs,
@@ -15,7 +15,8 @@ use crate::{
     executors::{
         Executor, ExitKind, HasExecHooks, HasExecHooksTuple, HasObservers, HasObserversHooks,
     },
-    feedbacks::Feedback,
+    feedbacks::{Feedback, FeedbackState, FeedbackStatesTuple},
+    fuzzer::{HasCorpusScheduler, HasFeedback},
     generators::Generator,
     inputs::Input,
     mark_feature_time,
@@ -34,6 +35,8 @@ use crate::inputs::bytes::BytesInput;
 
 /// The maximum size of a testcase
 pub const DEFAULT_MAX_SIZE: usize = 1_048_576;
+
+pub trait State: Serialize + DeserializeOwned {}
 
 /// Trait for elements offering a corpus
 pub trait HasCorpus<C, I>
@@ -114,29 +117,16 @@ pub trait HasMetadata {
 }
 
 /// Trait for elements offering a feedback
-pub trait HasFeedback<F, I>: Sized
+pub trait HasFeedbackStates<FT, I>: Sized
 where
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     I: Input,
 {
-    /// The feedback
-    fn feedback(&self) -> &F;
+    /// The feedback states
+    fn feedback_states(&self) -> &FT;
 
-    /// The feedback (mut)
-    fn feedback_mut(&mut self) -> &mut F;
-}
-
-/// Trait for elements offering an objective feedback tuple
-pub trait HasObjective<OF, I>: Sized
-where
-    OF: Feedback<I>,
-    I: Input,
-{
-    /// The objective feedback
-    fn objective(&self) -> &OF;
-
-    /// The objective feedback (mut)
-    fn objective_mut(&mut self) -> &mut OF;
+    /// The feedback states (mut)
+    fn feedback_states_mut(&mut self) -> &mut FT;
 }
 
 /// Trait for the execution counter
@@ -157,67 +147,16 @@ pub trait HasStartTime {
     fn start_time_mut(&mut self) -> &mut Duration;
 }
 
-/// Add to the state if interesting
-pub trait IfInteresting<I>: Sized
-where
-    I: Input,
-{
-    /// Evaluate if a set of observation channels has an interesting state
-    fn is_interesting<OT>(
-        &mut self,
-        input: &I,
-        observers: &OT,
-        exit_kind: &ExitKind,
-    ) -> Result<bool, Error>
-    where
-        OT: ObserversTuple;
-
-    /// Adds this input to the corpus, if it's intersting, and return the index
-    fn add_if_interesting<CS>(
-        &mut self,
-        input: &I,
-        is_interesting: bool,
-        scheduler: &CS,
-    ) -> Result<Option<usize>, Error>
-    where
-        CS: CorpusScheduler<I, Self>,
-        Self: Sized;
-}
-
-/// Evaluate an input modyfing the state of the fuzzer
-pub trait Evaluator<I>: Sized
-where
-    I: Input,
-{
-    /// Runs the input and triggers observers and feedback
-    fn evaluate_input<CS, E, EM, OT>(
-        &mut self,
-        input: I,
-        executor: &mut E,
-        manager: &mut EM,
-        scheduler: &CS,
-    ) -> Result<(bool, Option<usize>), Error>
-    where
-        E: Executor<I>
-            + HasObservers<OT>
-            + HasExecHooks<EM, I, Self>
-            + HasObserversHooks<EM, I, OT, Self>,
-        OT: ObserversTuple + HasExecHooksTuple<EM, I, Self>,
-        EM: EventManager<I, Self>,
-        CS: CorpusScheduler<I, Self>;
-}
-
 /// The state a fuzz run.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "F: serde::de::DeserializeOwned")]
-pub struct State<C, F, I, OF, R, SC>
+#[serde(bound = "FT: serde::de::DeserializeOwned")]
+pub struct StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     /// RNG instance
     rand: R,
@@ -227,12 +166,10 @@ where
     start_time: Duration,
     /// The corpus
     corpus: C,
-    /// Feedbacks used to evaluate an input
-    feedback: F,
+    /// States of the feedback used to evaluate an input
+    feedback_states: FT,
     // Solutions corpus
     solutions: SC,
-    /// Objective Feedbacks
-    objective: OF,
     /// Metadata stored for this state by one of the components
     metadata: SerdeAnyMap,
     /// MaxSize testcase size for mutators that appreciate it
@@ -245,14 +182,23 @@ where
     phantom: PhantomData<I>,
 }
 
-impl<C, F, I, OF, R, SC> HasRand<R> for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> State for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
+{
+}
+
+impl<C, FT, I, R, SC> HasRand<R> for StdState<C, FT, I, R, SC>
+where
+    C: Corpus<I>,
+    I: Input,
+    R: Rand,
+    FT: FeedbackStatesTuple<I>,
+    SC: Corpus<I>,
 {
     /// The rand instance
     #[inline]
@@ -267,14 +213,13 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> HasCorpus<C, I> for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasCorpus<C, I> for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     /// Returns the corpus
     #[inline]
@@ -289,14 +234,13 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> HasSolutions<SC, I> for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasSolutions<SC, I> for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     /// Returns the solutions corpus
     #[inline]
@@ -311,14 +255,13 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> HasMetadata for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasMetadata for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     /// Get all the metadata into an [`hashbrown::HashMap`]
     #[inline]
@@ -333,58 +276,34 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> HasFeedback<F, I> for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasFeedbackStates<FT, I> for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
-    /// The feedback
+    /// The feedback states
     #[inline]
-    fn feedback(&self) -> &F {
-        &self.feedback
+    fn feedback_states(&self) -> &FT {
+        &self.feedback_states
     }
 
-    /// The feedback (mut)
+    /// The feedback states (mut)
     #[inline]
-    fn feedback_mut(&mut self) -> &mut F {
-        &mut self.feedback
+    fn feedback_states_mut(&mut self) -> &mut FT {
+        &mut self.feedback_states
     }
 }
 
-impl<C, F, I, OF, R, SC> HasObjective<OF, I> for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasExecutions for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
-{
-    /// The objective feedback
-    #[inline]
-    fn objective(&self) -> &OF {
-        &self.objective
-    }
-
-    /// The objective feedback (mut)
-    #[inline]
-    fn objective_mut(&mut self) -> &mut OF {
-        &mut self.objective
-    }
-}
-
-impl<C, F, I, OF, R, SC> HasExecutions for State<C, F, I, OF, R, SC>
-where
-    C: Corpus<I>,
-    I: Input,
-    R: Rand,
-    F: Feedback<I>,
-    SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     /// The executions counter
     #[inline]
@@ -399,14 +318,13 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> HasMaxSize for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasMaxSize for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     fn max_size(&self) -> usize {
         self.max_size
@@ -417,14 +335,13 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> HasStartTime for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasStartTime for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     /// The starting time
     #[inline]
@@ -439,116 +356,9 @@ where
     }
 }
 
-impl<C, F, I, OF, R, SC> IfInteresting<I> for State<C, F, I, OF, R, SC>
-where
-    C: Corpus<I>,
-    I: Input,
-    R: Rand,
-    F: Feedback<I>,
-    SC: Corpus<I>,
-    OF: Feedback<I>,
-{
-    /// Evaluate if a set of observation channels has an interesting state
-    fn is_interesting<OT>(
-        &mut self,
-        input: &I,
-        observers: &OT,
-        exit_kind: &ExitKind,
-    ) -> Result<bool, Error>
-    where
-        OT: ObserversTuple,
-    {
-        self.feedback_mut()
-            .is_interesting(input, observers, exit_kind)
-    }
-
-    /// Adds this input to the corpus, if it's intersting, and return the index
-    #[inline]
-    fn add_if_interesting<CS>(
-        &mut self,
-        input: &I,
-        is_interesting: bool,
-        scheduler: &CS,
-    ) -> Result<Option<usize>, Error>
-    where
-        CS: CorpusScheduler<I, Self>,
-    {
-        if is_interesting {
-            let mut testcase = Testcase::new(input.clone());
-            self.feedback_mut().append_metadata(&mut testcase)?;
-            let idx = self.corpus.add(testcase)?;
-            scheduler.on_add(self, idx)?;
-            Ok(Some(idx))
-        } else {
-            self.feedback_mut().discard_metadata(&input)?;
-            Ok(None)
-        }
-    }
-}
-
-impl<C, F, I, OF, R, SC> Evaluator<I> for State<C, F, I, OF, R, SC>
-where
-    C: Corpus<I>,
-    I: Input,
-    R: Rand,
-    F: Feedback<I>,
-    SC: Corpus<I>,
-    OF: Feedback<I>,
-{
-    /// Process one input, adding to the respective corpuses if needed and firing the right events
-    #[inline]
-    fn evaluate_input<CS, E, EM, OT>(
-        &mut self,
-        // TODO probably we can take a ref to input and pass a cloned one to add_if_interesting
-        input: I,
-        executor: &mut E,
-        manager: &mut EM,
-        scheduler: &CS,
-    ) -> Result<(bool, Option<usize>), Error>
-    where
-        E: Executor<I>
-            + HasObservers<OT>
-            + HasExecHooks<EM, I, Self>
-            + HasObserversHooks<EM, I, OT, Self>,
-        OT: ObserversTuple + HasExecHooksTuple<EM, I, Self>,
-        C: Corpus<I>,
-        EM: EventManager<I, Self>,
-        CS: CorpusScheduler<I, Self>,
-    {
-        let (is_interesting, is_solution) = self.execute_input(&input, executor, manager)?;
-        let observers = executor.observers();
-
-        if is_solution {
-            // If the input is a solution, add it to the respective corpus
-            let mut testcase = Testcase::new(input.clone());
-            self.objective_mut().append_metadata(&mut testcase)?;
-            self.solutions_mut().add(testcase)?;
-        } else {
-            self.objective_mut().discard_metadata(&input)?;
-        }
-
-        let corpus_idx = self.add_if_interesting(&input, is_interesting, scheduler)?;
-        if corpus_idx.is_some() {
-            let observers_buf = manager.serialize_observers(observers)?;
-            manager.fire(
-                self,
-                Event::NewTestcase {
-                    input,
-                    observers_buf,
-                    corpus_size: self.corpus().count() + 1,
-                    client_config: "TODO".into(),
-                    time: crate::utils::current_time(),
-                    executions: *self.executions(),
-                },
-            )?;
-        }
-
-        Ok((is_interesting, corpus_idx))
-    }
-}
-
+/*
 #[cfg(feature = "std")]
-impl<C, F, OF, R, SC> State<C, F, BytesInput, OF, R, SC>
+impl<C, F, OF, R, SC> StdState<C, F, BytesInput, OF, R, SC>
 where
     C: Corpus<BytesInput>,
     R: Rand,
@@ -639,101 +449,23 @@ where
         Ok(())
     }
 }
+*/
 
-impl<C, F, I, OF, R, SC> State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
-    /// Runs the input and triggers observers and feedback
-    pub fn execute_input<E, EM, OT>(
-        &mut self,
-        input: &I,
-        executor: &mut E,
-        event_mgr: &mut EM,
-    ) -> Result<(bool, bool), Error>
-    where
-        E: Executor<I>
-            + HasObservers<OT>
-            + HasExecHooks<EM, I, Self>
-            + HasObserversHooks<EM, I, OT, Self>,
-        OT: ObserversTuple + HasExecHooksTuple<EM, I, Self>,
-        C: Corpus<I>,
-        EM: EventManager<I, Self>,
-    {
-        start_timer!(self);
-        executor.pre_exec_observers(self, event_mgr, input)?;
-        mark_feature_time!(self, PerfFeature::PreExecObservers);
-
-        start_timer!(self);
-        executor.pre_exec(self, event_mgr, input)?;
-        mark_feature_time!(self, PerfFeature::PreExec);
-
-        start_timer!(self);
-        let exit_kind = executor.run_target(input)?;
-        mark_feature_time!(self, PerfFeature::TargetExecution);
-
-        start_timer!(self);
-        executor.post_exec(self, event_mgr, input)?;
-        mark_feature_time!(self, PerfFeature::PostExec);
-
-        *self.executions_mut() += 1;
-
-        start_timer!(self);
-        executor.post_exec_observers(self, event_mgr, input)?;
-        mark_feature_time!(self, PerfFeature::PostExecObservers);
-
-        let observers = executor.observers();
-        #[cfg(not(feature = "introspection"))]
-        let is_interesting = self
-            .feedback_mut()
-            .is_interesting(&input, observers, &exit_kind)?;
-
-        #[cfg(feature = "introspection")]
-        let is_interesting = {
-            // Init temporary feedback stats here. We can't use the typical pattern above
-            // since we need a `mut self` for `feedbacks_mut`, so we can't also hand a
-            // new `mut self` to `is_interesting_with_perf`. We use this stack
-            // variable to get the stats and then update the feedbacks directly
-            let mut feedback_stats = [0_u64; crate::stats::NUM_FEEDBACKS];
-            let feedback_index = 0;
-            let is_interesting = self.feedback_mut().is_interesting_with_perf(
-                &input,
-                observers,
-                &exit_kind,
-                &mut feedback_stats,
-                feedback_index,
-            )?;
-
-            // Update the feedback stats
-            self.introspection_stats_mut()
-                .update_feedbacks(feedback_stats);
-
-            // Return the total fitness
-            is_interesting
-        };
-
-        start_timer!(self);
-        let is_solution = self
-            .objective_mut()
-            .is_interesting(&input, observers, &exit_kind)?;
-
-        mark_feature_time!(self, PerfFeature::GetObjectivesInterestingAll);
-
-        Ok((is_interesting, is_solution))
-    }
-
+    /*
     /// Generate `num` initial inputs, using the passed-in generator.
     pub fn generate_initial_inputs<CS, G, E, OT, EM>(
         &mut self,
         executor: &mut E,
         generator: &mut G,
         manager: &mut EM,
-        scheduler: &CS,
         num: usize,
     ) -> Result<(), Error>
     where
@@ -750,7 +482,7 @@ where
         let mut added = 0;
         for _ in 0..num {
             let input = generator.generate(self.rand_mut())?;
-            let (is_interesting, _) = self.evaluate_input(input, executor, manager, scheduler)?;
+            let (is_interesting, _) = fuzzer.evaluate_input(state, executor, manager, input)?;
             if is_interesting {
                 added += 1;
             }
@@ -765,19 +497,18 @@ where
         )?;
         manager.process(self, executor, scheduler)?;
         Ok(())
-    }
+    }*/
 
     /// Creates a new `State`, taking ownership of all of the individual components during fuzzing.
-    pub fn new(rand: R, corpus: C, feedback: F, solutions: SC, objective: OF) -> Self {
+    pub fn new(rand: R, corpus: C, solutions: SC, feedback_states: FT) -> Self {
         Self {
             rand,
             executions: 0,
             start_time: Duration::from_millis(0),
             metadata: SerdeAnyMap::default(),
             corpus,
-            feedback,
+            feedback_states,
             solutions,
-            objective,
             max_size: DEFAULT_MAX_SIZE,
             #[cfg(feature = "introspection")]
             introspection_stats: ClientPerfStats::new(),
@@ -787,14 +518,13 @@ where
 }
 
 #[cfg(feature = "introspection")]
-impl<C, F, I, OF, R, SC> HasClientPerfStats for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasClientPerfStats for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     fn introspection_stats(&self) -> &ClientPerfStats {
         &self.introspection_stats
@@ -806,14 +536,13 @@ where
 }
 
 #[cfg(not(feature = "introspection"))]
-impl<C, F, I, OF, R, SC> HasClientPerfStats for State<C, F, I, OF, R, SC>
+impl<C, FT, I, R, SC> HasClientPerfStats for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    F: Feedback<I>,
+    FT: FeedbackStatesTuple<I>,
     SC: Corpus<I>,
-    OF: Feedback<I>,
 {
     fn introspection_stats(&self) -> &ClientPerfStats {
         unimplemented!()

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -21,9 +21,6 @@ use crate::{
     Error,
 };
 
-#[cfg(feature = "introspection")]
-use crate::stats::PerfFeature;
-
 #[cfg(feature = "std")]
 use crate::inputs::bytes::BytesInput;
 

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -108,10 +108,9 @@ pub trait HasMetadata {
 }
 
 /// Trait for elements offering a feedback
-pub trait HasFeedbackStates<FT, I>: Sized
+pub trait HasFeedbackStates<FT>
 where
-    FT: FeedbackStatesTuple<I>,
-    I: Input,
+    FT: FeedbackStatesTuple,
 {
     /// The feedback states
     fn feedback_states(&self) -> &FT;
@@ -146,7 +145,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// RNG instance
@@ -178,7 +177,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
 }
@@ -188,7 +187,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// The rand instance
@@ -209,7 +208,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// Returns the corpus
@@ -230,7 +229,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// Returns the solutions corpus
@@ -251,7 +250,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// Get all the metadata into an [`hashbrown::HashMap`]
@@ -267,12 +266,12 @@ where
     }
 }
 
-impl<C, FT, I, R, SC> HasFeedbackStates<FT, I> for StdState<C, FT, I, R, SC>
+impl<C, FT, I, R, SC> HasFeedbackStates<FT> for StdState<C, FT, I, R, SC>
 where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// The feedback states
@@ -293,7 +292,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// The executions counter
@@ -314,7 +313,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     fn max_size(&self) -> usize {
@@ -331,7 +330,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /// The starting time
@@ -447,7 +446,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     /*
@@ -514,7 +513,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     fn introspection_stats(&self) -> &ClientPerfStats {
@@ -532,7 +531,7 @@ where
     C: Corpus<I>,
     I: Input,
     R: Rand,
-    FT: FeedbackStatesTuple<I>,
+    FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
     fn introspection_stats(&self) -> &ClientPerfStats {

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -10,18 +10,9 @@ use std::{
 
 use crate::{
     bolts::serdeany::{SerdeAny, SerdeAnyMap},
-    corpus::{Corpus, CorpusScheduler, Testcase},
-    events::{Event, EventManager, LogSeverity},
-    executors::{
-        Executor, ExitKind, HasExecHooks, HasExecHooksTuple, HasObservers, HasObserversHooks,
-    },
-    feedbacks::{Feedback, FeedbackState, FeedbackStatesTuple},
-    fuzzer::{HasCorpusScheduler, HasFeedback},
-    generators::Generator,
+    corpus::Corpus,
+    feedbacks::FeedbackStatesTuple,
     inputs::Input,
-    mark_feature_time,
-    observers::ObserversTuple,
-    start_timer,
     stats::ClientPerfStats,
     utils::Rand,
     Error,


### PR DESCRIPTION
In this PR, I change the design of LibAFL.

+ Now the Fuzzer is an entity that holds the feedbacks and the scheduler and any other entities that want to do alter entirely the State
+ Now the Feedback can store temporary data as before in its own fields, but needs to rely on FeedbackState to store persistent data (such as the history map) in the State