### PR TITLE
Use external, custom time function for no_std environments

### DIFF
--- a/fuzzers/baby_no_std/src/main.rs
+++ b/fuzzers/baby_no_std/src/main.rs
@@ -46,6 +46,14 @@ fn signals_set(idx: usize) {
     unsafe { SIGNALS[idx] = 1 };
 }
 
+/// Provide custom time in no_std environment
+/// Use a time provider of your choice
+#[no_mangle]
+pub extern "C" fn external_current_millis() -> u64 {
+    // TODO: use "real" time here
+    1000
+}
+
 #[allow(clippy::similar_names)]
 pub fn main() {
     // The closure that we want to fuzz

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -34,13 +34,22 @@ pub fn current_time() -> time::Duration {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
 }
 
+/// external defined function in case of no_std
+/// 
+/// Define your own `external_current_millis()` function via `extern "C"`
+/// which is linked into the binary and called from here.
+#[cfg(not(feature = "std"))]
+extern "C" {
+    #[no_mangle]
+    fn external_current_millis() -> u64;
+}
+
 /// Current time (fixed fallback for no_std)
 #[cfg(not(feature = "std"))]
 #[inline]
 pub fn current_time() -> time::Duration {
-    // We may not have a rt clock available.
-    // TODO: Make it somehow plugin-able
-    time::Duration::from_millis(1)
+    let millis = unsafe { external_current_millis() };
+    time::Duration::from_millis(millis)
 }
 
 /// Gets current nanoseconds since [`UNIX_EPOCH`]

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -35,7 +35,7 @@ pub fn current_time() -> time::Duration {
 }
 
 /// external defined function in case of no_std
-/// 
+///
 /// Define your own `external_current_millis()` function via `extern "C"`
 /// which is linked into the binary and called from here.
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Added the possibility to create a custom current_millis function for no_std environments (e.g. custom OS, microcontroller, etc.)