### PR TITLE
Fix TimeoutForkserverExecutor blocking on testcase timeout

### DIFF
--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -353,6 +353,9 @@ where
             .executor
             .forkserver_mut()
             .write_ctl(last_run_timed_out)?;
+
+        self.executor.forkserver_mut().set_last_run_timed_out(0);
+
         if send_len != 4 {
             return Err(Error::Forkserver(
                 "Unable to request new process from fork server (OOM?)".to_string(),


### PR DESCRIPTION
Maybe I'm misunderstanding, so if this is the case no worries just let me know. 

If a testcase times out when run by `TimeoutForkserverExecutor`, it will send a kill signal to the `child_pid` and mark `self.executor.forkserver().last_run_timed_out()` to a non zero value. Then, all sequential calls to `run_target` will send a non zero value on the CTL pipe. 

I think this is a problem as we should send a non-zero value only once. If not, we will hit `waitpid(child_pid...)` more than once, which by the second time will block. 

_The relevant code in afl_forkserver inside qemu_
```c
while (1) {
    // forkserver reading the CTL pipe
    if (read(FORKSRV_FD, &was_killed, 4) != 4) exit(2);

    if (child_stopped && was_killed) {
      child_stopped = 0;
      if (waitpid(child_pid, &status, 0) < 0) exit(8);

    }
    // ...
} 

```