### PR TITLE
shmem service speedup env

### DIFF
--- a/libafl/src/bolts/os/unix_shmem_server.rs
+++ b/libafl/src/bolts/os/unix_shmem_server.rs
@@ -347,7 +347,6 @@ where
     /// Returns [`ShMemService::Failed`] on error.
     #[must_use]
     pub fn start() -> Self {
-
         // Already running, no need to spawn additional thraeds anymore.
         if env::var(AFL_SHMEM_SERVICE_STARTED).is_ok() {
             return Self::Failed {


### PR DESCRIPTION
This PR adds an internal env variable that tells subsequent calls to `ShMemProvider` to not try to spawn a `ShMemService`.
This should keep thread and mutex use to a minimum.