### PR TITLE
new Rand method: choose. fixes #117

### DIFF
--- a/libafl/src/bolts/rands.rs
+++ b/libafl/src/bolts/rands.rs
@@ -49,6 +49,29 @@ pub trait Rand: Debug + Serialize + DeserializeOwned {
         debug_assert!(lower_bound_incl <= upper_bound_incl);
         lower_bound_incl + self.below(upper_bound_incl - lower_bound_incl + 1)
     }
+
+    /// Choose an item at random from the given iterator, sampling uniformly.
+    ///
+    /// Note: the runtime cost is bound by the iterator's [`nth`][`Iterator::nth`] implementation
+    ///  * For `Vec`, slice, array, this is O(1)
+    ///  * For `HashMap`, `HashSet`, this is O(n)
+    fn choose<I, E, T>(&mut self, from: I) -> T
+    where
+        I: IntoIterator<Item = T, IntoIter = E>,
+        E: ExactSizeIterator + Iterator<Item = T>,
+    {
+        // create iterator
+        let mut iter = from.into_iter();
+
+        // make sure there is something to choose from
+        debug_assert!(iter.len() > 0, "choosing from an empty iterator");
+
+        // pick a random, valid index
+        let index = self.below(iter.len() as u64) as usize;
+
+        // return the item chosen
+        iter.nth(index).unwrap()
+    }
 }
 
 /// Has a Rand field, that can be used to get random values

--- a/libafl/src/generators/mod.rs
+++ b/libafl/src/generators/mod.rs
@@ -86,9 +86,7 @@ where
             size = 1;
         }
         let printables = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz \t\n!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".as_bytes();
-        let random_bytes: Vec<u8> = (0..size)
-            .map(|_| printables[rand.below(printables.len() as u64) as usize])
-            .collect();
+        let random_bytes: Vec<u8> = (0..size).map(|_| *rand.choose(printables)).collect();
         Ok(BytesInput::new(random_bytes))
     }
 


### PR DESCRIPTION
The choose method takes an ExactSizeIterator and returns a randomly
chosen item from it. Using this method prevents chosing items with an
incorrect upper_bound on the index.

Various macros help with defining and implementing repetitive mutation
strategies.