### PR TITLE
Reload corpus size after restart (addresses #210)

### DIFF
--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -34,7 +34,7 @@ use libafl::{
         token_mutations::I2SRandReplace,
         tokens_mutations, Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{StdMapObserver, TimeObserver},
     stages::{StdMutationalStage, TracingStage},
     state::{HasCorpus, HasMetadata, StdState},
     stats::SimpleStats,

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -8,28 +8,32 @@ use core::{
 };
 #[cfg(feature = "std")]
 use serde::{de::DeserializeOwned, Serialize};
+#[cfg(feature = "std")]
 use std::convert::TryInto;
+
+use crate::{
+    bolts::llmp,
+    events::{
+        BrokerEventResult, Event, EventFirer, EventManager, EventManagerId, EventProcessor,
+        EventRestarter, HasEventManagerId,
+    },
+    inputs::Input,
+    stats::Stats,
+    Error,
+};
 
 #[cfg(all(feature = "std", windows))]
 use crate::bolts::os::startable_self;
 #[cfg(all(feature = "std", unix))]
 use crate::bolts::os::{fork, ForkResult};
 #[cfg(feature = "std")]
-use crate::bolts::{
-    llmp::{LlmpReceiver, LlmpSender},
-    shmem::ShMemProvider,
-};
 use crate::{
-    bolts::llmp,
-    corpus::Corpus,
-    events::{
-        BrokerEventResult, Event, EventFirer, EventManager, EventManagerId, EventProcessor,
-        EventRestarter, HasEventManagerId,
+    bolts::{
+        llmp::{LlmpReceiver, LlmpSender},
+        shmem::ShMemProvider,
     },
-    inputs::Input,
+    corpus::Corpus,
     state::{HasCorpus, HasSolutions},
-    stats::Stats,
-    Error,
 };
 
 /// The llmp connection from the actual fuzzer to the process supervising it

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -42,9 +42,8 @@ pub use fuzzer::*;
 use alloc::string::String;
 use core::fmt;
 
-use std::num::TryFromIntError;
 #[cfg(feature = "std")]
-use std::{env::VarError, io, num::ParseIntError, string::FromUtf8Error};
+use std::{env::VarError, io, num::ParseIntError, num::TryFromIntError, string::FromUtf8Error};
 
 #[cfg(all(unix, feature = "std"))]
 use nix;
@@ -160,6 +159,7 @@ impl From<ParseIntError> for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<TryFromIntError> for Error {
     fn from(err: TryFromIntError) -> Self {
         Self::IllegalState(format!("Expected conversion failed: {:?}", err))

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -42,6 +42,7 @@ pub use fuzzer::*;
 use alloc::string::String;
 use core::fmt;
 
+use std::num::TryFromIntError;
 #[cfg(feature = "std")]
 use std::{env::VarError, io, num::ParseIntError, string::FromUtf8Error};
 
@@ -156,6 +157,12 @@ impl From<VarError> for Error {
 impl From<ParseIntError> for Error {
     fn from(err: ParseIntError) -> Self {
         Self::Unknown(format!("Failed to parse Int: {:?}", err))
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(err: TryFromIntError) -> Self {
+        Self::IllegalState(format!("Expected conversion failed: {:?}", err))
     }
 }
 


### PR DESCRIPTION
This PR loads the corpus size stats after crash/timeout.
It does not reload the exec counter, though, as there is no place during fuzzing where we would have access to this information. We'd need some dirty hackery for that, I think. Probably not worth it(?)