### PR TITLE
fix introspection for multiple mutational stages

### DIFF
--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -141,7 +141,12 @@ where
         manager: &mut EM,
         corpus_idx: usize,
     ) -> Result<(), Error> {
-        self.perform_mutational(fuzzer, executor, state, manager, corpus_idx)
+        let ret = self.perform_mutational(fuzzer, executor, state, manager, corpus_idx);
+
+        #[cfg(feature = "introspection")]
+        state.introspection_stats_mut().finish_stage();
+
+        ret
     }
 }
 


### PR DESCRIPTION
When using the introspection feature, all statistics appear under Stage 0 instead of being displayed by separately for each stage.
This happens because no one ever calls `finish_stage()`   