### PR TITLE
Fix _LLMP_BIND_ADDR for Windows

### DIFF
--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -137,11 +137,17 @@ const _LLMP_B2B_BLOCK_TIME: Duration = Duration::from_millis(3_000);
 
 /// If broker2broker is enabled, bind to public IP
 #[cfg(feature = "llmp_bind_public")]
-const _LLMP_BIND_ADDR: &str = "::";
+const _LLMP_BIND_ADDR_V6: &str = "::";
+
+#[cfg(feature = "llmp_bind_public")]
+const _LLMP_BIND_ADDR: &str = "0.0.0.0";
 
 /// If broker2broker is disabled, bind to localhost
 #[cfg(not(feature = "llmp_bind_public"))]
 const _LLMP_BIND_ADDR: &str = "localhost";
+
+#[cfg(not(feature = "llmp_bind_public"))]
+const _LLMP_BIND_ADDR_V6: &str = "localhost";
 
 /// LLMP Client connects to this address
 const _LLMP_CONNECT_ADDR: &str = "localhost";
@@ -344,7 +350,10 @@ fn msg_offset_from_env(env_name: &str) -> Result<Option<u64>, Error> {
 /// Will set `SO_REUSEPORT` on unix.
 #[cfg(feature = "std")]
 fn tcp_bind(port: u16) -> Result<TcpListener, Error> {
-    let listener = TcpListener::bind((_LLMP_BIND_ADDR, port))?;
+    let listener = match TcpListener::bind((_LLMP_BIND_ADDR_V6, port)) {
+        Ok(l) => l,
+        Err(_) => TcpListener::bind((_LLMP_BIND_ADDR, port))?,
+    };
 
     #[cfg(unix)]
     socket::setsockopt(listener.as_raw_fd(), ReusePort, &true)?;

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -137,7 +137,7 @@ const _LLMP_B2B_BLOCK_TIME: Duration = Duration::from_millis(3_000);
 
 /// If broker2broker is enabled, bind to public IP
 #[cfg(feature = "llmp_bind_public")]
-const _LLMP_BIND_ADDR: &str = "0.0.0.0";
+const _LLMP_BIND_ADDR: &str = "::1";
 /// If broker2broker is disabled, bind to localhost
 #[cfg(not(feature = "llmp_bind_public"))]
 const _LLMP_BIND_ADDR: &str = "127.0.0.1";

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -137,17 +137,11 @@ const _LLMP_B2B_BLOCK_TIME: Duration = Duration::from_millis(3_000);
 
 /// If broker2broker is enabled, bind to public IP
 #[cfg(feature = "llmp_bind_public")]
-const _LLMP_BIND_ADDR_V6: &str = "::";
-
-#[cfg(feature = "llmp_bind_public")]
 const _LLMP_BIND_ADDR: &str = "0.0.0.0";
 
 /// If broker2broker is disabled, bind to localhost
 #[cfg(not(feature = "llmp_bind_public"))]
-const _LLMP_BIND_ADDR: &str = "localhost";
-
-#[cfg(not(feature = "llmp_bind_public"))]
-const _LLMP_BIND_ADDR_V6: &str = "localhost";
+const _LLMP_BIND_ADDR: &str = "127.0.0.1";
 
 /// LLMP Client connects to this address
 const _LLMP_CONNECT_ADDR: &str = "localhost";
@@ -350,10 +344,7 @@ fn msg_offset_from_env(env_name: &str) -> Result<Option<u64>, Error> {
 /// Will set `SO_REUSEPORT` on unix.
 #[cfg(feature = "std")]
 fn tcp_bind(port: u16) -> Result<TcpListener, Error> {
-    let listener = match TcpListener::bind((_LLMP_BIND_ADDR_V6, port)) {
-        Ok(l) => l,
-        Err(_) => TcpListener::bind((_LLMP_BIND_ADDR, port))?,
-    };
+    let listener = TcpListener::bind((_LLMP_BIND_ADDR, port))?;
 
     #[cfg(unix)]
     socket::setsockopt(listener.as_raw_fd(), ReusePort, &true)?;

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -137,10 +137,14 @@ const _LLMP_B2B_BLOCK_TIME: Duration = Duration::from_millis(3_000);
 
 /// If broker2broker is enabled, bind to public IP
 #[cfg(feature = "llmp_bind_public")]
-const _LLMP_BIND_ADDR: &str = "::1";
+const _LLMP_BIND_ADDR: &str = "::";
+
 /// If broker2broker is disabled, bind to localhost
 #[cfg(not(feature = "llmp_bind_public"))]
-const _LLMP_BIND_ADDR: &str = "127.0.0.1";
+const _LLMP_BIND_ADDR: &str = "localhost";
+
+/// LLMP Client connects to this address
+const _LLMP_CONNECT_ADDR: &str = "localhost";
 
 /// An env var of this value indicates that the set value was a NULL PTR
 const _NULL_ENV_STR: &str = "_NULL";
@@ -2577,14 +2581,14 @@ where
     #[cfg(feature = "std")]
     /// Create a [`LlmpClient`], getting the ID from a given port
     pub fn create_attach_to_tcp(mut shmem_provider: SP, port: u16) -> Result<Self, Error> {
-        let mut stream = match TcpStream::connect(format!("{}:{}", _LLMP_BIND_ADDR, port)) {
+        let mut stream = match TcpStream::connect((_LLMP_CONNECT_ADDR, port)) {
             Ok(stream) => stream,
             Err(e) => {
                 match e.kind() {
                     std::io::ErrorKind::ConnectionRefused => {
                         //connection refused. loop till the broker is up
                         loop {
-                            match TcpStream::connect(format!("{}:{}", _LLMP_BIND_ADDR, port)) {
+                            match TcpStream::connect((_LLMP_CONNECT_ADDR, port)) {
                                 Ok(stream) => break stream,
                                 Err(_) => {
                                     dbg!("Connection Refused.. Retrying");


### PR DESCRIPTION
#284 
with "0.0.0.0" windows gives this error `The requested address is not valid in its context. (os error 10049)` when broker2broker is used.