### PR TITLE
Add client_id to LauncherClientFnRef

### DIFF
--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -294,7 +294,7 @@ unsafe fn fuzz(
     AshmemService::start().expect("Failed to start Ashmem service");
     let shmem_provider = StdShMemProvider::new()?;
 
-    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr| {
+    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr, _| {
         // The restarting state will spawn the same process again as child, then restarted it each time it crashes.
 
         let lib = libloading::Library::new(module_name).unwrap();

--- a/fuzzers/generic_inmemory/src/lib.rs
+++ b/fuzzers/generic_inmemory/src/lib.rs
@@ -84,7 +84,7 @@ pub fn main() {
 
     let stats = MultiStats::new(|s| println!("{}", s));
 
-    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr| {
+    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr, _| {
         // Create an observation channel using the coverage map
         let edges = unsafe { &mut EDGES_MAP[0..MAX_EDGES_NUM] };
         let edges_observer = HitcountsMapObserver::new(StdMapObserver::new("edges", edges));

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -60,7 +60,7 @@ pub fn main() {
 
     let stats = MultiStats::new(|s| println!("{}", s));
 
-    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut restarting_mgr| {
+    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut restarting_mgr, _| {
         let corpus_dirs = &[PathBuf::from("./corpus")];
         let objective_dir = PathBuf::from("./crashes");
 


### PR DESCRIPTION
This provides an id to the client_run. I need this to use the value as a seed for my random number generator. That way the whole fuzzer becomes determinisitic.