### PR TITLE
StateRestorer.reset() removes old tmpfile

### DIFF
--- a/libafl/src/bolts/staterestore.rs
+++ b/libafl/src/bolts/staterestore.rs
@@ -27,7 +27,6 @@ struct StateShMemContent {
 
 impl StateShMemContent {
     /// Gets the (tmp-)filename, if the contents are stored on disk.
-    #[must_use]
     pub fn tmpfile(&self, shmem_size: usize) -> Result<Option<PathBuf>, Error> {
         Ok(if self.is_disk {
             let bytes = unsafe {
@@ -41,7 +40,6 @@ impl StateShMemContent {
     }
 
     /// Get a length that's safe to deref from this map, or error.
-    #[must_use]
     pub fn buf_len_checked(&self, shmem_size: usize) -> Result<usize, Error> {
         let buf_len = unsafe { read_volatile(&self.buf_len) };
         if size_of::<StateShMemContent>() + buf_len > shmem_size {

--- a/libafl/src/bolts/staterestore.rs
+++ b/libafl/src/bolts/staterestore.rs
@@ -8,12 +8,49 @@ use std::{
     env::temp_dir,
     fs::{self, File},
     io::{Read, Write},
+    path::PathBuf,
+    ptr::read_volatile,
 };
 
 use crate::{
     bolts::shmem::{ShMem, ShMemProvider},
     Error,
 };
+
+/// The struct stored on the shared map, containing either the data, or the filename to read contents from.
+#[repr(C)]
+struct StateShMemContent {
+    is_disk: bool,
+    buf_len: usize,
+    buf: [u8; 0],
+}
+
+impl StateShMemContent {
+    /// Gets the (tmp-)filename, if the contents are stored on disk.
+    #[must_use]
+    pub fn tmpfile(&self, shmem_size: usize) -> Result<Option<PathBuf>, Error> {
+        Ok(if self.is_disk {
+            let bytes = unsafe {
+                slice::from_raw_parts(self.buf.as_ptr(), self.buf_len_checked(shmem_size)?)
+            };
+            let filename = postcard::from_bytes::<String>(bytes)?;
+            Some(temp_dir().join(&filename))
+        } else {
+            None
+        })
+    }
+
+    /// Get a length that's safe to deref from this map, or error.
+    #[must_use]
+    pub fn buf_len_checked(&self, shmem_size: usize) -> Result<usize, Error> {
+        let buf_len = unsafe { read_volatile(&self.buf_len) };
+        if size_of::<StateShMemContent>() + buf_len > shmem_size {
+            Err(Error::IllegalState(format!("Stored buf_len is larger than the shared map! Shared data corrupted? Expected {} bytes max, but got {} (buf_len {})", shmem_size, size_of::<StateShMemContent>() + buf_len, buf_len)))
+        } else {
+            Ok(buf_len)
+        }
+    }
+}
 
 /// A [`StateRestorer`] saves and restores bytes to a shared map.
 /// If the state gets larger than the preallocated [`ShMem`] shared map,
@@ -28,17 +65,15 @@ where
     phantom: PhantomData<*const SP>,
 }
 
-#[repr(C)]
-struct StateShMemContent {
-    is_disk: bool,
-    buf_len: usize,
-    buf: [u8; 0],
-}
-
 impl<SP> StateRestorer<SP>
 where
     SP: ShMemProvider,
 {
+    /// Get the map size backing this [`StateRestorer`].
+    pub fn mapsize(&self) -> usize {
+        self.shmem.len()
+    }
+
     /// Writes this [`StateRestorer`] to env variable, to be restored later
     pub fn write_to_env(&self, env_name: &str) -> Result<(), Error> {
         self.shmem.write_to_env(env_name)
@@ -134,16 +169,11 @@ where
 
     /// Reset this [`StateRestorer`] to an empty state.
     pub fn reset(&mut self) {
+        let mapsize = self.mapsize();
         let content_mut = self.content_mut();
-        if content_mut.is_disk {
-            let bytes =
-                unsafe { slice::from_raw_parts(content_mut.buf.as_ptr(), content_mut.buf_len) };
-
-            // Remove tmpfile
-            if let Ok(filename) = postcard::from_bytes::<String>(bytes) {
-                let tmpfile = temp_dir().join(&filename);
-                let _ = fs::remove_file(tmpfile);
-            }
+        if let Ok(Some(tmpfile)) = content_mut.tmpfile(mapsize) {
+            // Remove tmpfile and ignore result
+            drop(fs::remove_file(tmpfile));
         }
         content_mut.is_disk = false;
         content_mut.buf_len = 0;
@@ -182,7 +212,7 @@ where
         let bytes = unsafe {
             slice::from_raw_parts(
                 state_shmem_content.buf.as_ptr(),
-                state_shmem_content.buf_len,
+                state_shmem_content.buf_len_checked(self.mapsize())?,
             )
         };
         let mut state = bytes;
@@ -209,12 +239,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::slice;
-    use std::env::temp_dir;
 
-    use crate::bolts::shmem::{ShMemProvider, StdShMemProvider};
-
-    use super::StateRestorer;
+    use crate::bolts::{
+        shmem::{ShMemProvider, StdShMemProvider},
+        staterestore::StateRestorer,
+    };
 
     #[test]
     fn test_state_restore() {
@@ -254,14 +283,10 @@ mod tests {
 
         // Check if file removal works.
         let state_shmem_content = state_restorer.content();
-        let bytes = unsafe {
-            slice::from_raw_parts(
-                state_shmem_content.buf.as_ptr(),
-                state_shmem_content.buf_len,
-            )
-        };
-        let filename: String = postcard::from_bytes(bytes).unwrap();
-        let tmpfile = temp_dir().join(&filename);
+        let tmpfile = state_shmem_content
+            .tmpfile(state_restorer.mapsize())
+            .unwrap()
+            .unwrap();
         assert!(tmpfile.exists());
 
         state_restorer.reset();


### PR DESCRIPTION
Previously, the fuzzer would fill up the tmp folder after crashes/restarts. This PR prunes them on `.reset()`