### PR TITLE
Sleep for `index` rather than `id`

### DIFF
--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -103,7 +103,7 @@ where
             .map(|filename| File::create(filename).unwrap());
 
         // Spawn clients
-        for (id, bind_to) in core_ids.iter().enumerate().take(num_cores) {
+        for (index, (id, bind_to)) in core_ids.iter().enumerate().take(num_cores).enumerate() {
             if self.cores.iter().any(|&x| x == id) {
                 self.shmem_provider.pre_fork()?;
                 match unsafe { fork() }? {
@@ -118,7 +118,7 @@ where
                         self.shmem_provider.post_fork(true)?;
 
                         #[cfg(feature = "std")]
-                        std::thread::sleep(std::time::Duration::from_secs((id + 1) as u64));
+                        std::thread::sleep(std::time::Duration::from_secs((index + 1) as u64));
 
                         #[cfg(feature = "std")]
                         if file.is_some() {


### PR DESCRIPTION
When launching, sleep for **index** seconds between cores instead of for **id**. This makes life much better when launching on e.g. cores 20-30, as you don't need to wait 20 seconds before fuzzing commences. 