### PR TITLE
Improve TimeoutExecutor

### DIFF
--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -112,7 +112,6 @@ where
         #[cfg(windows)]
         {
             // TODO
-            let _ = self.exec_tmout.as_millis();
         }
 
         let ret = self.executor.run_target(fuzzer, state, mgr, input);


### PR DESCRIPTION
Looking back at the TimeoutExecutor(#31), I think we don't need to allocate Timeval or Itimerval struct everytime we call run_targets,
This PR embeds the pre-set Itimerval into TimeoutExecutor struct (for unix only, of course)