### PR TITLE
Implemented rand::Rng for libafl::Rand as feature flag

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -40,8 +40,9 @@ default = ["std", "anymap_debug", "derive", "llmp_compression"]
 std = ["serde_json"] # print, env, launcher ... support
 anymap_debug = ["serde_json"] # uses serde_json to Debug the anymap trait. Disable for smaller footprint.
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
+rand_trait = ["rand_core"] # If set, libafl's rand implementations will implement `rand::Rng`
 llmp_bind_public = [] # If set, llmp will bind to 0.0.0.0, allowing cross-device communication. Binds to localhost by default.
-llmp_compression = [] # llmp compression using GZip
+llmp_compression = ["miniz_oxide"] # llmp compression using GZip
 llmp_debug = ["backtrace"] # Enables debug output for LLMP
 llmp_small_maps = [] # reduces initial map size for llmp
 introspection = [] # Include performance statistics of the fuzzing pipeline
@@ -63,12 +64,14 @@ postcard = { version = "0.5.1", features = ["alloc"] } # no_std compatible serde
 static_assertions = "1.1.0"
 ctor = "0.1.20"
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] } # an easy way to debug print SerdeAnyMap
-miniz_oxide = "0.4.4"
+miniz_oxide = { version = "0.4.4", optional = true}
 core_affinity = { version = "0.5", git = "https://github.com/s1341/core_affinity_rs" }
-num_enum = "0.5.1"
+num_enum = "0.5.1" # compression/decomrpession lib
 hostname = "^0.3" # Is there really no gethostname in the stdlib?
-typed-builder = "0.9.0"
-ahash ="0.7" 
+typed-builder = "0.9.0" # Implement the builder pattern at compiletime
+ahash ="0.7" # The hash function already used in hashbrown
+rand = { version = "0.8.1", optional = true } #
+rand_core = { version = "0.6.2", optional = true } # This dependency allows us to export our RomuRand as rand::Rng.
 
 [target.'cfg(target_os = "android")'.dependencies]
 backtrace = { version = "0.3", optional = true, default-features = false, features = ["std", "libbacktrace"] } # for llmp_debug

--- a/libafl/src/bolts/rands.rs
+++ b/libafl/src/bolts/rands.rs
@@ -113,7 +113,7 @@ pub trait RandomSeed: Rand + Default {
 }
 
 // helper macro to impl RandomSeed
-macro_rules! impl_randomseed {
+macro_rules! impl_random {
     ($rand: ty) => {
         #[cfg(feature = "std")]
         impl RandomSeed for $rand {
@@ -144,11 +144,11 @@ macro_rules! impl_randomseed {
     };
 }
 
-impl_randomseed!(Xoshiro256StarRand);
-impl_randomseed!(XorShift64Rand);
-impl_randomseed!(Lehmer64Rand);
-impl_randomseed!(RomuTrioRand);
-impl_randomseed!(RomuDuoJrRand);
+impl_random!(Xoshiro256StarRand);
+impl_random!(XorShift64Rand);
+impl_random!(Lehmer64Rand);
+impl_random!(RomuTrioRand);
+impl_random!(RomuDuoJrRand);
 
 /// XXH3 Based, hopefully speedy, rnd implementation
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/libafl/src/bolts/rands.rs
+++ b/libafl/src/bolts/rands.rs
@@ -126,15 +126,15 @@ macro_rules! impl_randomseed {
         #[cfg(feature = "rand_trait")]
         impl RngCore for $rand {
             fn next_u32(&mut self) -> u32 {
-                self::next() as u32
+                self.next() as u32
             }
 
             fn next_u64(&mut self) -> u64 {
-                self::next()
+                self.next()
             }
 
             fn fill_bytes(&mut self, dest: &mut [u8]) {
-                fill_bytes_via_next(&mut self, dest)
+                fill_bytes_via_next(self, dest)
             }
 
             fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -205,9 +205,10 @@ impl Forkserver {
         {
             Ok(_) => {}
             Err(err) => {
-                return Err(Error::Forkserver(
-                    format!("Could not spawn the forkserver: {:#?}", err).into(),
-                ));
+                return Err(Error::Forkserver(format!(
+                    "Could not spawn forkserver: {:#?}",
+                    err
+                )));
             }
         };
 

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -133,6 +133,7 @@ where
     Z: Evaluator<E, EM, I, S>,
 {
     #[inline]
+    #[allow(clippy::let_and_return)]
     fn perform(
         &mut self,
         fuzzer: &mut Z,


### PR DESCRIPTION
This PR optionally adds implements `Rng` (or rather, `RngCore`) for all of our Rand implementations.
With this, users can optionally use `rand::Rng` to fill buffers conveniently. This also makes it easy to use microsoft Lain for input generation, without having to fall back to slow randomness.