### PR TITLE
TimeoutForkserverExecutor fix

### DIFF
--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -388,7 +388,7 @@ where
             self.executor.forkserver_mut().set_last_run_timed_out(1);
 
             // We need to kill the child in case he has timed out, or we can't get the correct pid in the next call to self.executor.forkserver_mut().read_st()?
-            kill(self.executor.forkserver().child_pid(), Signal::SIGKILL)?;
+            kill(self.executor.forkserver().child_pid(), Signal::SIGKILL).unwrap();
             let (recv_status_len, _) = self.executor.forkserver_mut().read_st()?;
             if recv_status_len != 4 {
                 return Err(Error::Forkserver(

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -388,7 +388,7 @@ where
             self.executor.forkserver_mut().set_last_run_timed_out(1);
 
             // We need to kill the child in case he has timed out, or we can't get the correct pid in the next call to self.executor.forkserver_mut().read_st()?
-            kill(self.executor.forkserver().child_pid(), Signal::SIGKILL).unwrap();
+            let _ = kill(self.executor.forkserver().child_pid(), Signal::SIGKILL);
             let (recv_status_len, _) = self.executor.forkserver_mut().read_st()?;
             if recv_status_len != 4 {
                 return Err(Error::Forkserver(


### PR DESCRIPTION
Sorry for making a very small PR.

The call to kill would sometimes fail and return  `Unknown("Sys(ESRCH)")` if the child process has already exited before the call to the kill from the parent, so I modified it to call unwrap instead of `?`.