### PR TITLE
Fork feature flag to disable fork in Launcher

### DIFF
--- a/fuzzers/baby_fuzzer_gramatron/src/main.rs
+++ b/fuzzers/baby_fuzzer_gramatron/src/main.rs
@@ -109,7 +109,7 @@ pub fn main() {
     let automaton = read_automaton_from_file(PathBuf::from("auto.postcard"));
     let mut generator = GramatronGenerator::new(&automaton);
 
-    /// Use this code to profile the generator performance
+    // Use this code to profile the generator performance
     /*
     use libafl::generators::Generator;
     use std::collections::HashSet;

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -85,7 +85,7 @@ libm = "0.2.1"
 
 wait-timeout = { version = "0.2", optional = true } # used by CommandExecutor to wait for child process
 
-z3 = { version = "0.11", optional = true } # for concolic mutation
+z3 = { version = "0.11", features = ["static-link-z3"], optional = true } # for concolic mutation
 
 [target.'cfg(target_os = "android")'.dependencies]
 backtrace = { version = "0.3", optional = true, default-features = false, features = ["std", "libbacktrace"] } # for llmp_debug

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -37,10 +37,11 @@ harness = false
 #debug = true
 
 [features]
-default = ["std", "anymap_debug", "derive", "llmp_compression", "rand_trait"]
+default = ["std", "anymap_debug", "derive", "llmp_compression", "rand_trait", "fork"]
 std = ["serde_json", "hostname", "core_affinity", "nix", "serde/std", "bincode", "wait-timeout", "regex", "build_id", "uuid"] # print, env, launcher ... support
 anymap_debug = ["serde_json"] # uses serde_json to Debug the anymap trait. Disable for smaller footprint.
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
+fork = [] # uses the fork() syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on Windows, no_std).
 rand_trait = ["rand_core"] # If set, libafl's rand implementations will implement `rand::Rng`
 llmp_bind_public = [] # If set, llmp will bind to 0.0.0.0, allowing cross-device communication. Binds to localhost by default.
 llmp_compression = ["miniz_oxide"] # llmp compression using GZip

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -38,14 +38,7 @@ use std::{fs::File, os::unix::io::AsRawFd};
 #[cfg(feature = "std")]
 use typed_builder::TypedBuilder;
 
-/// The Launcher client callback type reference
-#[cfg(feature = "std")]
-pub type LauncherClientFnRef<'a, I, OT, S, SP> = &'a mut dyn FnOnce(
-    Option<S>,
-    LlmpRestartingEventManager<I, OT, S, SP>,
-    usize,
-) -> Result<(), Error>;
-
+/// The (internal) `env` that indicates we're running as client.
 const _AFL_LAUNCHER_CLIENT: &str = "AFL_LAUNCHER_CLIENT";
 /// Provides a Launcher, which can be used to launch a fuzzing run on a specified list of cores
 #[cfg(feature = "std")]

--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -24,11 +24,12 @@ use crate::{
     Error,
 };
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
 #[cfg(all(feature = "std", any(windows, not(feature = "fork"))))]
 use core_affinity::CoreId;
 #[cfg(feature = "std")]
 use serde::de::DeserializeOwned;
-use std::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::net::SocketAddr;
 #[cfg(all(feature = "std", any(windows, not(feature = "fork"))))]

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -6,6 +6,7 @@ pub mod compress;
 pub mod cpu;
 #[cfg(feature = "std")]
 pub mod fs;
+#[cfg(feature = "std")]
 pub mod launcher;
 pub mod llmp;
 pub mod os;

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -1,5 +1,7 @@
 //! The [`InProcessExecutor`] is a libfuzzer-like executor, that will simply call a function.
 //! It should usually be paired with extra error-handling, such as a restarting event manager, to be effective.
+//!
+//! Needs the `fork` feature flag.
 
 use core::{ffi::c_void, marker::PhantomData, ptr};
 
@@ -1008,16 +1010,15 @@ where
 mod tests {
     use core::{marker::PhantomData, ptr};
 
+    #[cfg(all(feature = "std", feature = "fork", unix))]
+    use crate::{
+        bolts::shmem::{ShMemProvider, StdShMemProvider},
+        executors::InProcessForkExecutor,
+    };
     use crate::{
         bolts::tuples::tuple_list,
         executors::{Executor, ExitKind, InProcessExecutor},
         inputs::NopInput,
-    };
-
-    #[cfg(all(feature = "std", unix))]
-    use crate::{
-        bolts::shmem::{ShMemProvider, StdShMemProvider},
-        executors::InProcessForkExecutor,
     };
 
     #[test]
@@ -1038,7 +1039,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "std", unix))]
+    #[cfg(all(feature = "std", feature = "fork", unix))]
     fn test_inprocessfork_exec() {
         let provider = StdShMemProvider::new().unwrap();
 

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod inprocess;
 pub use inprocess::InProcessExecutor;
-#[cfg(all(feature = "std", unix))]
+#[cfg(all(feature = "std", feature = "fork", unix))]
 pub use inprocess::InProcessForkExecutor;
 
 /// Timeout executor.
@@ -12,9 +12,9 @@ pub mod timeout;
 #[cfg(any(unix, feature = "std"))]
 pub use timeout::TimeoutExecutor;
 
-#[cfg(all(feature = "std", unix))]
+#[cfg(all(feature = "std", feature = "fork", unix))]
 pub mod forkserver;
-#[cfg(all(feature = "std", unix))]
+#[cfg(all(feature = "std", feature = "fork", unix))]
 pub use forkserver::{Forkserver, ForkserverExecutor, OutFile, TimeoutForkserverExecutor};
 
 pub mod combined;

--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -63,7 +63,16 @@ impl Allocator {
         #[allow(clippy::cast_sign_loss)]
         let page_size = ret as usize;
         // probe to find a usable shadow bit:
+        #[cfg(any(
+            target_arch = "aarch64",
+            all(target_arch = "x86_64", target_os = "linux")
+        ))]
         let mut shadow_bit: usize = 0;
+        #[cfg(not(any(
+            target_arch = "aarch64",
+            all(target_arch = "x86_64", target_os = "linux")
+        )))]
+        let shadow_bit = 0;
 
         #[cfg(target_arch = "aarch64")]
         for try_shadow_bit in &[46usize, 36usize] {


### PR DESCRIPTION
This allows us to disable fork when using Restarting Mgr and Launcher, for use cases that don't support `fork` (such as threaded applications)