### PR TITLE
Hook using frida gum interceptor instead of gothook

### DIFF
--- a/fuzzers/frida_libpng/Cargo.toml
+++ b/fuzzers/frida_libpng/Cargo.toml
@@ -24,8 +24,7 @@ which = "4.1"
 libafl = { path = "../../libafl/", features = [ "std", "llmp_compression", "llmp_bind_public" ] } #,  "llmp_small_maps", "llmp_debug"]}
 libafl_frida = { path = "../../libafl_frida" }
 capstone = "0.8.0"
-frida-gum = { version = "0.5.0", git = "https://github.com/frida/frida-rust", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"], rev = "69f5b8236ab4b66296507803b4b7bfec79700e84" }
-#frida-gum = { version = "0.5.0", path = "../../../frida-rust/frida-gum", features = [ "auto-download", "event-sink", "invocation-listener"] }
+frida-gum = { version = "0.5.1", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
 lazy_static = "1.4.0"
 libc = "0.2"
 libloading = "0.7.0"

--- a/fuzzers/frida_libpng/Cargo.toml
+++ b/fuzzers/frida_libpng/Cargo.toml
@@ -21,7 +21,7 @@ num_cpus = "1.0"
 which = "4.1"
 
 [target.'cfg(unix)'.dependencies]
-libafl = { path = "../../libafl/", features = [ "std", "llmp_compression", "llmp_bind_public" ] } #,  "llmp_small_maps", "llmp_debug"]}
+libafl = { path = "../../libafl/", features = [ "std", "llmp_bind_public" ] } #,  "llmp_small_maps", "llmp_debug"]}
 libafl_frida = { path = "../../libafl_frida" }
 capstone = "0.8.0"
 frida-gum = { version = "0.5.1", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -192,7 +192,7 @@ where
     ) -> Self {
         let mut stalker = Stalker::new(gum);
 
-        for range in helper.ranges().gaps(&(0..0xffffffffffffffff)) {
+        for range in helper.ranges().gaps(&(0..usize::MAX)) {
             println!("excluding range: {:x}-{:x}", range.start, range.end);
             stalker.exclude(&MemoryRange::new(
                 NativePointer(range.start as *mut c_void),

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -194,7 +194,10 @@ where
 
         for range in helper.ranges().gaps(&(0..0xffffffffffffffff)) {
             println!("excluding range: {:x}-{:x}", range.start, range.end);
-            stalker.exclude(&MemoryRange::new(NativePointer(range.start as *mut c_void), range.end - range.start));
+            stalker.exclude(&MemoryRange::new(
+                NativePointer(range.start as *mut c_void),
+                range.end - range.start,
+            ));
         }
 
         Self {

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -53,7 +53,7 @@ use std::{
 };
 
 use libafl_frida::{
-    asan_rt::{AsanErrorsFeedback, AsanErrorsObserver, ASAN_ERRORS},
+    asan_errors::{AsanErrorsFeedback, AsanErrorsObserver, ASAN_ERRORS},
     helper::{FridaHelper, FridaInstrumentationHelper, MAP_SIZE},
     FridaOptions,
 };

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -40,7 +40,7 @@ use libafl::{
 
 use frida_gum::{
     stalker::{NoneEventSink, Stalker},
-    Gum, NativePointer,
+    Gum, MemoryRange, NativePointer,
 };
 
 use std::{
@@ -190,17 +190,12 @@ where
         helper: &'c mut FH,
         timeout: Duration,
     ) -> Self {
-        let stalker = Stalker::new(gum);
+        let mut stalker = Stalker::new(gum);
 
-        // Let's exclude the main module and libc.so at least:
-        //stalker.exclude(&MemoryRange::new(
-        //Module::find_base_address(&env::args().next().unwrap()),
-        //get_module_size(&env::args().next().unwrap()),
-        //));
-        //stalker.exclude(&MemoryRange::new(
-        //Module::find_base_address("libc.so"),
-        //get_module_size("libc.so"),
-        //));
+        for range in helper.ranges().gaps(&(0..0xffffffffffffffff)) {
+            println!("excluding range: {:x}-{:x}", range.start, range.end);
+            stalker.exclude(&MemoryRange::new(NativePointer(range.start as *mut c_void), range.end - range.start));
+        }
 
         Self {
             base: TimeoutExecutor::new(base, timeout),
@@ -385,7 +380,8 @@ unsafe fn fuzz(
                 // RNG
                 StdRand::with_seed(current_nanos()),
                 // Corpus that will be evolved, we keep it in memory for performance
-                InMemoryCorpus::new(),
+                OnDiskCorpus::new(PathBuf::from("./corpus_discovered")).unwrap(),
+                //InMemoryCorpus::new(),
                 // Corpus in which we store solutions (crashes in this example),
                 // on disk so the user can get them after stopping the fuzzer
                 OnDiskCorpus::new_save_meta(
@@ -440,15 +436,6 @@ unsafe fn fuzz(
             &mut frida_helper,
             Duration::new(10, 0),
         );
-        // Let's exclude the main module and libc.so at least:
-        //executor.stalker.exclude(&MemoryRange::new(
-        //Module::find_base_address(&env::args().next().unwrap()),
-        //get_module_size(&env::args().next().unwrap()),
-        //));
-        //executor.stalker.exclude(&MemoryRange::new(
-        //Module::find_base_address("libc.so"),
-        //get_module_size("libc.so"),
-        //));
 
         // In case the corpus is empty (on first run), reset
         if state.corpus().count() < 1 {

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -851,10 +851,6 @@ where
 
         println!("We're a client, let's fuzz :)");
 
-        for (var, val) in std::env::vars() {
-            println!("ENV VARS: {:?}: {:?}", var, val);
-        }
-
         // If we're restarting, deserialize the old state.
         let (state, mut mgr) = match receiver.recv_buf()? {
             None => {

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -430,8 +430,7 @@ mod unix_signal_handler {
             {
                 println!("Double crash\n");
                 #[cfg(target_os = "android")]
-                let si_addr =
-                    { ((_info._pad[0] as usize) | ((_info._pad[1] as usize) << 32)) as usize };
+                let si_addr = (_info._pad[0] as i64) | ((_info._pad[1] as i64) << 32);
                 #[cfg(not(target_os = "android"))]
                 let si_addr = { _info.si_addr() as usize };
 
@@ -466,6 +465,7 @@ mod unix_signal_handler {
             #[cfg(feature = "std")]
             println!("Child crashed!");
 
+            #[allow(clippy::non_ascii_literal)]
             #[cfg(all(
                 feature = "std",
                 any(target_os = "linux", target_os = "android"),

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2.92"
 hashbrown = "0.11"
 libloading = "0.7.0"
 rangemap = "0.1.10"
-frida-gum = { version = "0.5.0", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
+frida-gum = { version = "0.5.1", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
 frida-gum-sys = { version = "0.3.0", features = [ "auto-download", "event-sink", "invocation-listener"] }
 core_affinity = { version = "0.5", git = "https://github.com/s1341/core_affinity_rs" }
 regex = "1.4"

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -21,10 +21,8 @@ libc = "0.2.92"
 hashbrown = "0.11"
 libloading = "0.7.0"
 rangemap = "0.1.10"
-frida-gum = { version = "0.5.0", git = "https://github.com/frida/frida-rust", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"], rev = "69f5b8236ab4b66296507803b4b7bfec79700e84" }
-frida-gum-sys = { version = "0.3.0", git = "https://github.com/frida/frida-rust", features = [ "auto-download", "event-sink", "invocation-listener"], rev = "69f5b8236ab4b66296507803b4b7bfec79700e84" }
-#frida-gum = { version = "0.5.0",  path = "../../frida-rust/frida-gum", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
-#frida-gum-sys = { version = "0.3.0", path = "../../frida-rust/frida-gum-sys", features = [ "auto-download", "event-sink", "invocation-listener"] }
+frida-gum = { version = "0.5.0", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
+frida-gum-sys = { version = "0.3.0", features = [ "auto-download", "event-sink", "invocation-listener"] }
 core_affinity = { version = "0.5", git = "https://github.com/s1341/core_affinity_rs" }
 regex = "1.4"
 dynasmrt = "1.0.1"
@@ -35,6 +33,4 @@ serde = "1.0"
 backtrace = { version = "0.3.58", default-features = false, features = ["std", "serde"] }
 num-traits = "0.2.14"
 ahash = "0.7"
-
-[target.'cfg(unix)'.dependencies]
-gothook = { version = "0.1" }
+paste = "1.0"

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -21,8 +21,8 @@ libc = "0.2.92"
 hashbrown = "0.11"
 libloading = "0.7.0"
 rangemap = "0.1.10"
-frida-gum = { version = "0.5.1", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
-frida-gum-sys = { version = "0.3.0", features = [ "auto-download", "event-sink", "invocation-listener"] }
+frida-gum-sys = { version = "0.3", features = [ "auto-download", "event-sink", "invocation-listener"] }
+frida-gum = { version = "0.5.1",  features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
 core_affinity = { version = "0.5", git = "https://github.com/s1341/core_affinity_rs" }
 regex = "1.4"
 dynasmrt = "1.0.1"

--- a/libafl_frida/build.rs
+++ b/libafl_frida/build.rs
@@ -2,4 +2,7 @@
 
 fn main() {
     cc::Build::new().file("src/gettls.c").compile("libgettls.a");
+
+    // Force linking against libc++
+    println!("cargo:rustc-link-lib=dylib=c++");
 }

--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -1,0 +1,423 @@
+use frida_gum::NativePointer;
+use hashbrown::HashMap;
+use libafl::{
+    bolts::{
+        os::{find_mapping_for_address, find_mapping_for_path, walk_self_maps},
+        ownedref::OwnedPtr,
+        tuples::Named,
+    },
+    corpus::Testcase,
+    events::EventFirer,
+    executors::{CustomExitKind, ExitKind, HasExecHooks},
+    feedbacks::Feedback,
+    inputs::{HasTargetBytes, Input},
+    observers::{Observer, ObserversTuple},
+    state::HasMetadata,
+    Error, SerdeAny,
+};
+use nix::{libc::{memmove, memset}, sys::mman::{MapFlags, ProtFlags, mmap}};
+
+use backtrace::Backtrace;
+use capstone::{
+    arch::{arm64::Arm64OperandType, ArchOperand::Arm64Operand, BuildsCapstone},
+    Capstone, Insn,
+};
+use color_backtrace::{default_output_stream, BacktracePrinter, Verbosity};
+use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
+use frida_gum::{interceptor::Interceptor, Gum, ModuleMap};
+#[cfg(unix)]
+use libc::{c_char, getrlimit64, rlimit64, sysconf, wchar_t, _SC_PAGESIZE};
+use rangemap::RangeMap;
+use rangemap::RangeSet;
+use serde::{Deserialize, Serialize};
+use std::{
+    cell::{RefCell, RefMut},
+    ffi::c_void,
+    io::{self, Write},
+    path::PathBuf,
+    rc::Rc,
+};
+use termcolor::{Color, ColorSpec, WriteColor};
+
+use crate::{FridaOptions, asan_errors::{AsanError, AsanErrors}};
+
+static mut ALLOCATOR_SINGLETON: Option<RefCell<Allocator>> = None;
+
+pub(crate) struct Allocator {
+    options: FridaOptions,
+    page_size: usize,
+    shadow_offset: usize,
+    shadow_bit: usize,
+    pre_allocated_shadow: bool,
+    allocations: HashMap<usize, AllocationMetadata>,
+    shadow_pages: RangeSet<usize>,
+    allocation_queue: HashMap<usize, Vec<AllocationMetadata>>,
+    largest_allocation: usize,
+}
+
+macro_rules! map_to_shadow {
+    ($self:expr, $address:expr) => {
+        (($address >> 3) + $self.shadow_offset) & ((1 << ($self.shadow_bit + 1)) - 1)
+    };
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct AllocationMetadata {
+    pub address: usize,
+    pub size: usize,
+    pub actual_size: usize,
+    pub allocation_site_backtrace: Option<Backtrace>,
+    pub release_site_backtrace: Option<Backtrace>,
+    pub freed: bool,
+    pub is_malloc_zero: bool,
+}
+
+impl Allocator {
+    pub fn new(options: FridaOptions) -> Self {
+        let ret = unsafe { sysconf(_SC_PAGESIZE) };
+        if ret < 0 {
+            panic!("Failed to read pagesize {:?}", io::Error::last_os_error());
+        }
+        #[allow(clippy::cast_sign_loss)]
+        let page_size = ret as usize;
+        // probe to find a usable shadow bit:
+        let mut shadow_bit: usize = 0;
+        for try_shadow_bit in &[46usize, 36usize] {
+            let addr: usize = 1 << try_shadow_bit;
+            if unsafe {
+                mmap(
+                    addr as *mut c_void,
+                    page_size,
+                    ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                    MapFlags::MAP_PRIVATE
+                        | MapFlags::MAP_ANONYMOUS
+                        | MapFlags::MAP_FIXED
+                        | MapFlags::MAP_NORESERVE,
+                    -1,
+                    0,
+                )
+            }
+            .is_ok()
+            {
+                shadow_bit = *try_shadow_bit;
+                break;
+            }
+        }
+        assert!(shadow_bit != 0);
+
+        // attempt to pre-map the entire shadow-memory space
+        let addr: usize = 1 << shadow_bit;
+        let pre_allocated_shadow = unsafe {
+            mmap(
+                addr as *mut c_void,
+                addr + addr,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                MapFlags::MAP_ANONYMOUS
+                    | MapFlags::MAP_FIXED
+                    | MapFlags::MAP_PRIVATE
+                    | MapFlags::MAP_NORESERVE,
+                -1,
+                0,
+            )
+        }
+        .is_ok();
+
+        Self {
+            options,
+            page_size,
+            pre_allocated_shadow,
+            shadow_offset: 1 << shadow_bit,
+            shadow_bit,
+            allocations: HashMap::new(),
+            shadow_pages: RangeSet::new(),
+            allocation_queue: HashMap::new(),
+            largest_allocation: 0,
+        }
+    }
+
+    /// Retreive the shadow bit used by this allocator.
+    pub fn shadow_bit(&self) -> u32 {
+        self.shadow_bit as u32
+    }
+
+    #[inline]
+    fn round_up_to_page(&self, size: usize) -> usize {
+        ((size + self.page_size) / self.page_size) * self.page_size
+    }
+
+    #[inline]
+    fn round_down_to_page(&self, value: usize) -> usize {
+        (value / self.page_size) * self.page_size
+    }
+
+    fn find_smallest_fit(&mut self, size: usize) -> Option<AllocationMetadata> {
+        let mut current_size = size;
+        while current_size <= self.largest_allocation {
+            if self.allocation_queue.contains_key(&current_size) {
+                if let Some(metadata) = self.allocation_queue.entry(current_size).or_default().pop()
+                {
+                    return Some(metadata);
+                }
+            }
+            current_size *= 2;
+        }
+        None
+    }
+
+    pub unsafe fn alloc(&mut self, size: usize, _alignment: usize) -> *mut c_void {
+        let mut is_malloc_zero = false;
+        let size = if size == 0 {
+            println!("zero-sized allocation!");
+            is_malloc_zero = true;
+            16
+        } else {
+            size
+        };
+        if size > (1 << 30) {
+            panic!("Allocation is too large: 0x{:x}", size);
+        }
+        let rounded_up_size = self.round_up_to_page(size) + 2 * self.page_size;
+
+        let metadata = if let Some(mut metadata) = self.find_smallest_fit(rounded_up_size) {
+            //println!("reusing allocation at {:x}, (actual mapping starts at {:x}) size {:x}", metadata.address, metadata.address - self.page_size, size);
+            metadata.is_malloc_zero = is_malloc_zero;
+            metadata.size = size;
+            if self
+                .options
+                .enable_asan_allocation_backtraces
+            {
+                metadata.allocation_site_backtrace = Some(Backtrace::new_unresolved());
+            }
+            metadata
+        } else {
+            let mapping = match mmap(
+                std::ptr::null_mut(),
+                rounded_up_size,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
+                -1,
+                0,
+            ) {
+                Ok(mapping) => mapping as usize,
+                Err(err) => {
+                    println!("An error occurred while mapping memory: {:?}", err);
+                    return std::ptr::null_mut();
+                }
+            };
+
+            self.map_shadow_for_region(mapping, mapping + rounded_up_size, false);
+
+            let mut metadata = AllocationMetadata {
+                address: mapping,
+                size,
+                actual_size: rounded_up_size,
+                ..AllocationMetadata::default()
+            };
+
+            if self
+                .options
+                .enable_asan_allocation_backtraces
+            {
+                metadata.allocation_site_backtrace = Some(Backtrace::new_unresolved());
+            }
+
+            metadata
+        };
+
+        self.largest_allocation = std::cmp::max(self.largest_allocation, metadata.actual_size);
+        // unpoison the shadow memory for the allocation itself
+        Self::unpoison(map_to_shadow!(self, metadata.address + self.page_size), size);
+        let address = (metadata.address + self.page_size) as *mut c_void;
+
+        self.allocations.insert(metadata.address + self.page_size, metadata);
+        //println!("serving address: {:?}, size: {:x}", address, size);
+        address
+    }
+
+    pub unsafe fn release(&mut self, ptr: *mut c_void) {
+        let mut metadata = if let Some(metadata) = self.allocations.get_mut(&(ptr as usize)) {
+            metadata
+        } else {
+            if !ptr.is_null() {
+                AsanErrors::get_mut().report_error(AsanError::UnallocatedFree((ptr as usize, Backtrace::new())), None);
+            }
+            return;
+        };
+
+        if metadata.freed {
+            AsanErrors::get_mut()
+                .report_error(AsanError::DoubleFree((
+                    ptr as usize,
+                    metadata.clone(),
+                    Backtrace::new(),
+                )), None);
+        }
+        let shadow_mapping_start = map_to_shadow!(self, ptr as usize);
+
+        metadata.freed = true;
+        if self
+            .options
+            .enable_asan_allocation_backtraces
+        {
+            metadata.release_site_backtrace = Some(Backtrace::new_unresolved());
+        }
+
+        // poison the shadow memory for the allocation
+        Self::poison(shadow_mapping_start, metadata.size);
+    }
+
+    pub fn find_metadata(
+        &mut self,
+        ptr: usize,
+        hint_base: usize,
+    ) -> Option<&mut AllocationMetadata> {
+        let mut metadatas: Vec<&mut AllocationMetadata> = self.allocations.values_mut().collect();
+        metadatas.sort_by(|a, b| a.address.cmp(&b.address));
+        let mut offset_to_closest = i64::max_value();
+        let mut closest = None;
+        for metadata in metadatas {
+            let new_offset = if hint_base == metadata.address {
+                (ptr as i64 - metadata.address as i64).abs()
+            } else {
+                std::cmp::min(
+                    offset_to_closest,
+                    (ptr as i64 - metadata.address as i64).abs(),
+                )
+            };
+            if new_offset < offset_to_closest {
+                offset_to_closest = new_offset;
+                closest = Some(metadata);
+            }
+        }
+        closest
+    }
+
+    pub fn reset(&mut self) {
+        for (address, mut allocation) in self.allocations.drain() {
+            // First poison the memory.
+            Self::poison(map_to_shadow!(self, address), allocation.size);
+
+            // Reset the allocaiton metadata object
+            allocation.size = 0;
+            allocation.freed = false;
+            allocation.allocation_site_backtrace = None;
+            allocation.release_site_backtrace = None;
+
+            // Move the allocation from the allocations to the to-be-allocated queues
+            self.allocation_queue
+                .entry(allocation.actual_size)
+                .or_default()
+                .push(allocation);
+        }
+    }
+
+    pub fn get_usable_size(&self, ptr: *mut c_void) -> usize {
+        match self.allocations.get(&(ptr as usize)) {
+            Some(metadata) => metadata.size,
+            None => {
+                panic!(
+                    "Attempted to get_usable_size on a pointer ({:?}) which was not allocated!",
+                    ptr
+                );
+            }
+        }
+    }
+
+    fn unpoison(start: usize, size: usize) {
+        //println!("unpoisoning {:x} for {:x}", start, size / 8 + 1);
+        unsafe {
+            //println!("memset: {:?}", start as *mut c_void);
+            memset(start as *mut c_void, 0xff, size / 8);
+
+            let remainder = size % 8;
+            if remainder > 0 {
+                //println!("remainder: {:x}, offset: {:x}", remainder, start + size / 8);
+                memset(
+                    (start + size / 8) as *mut c_void,
+                    (0xff << (8 - remainder)) & 0xff,
+                    1,
+                );
+            }
+        }
+    }
+
+    pub fn poison(start: usize, size: usize) {
+        //println!("poisoning {:x} for {:x}", start, size / 8 + 1);
+        unsafe {
+            //println!("memset: {:?}", start as *mut c_void);
+            memset(start as *mut c_void, 0x00, size / 8);
+
+            let remainder = size % 8;
+            if remainder > 0 {
+                //println!("remainder: {:x}, offset: {:x}", remainder, start + size / 8);
+                memset((start + size / 8) as *mut c_void, 0x00, 1);
+            }
+        }
+    }
+
+    /// Map shadow memory for a region, and optionally unpoison it
+    pub fn map_shadow_for_region(
+        &mut self,
+        start: usize,
+        end: usize,
+        unpoison: bool,
+    ) -> (usize, usize) {
+        //println!("start: {:x}, end {:x}, size {:x}", start, end, end - start);
+
+        let shadow_mapping_start = map_to_shadow!(self, start);
+
+        if !self.pre_allocated_shadow {
+            let shadow_start = self.round_down_to_page(shadow_mapping_start);
+            let shadow_end =
+                self.round_up_to_page((end - start) / 8) + self.page_size + shadow_start;
+            for range in self.shadow_pages.gaps(&(shadow_start..shadow_end)) {
+                //println!("range: {:x}-{:x}, pagesize: {}", range.start, range.end, self.page_size);
+                unsafe {
+                    mmap(
+                        range.start as *mut c_void,
+                        range.end - range.start,
+                        ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                        MapFlags::MAP_ANONYMOUS | MapFlags::MAP_FIXED | MapFlags::MAP_PRIVATE,
+                        -1,
+                        0,
+                    )
+                    .expect("An error occurred while mapping shadow memory");
+                }
+            }
+
+            self.shadow_pages.insert(shadow_start..shadow_end);
+        }
+
+        //println!("shadow_mapping_start: {:x}, shadow_size: {:x}", shadow_mapping_start, (end - start) / 8);
+        if unpoison {
+            Self::unpoison(shadow_mapping_start, end - start);
+        }
+
+        (shadow_mapping_start, (end - start) / 8)
+    }
+
+    pub fn map_to_shadow(&self, start: usize) -> usize {
+        map_to_shadow!(self, start)
+    }
+
+    pub fn check_for_leaks(&self) {
+        for metadata in self.allocations.values() {
+            if !metadata.freed {
+                AsanErrors::get_mut().report_error(AsanError::Leak((metadata.address, metadata.clone())), None);
+            }
+        }
+    }
+
+    /// Unpoison all the memory that is currently mapped with read/write permissions.
+    pub fn unpoison_all_existing_memory(&mut self) {
+        walk_self_maps(&mut |start, end, permissions, _path| {
+            if permissions.as_bytes()[0] == b'r' || permissions.as_bytes()[1] == b'w' {
+                if self.pre_allocated_shadow && start == 1 << self.shadow_bit {
+                    return false;
+                }
+                self.map_shadow_for_region(start, end, true);
+            }
+            false
+        });
+    }
+}

--- a/libafl_frida/src/asan_errors.rs
+++ b/libafl_frida/src/asan_errors.rs
@@ -257,25 +257,27 @@ impl AsanErrors {
                 .unwrap();
                 let invocation = Interceptor::current_invocation();
                 let cpu_context = invocation.cpu_context();
-
-                #[allow(clippy::non_ascii_literal)]
-                writeln!(output, "{:━^100}", " REGISTERS ").unwrap();
-                for reg in 0..29 {
-                    let val = cpu_context.reg(reg);
-                    if val as usize == address {
-                        output
-                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
-                            .unwrap();
+                #[cfg(target_arch = "aarch64")]
+                {
+                    #[allow(clippy::non_ascii_literal)]
+                    writeln!(output, "{:━^100}", " REGISTERS ").unwrap();
+                    for reg in 0..29 {
+                        let val = cpu_context.reg(reg);
+                        if val as usize == address {
+                            output
+                                .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                                .unwrap();
+                        }
+                        write!(output, "x{:02}: 0x{:016x} ", reg, val).unwrap();
+                        output.reset().unwrap();
+                        if reg % 4 == 3 {
+                            writeln!(output).unwrap();
+                        }
                     }
-                    write!(output, "x{:02}: 0x{:016x} ", reg, val).unwrap();
-                    output.reset().unwrap();
-                    if reg % 4 == 3 {
-                        writeln!(output).unwrap();
-                    }
+                    write!(output, "sp : 0x{:016x} ", cpu_context.sp()).unwrap();
+                    write!(output, "lr : 0x{:016x} ", cpu_context.lr()).unwrap();
+                    writeln!(output, "pc : 0x{:016x} ", cpu_context.pc()).unwrap();
                 }
-                write!(output, "sp : 0x{:016x} ", cpu_context.sp()).unwrap();
-                write!(output, "lr : 0x{:016x} ", cpu_context.lr()).unwrap();
-                writeln!(output, "pc : 0x{:016x} ", cpu_context.pc()).unwrap();
 
                 backtrace_printer.print_trace(&backtrace, output).unwrap();
             }

--- a/libafl_frida/src/asan_errors.rs
+++ b/libafl_frida/src/asan_errors.rs
@@ -1,0 +1,584 @@
+use frida_gum::NativePointer;
+use hashbrown::HashMap;
+use libafl::{
+    bolts::{
+        os::{find_mapping_for_address, find_mapping_for_path, walk_self_maps},
+        ownedref::OwnedPtr,
+        tuples::Named,
+    },
+    corpus::Testcase,
+    events::EventFirer,
+    executors::{CustomExitKind, ExitKind, HasExecHooks},
+    feedbacks::Feedback,
+    inputs::{HasTargetBytes, Input},
+    observers::{Observer, ObserversTuple},
+    state::HasMetadata,
+    Error, SerdeAny,
+};
+use nix::{libc::{memmove, memset}, sys::mman::{MapFlags, ProtFlags, mmap}};
+
+use backtrace::Backtrace;
+use capstone::{
+    arch::{arm64::Arm64OperandType, ArchOperand::Arm64Operand, BuildsCapstone},
+    Capstone, Insn,
+};
+use color_backtrace::{default_output_stream, BacktracePrinter, Verbosity};
+use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
+use frida_gum::{interceptor::Interceptor, Gum, ModuleMap};
+#[cfg(unix)]
+use libc::{c_char, getrlimit64, rlimit64, sysconf, wchar_t, _SC_PAGESIZE};
+use rangemap::RangeMap;
+use rangemap::RangeSet;
+use serde::{Deserialize, Serialize};
+use std::{
+    cell::{RefCell, RefMut},
+    ffi::c_void,
+    io::{self, Write},
+    path::PathBuf,
+    rc::Rc,
+};
+use termcolor::{Color, ColorSpec, WriteColor};
+
+use crate::{FridaOptions, alloc::AllocationMetadata};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AsanReadWriteError {
+    pub registers: [usize; 32],
+    pub pc: usize,
+    pub fault: (u16, u16, usize, usize),
+    pub metadata: AllocationMetadata,
+    pub backtrace: Backtrace,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeAny)]
+pub(crate) enum AsanError {
+    OobRead(AsanReadWriteError),
+    OobWrite(AsanReadWriteError),
+    ReadAfterFree(AsanReadWriteError),
+    WriteAfterFree(AsanReadWriteError),
+    DoubleFree((usize, AllocationMetadata, Backtrace)),
+    UnallocatedFree((usize, Backtrace)),
+    Unknown(([usize; 32], usize, (u16, u16, usize, usize), Backtrace)),
+    Leak((usize, AllocationMetadata)),
+    StackOobRead(([usize; 32], usize, (u16, u16, usize, usize), Backtrace)),
+    StackOobWrite(([usize; 32], usize, (u16, u16, usize, usize), Backtrace)),
+    BadFuncArgRead((String, usize, usize, Backtrace)),
+    BadFuncArgWrite((String, usize, usize, Backtrace)),
+}
+
+impl AsanError {
+    fn description(&self) -> &str {
+        match self {
+            AsanError::OobRead(_) => "heap out-of-bounds read",
+            AsanError::OobWrite(_) => "heap out-of-bounds write",
+            AsanError::DoubleFree(_) => "double-free",
+            AsanError::UnallocatedFree(_) => "unallocated-free",
+            AsanError::WriteAfterFree(_) => "heap use-after-free write",
+            AsanError::ReadAfterFree(_) => "heap use-after-free read",
+            AsanError::Unknown(_) => "heap unknown",
+            AsanError::Leak(_) => "memory-leak",
+            AsanError::StackOobRead(_) => "stack out-of-bounds read",
+            AsanError::StackOobWrite(_) => "stack out-of-bounds write",
+            AsanError::BadFuncArgRead(_) => "function arg resulting in bad read",
+            AsanError::BadFuncArgWrite(_) => "function arg resulting in bad write",
+        }
+    }
+}
+
+/// A struct holding errors that occurred during frida address sanitizer runs
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeAny)]
+pub struct AsanErrors {
+    options: FridaOptions,
+    errors: Vec<AsanError>,
+}
+
+impl AsanErrors {
+    /// Creates a new `AsanErrors` struct
+    #[must_use]
+    pub fn new(options: FridaOptions) -> Self {
+        Self { options, errors: Vec::new() }
+    }
+
+    /// Clears this `AsanErrors` struct
+    pub fn clear(&mut self) {
+        self.errors.clear()
+    }
+
+    /// Gets the amount of `AsanErrors` in this struct
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.errors.len()
+    }
+
+    /// Returns `true` if no errors occurred
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Get a mutable reference to the global [`AsanErrors`] object
+    pub fn get_mut<'a>() -> &'a mut Self {
+        unsafe {
+            ASAN_ERRORS.as_mut().unwrap()
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    /// Report an error
+    pub(crate) fn report_error(&mut self, error: AsanError, instrumented_ranges: Option<&RangeMap<usize, String>>) {
+        self.errors.push(error.clone());
+
+        let mut out_stream = default_output_stream();
+        let output = out_stream.as_mut();
+
+        let backtrace_printer = BacktracePrinter::new()
+            .clear_frame_filters()
+            .print_addresses(true)
+            .verbosity(Verbosity::Full)
+            .add_frame_filter(Box::new(|frames| {
+                frames.retain(
+                    |x| matches!(&x.name, Some(n) if !n.starts_with("libafl_frida::asan_rt::")),
+                )
+            }));
+
+        #[allow(clippy::non_ascii_literal)]
+        writeln!(output, "{:━^100}", " Memory error detected! ").unwrap();
+        output
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+            .unwrap();
+        write!(output, "{}", error.description()).unwrap();
+        match error {
+            AsanError::OobRead(mut error)
+            | AsanError::OobWrite(mut error)
+            | AsanError::ReadAfterFree(mut error)
+            | AsanError::WriteAfterFree(mut error) => {
+                let (basereg, indexreg, _displacement, fault_address) = error.fault;
+
+                if let Some((range, path)) = instrumented_ranges.unwrap().get_key_value(&error.pc) {
+                    writeln!(
+                        output,
+                        " at 0x{:x} ({}@0x{:04x}), faulting address 0x{:x}",
+                        error.pc,
+                        path,
+                        error.pc - range.start,
+                        fault_address
+                    )
+                    .unwrap();
+                } else {
+                    writeln!(
+                        output,
+                        " at 0x{:x}, faulting address 0x{:x}",
+                        error.pc, fault_address
+                    )
+                    .unwrap();
+                }
+                output.reset().unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " REGISTERS ").unwrap();
+                for reg in 0..=30 {
+                    if reg == basereg {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                            .unwrap();
+                    } else if reg == indexreg {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))
+                            .unwrap();
+                    }
+                    write!(
+                        output,
+                        "x{:02}: 0x{:016x} ",
+                        reg, error.registers[reg as usize]
+                    )
+                    .unwrap();
+                    output.reset().unwrap();
+                    if reg % 4 == 3 {
+                        writeln!(output).unwrap();
+                    }
+                }
+                writeln!(output, "pc : 0x{:016x} ", error.pc).unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " CODE ").unwrap();
+                let mut cs = Capstone::new()
+                    .arm64()
+                    .mode(capstone::arch::arm64::ArchMode::Arm)
+                    .build()
+                    .unwrap();
+                cs.set_skipdata(true).expect("failed to set skipdata");
+
+                let start_pc = error.pc - 4 * 5;
+                for insn in cs
+                    .disasm_count(
+                        unsafe { std::slice::from_raw_parts(start_pc as *mut u8, 4 * 11) },
+                        start_pc as u64,
+                        11,
+                    )
+                    .expect("failed to disassemble instructions")
+                    .iter()
+                {
+                    if insn.address() as usize == error.pc {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                            .unwrap();
+                        writeln!(output, "\t => {}", insn).unwrap();
+                        output.reset().unwrap();
+                    } else {
+                        writeln!(output, "\t    {}", insn).unwrap();
+                    }
+                }
+                backtrace_printer
+                    .print_trace(&error.backtrace, output)
+                    .unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " ALLOCATION INFO ").unwrap();
+                let offset: i64 = fault_address as i64 - error.metadata.address as i64;
+                let direction = if offset > 0 { "right" } else { "left" };
+                writeln!(
+                    output,
+                    "access is {} to the {} of the 0x{:x} byte allocation at 0x{:x}",
+                    offset, direction, error.metadata.size, error.metadata.address
+                )
+                .unwrap();
+
+                if error.metadata.is_malloc_zero {
+                    writeln!(output, "allocation was zero-sized").unwrap();
+                }
+
+                if let Some(backtrace) = error.metadata.allocation_site_backtrace.as_mut() {
+                    writeln!(output, "allocation site backtrace:").unwrap();
+                    backtrace.resolve();
+                    backtrace_printer.print_trace(backtrace, output).unwrap();
+                }
+
+                if error.metadata.freed {
+                    #[allow(clippy::non_ascii_literal)]
+                    writeln!(output, "{:━^100}", " FREE INFO ").unwrap();
+                    if let Some(backtrace) = error.metadata.release_site_backtrace.as_mut() {
+                        writeln!(output, "free site backtrace:").unwrap();
+                        backtrace.resolve();
+                        backtrace_printer.print_trace(backtrace, output).unwrap();
+                    }
+                }
+            }
+            AsanError::BadFuncArgRead((name, address, size, backtrace)) | AsanError::BadFuncArgWrite((name, address, size, backtrace)) => {
+                writeln!(output, " in call to {}, argument {:#016x}, size: {:#x}", name, address, size).unwrap();
+                let invocation = Interceptor::current_invocation();
+                let cpu_context = invocation.cpu_context();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " REGISTERS ").unwrap();
+                for reg in 0..29 {
+                    let val = cpu_context.reg(reg);
+                    if val as usize == address {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                            .unwrap();
+                    }
+                    write!(
+                        output,
+                        "x{:02}: 0x{:016x} ",
+                        reg, val
+                    )
+                    .unwrap();
+                    output.reset().unwrap();
+                    if reg % 4 == 3 {
+                        writeln!(output).unwrap();
+                    }
+                }
+                write!(output, "sp : 0x{:016x} ", cpu_context.sp()).unwrap();
+                write!(output, "lr : 0x{:016x} ", cpu_context.lr()).unwrap();
+                writeln!(output, "pc : 0x{:016x} ", cpu_context.pc()).unwrap();
+
+                backtrace_printer
+                    .print_trace(&backtrace, output)
+                    .unwrap();
+
+            }
+            AsanError::DoubleFree((ptr, mut metadata, backtrace)) => {
+                writeln!(output, " of {:?}", ptr).unwrap();
+                output.reset().unwrap();
+                backtrace_printer.print_trace(&backtrace, output).unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " ALLOCATION INFO ").unwrap();
+                writeln!(
+                    output,
+                    "allocation at 0x{:x}, with size 0x{:x}",
+                    metadata.address, metadata.size
+                )
+                .unwrap();
+                if metadata.is_malloc_zero {
+                    writeln!(output, "allocation was zero-sized").unwrap();
+                }
+
+                if let Some(backtrace) = metadata.allocation_site_backtrace.as_mut() {
+                    writeln!(output, "allocation site backtrace:").unwrap();
+                    backtrace.resolve();
+                    backtrace_printer.print_trace(backtrace, output).unwrap();
+                }
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " FREE INFO ").unwrap();
+                if let Some(backtrace) = metadata.release_site_backtrace.as_mut() {
+                    writeln!(output, "previous free site backtrace:").unwrap();
+                    backtrace.resolve();
+                    backtrace_printer.print_trace(backtrace, output).unwrap();
+                }
+            }
+            AsanError::UnallocatedFree((ptr, backtrace)) => {
+                writeln!(output, " of {:#016x}", ptr).unwrap();
+                output.reset().unwrap();
+                backtrace_printer.print_trace(&backtrace, output).unwrap();
+            }
+            AsanError::Leak((ptr, mut metadata)) => {
+                writeln!(output, " of {:#016x}", ptr).unwrap();
+                output.reset().unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " ALLOCATION INFO ").unwrap();
+                writeln!(
+                    output,
+                    "allocation at 0x{:x}, with size 0x{:x}",
+                    metadata.address, metadata.size
+                )
+                .unwrap();
+                if metadata.is_malloc_zero {
+                    writeln!(output, "allocation was zero-sized").unwrap();
+                }
+
+                if let Some(backtrace) = metadata.allocation_site_backtrace.as_mut() {
+                    writeln!(output, "allocation site backtrace:").unwrap();
+                    backtrace.resolve();
+                    backtrace_printer.print_trace(backtrace, output).unwrap();
+                }
+            }
+            AsanError::Unknown((registers, pc, fault, backtrace))
+            | AsanError::StackOobRead((registers, pc, fault, backtrace))
+            | AsanError::StackOobWrite((registers, pc, fault, backtrace)) => {
+                let (basereg, indexreg, _displacement, fault_address) = fault;
+
+                if let Ok((start, _, _, path)) = find_mapping_for_address(pc) {
+                    writeln!(
+                        output,
+                        " at 0x{:x} ({}:0x{:04x}), faulting address 0x{:x}",
+                        pc,
+                        path,
+                        pc - start,
+                        fault_address
+                    )
+                    .unwrap();
+                } else {
+                    writeln!(
+                        output,
+                        " at 0x{:x}, faulting address 0x{:x}",
+                        pc, fault_address
+                    )
+                    .unwrap();
+                }
+                output.reset().unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " REGISTERS ").unwrap();
+                for reg in 0..=30 {
+                    if reg == basereg {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                            .unwrap();
+                    } else if reg == indexreg {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))
+                            .unwrap();
+                    }
+                    write!(output, "x{:02}: 0x{:016x} ", reg, registers[reg as usize]).unwrap();
+                    output.reset().unwrap();
+                    if reg % 4 == 3 {
+                        writeln!(output).unwrap();
+                    }
+                }
+                writeln!(output, "pc : 0x{:016x} ", pc).unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " CODE ").unwrap();
+                let mut cs = Capstone::new()
+                    .arm64()
+                    .mode(capstone::arch::arm64::ArchMode::Arm)
+                    .build()
+                    .unwrap();
+                cs.set_skipdata(true).expect("failed to set skipdata");
+
+                let start_pc = pc - 4 * 5;
+                for insn in cs
+                    .disasm_count(
+                        unsafe { std::slice::from_raw_parts(start_pc as *mut u8, 4 * 11) },
+                        start_pc as u64,
+                        11,
+                    )
+                    .expect("failed to disassemble instructions")
+                    .iter()
+                {
+                    if insn.address() as usize == pc {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                            .unwrap();
+                        writeln!(output, "\t => {}", insn).unwrap();
+                        output.reset().unwrap();
+                    } else {
+                        writeln!(output, "\t    {}", insn).unwrap();
+                    }
+                }
+                backtrace_printer.print_trace(&backtrace, output).unwrap();
+            }
+        };
+
+        if !self.options.asan_continue_after_error() {
+            panic!("Crashing target!");
+        }
+    }
+}
+
+/// static field for `AsanErrors` for a run
+pub static mut ASAN_ERRORS: Option<AsanErrors> = None;
+
+/// An observer for frida address sanitizer `AsanError`s for a frida executor run
+#[derive(Serialize, Deserialize)]
+#[allow(clippy::unsafe_derive_deserialize)]
+pub struct AsanErrorsObserver {
+    errors: OwnedPtr<Option<AsanErrors>>,
+}
+
+impl Observer for AsanErrorsObserver {}
+
+impl<EM, I, S, Z> HasExecHooks<EM, I, S, Z> for AsanErrorsObserver {
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _state: &mut S,
+        _mgr: &mut EM,
+        _input: &I,
+    ) -> Result<(), Error> {
+        unsafe {
+            if ASAN_ERRORS.is_some() {
+                ASAN_ERRORS.as_mut().unwrap().clear();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Named for AsanErrorsObserver {
+    #[inline]
+    fn name(&self) -> &str {
+        "AsanErrors"
+    }
+}
+
+impl AsanErrorsObserver {
+    /// Creates a new `AsanErrorsObserver`, pointing to a constant `AsanErrors` field
+    #[must_use]
+    pub fn new(errors: &'static Option<AsanErrors>) -> Self {
+        Self {
+            errors: OwnedPtr::Ptr(errors as *const Option<AsanErrors>),
+        }
+    }
+
+    /// Creates a new `AsanErrorsObserver`, owning the `AsanErrors`
+    #[must_use]
+    pub fn new_owned(errors: Option<AsanErrors>) -> Self {
+        Self {
+            errors: OwnedPtr::Owned(Box::new(errors)),
+        }
+    }
+
+    /// Creates a new `AsanErrorsObserver` from a raw ptr
+    #[must_use]
+    pub fn new_from_ptr(errors: *const Option<AsanErrors>) -> Self {
+        Self {
+            errors: OwnedPtr::Ptr(errors),
+        }
+    }
+
+    /// gets the [`AsanErrors`] from the previous run
+    #[must_use]
+    pub fn errors(&self) -> Option<&AsanErrors> {
+        match &self.errors {
+            OwnedPtr::Ptr(p) => unsafe { p.as_ref().unwrap().as_ref() },
+            OwnedPtr::Owned(b) => b.as_ref().as_ref(),
+        }
+    }
+}
+
+/// A feedback reporting potential [`AsanErrors`] from an `AsanErrorsObserver`
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AsanErrorsFeedback {
+    errors: Option<AsanErrors>,
+}
+
+impl<I, S> Feedback<I, S> for AsanErrorsFeedback
+where
+    I: Input + HasTargetBytes,
+{
+    fn is_interesting<EM, OT>(
+        &mut self,
+        _state: &mut S,
+        _manager: &mut EM,
+        _input: &I,
+        observers: &OT,
+        _exit_kind: &ExitKind,
+    ) -> Result<bool, Error>
+    where
+        EM: EventFirer<I, S>,
+        OT: ObserversTuple,
+    {
+        let observer = observers
+            .match_name::<AsanErrorsObserver>("AsanErrors")
+            .expect("An AsanErrorsFeedback needs an AsanErrorsObserver");
+        match observer.errors() {
+            None => Ok(false),
+            Some(errors) => {
+                if errors.errors.is_empty() {
+                    Ok(false)
+                } else {
+                    self.errors = Some(errors.clone());
+                    Ok(true)
+                }
+            }
+        }
+    }
+
+    fn append_metadata(&mut self, _state: &mut S, testcase: &mut Testcase<I>) -> Result<(), Error> {
+        if let Some(errors) = &self.errors {
+            testcase.add_metadata(errors.clone());
+        }
+
+        Ok(())
+    }
+
+    fn discard_metadata(&mut self, _state: &mut S, _input: &I) -> Result<(), Error> {
+        self.errors = None;
+        Ok(())
+    }
+}
+
+impl Named for AsanErrorsFeedback {
+    #[inline]
+    fn name(&self) -> &str {
+        "AsanErrors"
+    }
+}
+
+impl AsanErrorsFeedback {
+    /// Create a new `AsanErrorsFeedback`
+    #[must_use]
+    pub fn new() -> Self {
+        Self { errors: None }
+    }
+}
+
+impl Default for AsanErrorsFeedback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libafl_frida/src/asan_errors.rs
+++ b/libafl_frida/src/asan_errors.rs
@@ -65,6 +65,7 @@ impl AsanError {
 }
 
 /// A struct holding errors that occurred during frida address sanitizer runs
+#[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeAny)]
 pub struct AsanErrors {
     options: FridaOptions,

--- a/libafl_frida/src/asan_errors.rs
+++ b/libafl_frida/src/asan_errors.rs
@@ -104,8 +104,8 @@ impl AsanErrors {
         unsafe { ASAN_ERRORS.as_mut().unwrap() }
     }
 
-    #[allow(clippy::too_many_lines)]
     /// Report an error
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn report_error(
         &mut self,
         error: AsanError,

--- a/libafl_frida/src/asan_errors.rs
+++ b/libafl_frida/src/asan_errors.rs
@@ -1,42 +1,28 @@
-use frida_gum::NativePointer;
-use hashbrown::HashMap;
 use libafl::{
     bolts::{
-        os::{find_mapping_for_address, find_mapping_for_path, walk_self_maps},
+        os::find_mapping_for_address,
         ownedref::OwnedPtr,
         tuples::Named,
     },
     corpus::Testcase,
     events::EventFirer,
-    executors::{CustomExitKind, ExitKind, HasExecHooks},
+    executors::{ExitKind, HasExecHooks},
     feedbacks::Feedback,
     inputs::{HasTargetBytes, Input},
     observers::{Observer, ObserversTuple},
     state::HasMetadata,
     Error, SerdeAny,
 };
-use nix::{libc::{memmove, memset}, sys::mman::{MapFlags, ProtFlags, mmap}};
-
 use backtrace::Backtrace;
 use capstone::{
-    arch::{arm64::Arm64OperandType, ArchOperand::Arm64Operand, BuildsCapstone},
-    Capstone, Insn,
+    arch::BuildsCapstone,
+    Capstone,
 };
 use color_backtrace::{default_output_stream, BacktracePrinter, Verbosity};
-use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
-use frida_gum::{interceptor::Interceptor, Gum, ModuleMap};
-#[cfg(unix)]
-use libc::{c_char, getrlimit64, rlimit64, sysconf, wchar_t, _SC_PAGESIZE};
+use frida_gum::interceptor::Interceptor;
 use rangemap::RangeMap;
-use rangemap::RangeSet;
 use serde::{Deserialize, Serialize};
-use std::{
-    cell::{RefCell, RefMut},
-    ffi::c_void,
-    io::{self, Write},
-    path::PathBuf,
-    rc::Rc,
-};
+use std::io::Write;
 use termcolor::{Color, ColorSpec, WriteColor};
 
 use crate::{FridaOptions, alloc::AllocationMetadata};

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -23,10 +23,7 @@ use libafl::{
     state::HasMetadata,
     Error, SerdeAny,
 };
-use nix::{
-    libc::{memmove, memset},
-    sys::mman::{mmap, MapFlags, ProtFlags},
-};
+use nix::{libc::{memmove, memset}, sys::mman::{MapFlags, ProtFlags, mmap, mprotect}};
 
 use backtrace::Backtrace;
 use capstone::{
@@ -37,7 +34,7 @@ use color_backtrace::{default_output_stream, BacktracePrinter, Verbosity};
 use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 use frida_gum::{interceptor::Interceptor, Gum, ModuleMap};
 #[cfg(unix)]
-use libc::{getrlimit64, rlimit64, sysconf, _SC_PAGESIZE};
+use libc::{c_char, getrlimit64, rlimit64, sysconf, wchar_t, _SC_PAGESIZE};
 use rangemap::RangeMap;
 use rangemap::RangeSet;
 use serde::{Deserialize, Serialize};
@@ -203,7 +200,7 @@ impl Allocator {
         if size > (1 << 30) {
             panic!("Allocation is too large: 0x{:x}", size);
         }
-        let rounded_up_size = self.round_up_to_page(size);
+        let rounded_up_size = self.round_up_to_page(size) + 2 * self.page_size;
 
         let metadata = if let Some(mut metadata) = self.find_smallest_fit(rounded_up_size) {
             //println!("reusing allocation at {:x}, (actual mapping starts at {:x}) size {:x}", metadata.address, metadata.address - self.page_size, size);
@@ -243,24 +240,24 @@ impl Allocator {
                 ..AllocationMetadata::default()
             };
 
-            if self
-                .runtime
-                .borrow()
-                .options
-                .enable_asan_allocation_backtraces
-            {
-                metadata.allocation_site_backtrace = Some(Backtrace::new_unresolved());
-            }
+            //if self
+                //.runtime
+                //.borrow()
+                //.options
+                //.enable_asan_allocation_backtraces
+            //{
+                //metadata.allocation_site_backtrace = Some(Backtrace::new_unresolved());
+            //}
 
             metadata
         };
 
         self.largest_allocation = std::cmp::max(self.largest_allocation, metadata.actual_size);
         // unpoison the shadow memory for the allocation itself
-        Self::unpoison(map_to_shadow!(self, metadata.address), size);
-        let address = metadata.address as *mut c_void;
+        Self::unpoison(map_to_shadow!(self, metadata.address + self.page_size), size);
+        let address = (metadata.address + self.page_size) as *mut c_void;
 
-        self.allocations.insert(metadata.address, metadata);
+        self.allocations.insert(metadata.address + self.page_size, metadata);
         //println!("serving address: {:?}, size: {:x}", address, size);
         address
     }
@@ -463,6 +460,8 @@ pub struct AsanRuntime {
     options: FridaOptions,
     instrumented_ranges: RangeMap<usize, String>,
     module_map: Option<ModuleMap>,
+    shadow_check_func_blob: Option<Box<[u8]>>,
+    shadow_check_func: Option<extern "C" fn(*const c_void, usize) -> bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -486,6 +485,8 @@ enum AsanError {
     Leak((usize, AllocationMetadata)),
     StackOobRead(([usize; 32], usize, (u16, u16, usize, usize), Backtrace)),
     StackOobWrite(([usize; 32], usize, (u16, u16, usize, usize), Backtrace)),
+    BadFuncArgRead((String, usize, usize, Backtrace)),
+    BadFuncArgWrite((String, usize, usize, Backtrace)),
 }
 
 impl AsanError {
@@ -501,6 +502,8 @@ impl AsanError {
             AsanError::Leak(_) => "memory-leak",
             AsanError::StackOobRead(_) => "stack out-of-bounds read",
             AsanError::StackOobWrite(_) => "stack out-of-bounds write",
+            AsanError::BadFuncArgRead(_) => "function arg resulting in bad read",
+            AsanError::BadFuncArgWrite(_) => "function arg resulting in bad write",
         }
     }
 }
@@ -560,6 +563,8 @@ impl AsanRuntime {
             options,
             instrumented_ranges: RangeMap::new(),
             module_map: None,
+            shadow_check_func_blob: None,
+            shadow_check_func: None,
         }));
         Allocator::init(res.clone());
         res
@@ -573,13 +578,13 @@ impl AsanRuntime {
         }
 
         self.generate_instrumentation_blobs();
+        self.generate_shadow_check_function();
         self.unpoison_all_existing_memory();
+
         for module_name in modules_to_instrument {
             let (start, end) = find_mapping_for_path(module_name.to_str().unwrap());
             self.instrumented_ranges
                 .insert(start..end, module_name.to_str().unwrap().to_string());
-            //#[cfg(unix)]
-            //self.hook_library(module_name.to_str().unwrap());
         }
         let module_names: Vec<&str> = modules_to_instrument
             .iter()
@@ -587,6 +592,20 @@ impl AsanRuntime {
             .collect();
         self.module_map = Some(ModuleMap::new_from_names(&module_names));
         self.hook_functions(gum);
+        //unsafe {
+            //let mem = Allocator::get().alloc(0xac + 2, 8);
+
+            //unsafe {mprotect((self.shadow_check_func.unwrap() as usize & 0xffffffffffff000) as *mut c_void, 0x1000, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE | ProtFlags::PROT_EXEC)};
+            //assert!((self.shadow_check_func.unwrap())(((mem as usize) + 0) as *const c_void, 0xac));
+            //assert!((self.shadow_check_func.unwrap())(((mem as usize) + 2) as *const c_void, 0xac));
+            //assert!(!(self.shadow_check_func.unwrap())(((mem as usize) + 3) as *const c_void, 0xac));
+            //assert!(!(self.shadow_check_func.unwrap())(((mem as isize) + -1) as *const c_void, 0xac));
+            //assert!((self.shadow_check_func.unwrap())(((mem as usize) + 2 + 0xa4) as *const c_void, 8));
+            //assert!((self.shadow_check_func.unwrap())(((mem as usize) + 2 + 0xa6) as *const c_void, 6));
+            //assert!(!(self.shadow_check_func.unwrap())(((mem as usize) + 2 + 0xa8) as *const c_void, 6));
+            //assert!(!(self.shadow_check_func.unwrap())(((mem as usize) + 2 + 0xa8) as *const c_void, 0xac));
+            //assert!((self.shadow_check_func.unwrap())(((mem as usize) + 4 + 0xa8) as *const c_void, 0x1));
+        //}
     }
 
     /// Reset all allocations so that they can be reused for new allocation requests.
@@ -699,7 +718,7 @@ impl AsanRuntime {
     /// Determine the tls start, end for the currently running thread
     fn current_tls() -> (usize, usize) {
         let tls_address = unsafe { tls_ptr() } as usize;
-        // we need to mask off the highest byte, due to 'High Byte Ignore"
+
         #[cfg(target_os = "android")]
         let tls_address = tls_address & 0xffffffffffffff;
 
@@ -928,6 +947,530 @@ impl AsanRuntime {
         }
     }
 
+    #[inline]
+    fn hook_write(&mut self, fd: i32, buf: *const c_void, count: usize) -> usize {
+        extern "C" {
+            fn write(fd: i32, buf: *const c_void, count: usize) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(buf, count) {
+            self.report_error(AsanError::BadFuncArgWrite(("write".to_string(), buf as usize, count, Backtrace::new())));
+        }
+        unsafe {
+            write(fd, buf, count)
+        }
+    }
+
+    #[inline]
+    fn hook_read(&mut self, fd: i32, buf: *mut c_void, count: usize) -> usize {
+        extern "C" {
+            fn read(fd: i32, buf: *mut c_void, count: usize) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(buf, count) {
+            self.report_error(AsanError::BadFuncArgRead(("read".to_string(), buf as usize, count, Backtrace::new())));
+        }
+        unsafe {
+            read(fd, buf, count)
+        }
+    }
+
+    #[inline]
+    fn hook_fgets(&mut self, s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void {
+        extern "C" {
+            fn fgets(s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(s, size as usize) {
+            self.report_error(AsanError::BadFuncArgRead(("fgets".to_string(), s as usize, size as usize, Backtrace::new())));
+        }
+        unsafe {
+            fgets(s, size, stream)
+        }
+    }
+
+    #[inline]
+    fn hook_memcmp(&mut self, s1: *const c_void, s2: *const c_void, n: usize) -> i32 {
+        extern "C" {
+            fn memcmp(s1: *const c_void, s2: *const c_void, n: usize) -> i32;
+        }
+        if !(self.shadow_check_func.unwrap())(s1, n) {
+            self.report_error(AsanError::BadFuncArgRead(("memcmp".to_string(), s1 as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2, n) {
+            self.report_error(AsanError::BadFuncArgRead(("memcmp".to_string(), s2 as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            memcmp(s1, s2, n)
+        }
+    }
+
+    #[inline]
+    fn hook_memcpy(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
+        extern "C" {
+            fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(dest, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("memcpy".to_string(), dest as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src, n) {
+            self.report_error(AsanError::BadFuncArgRead(("memcpy".to_string(), src as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            memcpy(dest, src, n)
+        }
+    }
+
+    #[inline]
+    fn hook_mempcpy(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
+        extern "C" {
+            fn mempcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(dest, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("mempcpy".to_string(), dest as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src, n) {
+            self.report_error(AsanError::BadFuncArgRead(("mempcpy".to_string(), src as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            mempcpy(dest, src, n)
+        }
+    }
+
+    #[inline]
+    fn hook_memmove(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
+        extern "C" {
+            fn memmove(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(dest, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("memmove".to_string(), dest as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src, n) {
+            self.report_error(AsanError::BadFuncArgRead(("memmove".to_string(), src as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            memmove(dest, src, n)
+        }
+    }
+
+    #[inline]
+    fn hook_memset(&mut self, dest: *mut c_void, c: i32, n: usize) -> *mut c_void {
+        extern "C" {
+            fn memset(dest: *mut c_void, c: i32, n: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(dest, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("memset".to_string(), dest as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            memset(dest, c, n)
+        }
+    }
+
+    #[inline]
+    fn hook_memchr(&mut self, s: *mut c_void, c: i32, n: usize) -> *mut c_void {
+        extern "C" {
+            fn memchr(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(s, n) {
+            self.report_error(AsanError::BadFuncArgRead(("memchr".to_string(), s as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            memchr(s, c, n)
+        }
+    }
+
+    #[inline]
+    fn hook_memrchr(&mut self, s: *mut c_void, c: i32, n: usize) -> *mut c_void {
+        extern "C" {
+            fn memrchr(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(s, n) {
+            self.report_error(AsanError::BadFuncArgRead(("memrchr".to_string(), s as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            memrchr(s, c, n)
+        }
+    }
+
+    #[inline]
+    fn hook_memmem(&mut self, haystack: *const c_void, haystacklen: usize, needle: *const c_void, needlelen: usize) -> *mut c_void {
+        extern "C" {
+            fn memmem(haystack: *const c_void, haystacklen: usize, needle: *const c_void, needlelen: usize) -> *mut c_void;
+        }
+        if !(self.shadow_check_func.unwrap())(haystack, haystacklen) {
+            self.report_error(AsanError::BadFuncArgRead(("memmem".to_string(), haystack as usize, haystacklen, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(needle, needlelen) {
+            self.report_error(AsanError::BadFuncArgRead(("memmem".to_string(), needle as usize, needlelen, Backtrace::new())));
+        }
+        unsafe {
+            memmem(haystack, haystacklen, needle, needlelen)
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[inline]
+    fn hook_bzero(&mut self, s: *mut c_void, n: usize) {
+        extern "C" {
+            fn bzero(s: *mut c_void, n: usize);
+        }
+        if !(self.shadow_check_func.unwrap())(s, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("bzero".to_string(), s as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            bzero(s, n)
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[inline]
+    fn hook_explicit_bzero(&mut self, s: *mut c_void, n: usize) {
+        extern "C" {
+            fn explicit_bzero(s: *mut c_void, n: usize);
+        }
+        if !(self.shadow_check_func.unwrap())(s, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("explicit_bzero".to_string(), s as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            explicit_bzero(s, n)
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[inline]
+    fn hook_bcmp(&mut self, s1: *const c_void, s2: *const c_void, n: usize) -> i32 {
+        extern "C" {
+            fn bcmp(s1: *const c_void, s2: *const c_void, n: usize) -> i32;
+        }
+        if !(self.shadow_check_func.unwrap())(s1, n) {
+            self.report_error(AsanError::BadFuncArgRead(("bcmp".to_string(), s1 as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2, n) {
+            self.report_error(AsanError::BadFuncArgRead(("bcmp".to_string(), s2 as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            bcmp(s1, s2, n)
+        }
+    }
+
+    #[inline]
+    fn hook_strchr(&mut self, s: *mut c_char, c: i32) -> *mut c_char {
+        extern "C" {
+            fn strchr(s: *mut c_char, c: i32) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, unsafe { strlen(s) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strchr".to_string(), s as usize, unsafe { strlen(s) }, Backtrace::new())));
+        }
+        unsafe {
+            strchr(s, c)
+        }
+    }
+
+    #[inline]
+    fn hook_strrchr(&mut self, s: *mut c_char, c: i32) -> *mut c_char {
+        extern "C" {
+            fn strrchr(s: *mut c_char, c: i32) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, unsafe { strlen(s) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strrchr".to_string(), s as usize, unsafe { strlen(s) }, Backtrace::new())));
+        }
+        unsafe {
+            strrchr(s, c)
+        }
+    }
+
+    #[inline]
+    fn hook_strcasecmp(&mut self, s1: *const c_char, s2: *const c_char) -> i32 {
+        extern "C" {
+            fn strcasecmp(s1: *const c_char, s2: *const c_char) -> i32;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s1 as *const c_void, unsafe { strlen(s1) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcasecmp".to_string(), s1 as usize, unsafe { strlen(s1) }, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { strlen(s2) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcasecmp".to_string(), s2 as usize, unsafe { strlen(s2) }, Backtrace::new())));
+        }
+        unsafe {
+            strcasecmp(s1, s2)
+        }
+    }
+
+    #[inline]
+    fn hook_strncasecmp(&mut self, s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
+        extern "C" {
+            fn strncasecmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32;
+        }
+        if !(self.shadow_check_func.unwrap())(s1 as *const c_void, n) {
+            self.report_error(AsanError::BadFuncArgRead(("strncasecmp".to_string(), s1 as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2 as *const c_void, n) {
+            self.report_error(AsanError::BadFuncArgRead(("strncasecmp".to_string(), s2 as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            strncasecmp(s1, s2, n)
+        }
+    }
+
+    #[inline]
+    fn hook_strcat(&mut self, s1: *mut c_char, s2: *const c_char) -> *mut c_char {
+        extern "C" {
+            fn strcat(s1: *mut c_char, s2: *const c_char) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s1 as *const c_void, unsafe { strlen(s1) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcat".to_string(), s1 as usize, unsafe { strlen(s1) }, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { strlen(s2) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcat".to_string(), s2 as usize, unsafe { strlen(s2) }, Backtrace::new())));
+        }
+        unsafe {
+            strcat(s1, s2)
+        }
+    }
+
+    #[inline]
+    fn hook_strcmp(&mut self, s1: *const c_char, s2: *const c_char) -> i32 {
+        extern "C" {
+            fn strcmp(s1: *const c_char, s2: *const c_char) -> i32;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s1 as *const c_void, unsafe { strlen(s1) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcmp".to_string(), s1 as usize, unsafe { strlen(s1) }, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { strlen(s2) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcmp".to_string(), s2 as usize, unsafe { strlen(s2) }, Backtrace::new())));
+        }
+        unsafe {
+            strcmp(s1, s2)
+        }
+    }
+
+    #[inline]
+    fn hook_strncmp(&mut self, s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
+        extern "C" {
+            fn strncmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32;
+        }
+        if !(self.shadow_check_func.unwrap())(s1 as *const c_void, n) {
+            self.report_error(AsanError::BadFuncArgRead(("strncmp".to_string(), s1 as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2 as *const c_void, n) {
+            self.report_error(AsanError::BadFuncArgRead(("strncmp".to_string(), s2 as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            strncmp(s1, s2, n)
+        }
+    }
+
+    #[inline]
+    fn hook_strcpy(&mut self, dest: *mut c_char, src: *const c_char) -> *mut c_char {
+        extern "C" {
+            fn strcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(dest as *const c_void, unsafe { strlen(src) }) {
+            self.report_error(AsanError::BadFuncArgWrite(("strcpy".to_string(), dest as usize, unsafe { strlen(src) }, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src as *const c_void, unsafe { strlen(src) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcpy".to_string(), src as usize, unsafe { strlen(src) }, Backtrace::new())));
+        }
+        unsafe {
+            strcpy(dest, src)
+        }
+    }
+
+    #[inline]
+    fn hook_strncpy(&mut self, dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char {
+        extern "C" {
+            fn strncpy(dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char;
+        }
+        if !(self.shadow_check_func.unwrap())(dest as *const c_void, n) {
+            self.report_error(AsanError::BadFuncArgWrite(("strncpy".to_string(), dest as usize, n, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src as *const c_void, n) {
+            self.report_error(AsanError::BadFuncArgRead(("strncpy".to_string(), src as usize, n, Backtrace::new())));
+        }
+        unsafe {
+            strncpy(dest, src, n)
+        }
+    }
+
+    #[inline]
+    fn hook_stpcpy(&mut self, dest: *mut c_char, src: *const c_char) -> *mut c_char {
+        extern "C" {
+            fn stpcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(dest as *const c_void, unsafe { strlen(src) }) {
+            self.report_error(AsanError::BadFuncArgWrite(("stpcpy".to_string(), dest as usize, unsafe { strlen(src) }, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src as *const c_void, unsafe { strlen(src) }) {
+            self.report_error(AsanError::BadFuncArgRead(("stpcpy".to_string(), src as usize, unsafe { strlen(src) }, Backtrace::new())));
+        }
+        unsafe {
+            stpcpy(dest, src)
+        }
+    }
+
+    #[inline]
+    fn hook_strdup(&mut self, s: *const c_char) -> *mut c_char {
+        extern "C" {
+            fn strdup(s: *const c_char) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, unsafe { strlen(s) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strdup".to_string(), s as usize, unsafe { strlen(s) }, Backtrace::new())));
+        }
+        unsafe {
+            strdup(s)
+        }
+    }
+
+    #[inline]
+    fn hook_strlen(&mut self, s: *const c_char) -> usize {
+        extern "C" {
+            fn strlen(s: *const c_char) -> usize;
+        }
+        let size = unsafe { strlen(s) };
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, size) {
+            self.report_error(AsanError::BadFuncArgRead(("strlen".to_string(), s as usize, size, Backtrace::new())));
+        }
+        size
+    }
+
+    #[inline]
+    fn hook_strnlen(&mut self, s: *const c_char, n: usize) -> usize {
+        extern "C" {
+            fn strnlen(s: *const c_char, n: usize) -> usize;
+        }
+        let size = unsafe { strnlen(s, n) };
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, size) {
+            self.report_error(AsanError::BadFuncArgRead(("strnlen".to_string(), s as usize, size, Backtrace::new())));
+        }
+        size
+    }
+
+    #[inline]
+    fn hook_strstr(&mut self, haystack: *const c_char, needle: *const c_char) -> *mut c_char {
+        extern "C" {
+            fn strstr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(haystack as *const c_void, unsafe { strlen(haystack) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strstr".to_string(), haystack as usize, unsafe { strlen(haystack) }, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(needle as *const c_void, unsafe { strlen(needle) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strstr".to_string(), needle as usize, unsafe { strlen(needle) }, Backtrace::new())));
+        }
+        unsafe {
+            strstr(haystack, needle)
+        }
+    }
+
+    #[inline]
+    fn hook_strcasestr(&mut self, haystack: *const c_char, needle: *const c_char) -> *mut c_char {
+        extern "C" {
+            fn strcasestr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(haystack as *const c_void, unsafe { strlen(haystack) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcasestr".to_string(), haystack as usize, unsafe {strlen(haystack)}, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(needle as *const c_void, unsafe { strlen(needle) }) {
+            self.report_error(AsanError::BadFuncArgRead(("strcasestr".to_string(), needle as usize, unsafe {strlen(needle)}, Backtrace::new())));
+        }
+        unsafe {
+            strcasestr(haystack, needle)
+        }
+    }
+
+    #[inline]
+    fn hook_atoi(&mut self, s: *const c_char) -> i32 {
+        extern "C" {
+            fn atoi(s: *const c_char) -> i32;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, unsafe { strlen(s) }) {
+            self.report_error(AsanError::BadFuncArgRead(("atoi".to_string(), s as usize, unsafe {strlen(s)}, Backtrace::new())));
+        }
+        unsafe {
+            atoi(s)
+        }
+    }
+
+    #[inline]
+    fn hook_atol(&mut self, s: *const c_char) -> i32 {
+        extern "C" {
+            fn atol(s: *const c_char) -> i32;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, unsafe { strlen(s) }) {
+            self.report_error(AsanError::BadFuncArgRead(("atol".to_string(), s as usize,unsafe {strlen(s)},  Backtrace::new())));
+        }
+        unsafe {
+            atol(s)
+        }
+    }
+
+    #[inline]
+    fn hook_atoll(&mut self, s: *const c_char) -> i64 {
+        extern "C" {
+            fn atoll(s: *const c_char) -> i64;
+            fn strlen(s: *const c_char) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, unsafe { strlen(s) }) {
+            self.report_error(AsanError::BadFuncArgRead(("atoll".to_string(), s as usize, unsafe {strlen(s)}, Backtrace::new())));
+        }
+        unsafe {
+            atoll(s)
+        }
+    }
+
+    #[inline]
+    fn hook_wcslen(&mut self, s: *const wchar_t) -> usize {
+        extern "C" {
+            fn wcslen(s: *const wchar_t) -> usize;
+        }
+        let size = unsafe { wcslen(s) };
+        if !(self.shadow_check_func.unwrap())(s as *const c_void, (size + 1) * 2) {
+            self.report_error(AsanError::BadFuncArgRead(("wcslen".to_string(), s as usize, (size + 1) * 2, Backtrace::new())));
+        }
+        size
+    }
+
+    #[inline]
+    fn hook_wcscpy(&mut self, dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t {
+        extern "C" {
+            fn wcscpy(dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t;
+            fn wcslen(s: *const wchar_t) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(dest as *const c_void, unsafe { (wcslen(src) + 1) * 2 }) {
+            self.report_error(AsanError::BadFuncArgWrite(("wcscpy".to_string(), dest as usize,(unsafe {wcslen(src)} + 1) * 2, Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(src as *const c_void, unsafe { (wcslen(src) + 1) * 2 }) {
+            self.report_error(AsanError::BadFuncArgRead(("wcscpy".to_string(), src as usize, (unsafe {wcslen(src)} + 1) * 2, Backtrace::new())));
+        }
+        unsafe {
+            wcscpy(dest, src)
+        }
+    }
+
+    #[inline]
+    fn hook_wcscmp(&mut self, s1: *const wchar_t, s2: *const wchar_t) -> i32 {
+        extern "C" {
+            fn wcscmp(s1: *const wchar_t, s2: *const wchar_t) -> i32;
+            fn wcslen(s: *const wchar_t) -> usize;
+        }
+        if !(self.shadow_check_func.unwrap())(s1 as *const c_void, unsafe { (wcslen(s1) + 1) * 2 }) {
+            self.report_error(AsanError::BadFuncArgRead(("wcscmp".to_string(), s1 as usize, (unsafe {wcslen(s1)} +1) * 2,  Backtrace::new())));
+        }
+        if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { (wcslen(s2) + 1) * 2 }) {
+            self.report_error(AsanError::BadFuncArgRead(("wcscmp".to_string(), s2 as usize, (unsafe {wcslen(s2)} + 1) * 2, Backtrace::new())));
+        }
+        unsafe {
+            wcscmp(s1, s2)
+        }
+    }
+
     /// Hook all functions required for ASAN to function, replacing them with our own
     /// implementations.
     fn hook_functions(&mut self, gum: &Gum) {
@@ -942,7 +1485,7 @@ impl AsanRuntime {
                     #[allow(non_snake_case)]
                     unsafe extern "C" fn [<replacement_ $name>]($($param: $param_type),*) -> $return_type {
                         let mut invocation = Interceptor::current_invocation();
-                        let this = &mut *(invocation.replacement_data() as *mut AsanRuntime);
+                        let this = &mut *(invocation.replacement_data().unwrap().0 as *mut AsanRuntime);
                         if this.module_map.as_ref().unwrap().find(invocation.return_addr() as u64).is_some() {
                             this.[<hook_ $name>]($($param),*)
                         } else {
@@ -1061,6 +1604,222 @@ impl AsanRuntime {
             (ptr: *mut c_void, _alignment: usize, _nothrow: *const c_void),
             ()
         );
+
+        // Hook libc functions which may access allocated memory
+        hook_func!(
+            None,
+            write,
+            (fd: i32, buf: *const c_void, count: usize),
+            usize
+        );
+        hook_func!(
+            None,
+            read,
+            (fd: i32, buf: *mut c_void, count: usize),
+            usize
+        );
+        hook_func!(
+            None,
+            fgets,
+            (s: *mut c_void, size: u32, stream: *mut c_void),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            memcmp,
+            (s1: *const c_void, s2: *const c_void, n: usize),
+            i32
+        );
+        hook_func!(
+            None,
+            memcpy,
+            (dest: *mut c_void, src: *const c_void, n: usize),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            mempcpy,
+            (dest: *mut c_void, src: *const c_void, n: usize),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            memmove,
+            (dest: *mut c_void, src: *const c_void, n: usize),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            memset,
+            (s: *mut c_void, c: i32, n: usize),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            memchr,
+            (s: *mut c_void, c: i32, n: usize),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            memrchr,
+            (s: *mut c_void, c: i32, n: usize),
+            *mut c_void
+        );
+        hook_func!(
+            None,
+            memmem,
+            (haystack: *const c_void, haystacklen: usize, needle: *const c_void, needlelen: usize),
+            *mut c_void
+        );
+        #[cfg(not(target_os = "android"))]
+        hook_func!(
+            None,
+            bzero,
+            (s: *mut c_void, n: usize),
+            ()
+        );
+        #[cfg(not(target_os = "android"))]
+        hook_func!(
+            None,
+            explicit_bzero,
+            (s: *mut c_void, n: usize),
+            ()
+        );
+        #[cfg(not(target_os = "android"))]
+        hook_func!(
+            None,
+            bcmp,
+            (s1: *const c_void, s2: *const c_void, n: usize),
+            i32
+        );
+        hook_func!(
+            None,
+            strchr,
+            (s: *mut c_char, c: i32),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strrchr,
+            (s: *mut c_char, c: i32),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strcasecmp,
+            (s1: *const c_char, s2: *const c_char),
+            i32
+        );
+        hook_func!(
+            None,
+            strncasecmp,
+            (s1: *const c_char, s2: *const c_char, n: usize),
+            i32
+        );
+        hook_func!(
+            None,
+            strcat,
+            (dest: *mut c_char, src: *const c_char),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strcmp,
+            (s1: *const c_char, s2: *const c_char),
+            i32
+        );
+        hook_func!(
+            None,
+            strncmp,
+            (s1: *const c_char, s2: *const c_char, n: usize),
+            i32
+        );
+        hook_func!(
+            None,
+            strcpy,
+            (dest: *mut c_char, src: *const c_char),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strncpy,
+            (dest: *mut c_char, src: *const c_char, n: usize),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            stpcpy,
+            (dest: *mut c_char, src: *const c_char),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strdup,
+            (s: *const c_char),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strlen,
+            (s: *const c_char),
+            usize
+        );
+        hook_func!(
+            None,
+            strnlen,
+            (s: *const c_char, n: usize),
+            usize
+        );
+        hook_func!(
+            None,
+            strstr,
+            (haystack: *const c_char, needle: *const c_char),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            strcasestr,
+            (haystack: *const c_char, needle: *const c_char),
+            *mut c_char
+        );
+        hook_func!(
+            None,
+            atoi,
+            (nptr: *const c_char),
+            i32
+        );
+        hook_func!(
+            None,
+            atol,
+            (nptr: *const c_char),
+            i32
+        );
+        hook_func!(
+            None,
+            atoll,
+            (nptr: *const c_char),
+            i64
+        );
+        hook_func!(
+            None,
+            wcslen,
+            (s: *const wchar_t),
+            usize
+        );
+        hook_func!(
+            None,
+            wcscpy,
+            (dest: *mut wchar_t, src: *const wchar_t),
+            *mut wchar_t
+        );
+        hook_func!(
+            None,
+            wcscmp,
+            (s1: *const wchar_t, s2: *const wchar_t),
+            i32
+        );
+
     }
 
     #[allow(clippy::cast_sign_loss)] // for displacement
@@ -1359,6 +2118,47 @@ impl AsanRuntime {
                     }
                 }
             }
+            AsanError::BadFuncArgRead((name, address, size, backtrace)) | AsanError::BadFuncArgWrite((name, address, size, backtrace)) => {
+                writeln!(output, " in call to {}, argument {:#016x}", name, address).unwrap();
+                let invocation = Interceptor::current_invocation();
+                let cpu_context = invocation.cpu_context();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " REGISTERS ").unwrap();
+                for reg in 0..29 {
+                    let val = cpu_context.reg(reg);
+                    if val as usize == address {
+                        output
+                            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+                            .unwrap();
+                    }
+                    write!(
+                        output,
+                        "x{:02}: 0x{:016x} ",
+                        reg, val
+                    )
+                    .unwrap();
+                    output.reset().unwrap();
+                    if reg % 4 == 3 {
+                        writeln!(output).unwrap();
+                    }
+                }
+                write!(output, "sp : 0x{:016x} ", cpu_context.sp()).unwrap();
+                write!(output, "lr : 0x{:016x} ", cpu_context.lr()).unwrap();
+                writeln!(output, "pc : 0x{:016x} ", cpu_context.pc()).unwrap();
+
+                #[allow(clippy::non_ascii_literal)]
+                writeln!(output, "{:━^100}", " SHADOW ").unwrap();
+                let shadow_start = (address >> 3) | (1 << 36) ;
+                writeln!(output, "shadow_start: {:#016x}", shadow_start);
+                let shadow = unsafe { std::slice::from_raw_parts(shadow_start as *const u8, (size / 8) + 1) };
+                writeln!(output, "{:02x?}", shadow);
+
+                backtrace_printer
+                    .print_trace(&backtrace, output)
+                    .unwrap();
+
+            }
             AsanError::DoubleFree((ptr, mut metadata, backtrace)) => {
                 writeln!(output, " of {:?}", ptr).unwrap();
                 output.reset().unwrap();
@@ -1497,6 +2297,115 @@ impl AsanRuntime {
         if !self.options.asan_continue_after_error() {
             panic!("Crashing target!");
         }
+    }
+
+    #[allow(clippy::unused_self)]
+    fn generate_shadow_check_function(&mut self) {
+        let shadow_bit = Allocator::get().shadow_bit as u32;
+        let mut ops = dynasmrt::VecAssembler::<dynasmrt::aarch64::Aarch64Relocation>::new(0);
+        dynasm!(ops
+            ; .arch aarch64
+
+            // calculate the shadow address
+            ; mov x5, #1
+            ; add x5, xzr, x5, lsl #shadow_bit
+            ; add x5, x5, x0, lsr #3
+            ; ubfx x5, x5, #0, #(shadow_bit + 2)
+
+            ; cmp x1, #0
+            ; b.eq >return_success
+            // check if the ptr is not aligned to 8 bytes
+            ; ands x6, x0, #7
+            ; b.eq >no_start_offset
+
+            // we need to test the high bits from the first shadow byte
+            ; ldrh w7, [x5, #0]
+            ; rev16 w7, w7
+            ; rbit w7, w7
+            ; lsr x7, x7, #16
+            ; lsr x7, x7, x6
+
+            ; cmp x1, #8
+            ; b.lt >dont_fill_to_8
+            ; mov x2, #8
+            ; sub x6, x2, x6
+            ; b >check_bits
+            ; dont_fill_to_8:
+            ; mov x6, x1
+            ; check_bits:
+            ; mov x2, #1
+            ; lsl x2, x2, x6
+            ; sub x4, x2, #1
+
+            // if shadow_bits & size_to_test != size_to_test: fail
+            ; and x7, x7, x4
+            ; cmp x7, x4
+            ; b.ne >return_failure
+
+            // size -= size_to_test
+            ; sub x1, x1, x6
+            // shadow_addr += 1 (we consumed the initial byte in the above test)
+            ; add x5, x5, 1
+
+            ; no_start_offset:
+            // num_shadow_bytes = size / 8
+            ; lsr x4, x1, #3
+            ; eor x3, x3, x3
+            ; sub x3, x3, #1
+
+            // if num_shadow_bytes < 8; then goto check_bytes; else check_8_shadow_bytes
+            ; check_8_shadow_bytes:
+            ; cmp x4, #0x8
+            ; b.lt >less_than_8_shadow_bytes_remaining
+            ; ldr x7, [x5], #8
+            ; cmp x7, x3
+            ; b.ne >return_failure
+            ; sub x4, x4, #8
+            ; sub x1, x1, #64
+            ; b <check_8_shadow_bytes
+
+            ; less_than_8_shadow_bytes_remaining:
+            ; cmp x4, #1
+            ; b.lt >check_trailing_bits
+            ; ldrb w7, [x5], #1
+            ; cmp w7, #0xff
+            ; b.ne >return_failure
+            ; sub x4, x4, #1
+            ; sub x1, x1, #8
+            ; b <less_than_8_shadow_bytes_remaining
+
+            ; check_trailing_bits:
+            ; cmp x1, #0x0
+            ; b.eq >return_success
+
+            ; and x4, x1, #7
+            ; mov x2, #1
+            ; lsl x2, x2, x4
+            ; sub x4, x2, #1
+
+            ; ldrh w7, [x5, #0]
+            ; rev16 w7, w7
+            ; rbit w7, w7
+            ; lsr x7, x7, #16
+            ; and x7, x7, x4
+            ; cmp x7, x4
+            ; b.ne >return_failure
+
+            ; return_success:
+            ; mov x0, #1
+            ; b >prologue
+
+            ; return_failure:
+            ; mov x0, #0
+
+
+            ; prologue:
+            ; ret
+        );
+
+        let mut blob = ops.finalize().unwrap();
+        self.shadow_check_func = Some(unsafe { std::mem::transmute(blob.as_ptr()) });
+        self.shadow_check_func_blob = Some(blob.into_boxed_slice());
     }
 
     #[allow(clippy::unused_self)]

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -1378,13 +1378,13 @@ impl AsanRuntime {
 
     /// Hook all functions required for ASAN to function, replacing them with our own
     /// implementations.
+    #[allow(clippy::items_after_statements)]
     fn hook_functions(&mut self, gum: &Gum) {
         let mut interceptor = frida_gum::interceptor::Interceptor::obtain(gum);
 
         macro_rules! hook_func {
             ($lib:expr, $name:ident, ($($param:ident : $param_type:ty),*), $return_type:ty) => {
                 paste::paste! {
-                    #[allow(clippy::items_after_statements)]
                     extern "C" {
                         fn $name($($param: $param_type),*) -> $return_type;
                     }

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -488,7 +488,7 @@ impl AsanRuntime {
             ) -> *mut c_void;
         }
         let res = unsafe { mmap(addr, length, prot, flags, fd, offset) };
-        if res != (-1isize as *mut c_void) {
+        if res != (-1_isize as *mut c_void) {
             self.allocator
                 .map_shadow_for_region(res as usize, res as usize + length, true);
         }

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -1384,6 +1384,7 @@ impl AsanRuntime {
         macro_rules! hook_func {
             ($lib:expr, $name:ident, ($($param:ident : $param_type:ty),*), $return_type:ty) => {
                 paste::paste! {
+                    #[allow(clippy::items_after_statements)]
                     extern "C" {
                         fn $name($($param: $param_type),*) -> $return_type;
                     }

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -19,7 +19,6 @@ use capstone::{
     Capstone, Insn,
 };
 
-use core::cell::RefCell;
 #[cfg(target_arch = "x86_64")]
 use frida_gum::instruction_writer::X86Register;
 #[cfg(target_arch = "aarch64")]
@@ -34,7 +33,7 @@ use frida_gum::{Gum, Module, PageProtection};
 use num_traits::cast::FromPrimitive;
 
 use rangemap::RangeMap;
-use std::{path::PathBuf, rc::Rc};
+use std::path::PathBuf;
 
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -59,6 +59,8 @@ pub trait FridaHelper<'a> {
 
     /// pointer to the frida coverage map
     fn map_ptr(&mut self) -> *mut u8;
+
+    fn ranges(&self) -> &RangeMap<usize, (u16, &str)>;
 }
 
 /// (Default) map size for frida coverage reporting
@@ -123,6 +125,10 @@ impl<'a> FridaHelper<'a> for FridaInstrumentationHelper<'a> {
 
     fn map_ptr(&mut self) -> *mut u8 {
         self.map.as_mut_ptr()
+    }
+
+    fn ranges(&self) -> &RangeMap<usize, (u16, &str)> {
+        &self.ranges
     }
 }
 

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -358,7 +358,10 @@ impl<'a> FridaInstrumentationHelper<'a> {
             });
             helper.transformer = Some(transformer);
             if helper.options().asan_enabled() || helper.options().drcov_enabled() {
-                helper.asan_runtime.borrow_mut().init(modules_to_instrument);
+                helper
+                    .asan_runtime
+                    .borrow_mut()
+                    .init(gum, modules_to_instrument);
             }
         }
         helper

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -361,9 +361,7 @@ impl<'a> FridaInstrumentationHelper<'a> {
             });
             helper.transformer = Some(transformer);
             if helper.options().asan_enabled() || helper.options().drcov_enabled() {
-                helper
-                    .asan_runtime
-                    .init(gum, modules_to_instrument);
+                helper.asan_runtime.init(gum, modules_to_instrument);
             }
         }
         helper

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -3,14 +3,14 @@ The frida executor is a binary-only mode for `LibAFL`.
 It can report coverage and, on supported architecutres, even reports memory access errors.
 */
 
-/// The frida address sanitizer runtime
-pub mod asan_rt;
-/// The `LibAFL` frida helper
-pub mod helper;
 /// The frida-asan allocator
 pub mod alloc;
 /// Handling of ASAN errors
 pub mod asan_errors;
+/// The frida address sanitizer runtime
+pub mod asan_rt;
+/// The `LibAFL` frida helper
+pub mod helper;
 
 // for parsing asan cores
 use libafl::bolts::os::parse_core_bind_arg;

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -7,13 +7,18 @@ It can report coverage and, on supported architecutres, even reports memory acce
 pub mod asan_rt;
 /// The `LibAFL` frida helper
 pub mod helper;
+/// The frida-asan allocator
+pub mod alloc;
+/// Handling of ASAN errors
+pub mod asan_errors;
+
 // for parsing asan cores
 use libafl::bolts::os::parse_core_bind_arg;
 // for getting current core_id
 use core_affinity::get_core_ids;
 
 /// A representation of the various Frida options
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct FridaOptions {
     enable_asan: bool,


### PR DESCRIPTION
This PR implements #72, refactoring `asan_rt` to use Frida's interceptor to hook functions instead of the `gothook` crate.

This should be both more portable and more hermetic.

Currently this requires features in https://github.com/frida/frida-rust/pull/18, which is yet to be merged. Should hopefully be merged in the next couple of days.