### PR TITLE
Don't panic on time subtraction failure

### DIFF
--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -90,7 +90,7 @@ impl<EM, I, S, Z> HasExecHooks<EM, I, S, Z> for TimeObserver {
         _mgr: &mut EM,
         _input: &I,
     ) -> Result<(), Error> {
-        self.last_runtime = Some(current_time() - self.start_time);
+        self.last_runtime = current_time().checked_sub(self.start_time);
         Ok(())
     }
 }


### PR DESCRIPTION
On some machines the system clock can be faulty and `start_time` maybe
actually be after the end time. This causes a panic, instead gracefully
just put a None time in `self.last_runtime`

See POC here https://github.com/bitterbit/rust-docker-timetravel-error
