### PR TITLE
Added mgr_id to EventManager

### DIFF
--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -25,7 +25,10 @@ use crate::{
         llmp::{self, Flags, LlmpClientDescription, LlmpSender, Tag},
         shmem::ShMemProvider,
     },
-    events::{BrokerEventResult, Event, EventFirer, EventManager, EventProcessor, EventRestarter},
+    events::{
+        BrokerEventResult, Event, EventFirer, EventManager, EventManagerId, EventProcessor,
+        EventRestarter,
+    },
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
     inputs::Input,
@@ -502,6 +505,12 @@ where
     OT: ObserversTuple<I, S>,
     Z: ExecutionProcessor<I, OT, S> + EvaluatorObservers<I, OT, S>, //CE: CustomEvent<I>,
 {
+    /// Gets the id assigned to this sender.
+    fn mgr_id(&self) -> EventManagerId {
+        EventManagerId {
+            id: self.llmp.sender.id as usize,
+        }
+    }
 }
 
 /// Serialize the current state and corpus during an executiont to bytes.

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -13,6 +13,20 @@ use crate::{
     executors::ExitKind, inputs::Input, observers::ObserversTuple, stats::UserStats, Error,
 };
 
+/// A per-fuzzer unique ID, usually starting with `0` and increasing
+/// by `1` in multiprocessed `EventManager`s, such as [`self::llmp::LlmpEventManager`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct EventManagerId {
+    /// The id
+    pub id: usize,
+}
+
+impl Default for EventManagerId {
+    fn default() -> Self {
+        Self { id: 0 }
+    }
+}
+
 #[cfg(feature = "introspection")]
 use crate::stats::ClientPerfStats;
 #[cfg(feature = "introspection")]
@@ -240,12 +254,18 @@ pub trait EventProcessor<E, I, S, Z> {
 }
 
 /// [`EventManager`] is the main communications hub.
-/// For the "normal" multi-processed mode, you may want to look into `RestartingEventManager`
+/// For the "normal" multi-processed mode, you may want to look into [`RestartingEventManager`]
 pub trait EventManager<E, I, S, Z>:
     EventFirer<I, S> + EventProcessor<E, I, S, Z> + EventRestarter<S>
 where
     I: Input,
 {
+    /// The id of this `0` for
+    fn mgr_id(&self) -> EventManagerId {
+        EventManagerId {
+            ..EventManagerId::default()
+        }
+    }
 }
 
 /// An eventmgr for tests, and as placeholder if you really don't need an event manager.


### PR DESCRIPTION
This PR should make it easy to identify which client is currently running, and to enable and sdisable features because of it.