### PR TITLE
armv7 support: add ucontext struct definition

### DIFF
--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -84,9 +84,9 @@ use std::{
 use backtrace::Backtrace;
 
 #[cfg(unix)]
-use crate::bolts::os::unix_signals::ucontext_t;
-#[cfg(unix)]
-use crate::bolts::os::unix_signals::{setup_signal_handler, siginfo_t, Handler, Signal};
+use crate::bolts::os::unix_signals::{
+    setup_signal_handler, siginfo_t, ucontext_t, Handler, Signal,
+};
 use crate::{
     bolts::shmem::{ShMem, ShMemDescription, ShMemId, ShMemProvider},
     Error,

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -90,7 +90,7 @@ use crate::{
     Error,
 };
 #[cfg(unix)]
-use libc::ucontext_t;
+use crate::bolts::os::unix_signals::ucontext_t;
 #[cfg(all(unix, feature = "std"))]
 use nix::sys::socket::{self, sockopt::ReusePort};
 #[cfg(all(unix, feature = "std"))]

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -84,13 +84,13 @@ use std::{
 use backtrace::Backtrace;
 
 #[cfg(unix)]
+use crate::bolts::os::unix_signals::ucontext_t;
+#[cfg(unix)]
 use crate::bolts::os::unix_signals::{setup_signal_handler, siginfo_t, Handler, Signal};
 use crate::{
     bolts::shmem::{ShMem, ShMemDescription, ShMemId, ShMemProvider},
     Error,
 };
-#[cfg(unix)]
-use crate::bolts::os::unix_signals::ucontext_t;
 #[cfg(all(unix, feature = "std"))]
 use nix::sys::socket::{self, sockopt::ReusePort};
 #[cfg(all(unix, feature = "std"))]

--- a/libafl/src/bolts/os/unix_signals.rs
+++ b/libafl/src/bolts/os/unix_signals.rs
@@ -13,10 +13,10 @@ use core::{
 use std::ffi::CString;
 
 /// armv7 `libc` does not feature a `uncontext_t` implementation
-#[cfg(target_arch = "arm")] 
+#[cfg(target_arch = "arm")]
 pub use libc::c_ulong;
 
-#[cfg(target_arch = "arm")] 
+#[cfg(target_arch = "arm")]
 pub struct mcontext_t {
     pub trap_no: c_ulong,
     pub error_code: c_ulong,
@@ -54,9 +54,9 @@ pub struct ucontext_t {
 pub use libc::ucontext_t;
 
 use libc::{
-    c_int, malloc, sigaction, sigaltstack, sigemptyset, stack_t, SA_NODEFER,
-    SA_ONSTACK, SA_SIGINFO, SIGABRT, SIGALRM, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL,
-    SIGPIPE, SIGQUIT, SIGSEGV, SIGTERM, SIGTRAP, SIGUSR2,
+    c_int, malloc, sigaction, sigaltstack, sigemptyset, stack_t, SA_NODEFER, SA_ONSTACK,
+    SA_SIGINFO, SIGABRT, SIGALRM, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE,
+    SIGQUIT, SIGSEGV, SIGTERM, SIGTRAP, SIGUSR2,
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 

--- a/libafl/src/bolts/os/unix_signals.rs
+++ b/libafl/src/bolts/os/unix_signals.rs
@@ -12,8 +12,49 @@ use core::{
 #[cfg(feature = "std")]
 use std::ffi::CString;
 
+/// armv7 `libc` does not feature a `uncontext_t` implementation
+#[cfg(target_arch = "arm")] 
+pub use libc::c_ulong;
+
+#[cfg(target_arch = "arm")] 
+pub struct mcontext_t {
+    pub trap_no: c_ulong,
+    pub error_code: c_ulong,
+    pub oldmask: c_ulong,
+    pub arm_r0: c_ulong,
+    pub arm_r1: c_ulong,
+    pub arm_r2: c_ulong,
+    pub arm_r3: c_ulong,
+    pub arm_r4: c_ulong,
+    pub arm_r5: c_ulong,
+    pub arm_r6: c_ulong,
+    pub arm_r7: c_ulong,
+    pub arm_r8: c_ulong,
+    pub arm_r9: c_ulong,
+    pub arm_r10: c_ulong,
+    pub arm_fp: c_ulong,
+    pub arm_ip: c_ulong,
+    pub arm_sp: c_ulong,
+    pub arm_lr: c_ulong,
+    pub arm_pc: c_ulong,
+    pub arm_cpsr: c_ulong,
+    pub fault_address: c_ulong,
+}
+
+#[cfg(target_arch = "arm")]
+pub struct ucontext_t {
+    pub uc_flags: u32,
+    pub uc_link: *mut ucontext_t,
+    pub uc_stack: stack_t,
+    pub uc_mcontext: mcontext_t,
+    pub uc_sigmask: nix::sys::signal::SigSet,
+}
+
+#[cfg(not(target_arch = "arm"))]
+pub use libc::ucontext_t;
+
 use libc::{
-    c_int, malloc, sigaction, sigaltstack, sigemptyset, stack_t, ucontext_t, SA_NODEFER,
+    c_int, malloc, sigaction, sigaltstack, sigemptyset, stack_t, SA_NODEFER,
     SA_ONSTACK, SA_SIGINFO, SIGABRT, SIGALRM, SIGBUS, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL,
     SIGPIPE, SIGQUIT, SIGSEGV, SIGTERM, SIGTRAP, SIGUSR2,
 };

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -289,7 +289,8 @@ pub static mut GLOBAL_STATE: InProcessExecutorHandlerData = InProcessExecutorHan
 mod unix_signal_handler {
     use alloc::vec::Vec;
     use core::{mem::transmute, ptr};
-    use libc::{siginfo_t, ucontext_t};
+    use libc::siginfo_t;
+    use crate::bolts::os::unix_signals::ucontext_t;
     #[cfg(feature = "std")]
     use std::io::{stdout, Write};
 

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -287,7 +287,6 @@ pub static mut GLOBAL_STATE: InProcessExecutorHandlerData = InProcessExecutorHan
 
 #[cfg(unix)]
 mod unix_signal_handler {
-    use crate::bolts::os::unix_signals::ucontext_t;
     use alloc::vec::Vec;
     use core::{mem::transmute, ptr};
     use libc::siginfo_t;
@@ -295,7 +294,7 @@ mod unix_signal_handler {
     use std::io::{stdout, Write};
 
     use crate::{
-        bolts::os::unix_signals::{Handler, Signal},
+        bolts::os::unix_signals::{ucontext_t, Handler, Signal},
         corpus::{Corpus, Testcase},
         events::{Event, EventFirer, EventRestarter},
         executors::{

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -287,10 +287,10 @@ pub static mut GLOBAL_STATE: InProcessExecutorHandlerData = InProcessExecutorHan
 
 #[cfg(unix)]
 mod unix_signal_handler {
+    use crate::bolts::os::unix_signals::ucontext_t;
     use alloc::vec::Vec;
     use core::{mem::transmute, ptr};
     use libc::siginfo_t;
-    use crate::bolts::os::unix_signals::ucontext_t;
     #[cfg(feature = "std")]
     use std::io::{stdout, Write};
 


### PR DESCRIPTION
The ucontext_t and mcontext_t structs are missing in libc for 32 bit armv7 (e.g., rust target armv7-unknown-linux-gnueabihf).
Adding their definitions enables compilation for such targets.