### PR TITLE
Fix frida bugs

### DIFF
--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -113,9 +113,6 @@ where
                 libc::raise(libc::SIGABRT);
             }
         }
-        if self.helper.stalker_enabled() {
-            self.stalker.deactivate();
-        }
         self.helper.post_exec(input);
         res
     }

--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -1,5 +1,5 @@
 use hashbrown::HashMap;
-#[cfg(all(feature = "std", any(target_os = "linux", target_os = "android")))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use libafl::bolts::os::walk_self_maps;
 use nix::{
     libc::memset,

--- a/libafl_frida/src/asan_errors.rs
+++ b/libafl_frida/src/asan_errors.rs
@@ -277,12 +277,7 @@ impl AsanErrors {
                         )
                         .unwrap();
                     } else {
-                        writeln!(
-                            output,
-                            " at 0x{:x}",
-                            pc,
-                        )
-                        .unwrap();
+                        writeln!(output, " at 0x{:x}", pc,).unwrap();
                     }
 
                     #[allow(clippy::non_ascii_literal)]

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -121,6 +121,7 @@ impl AsanRuntime {
             .map(|modname| modname.to_str().unwrap())
             .collect();
         self.module_map = Some(ModuleMap::new_from_names(&module_names));
+        #[cfg(target_arch = "aarch64")]
         self.hook_functions(gum);
         //unsafe {
         //let mem = self.allocator.alloc(0xac + 2, 8);
@@ -518,6 +519,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_write(&mut self, fd: i32, buf: *const c_void, count: usize) -> usize {
         extern "C" {
             fn write(fd: i32, buf: *const c_void, count: usize) -> usize;
@@ -540,6 +542,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_read(&mut self, fd: i32, buf: *mut c_void, count: usize) -> usize {
         extern "C" {
             fn read(fd: i32, buf: *mut c_void, count: usize) -> usize;
@@ -562,6 +565,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_fgets(&mut self, s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void {
         extern "C" {
             fn fgets(s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void;
@@ -584,6 +588,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memcmp(&mut self, s1: *const c_void, s2: *const c_void, n: usize) -> i32 {
         extern "C" {
             fn memcmp(s1: *const c_void, s2: *const c_void, n: usize) -> i32;
@@ -620,6 +625,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memcpy(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
         extern "C" {
             fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
@@ -656,6 +662,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_mempcpy(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
         extern "C" {
             fn mempcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
@@ -692,6 +699,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memmove(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
         extern "C" {
             fn memmove(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
@@ -728,6 +736,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memset(&mut self, dest: *mut c_void, c: i32, n: usize) -> *mut c_void {
         extern "C" {
             fn memset(dest: *mut c_void, c: i32, n: usize) -> *mut c_void;
@@ -750,6 +759,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memchr(&mut self, s: *mut c_void, c: i32, n: usize) -> *mut c_void {
         extern "C" {
             fn memchr(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
@@ -772,6 +782,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memrchr(&mut self, s: *mut c_void, c: i32, n: usize) -> *mut c_void {
         extern "C" {
             fn memrchr(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
@@ -794,6 +805,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_memmem(
         &mut self,
         haystack: *const c_void,
@@ -840,7 +852,7 @@ impl AsanRuntime {
         unsafe { memmem(haystack, haystacklen, needle, needlelen) }
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(all(not(target_os = "android"), target_arch = "aarch64"))]
     #[inline]
     fn hook_bzero(&mut self, s: *mut c_void, n: usize) {
         extern "C" {
@@ -863,7 +875,7 @@ impl AsanRuntime {
         unsafe { bzero(s, n) }
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(all(not(target_os = "android"), target_arch = "aarch64"))]
     #[inline]
     fn hook_explicit_bzero(&mut self, s: *mut c_void, n: usize) {
         extern "C" {
@@ -886,7 +898,7 @@ impl AsanRuntime {
         unsafe { explicit_bzero(s, n) }
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(all(not(target_os = "android"), target_arch = "aarch64"))]
     #[inline]
     fn hook_bcmp(&mut self, s1: *const c_void, s2: *const c_void, n: usize) -> i32 {
         extern "C" {
@@ -924,6 +936,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strchr(&mut self, s: *mut c_char, c: i32) -> *mut c_char {
         extern "C" {
             fn strchr(s: *mut c_char, c: i32) -> *mut c_char;
@@ -947,6 +960,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strrchr(&mut self, s: *mut c_char, c: i32) -> *mut c_char {
         extern "C" {
             fn strrchr(s: *mut c_char, c: i32) -> *mut c_char;
@@ -970,6 +984,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strcasecmp(&mut self, s1: *const c_char, s2: *const c_char) -> i32 {
         extern "C" {
             fn strcasecmp(s1: *const c_char, s2: *const c_char) -> i32;
@@ -1007,6 +1022,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strncasecmp(&mut self, s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
         extern "C" {
             fn strncasecmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32;
@@ -1043,6 +1059,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strcat(&mut self, s1: *mut c_char, s2: *const c_char) -> *mut c_char {
         extern "C" {
             fn strcat(s1: *mut c_char, s2: *const c_char) -> *mut c_char;
@@ -1080,6 +1097,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strcmp(&mut self, s1: *const c_char, s2: *const c_char) -> i32 {
         extern "C" {
             fn strcmp(s1: *const c_char, s2: *const c_char) -> i32;
@@ -1117,6 +1135,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strncmp(&mut self, s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
         extern "C" {
             fn strncmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32;
@@ -1153,6 +1172,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strcpy(&mut self, dest: *mut c_char, src: *const c_char) -> *mut c_char {
         extern "C" {
             fn strcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
@@ -1190,6 +1210,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strncpy(&mut self, dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char {
         extern "C" {
             fn strncpy(dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char;
@@ -1226,6 +1247,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_stpcpy(&mut self, dest: *mut c_char, src: *const c_char) -> *mut c_char {
         extern "C" {
             fn stpcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
@@ -1263,6 +1285,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strdup(&mut self, s: *const c_char) -> *mut c_char {
         extern "C" {
             fn strdup(s: *const c_char) -> *mut c_char;
@@ -1286,6 +1309,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strlen(&mut self, s: *const c_char) -> usize {
         extern "C" {
             fn strlen(s: *const c_char) -> usize;
@@ -1309,6 +1333,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strnlen(&mut self, s: *const c_char, n: usize) -> usize {
         extern "C" {
             fn strnlen(s: *const c_char, n: usize) -> usize;
@@ -1332,6 +1357,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strstr(&mut self, haystack: *const c_char, needle: *const c_char) -> *mut c_char {
         extern "C" {
             fn strstr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
@@ -1371,6 +1397,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_strcasestr(&mut self, haystack: *const c_char, needle: *const c_char) -> *mut c_char {
         extern "C" {
             fn strcasestr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
@@ -1410,6 +1437,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_atoi(&mut self, s: *const c_char) -> i32 {
         extern "C" {
             fn atoi(s: *const c_char) -> i32;
@@ -1433,6 +1461,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_atol(&mut self, s: *const c_char) -> i32 {
         extern "C" {
             fn atol(s: *const c_char) -> i32;
@@ -1456,6 +1485,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_atoll(&mut self, s: *const c_char) -> i64 {
         extern "C" {
             fn atoll(s: *const c_char) -> i64;
@@ -1479,6 +1509,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_wcslen(&mut self, s: *const wchar_t) -> usize {
         extern "C" {
             fn wcslen(s: *const wchar_t) -> usize;
@@ -1502,6 +1533,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_wcscpy(&mut self, dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t {
         extern "C" {
             fn wcscpy(dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t;
@@ -1543,6 +1575,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[cfg(target_arch = "aarch64")]
     fn hook_wcscmp(&mut self, s1: *const wchar_t, s2: *const wchar_t) -> i32 {
         extern "C" {
             fn wcscmp(s1: *const wchar_t, s2: *const wchar_t) -> i32;
@@ -1584,6 +1617,7 @@ impl AsanRuntime {
     /// Hook all functions required for ASAN to function, replacing them with our own
     /// implementations.
     #[allow(clippy::items_after_statements)]
+    #[cfg(target_arch = "aarch64")]
     fn hook_functions(&mut self, gum: &Gum) {
         let mut interceptor = frida_gum::interceptor::Interceptor::obtain(gum);
 

--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -328,11 +328,7 @@ impl AsanRuntime {
             let ret = self.allocator.alloc(size, 0x8);
             if ptr != std::ptr::null_mut() && ret != std::ptr::null_mut() {
                 let old_size = self.allocator.get_usable_size(ptr);
-                let copy_size = if size < old_size {
-                    size
-                } else {
-                    old_size
-                };
+                let copy_size = if size < old_size { size } else { old_size };
                 (ptr as *mut u8).copy_to(ret as *mut u8, copy_size);
             }
             self.allocator.release(ptr);
@@ -530,12 +526,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "write".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     buf as usize,
                     count,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { write(fd, buf, count) }
@@ -550,12 +548,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "read".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     buf as usize,
                     count,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { read(fd, buf, count) }
@@ -570,12 +570,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "fgets".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     size as usize,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { fgets(s, size, stream) }
@@ -588,18 +590,30 @@ impl AsanRuntime {
         }
         if !(self.shadow_check_func.unwrap())(s1, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgRead(("memcmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s1 as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgRead((
+                    "memcmp".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s1 as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgRead(("memcmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s2 as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgRead((
+                    "memcmp".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s2 as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memcmp(s1, s2, n) }
@@ -614,24 +628,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "memcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src, n) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "memcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memcpy(dest, src, n) }
@@ -646,24 +664,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "mempcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src, n) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "mempcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { mempcpy(dest, src, n) }
@@ -678,24 +700,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "memmove".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src, n) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "memmove".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memmove(dest, src, n) }
@@ -710,12 +736,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "memset".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memset(dest, c, n) }
@@ -728,10 +756,16 @@ impl AsanRuntime {
         }
         if !(self.shadow_check_func.unwrap())(s, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgRead(("memchr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgRead((
+                    "memchr".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memchr(s, c, n) }
@@ -744,10 +778,16 @@ impl AsanRuntime {
         }
         if !(self.shadow_check_func.unwrap())(s, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgRead(("memrchr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgRead((
+                    "memrchr".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memrchr(s, c, n) }
@@ -773,24 +813,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "memmem".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     haystack as usize,
                     haystacklen,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(needle, needlelen) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "memmem".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     needle as usize,
                     needlelen,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { memmem(haystack, haystacklen, needle, needlelen) }
@@ -804,10 +848,16 @@ impl AsanRuntime {
         }
         if !(self.shadow_check_func.unwrap())(s, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgWrite(("bzero".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgWrite((
+                    "bzero".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { bzero(s, n) }
@@ -823,12 +873,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "explicit_bzero".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { explicit_bzero(s, n) }
@@ -842,18 +894,30 @@ impl AsanRuntime {
         }
         if !(self.shadow_check_func.unwrap())(s1, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgRead(("bcmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s1 as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgRead((
+                    "bcmp".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s1 as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2, n) {
             AsanErrors::get_mut().report_error(
-                AsanError::BadFuncArgRead(("bcmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
-                        s2 as usize, n, Backtrace::new())),
-                Some(&self.instrumented_ranges)
+                AsanError::BadFuncArgRead((
+                    "bcmp".to_string(),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
+                    s2 as usize,
+                    n,
+                    Backtrace::new(),
+                )),
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { bcmp(s1, s2, n) }
@@ -869,12 +933,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strchr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     unsafe { strlen(s) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strchr(s, c) }
@@ -890,12 +956,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strrchr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     unsafe { strlen(s) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strrchr(s, c) }
@@ -911,24 +979,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcasecmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s1 as usize,
                     unsafe { strlen(s1) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { strlen(s2) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcasecmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s2 as usize,
                     unsafe { strlen(s2) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strcasecmp(s1, s2) }
@@ -943,24 +1015,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strncasecmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s1 as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2 as *const c_void, n) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strncasecmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s2 as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strncasecmp(s1, s2, n) }
@@ -976,24 +1052,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcat".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s1 as usize,
                     unsafe { strlen(s1) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { strlen(s2) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcat".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s2 as usize,
                     unsafe { strlen(s2) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strcat(s1, s2) }
@@ -1009,24 +1089,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s1 as usize,
                     unsafe { strlen(s1) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { strlen(s2) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s2 as usize,
                     unsafe { strlen(s2) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strcmp(s1, s2) }
@@ -1041,24 +1125,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strncmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s1 as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2 as *const c_void, n) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strncmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s2 as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strncmp(s1, s2, n) }
@@ -1074,24 +1162,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "strcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     unsafe { strlen(src) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src as *const c_void, unsafe { strlen(src) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     unsafe { strlen(src) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strcpy(dest, src) }
@@ -1106,24 +1198,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "strncpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src as *const c_void, n) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strncpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     n,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strncpy(dest, src, n) }
@@ -1139,24 +1235,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "stpcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     unsafe { strlen(src) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src as *const c_void, unsafe { strlen(src) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "stpcpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     unsafe { strlen(src) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { stpcpy(dest, src) }
@@ -1172,12 +1272,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strdup".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     unsafe { strlen(s) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strdup(s) }
@@ -1193,12 +1295,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strlen".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     size,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         size
@@ -1214,12 +1318,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strnlen".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     size,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         size
@@ -1237,24 +1343,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strstr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     haystack as usize,
                     unsafe { strlen(haystack) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(needle as *const c_void, unsafe { strlen(needle) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strstr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     needle as usize,
                     unsafe { strlen(needle) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strstr(haystack, needle) }
@@ -1272,24 +1382,28 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcasestr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     haystack as usize,
                     unsafe { strlen(haystack) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(needle as *const c_void, unsafe { strlen(needle) }) {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "strcasestr".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     needle as usize,
                     unsafe { strlen(needle) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { strcasestr(haystack, needle) }
@@ -1305,12 +1419,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "atoi".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     unsafe { strlen(s) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { atoi(s) }
@@ -1326,12 +1442,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "atol".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     unsafe { strlen(s) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { atol(s) }
@@ -1347,12 +1465,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "atoll".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     unsafe { strlen(s) },
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { atoll(s) }
@@ -1368,12 +1488,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "wcslen".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s as usize,
                     (size + 1) * 2,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         size
@@ -1391,12 +1513,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgWrite((
                     "wcscpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     dest as usize,
                     (unsafe { wcslen(src) } + 1) * 2,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(src as *const c_void, unsafe {
@@ -1405,12 +1529,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "wcscpy".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     src as usize,
                     (unsafe { wcslen(src) } + 1) * 2,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { wcscpy(dest, src) }
@@ -1427,12 +1553,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "wcscmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s1 as usize,
                     (unsafe { wcslen(s1) } + 1) * 2,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         if !(self.shadow_check_func.unwrap())(s2 as *const c_void, unsafe { (wcslen(s2) + 1) * 2 })
@@ -1440,12 +1568,14 @@ impl AsanRuntime {
             AsanErrors::get_mut().report_error(
                 AsanError::BadFuncArgRead((
                     "wcscmp".to_string(),
-                    self.real_address_for_stalked(Interceptor::current_invocation().cpu_context().pc() as usize),
+                    self.real_address_for_stalked(
+                        Interceptor::current_invocation().cpu_context().pc() as usize,
+                    ),
                     s2 as usize,
                     (unsafe { wcslen(s2) } + 1) * 2,
                     Backtrace::new(),
                 )),
-                Some(&self.instrumented_ranges)
+                Some(&self.instrumented_ranges),
             );
         }
         unsafe { wcscmp(s1, s2) }

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -304,6 +304,7 @@ impl<'a> FridaInstrumentationHelper<'a> {
                 for instruction in basic_block {
                     let instr = instruction.instr();
                     let address = instr.address();
+                    //println!("block @ {:x} transformed to {:x}", address, output.writer().pc());
                     //println!("address: {:x} contains: {:?}", address, helper.ranges.contains_key(&(address as usize)));
                     if helper.ranges.contains_key(&(address as usize)) {
                         if first {
@@ -314,13 +315,9 @@ impl<'a> FridaInstrumentationHelper<'a> {
                             }
                             if helper.options().drcov_enabled() {
                                 instruction.put_callout(|context| {
-                                    let real_address = match helper
+                                    let real_address = helper
                                         .asan_runtime
-                                        .real_address_for_stalked(pc(&context))
-                                    {
-                                        Some(address) => *address,
-                                        None => pc(&context),
-                                    };
+                                        .real_address_for_stalked(pc(&context));
                                     //let (range, (id, name)) = helper.ranges.get_key_value(&real_address).unwrap();
                                     //println!("{}:0x{:016x}", name, real_address - range.start);
                                     helper

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -315,9 +315,8 @@ impl<'a> FridaInstrumentationHelper<'a> {
                             }
                             if helper.options().drcov_enabled() {
                                 instruction.put_callout(|context| {
-                                    let real_address = helper
-                                        .asan_runtime
-                                        .real_address_for_stalked(pc(&context));
+                                    let real_address =
+                                        helper.asan_runtime.real_address_for_stalked(pc(&context));
                                     //let (range, (id, name)) = helper.ranges.get_key_value(&real_address).unwrap();
                                     //println!("{}:0x{:016x}", name, real_address - range.start);
                                     helper


### PR DESCRIPTION
Fix the following bugs:
- `posix_memalign`/`memalign` hooks had incorrect signatures, resulting in ASAN false-positives
- `realloc` hook did not deal with the case that the `realloc` shrinks the allocation
- when checking the `ModuleMap` to see whether a function should be hooked or not, we did not translate addresses from stalked addresses to real addresses
- somewhere in the merge, the `cfg` attributes on `walk_proc_maps` and `find_mapping_for_path` broke.
- there was an extra call to `stalker.deactivate` resulting from a bad merge.