### PR TITLE
Add core_id to launcher `run_client` closure signature

### DIFF
--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -294,7 +294,7 @@ unsafe fn fuzz(
 
     let shmem_provider = StdShMemProvider::new()?;
 
-    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr| {
+    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr, _core_id| {
         // The restarting state will spawn the same process again as child, then restarted it each time it crashes.
 
         let lib = libloading::Library::new(module_name).unwrap();

--- a/fuzzers/generic_inmemory/src/lib.rs
+++ b/fuzzers/generic_inmemory/src/lib.rs
@@ -83,7 +83,7 @@ pub fn libafl_main() {
 
     let stats = MultiStats::new(|s| println!("{}", s));
 
-    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr| {
+    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr, _core_id| {
         // Create an observation channel using the coverage map
         let edges = unsafe { &mut EDGES_MAP[0..MAX_EDGES_NUM] };
         let edges_observer = HitcountsMapObserver::new(StdMapObserver::new("edges", edges));

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -60,7 +60,7 @@ pub fn libafl_main() {
 
     let stats = MultiStats::new(|s| println!("{}", s));
 
-    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut restarting_mgr| {
+    let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut restarting_mgr, _core_id| {
         let corpus_dirs = &[PathBuf::from("./corpus")];
         let objective_dir = PathBuf::from("./crashes");
 

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -33,8 +33,11 @@ use typed_builder::TypedBuilder;
 
 /// The Launcher client callback type reference
 #[cfg(feature = "std")]
-pub type LauncherClientFnRef<'a, I, OT, S, SP> =
-    &'a mut dyn FnMut(Option<S>, LlmpRestartingEventManager<I, OT, S, SP>, usize) -> Result<(), Error>;
+pub type LauncherClientFnRef<'a, I, OT, S, SP> = &'a mut dyn FnMut(
+    Option<S>,
+    LlmpRestartingEventManager<I, OT, S, SP>,
+    usize,
+) -> Result<(), Error>;
 
 const _AFL_LAUNCHER_CLIENT: &str = "AFL_LAUNCHER_CLIENT";
 /// Provides a Launcher, which can be used to launch a fuzzing run on a specified list of cores

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -103,7 +103,7 @@ where
             .map(|filename| File::create(filename).unwrap());
 
         // Spawn clients
-        for (id, bind_to) in core_ids.iter().enumerate().take(num_cores) {
+        for (index, (id, bind_to)) in core_ids.iter().enumerate().take(num_cores).enumerate() {
             if self.cores.iter().any(|&x| x == id) {
                 self.shmem_provider.pre_fork()?;
                 match unsafe { fork() }? {
@@ -118,7 +118,7 @@ where
                         self.shmem_provider.post_fork(true)?;
 
                         #[cfg(feature = "std")]
-                        std::thread::sleep(std::time::Duration::from_secs((id + 1) as u64));
+                        std::thread::sleep(std::time::Duration::from_secs((index + 1) as u64));
 
                         #[cfg(feature = "std")]
                         if file.is_some() {

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -34,7 +34,7 @@ use typed_builder::TypedBuilder;
 /// The Launcher client callback type reference
 #[cfg(feature = "std")]
 pub type LauncherClientFnRef<'a, I, OT, S, SP> =
-    &'a mut dyn FnMut(Option<S>, LlmpRestartingEventManager<I, OT, S, SP>) -> Result<(), Error>;
+    &'a mut dyn FnMut(Option<S>, LlmpRestartingEventManager<I, OT, S, SP>, usize) -> Result<(), Error>;
 
 const _AFL_LAUNCHER_CLIENT: &str = "AFL_LAUNCHER_CLIENT";
 /// Provides a Launcher, which can be used to launch a fuzzing run on a specified list of cores
@@ -133,7 +133,7 @@ where
                             .build()
                             .launch()?;
 
-                        (self.run_client)(state, mgr)?;
+                        (self.run_client)(state, mgr, bind_to.id)?;
                         break;
                     }
                 };
@@ -200,7 +200,7 @@ where
                     .build()
                     .launch()?;
 
-                (self.run_client)(state, mgr)?;
+                (self.run_client)(state, mgr, core_conf.parse()?.id)?;
 
                 unreachable!("Fuzzer client code should never get here!");
             }

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -203,7 +203,8 @@ where
                     .build()
                     .launch()?;
 
-                (self.run_client)(state, mgr, core_conf.parse()?.id)?;
+                let core_id: CoreId = core_conf.parse()?;
+                (self.run_client)(state, mgr, core_id.id)?;
 
                 unreachable!("Fuzzer client code should never get here!");
             }

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -203,8 +203,7 @@ where
                     .build()
                     .launch()?;
 
-                let core_id: CoreId = core_conf.parse()?;
-                (self.run_client)(state, mgr, core_id.id)?;
+                (self.run_client)(state, mgr, core_conf.parse()?)?;
 
                 unreachable!("Fuzzer client code should never get here!");
             }

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -63,7 +63,7 @@ where
     /// clusters.
     #[builder(default = None, setter(strip_option))]
     remote_broker_addr: Option<SocketAddr>,
-    /// Bytes harness    
+    /// Bytes harness
     #[builder(setter(strip_option))]
     harness: Option<H>,
 }
@@ -99,7 +99,7 @@ where
 
         let stats = MultiStats::new(|s| println!("{}", s));
 
-        let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr| {
+        let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr, _core_id| {
             // Create an observation channel using the coverage map
             let edges = unsafe { &mut EDGES_MAP[0..MAX_EDGES_NUM] };
             let edges_observer = HitcountsMapObserver::new(StdMapObserver::new("edges", edges));

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -63,7 +63,7 @@ where
     /// clusters.
     #[builder(default = None, setter(strip_option))]
     remote_broker_addr: Option<SocketAddr>,
-    /// Bytes harness    
+    /// Bytes harness
     #[builder(setter(strip_option))]
     harness: Option<H>,
     // Syscall hook
@@ -113,7 +113,7 @@ where
 
         let stats = MultiStats::new(|s| println!("{}", s));
 
-        let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr| {
+        let mut run_client = |state: Option<StdState<_, _, _, _, _>>, mut mgr, _core_id| {
             // Create an observation channel using the coverage map
             let edges = unsafe { &mut hooks::EDGES_MAP };
             let edges_counter = unsafe { &mut hooks::MAX_EDGES_NUM };


### PR DESCRIPTION
This allows you to do per-core configuration such as setting a core-id-suffixed corpus directory.