### PR TITLE
Implement Event and Stats fields needed to display coverage stats

### DIFF
--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -272,6 +272,11 @@ where
                 // Correctly handled the event
                 Ok(BrokerEventResult::Handled)
             }
+            Event::FeedbackStats { feedbacks } => {
+                let client = stats.client_stats_mut_for(sender_id);
+                client.update_feedbacks(*feedbacks as u64);
+                Ok(BrokerEventResult::Handled)
+            }
             Event::Objective { objective_size } => {
                 let client = stats.client_stats_mut_for(sender_id);
                 client.update_objective_size(*objective_size as u64);

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -95,18 +95,20 @@ where
         /// [`PhantomData`]
         phantom: PhantomData<I>,
     },
+    FeedbackStats {
+        /// The number of distinct feedbacks for this client
+        feedbacks: usize,
+    },
     /// New stats with performance stats.
     #[cfg(feature = "introspection")]
     UpdatePerfStats {
         /// The time of generation of the event
         time: Duration,
-
         /// The executions of this client
         executions: usize,
-
         /// Current performance statistics
         introspection_stats: Box<ClientPerfStats>,
-
+        /// [`PhantomData`]
         phantom: PhantomData<I>,
     },
     /// A new objective was found
@@ -156,6 +158,9 @@ where
                 introspection_stats: _,
                 phantom: _,
             } => "PerfStats",
+            Event::FeedbackStats {
+                feedbacks: _,
+            } => "FeedbackStats",
             Event::Objective { objective_size: _ } => "Objective",
             Event::Log {
                 severity_level: _,

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -128,6 +128,12 @@ where
                 stats.display(event.name().to_string());
                 Ok(BrokerEventResult::Handled)
             }
+            Event::FeedbackStats { feedbacks } => {
+                if stats.client_stats_mut().len() > 0 {
+                    stats.client_stats_mut()[0].update_feedbacks(*feedbacks as u64);
+                }
+                Ok(BrokerEventResult::Handled)
+            },
             Event::Objective { objective_size } => {
                 stats
                     .client_stats_mut_for(0)


### PR DESCRIPTION
This PR introduces`FeedbackEvent`. 
The `FeedbackEvent` holds a counter with the total number of unique points it has seen. For example when using for coverage it describes the total number of edges seen up until now. This event can be sent by anyone with access to the event manager, in my case I implemented a shared memory observer which sends an event when execution hooks are called and before zeroing out the memory (only if seen new edges).

One thing I wasn't sure about was how to print out the data, In my case I have one client but when I will have more than one it wouldn't make sense to sum it up like we do with executions so I just defaulted to printing the whole slice. 

Let me know what you think