### PR TITLE
Branch = "main" in Cargo.toml

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -53,7 +53,7 @@ path = "./examples/llmp_test/main.rs"
 required-features = ["std"]
 
 [dependencies]
-tuple_list = { version = "0.1.2", git = "https://github.com/domenukk/tuple_list" }
+tuple_list = { version = "0.1.2", git = "https://github.com/domenukk/tuple_list", branch = "main" }
 hashbrown =  { version = "0.9", features = ["serde", "ahash-compile-time-rng"], default-features=false } # A faster hashmap, nostd compatible
 num = { version = "0.4.0", default-features = false }
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] } # xxh3 hashing for rust


### PR DESCRIPTION
Without setting branch = "main", `cargo build` gives me this error
```
toka@desktop:~/LibAFL$ cargo build --release
    Updating git repository `https://github.com/domenukk/tuple_list`
error: failed to get `tuple_list` as a dependency of package `libafl v0.5.0 (/home/toka/LibAFL/libafl)`

Caused by:
  failed to load source for dependency `tuple_list`

Caused by:
  Unable to update https://github.com/domenukk/tuple_list

Caused by:
  failed to find branch `master`

Caused by:
  cannot locate remote-tracking branch 'origin/master'; class=Reference (4); code=NotFound (-3)
```