### PR TITLE
Symcc runtime docsrs fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libafl_concolic/symcc_runtime/symcc"]
+	path = libafl_concolic/symcc_runtime/symcc
+	url = ../symcc.git

--- a/libafl_concolic/symcc_runtime/Cargo.toml
+++ b/libafl_concolic/symcc_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symcc_runtime"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Julius Hohnerlein <julihoh@users.noreply.github.com>", "Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 description = "Build Concolic Tracing tools based on SymCC in Rust"

--- a/libafl_concolic/symcc_runtime/build.rs
+++ b/libafl_concolic/symcc_runtime/build.rs
@@ -66,7 +66,9 @@ fn main() {
         write_symcc_runtime_bindings_file(&out_path, &cpp_bindings);
         write_cpp_function_export_macro(&out_path, &cpp_bindings);
 
-        if std::env::var("CARGO_FEATURE_NO_CPP_RUNTIME").is_err() {
+        if std::env::var("CARGO_FEATURE_NO_CPP_RUNTIME").is_err()
+            && std::env::var("DOCS_RS").is_err()
+        {
             let rename_header_path = out_path.join("rename.h");
             write_symcc_rename_header(&rename_header_path, &cpp_bindings);
             build_and_link_symcc_runtime(&symcc_src_path, &rename_header_path);
@@ -105,11 +107,15 @@ fn write_cpp_function_export_macro(out_path: &Path, cpp_bindings: &bindgen::Bind
 }
 
 fn checkout_symcc(out_path: &Path) -> PathBuf {
-    let repo_dir = out_path.join("libafl_symcc_src");
-    if !repo_dir.exists() {
-        clone_symcc(&repo_dir);
+    if std::env::var("DOCS_RS").is_ok() {
+        "symcc".into()
+    } else {
+        let repo_dir = out_path.join("libafl_symcc_src");
+        if !repo_dir.exists() {
+            clone_symcc(&repo_dir);
+        }
+        repo_dir
     }
-    repo_dir
 }
 
 fn write_rust_runtime_macro_file(out_path: &Path, symcc_src_path: &Path) {


### PR DESCRIPTION
symcc_runtime doesn't build on docs.rs, because the worker there does not have access to the network and the build.rs script attempts to download symcc from git.

the workaround to this problem is to include symcc as a submodule which will be included in the packaged crate file, so no network access is necessary to build the symcc_runtime on docs.rs.

This does add a submodule to the repository.