### PR TITLE
Timeout forkserver

### DIFF
--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -274,7 +274,7 @@ impl Forkserver {
                 return Err(Error::File(io::Error::new(
                     ErrorKind::BrokenPipe,
                     "Read pipe end was already closed",
-                )))
+                )));
             }
         };
         let mut readfds = FdSet::new();

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -350,6 +350,13 @@ where
                 "Unable to request new process from fork server (OOM?)".to_string(),
             ));
         }
+
+        if pid <= 0 {
+            return Err(Error::Forkserver(
+                "Fork server is misbehaving (OOM?)".to_string(),
+            ));
+        }
+
         self.executor
             .forkserver_mut()
             .set_child_pid(Pid::from_raw(pid));
@@ -510,6 +517,8 @@ where
                 "Fork server is misbehaving (OOM?)".to_string(),
             ));
         }
+
+        self.forkserver.set_child_pid(Pid::from_raw(pid));
 
         let (_, status) = self.forkserver.read_st()?;
 

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -289,14 +289,12 @@ impl Forkserver {
             &mut copy,
         )?;
         if sret > 0 {
-            match self.st_pipe.read_exact(&mut buf) {
-                Ok(_) => (),
-                Err(_) => {
-                    return Err(Error::Forkserver(
-                        "Unable to communicate with fork server (OOM?)".to_string(),
-                    ));
-                }
+            if let Err(_) = self.st_pipe.read_exact(&mut buf) {
+                return Err(Error::Forkserver(
+                    "Unable to communicate with fork server (OOM?)".to_string(),
+                ));
             }
+
             let val: i32 = i32::from_ne_bytes(buf);
             Ok(Some(val))
         } else {

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -362,11 +362,17 @@ where
             .forkserver_mut()
             .set_child_pid(Pid::from_raw(pid));
 
-        if let Some((_, status)) = self
+        if let Some((recv_status_len, status)) = self
             .executor
             .forkserver_mut()
             .read_st_timed(&mut self.timeout)?
         {
+            if recv_status_len != 4 {
+                return Err(Error::Forkserver(
+                    "Unable to communicate with fork server (OOM?)".to_string(),
+                ));
+            }
+
             self.executor.forkserver_mut().set_status(status);
             if libc::WIFSIGNALED(self.executor.forkserver().status()) {
                 exit_kind = ExitKind::Crash;

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -272,7 +272,7 @@ impl Forkserver {
         let mut readfds = FdSet::new();
         let mut copy = *timeout;
         readfds.insert(st_read);
-        // We'll pass timeout.clone() not timeout, because select updates timeout to indicate how much time was left. See select(2)
+        // We'll pass a copied timeout to keep the original timeout intact, because select updates timeout to indicate how much time was left. See select(2)
         let sret = select(
             Some(readfds.highest().unwrap() + 1),
             &mut readfds,
@@ -300,6 +300,7 @@ pub trait HasForkserver {
     fn out_file_mut(&mut self) -> &mut OutFile;
 }
 
+/// The timeout forkserver executor that wraps around the standard forkserver executor and sets a timeout before each run.
 pub struct TimeoutForkserverExecutor<E> {
     executor: E,
     timeout: TimeVal,

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -8,7 +8,7 @@ pub use timeout::TimeoutExecutor;
 #[cfg(all(feature = "std", unix))]
 pub mod forkserver;
 #[cfg(all(feature = "std", unix))]
-pub use forkserver::{Forkserver, ForkserverExecutor, OutFile};
+pub use forkserver::{Forkserver, ForkserverExecutor, OutFile, TimeoutForkserverExecutor};
 
 pub mod combined;
 pub use combined::CombinedExecutor;

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -36,7 +36,7 @@ extern "C" {
 #[cfg(unix)]
 const ITIMER_REAL: c_int = 0;
 
-/// The timeout excutor is a wrapper that set a timeout before each run
+/// The timeout excutor is a wrapper that sets a timeout before each run
 pub struct TimeoutExecutor<E> {
     executor: E,
     #[cfg(unix)]


### PR DESCRIPTION
#82 #111 
I've made the TimeoutForkserverExecutor that wraps around the normal ForkserverExecutor and can check timeout also. It can be used similarly as the TimeoutExecutor, (just pass the Executor and the Duration to call the constructor).
