### PR TITLE
symcc_runtime dependency fix for next libafl version & bump to 0.6.0

### DIFF
--- a/fuzzers/baby_fuzzer/Cargo.toml
+++ b/fuzzers/baby_fuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baby_fuzzer"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/baby_no_std/Cargo.toml
+++ b/fuzzers/baby_no_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baby_no_std"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/forkserver_simple/Cargo.toml
+++ b/fuzzers/forkserver_simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forkserver_simple"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["tokatoka <tokazerkje@outlook.com>"]
 edition = "2018"
 

--- a/fuzzers/frida_libpng/Cargo.toml
+++ b/fuzzers/frida_libpng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frida_libpng"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -24,8 +24,8 @@ which = "4.1"
 libafl = { path = "../../libafl/", features = [ "std", "llmp_compression", "llmp_bind_public" ] } #,  "llmp_small_maps", "llmp_debug"]}
 capstone = "0.8.0"
 frida-gum = { version = "0.5.2", features = [ "auto-download", "backtrace", "event-sink", "invocation-listener"] }
-libafl_frida = { path = "../../libafl_frida", version = "0.5.0", features = ["cmplog"] }
-libafl_targets = { path = "../../libafl_targets", version = "0.5.0" , features = ["sancov_cmplog"] }
+libafl_frida = { path = "../../libafl_frida", version = "0.6.0", features = ["cmplog"] }
+libafl_targets = { path = "../../libafl_targets", version = "0.6.0" , features = ["sancov_cmplog"] }
 lazy_static = "1.4.0"
 libc = "0.2"
 libloading = "0.7.0"

--- a/fuzzers/fuzzbench/Cargo.toml
+++ b/fuzzers/fuzzbench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzzbench"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/fuzzbench_qemu/Cargo.toml
+++ b/fuzzers/fuzzbench_qemu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzzbench_qemu"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/generic_inmemory/Cargo.toml
+++ b/fuzzers/generic_inmemory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generic_inmemory"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/libfuzzer_libmozjpeg/Cargo.toml
+++ b/fuzzers/libfuzzer_libmozjpeg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_libmozjpeg"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/libfuzzer_libpng/Cargo.toml
+++ b/fuzzers/libfuzzer_libpng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_libpng"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/libfuzzer_libpng_launcher/Cargo.toml
+++ b/fuzzers/libfuzzer_libpng_launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_libpng_launcher"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/libfuzzer_reachability/Cargo.toml
+++ b/fuzzers/libfuzzer_reachability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_reachability"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 

--- a/fuzzers/libfuzzer_stb_image/Cargo.toml
+++ b/fuzzers/libfuzzer_stb_image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_stb_image"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/Cargo.toml
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_stb_image_concolic"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>", "Julius Hohnerlein"]
 edition = "2018"
 build = "build.rs"

--- a/fuzzers/libfuzzer_stb_image_sugar/Cargo.toml
+++ b/fuzzers/libfuzzer_stb_image_sugar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libfuzzer_stb_image"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libafl"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 description = "Slot your own fuzzers together and extend their features using Rust"
 documentation = "https://docs.rs/libafl"
@@ -69,7 +69,7 @@ num_enum = { version = "0.5.1", default-features = false }
 typed-builder = "0.9.0" # Implement the builder pattern at compiletime
 ahash = { version = "0.7", default-features=false, features=["compile-time-rng"] } # The hash function already used in hashbrown
 
-libafl_derive = { version = "0.5.0", optional = true, path = "../libafl_derive" }
+libafl_derive = { version = "0.6.0", optional = true, path = "../libafl_derive" }
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] } # an easy way to debug print SerdeAnyMap
 miniz_oxide = { version = "0.4.4", optional = true}
 core_affinity = { version = "0.5", git = "https://github.com/s1341/core_affinity_rs", optional = true }

--- a/libafl_cc/Cargo.toml
+++ b/libafl_cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libafl_cc"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
 description = "Commodity library to wrap compilers and link LibAFL"
 documentation = "https://docs.rs/libafl_cc"

--- a/libafl_concolic/symcc_runtime/Cargo.toml
+++ b/libafl_concolic/symcc_runtime/Cargo.toml
@@ -21,7 +21,7 @@ no-cpp-runtime = []
 unchecked_unwrap = "3"
 ctor = "0.1"
 libc = "0.2"
-libafl = {path = "../../libafl", version="0.5"}
+libafl = {path = "../../libafl", version="0.6"}
 
 [build-dependencies]
 cmake = "0.1"

--- a/libafl_derive/Cargo.toml
+++ b/libafl_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libafl_derive"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
 description = "Derive proc-macro crate for LibAFL"
 documentation = "https://docs.rs/libafl_derive"

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libafl_frida"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["s1341 <github@shmarya.net>"]
 description = "Frida backend library for LibAFL"
 documentation = "https://docs.rs/libafl_frida"
@@ -19,8 +19,8 @@ cmplog = []
 cc = { version = "1.0", features = ["parallel"] }
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.5.0", features = ["std", "libafl_derive"] }
-libafl_targets = { path = "../libafl_targets", version = "0.5.0", features = ["sancov_cmplog"] }
+libafl = { path = "../libafl", version = "0.6.0", features = ["std", "libafl_derive"] }
+libafl_targets = { path = "../libafl_targets", version = "0.6.0", features = ["sancov_cmplog"] }
 nix = "0.20.0"
 libc = "0.2.92"
 hashbrown = "0.11"

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libafl_qemu"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
 description = "QEMU user backend library for LibAFL"
 documentation = "https://docs.rs/libafl_qemu"
@@ -14,8 +14,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.5.0" }
-libafl_targets = { path = "../libafl_targets", version = "0.5.0" }
+libafl = { path = "../libafl", version = "0.6.0" }
+libafl_targets = { path = "../libafl_targets", version = "0.6.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib
 hashbrown =  { version = "0.9", features = ["serde", "ahash-compile-time-rng"] } # A faster hashmap, nostd compatible
 num = "0.4"

--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "libafl_sugar"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.5.0" }
-libafl_targets = { path = "../libafl_targets", version = "0.5.0" }
-libafl_qemu = { path = "../libafl_qemu", version = "0.5.0" }
+libafl = { path = "../libafl", version = "0.6.0" }
+libafl_targets = { path = "../libafl_targets", version = "0.6.0" }
+libafl_qemu = { path = "../libafl_qemu", version = "0.6.0" }
 typed-builder = "0.9.0" # Implement the builder pattern at compiletime

--- a/libafl_targets/Cargo.toml
+++ b/libafl_targets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libafl_targets"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>"]
 description = "Common code for target instrumentation that can be used combined with LibAFL"
 documentation = "https://docs.rs/libafl_targets"
@@ -27,6 +27,6 @@ cc = { version = "1.0", features = ["parallel"] }
 
 [dependencies]
 rangemap = "0.1.10"
-libafl = { path = "../libafl", version = "0.5.0", features = [] }
+libafl = { path = "../libafl", version = "0.6.0", features = [] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib
 # serde-big-array = "0.3.2"


### PR DESCRIPTION
this changes the dependency version of libafl to the next released version (0.6) to prepare for the release of the next version of libafl (0.6.0)