### PR TITLE
Address Dockerfile issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,7 @@ AFLplusplus
 # Ignore common dummy and logfiles
 *.log
 a
+
+# ignore files from concolic tests
+symcc_build
+symcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,8 @@ RUN touch libafl_qemu/src/lib.rs
 COPY libafl_qemu/src libafl_qemu/src
 RUN touch libafl_frida/src/lib.rs
 COPY libafl_concolic/symcc_libafl libafl_concolic/symcc_libafl
+COPY libafl_concolic/symcc_runtime libafl_concolic/symcc_runtime
+COPY libafl_concolic/test libafl_concolic/test
 RUN cargo build && cargo build --release
 
 # Copy fuzzers over


### PR DESCRIPTION
Copy crates and scripts from `libafl_concolic` folder to docker image.

Tested this by running the smoke test in the produced image.