### PR TITLE
Fix warnings for windows

### DIFF
--- a/libafl/build.rs
+++ b/libafl/build.rs
@@ -5,7 +5,6 @@ use rustc_version::{version_meta, Channel};
 #[allow(clippy::ptr_arg, clippy::upper_case_acronyms)]
 fn main() {
     #[cfg(target_os = "windows")]
-    #[allow(clippy::ptr_arg, clippy::upper_case_acronyms)]
     windows::build!(
         Windows::Win32::Foundation::{HANDLE, HWND, BOOL, PSTR, CloseHandle, NTSTATUS},
         Windows::Win32::System::{

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -25,6 +25,10 @@ use frida_gum::{
     stalker::{StalkerOutput, Transformer},
     CpuContext, ModuleDetails, ModuleMap,
 };
+
+#[cfg(unix)]
+use frida_gum::CpuContext;
+
 use frida_gum::{Gum, Module, PageProtection};
 #[cfg(target_arch = "aarch64")]
 use num_traits::cast::FromPrimitive;


### PR DESCRIPTION
very small pr; I noticed two warnings popping up when I upgraded rust to the latest
```
note: the built-in attribute `allow` will be ignored, since it's applied to the macro invocation `windows::build`
 --> C:\Users\toka9\source\repos\LibAFL\libafl\build.rs:9:5
9 |     windows::build!(
  |     ^^^^^^^^^^^^^^

warning: `libafl` (build script) generated 1 warning
   Compiling frida_libpng v0.6.1 (C:\Users\toka9\source\repos\LibAFL\fuzzers\frida_libpng)
warning: unused import: `CpuContext`
  --> C:\Users\toka9\source\repos\LibAFL\libafl_frida\src\helper.rs:26:5
   |
26 |     CpuContext, ModuleDetails, ModuleMap,
   |     ^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `libafl_frida` (lib) generated 1 warning
warning: Now compile libpng with either visual studio or msys2
    Finished release [optimized + debuginfo] target(s) in 1m 01s
```