### PR TITLE
check each feature in CI and fix introspection on no_std

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
       run: cargo build --verbose
     # cargo-hack tests/checks each crate in the workspace
     - name: Run tests
-      run: cargo hack test
+      run: cargo hack test --all-features
     # cargo-hack's --feature-powerset would be nice here but libafl has a too many knobs
     - name: Check each feature
       run: cargo hack check --each-feature

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,18 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Default Build
+    - name: Install cargo-hack
+      run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - name: Run a normal build
       run: cargo build --verbose
-    - name: Default Test
-      run: cargo test --verbose
-    - name: Build all features
-      run: cd libafl && cargo build --all-features --verbose
-    - name: Test all features
-      run: cd libafl && cargo test --all-features --verbose
-    - name: Build no_std
-      run: cd libafl && cargo build --no-default-features --verbose
-    - name: Test no_std
-      run: cd libafl && cargo test --no-default-features --verbose
+    # cargo-hack tests/checks each crate in the workspace
+    - name: Run tests
+      run: cargo hack test
+    # cargo-hack's --feature-powerset would be nice here but libafl has a too many knobs
+    - name: Check each feature
+      run: cargo hack check --each-feature
     - name: Build examples
       run: cargo build --examples --verbose
     - uses: actions/checkout@v2

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -37,7 +37,7 @@ harness = false
 
 [features]
 default = ["std", "anymap_debug", "derive", "llmp_compression"]
-std = [] # print, env, launcher ... support
+std = ["serde_json"] # print, env, launcher ... support
 anymap_debug = ["serde_json"] # uses serde_json to Debug the anymap trait. Disable for smaller footprint.
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
 llmp_bind_public = [] # If set, llmp will bind to 0.0.0.0, allowing cross-device communication. Binds to localhost by default.

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -13,6 +13,8 @@ use crate::{inputs::Input, observers::ObserversTuple, stats::UserStats, Error};
 
 #[cfg(feature = "introspection")]
 use crate::stats::ClientPerfStats;
+#[cfg(feature = "introspection")]
+use alloc::boxed::Box;
 
 /// The log event severity
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]

--- a/libafl/src/fuzzer.rs
+++ b/libafl/src/fuzzer.rs
@@ -17,6 +17,8 @@ use crate::{
 
 #[cfg(feature = "introspection")]
 use crate::stats::PerfFeature;
+#[cfg(feature = "introspection")]
+use alloc::boxed::Box;
 
 use alloc::string::ToString;
 use core::{marker::PhantomData, time::Duration};


### PR DESCRIPTION
This uses [cargo-hack's](https://github.com/taiki-e/cargo-hack) `--each-feature` to run `cargo check` for every feature on each crate in the workspace. This should only add a few seconds of build time.
`cargo-hack` can also check every combination with `--feature-powerset` but that doesn't seem viable with 9 features :slightly_smiling_face: 