### PR TITLE
Make InProcessExecutor use a plain Input instead of bytes

### DIFF
--- a/fuzzers/baby_fuzzer/src/main.rs
+++ b/fuzzers/baby_fuzzer/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use libafl::inputs::{BytesInput, HasTargetBytes};
 use libafl::{
     bolts::{current_nanos, rands::StdRand, tuples::tuple_list},
     corpus::{InMemoryCorpus, OnDiskCorpus, QueueCorpusScheduler},
@@ -14,7 +15,6 @@ use libafl::{
     state::StdState,
     stats::SimpleStats,
 };
-use libafl::inputs::{BytesInput, HasBytesVec};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];
@@ -28,7 +28,8 @@ fn signals_set(idx: usize) {
 pub fn main() {
     // The closure that we want to fuzz
     let mut harness = |input: &BytesInput| {
-        let buf = input.bytes();
+        let target = input.target_bytes();
+        let buf = target.as_slice();
         signals_set(0);
         if !buf.is_empty() && buf[0] == b'a' {
             signals_set(1);

--- a/fuzzers/baby_fuzzer/src/main.rs
+++ b/fuzzers/baby_fuzzer/src/main.rs
@@ -14,6 +14,7 @@ use libafl::{
     state::StdState,
     stats::SimpleStats,
 };
+use libafl::inputs::{BytesInput, HasBytesVec};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];
@@ -26,7 +27,8 @@ fn signals_set(idx: usize) {
 #[allow(clippy::similar_names)]
 pub fn main() {
     // The closure that we want to fuzz
-    let mut harness = |buf: &[u8]| {
+    let mut harness = |input: &BytesInput| {
+        let buf = input.bytes();
         signals_set(0);
         if !buf.is_empty() && buf[0] == b'a' {
             signals_set(1);

--- a/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
@@ -27,6 +27,7 @@ use libafl::{
 use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, CMP_MAP, EDGES_MAP, MAX_EDGES_NUM,
 };
+use libafl::inputs::{BytesInput, HasBytesVec};
 
 const ALLOC_MAP_SIZE: usize = 16 * 1024;
 extern "C" {
@@ -128,7 +129,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness
-    let mut harness = |buf: &[u8]| {
+    let mut harness = |input: &BytesInput| {
+        let buf = input.bytes();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
@@ -15,6 +15,7 @@ use libafl::{
     feedback_or,
     feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
+    inputs::{BytesInput, HasTargetBytes},
     mutators::scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
     observers::StdMapObserver,
@@ -27,7 +28,6 @@ use libafl::{
 use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, CMP_MAP, EDGES_MAP, MAX_EDGES_NUM,
 };
-use libafl::inputs::{BytesInput, HasBytesVec};
 
 const ALLOC_MAP_SIZE: usize = 16 * 1024;
 extern "C" {
@@ -130,7 +130,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |input: &BytesInput| {
-        let buf = input.bytes();
+        let target = input.target_bytes();
+        let buf = target.as_slice();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -26,6 +26,7 @@ use libafl::{
 };
 
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
+use libafl::inputs::{BytesInput, HasBytesVec};
 
 /// The main fn, `no_mangle` as it is a C main
 #[no_mangle]
@@ -126,7 +127,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness
-    let mut harness = |buf: &[u8]| {
+    let mut harness = |input: &BytesInput| {
+        let buf = input.bytes();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -16,6 +16,7 @@ use libafl::{
     feedback_or,
     feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback, TimeFeedback, TimeoutFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
+    inputs::{BytesInput, HasTargetBytes},
     mutators::scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
     observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
@@ -26,7 +27,6 @@ use libafl::{
 };
 
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
-use libafl::inputs::{BytesInput, HasBytesVec};
 
 /// The main fn, `no_mangle` as it is a C main
 #[no_mangle]
@@ -128,7 +128,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |input: &BytesInput| {
-        let buf = input.bytes();
+        let target = input.target_bytes();
+        let buf = target.as_slice();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -24,6 +24,7 @@ use libafl::{
     feedback_or,
     feedbacks::{CrashFeedback, MapFeedbackState, MaxMapFeedback, TimeFeedback, TimeoutFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
+    inputs::{BytesInput, HasTargetBytes},
     mutators::scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
     mutators::token_mutations::Tokens,
     observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
@@ -33,7 +34,6 @@ use libafl::{
 };
 
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
-use libafl::inputs::{BytesInput, HasBytesVec};
 
 /// The main fn, `no_mangle` as it is a C main
 #[no_mangle]
@@ -129,7 +129,8 @@ pub fn main() {
 
         // The wrapped harness function, calling out to the LLVM-style harness
         let mut harness = |input: &BytesInput| {
-            let buf = input.bytes();
+            let target = input.target_bytes();
+            let buf = target.as_slice();
             libfuzzer_test_one_input(buf);
             ExitKind::Ok
         };

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -33,6 +33,7 @@ use libafl::{
 };
 
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
+use libafl::inputs::{BytesInput, HasBytesVec};
 
 /// The main fn, `no_mangle` as it is a C main
 #[no_mangle]
@@ -127,7 +128,8 @@ pub fn main() {
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
         // The wrapped harness function, calling out to the LLVM-style harness
-        let mut harness = |buf: &[u8]| {
+        let mut harness = |input: &BytesInput| {
+            let buf = input.bytes();
             libfuzzer_test_one_input(buf);
             ExitKind::Ok
         };

--- a/fuzzers/libfuzzer_reachability/src/lib.rs
+++ b/fuzzers/libfuzzer_reachability/src/lib.rs
@@ -18,6 +18,7 @@ use libafl::{
     Error,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
+use libafl::inputs::{BytesInput, HasBytesVec};
 
 const TARGET_SIZE: usize = 4;
 
@@ -107,7 +108,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // The wrapped harness function, calling out to the LLVM-style harness
-    let mut harness = |buf: &[u8]| {
+    let mut harness = |input: &BytesInput| {
+        let buf = input.bytes();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/fuzzers/libfuzzer_reachability/src/lib.rs
+++ b/fuzzers/libfuzzer_reachability/src/lib.rs
@@ -10,6 +10,7 @@ use libafl::{
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedbacks::{MapFeedbackState, MaxMapFeedback, ReachabilityFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
+    inputs::{BytesInput, HasTargetBytes},
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     observers::{HitcountsMapObserver, StdMapObserver},
     stages::mutational::StdMutationalStage,
@@ -18,7 +19,6 @@ use libafl::{
     Error,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
-use libafl::inputs::{BytesInput, HasBytesVec};
 
 const TARGET_SIZE: usize = 4;
 
@@ -109,7 +109,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |input: &BytesInput| {
-        let buf = input.bytes();
+        let target = input.target_bytes();
+        let buf = target.as_slice();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -27,6 +27,7 @@ use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, CmpLogObserver, CMPLOG_MAP, EDGES_MAP,
     MAX_EDGES_NUM,
 };
+use libafl::inputs::{BytesInput, HasBytesVec};
 
 pub fn main() {
     // Registry the metadata types used in this fuzzer
@@ -149,7 +150,8 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     }
 
     // Secondary harness due to mut ownership
-    let mut harness = |buf: &[u8]| {
+    let mut harness = |input: &BytesInput| {
+        let buf = input.bytes();
         libfuzzer_test_one_input(buf);
         ExitKind::Ok
     };

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -201,7 +201,7 @@ mod tests {
         let scheduler = RandCorpusScheduler::new();
         let mut fuzzer = StdFuzzer::new(scheduler, (), ());
 
-        let mut harness = |_buf: &[u8]| ExitKind::Ok;
+        let mut harness = |_buf: &BytesInput| ExitKind::Ok;
         let mut executor = InProcessExecutor::new(
             &mut harness,
             tuple_list!(),


### PR DESCRIPTION
This PR alllws the usage of abstract non-binary inputs for the InProcessExecutor. This can be used for ASTs for example.

I hope I found all references, if not I think the CI should fail.