### PR TITLE
Add minibsod

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -28,7 +28,7 @@ nautilus = ["grammartec", "std", "serde_json/std"]
 # LLMP features
 llmp_bind_public = [] # If set, llmp will bind to 0.0.0.0, allowing cross-device communication. Binds to localhost by default.
 llmp_compression = ["miniz_oxide"] # llmp compression using GZip
-llmp_debug = ["backtrace"] # Enables debug output for LLMP
+llmp_debug = [] # Enables debug output for LLMP
 llmp_small_maps = [] # reduces initial map size for llmp
 
 [build-dependencies]
@@ -78,17 +78,12 @@ z3 = { version = "0.11", features = ["static-link-z3"], optional = true } # for 
 # AGPL
 grammartec = { git = "https://github.com/andreafioraldi/nautilus", optional = true }
 
-[target.'cfg(target_os = "android")'.dependencies]
-backtrace = { version = "0.3", optional = true, default-features = false, features = ["std", "libbacktrace"] } # for llmp_debug
-
-[target.'cfg(not(target_os = "android"))'.dependencies]
-backtrace = { version = "0.3", optional = true } # for llmp_debug
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2" # For (*nix) libc
 uds = "0.2.3"
 lock_api = "0.4.3"
 regex = "1.4.5"
+backtrace = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 windows = "0.18.0"

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -187,8 +187,12 @@ fn write_crash<W: Write>(
 
     writeln!(
         writer,
-        "Received signal {} at 0x{:016x}, fault address: 0x{:016x}, trapno: {}",
-        signal, mcontext.__ss.__rip, mcontext.__es.__faultvaddr, mcontext.__es.__trapno
+        "Received signal {} at 0x{:016x}, fault address: 0x{:016x}, trapno: 0x{:x}, err: 0x{:x}",
+        signal,
+        mcontext.__ss.__rip,
+        mcontext.__es.__faultvaddr,
+        mcontext.__es.__trapno,
+        mcontext.__es.__err
     )?;
 
     Ok(())
@@ -200,6 +204,7 @@ fn write_crash<W: Write>(
     signal: Signal,
     _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
+    // TODO add fault addr for other platforms.
     writeln!(writer, "Received signal {}", signal,)?;
 
     Ok(())

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -85,7 +85,7 @@ fn dump_registers<W: Write>(
     Ok(())
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[allow(clippy::unnecessary_wraps, clippy::similar_names)]
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -9,7 +9,7 @@ use crate::bolts::os::unix_signals::Signal;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     use libc::{
         REG_EFL, REG_R10, REG_R11, REG_R12, REG_R13, REG_R14, REG_R15, REG_R8, REG_R9, REG_RAX,
@@ -46,7 +46,7 @@ fn dump_registers<W: Write>(
 ))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     for reg in 0..31 {
         write!(
@@ -66,7 +66,7 @@ fn dump_registers<W: Write>(
 #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     let mcontext = unsafe { *ucontext.uc_mcontext };
     for reg in 0..29 {
@@ -90,7 +90,7 @@ fn dump_registers<W: Write>(
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
     _writer: &mut BufWriter<W>,
-    _ucontext: ucontext_t,
+    _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     Ok(())
 }
@@ -99,7 +99,7 @@ fn dump_registers<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(
         writer,
@@ -119,7 +119,7 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(
         writer,
@@ -134,7 +134,7 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     let mcontext = unsafe { *ucontext.uc_mcontext };
     writeln!(
@@ -150,7 +150,7 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    _ucontext: ucontext_t,
+    _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(writer, "Received signal {}", signal,)?;
 
@@ -163,7 +163,7 @@ pub fn generate_minibsod<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
     _siginfo: siginfo_t,
-    ucontext: ucontext_t,
+    ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(writer, "{:━^100}", " CRASH ")?;
     write_crash(writer, signal, ucontext)?;

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -88,8 +88,8 @@ fn dump_registers<W: Write>(
 
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
-    writer: &mut BufWriter<W>,
-    ucontext: &ucontext_t,
+    _writer: &mut BufWriter<W>,
+    _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     Ok(())
 }
@@ -149,9 +149,8 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: &ucontext_t,
+    _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
-    let mcontext = *ucontext.uc_mcontext;
     writeln!(writer, "Received signal {}", signal,)?;
 
     Ok(())

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -1,0 +1,124 @@
+//! Implements a mini-bsod generator
+
+use std::io::{BufWriter, Write};
+
+use libc::{siginfo_t, ucontext_t};
+
+use crate::bolts::os::unix_signals::Signal;
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn dump_registers<W: Write>(writer: &mut BufWriter<W>, ucontext: &ucontext_t) -> Result<(), std::io::Error>{
+    use libc::{REG_R8, REG_R9, REG_R10, REG_R11, REG_R12, REG_R13, REG_R14, REG_R15, REG_RDI, REG_RSI, REG_RBP, REG_RBX, REG_RDX, REG_RAX, REG_RCX, REG_RSP, REG_RIP, REG_EFL};
+
+    let mcontext = &ucontext.uc_mcontext;
+
+    write!(writer, "r8 : {:#016x}, ", mcontext.gregs[REG_R8 as usize])?;
+    write!(writer, "r9 : {:#016x}, ", mcontext.gregs[REG_R9 as usize])?;
+    write!(writer, "r10: {:#016x}, ", mcontext.gregs[REG_R10 as usize])?;
+    writeln!(writer, "r11: {:#016x}, ", mcontext.gregs[REG_R11 as usize])?;
+    write!(writer, "r12: {:#016x}, ", mcontext.gregs[REG_R12 as usize])?;
+    write!(writer, "r13: {:#016x}, ", mcontext.gregs[REG_R13 as usize])?;
+    write!(writer, "r14: {:#016x}, ", mcontext.gregs[REG_R14 as usize])?;
+    writeln!(writer, "r15: {:#016x}, ", mcontext.gregs[REG_R15 as usize])?;
+    write!(writer, "rdi: {:#016x}, ", mcontext.gregs[REG_RDI as usize])?;
+    write!(writer, "rsi: {:#016x}, ", mcontext.gregs[REG_RSI as usize])?;
+    write!(writer, "rbp: {:#016x}, ", mcontext.gregs[REG_RBP as usize])?;
+    writeln!(writer, "rbx: {:#016x}, ", mcontext.gregs[REG_RBX as usize])?;
+    write!(writer, "rdx: {:#016x}, ", mcontext.gregs[REG_RDX as usize])?;
+    write!(writer, "rax: {:#016x}, ", mcontext.gregs[REG_RAX as usize])?;
+    write!(writer, "rcx: {:#016x}, ", mcontext.gregs[REG_RCX as usize])?;
+    writeln!(writer, "rsp: {:#016x}, ", mcontext.gregs[REG_RSP as usize])?;
+    write!(writer, "rip: {:#016x}, ", mcontext.gregs[REG_RIP as usize])?;
+    writeln!(writer, "efl: {:#016x}, ", mcontext.gregs[REG_EFL as usize])?;
+
+    Ok(())
+}
+
+#[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+fn dump_registers<W: Write>(writer: &mut BufWriter<W>, ucontext: &ucontext_t) -> Result<(), std::io::Error>{
+    for reg in 0..31 {
+        write!(
+            writer,
+            "x{:02}: 0x{:016x} ",
+            reg, ucontext.uc_mcontext.regs[reg as usize]
+        );
+        if reg % 4 == 3 {
+            writeln!(writer, "");
+        }
+    }
+    writeln!(writer, "pc : 0x{:016x} ", ucontext.uc_mcontext.pc);
+
+    Ok(())
+}
+
+#[cfg(all(target_vendor = "apple", target_arch = "aarch64"))]
+fn dump_registers<W: Write>(writer: &mut BufWriter<W>, ucontext: &ucontext_t) -> Result<(), std::io::Error>{
+    let mcontext = *ucontext.uc_mcontext;
+    for reg in 0..29 {
+        writeln!(writer, "x{:02}: 0x{:016x} ", reg, mcontext.__ss.__x[reg as usize]);
+        if reg % 4 == 3 {
+            writeln!(writer, "");
+        }
+    }
+    write!(writer, "fp: 0x{:016x} ", mcontext.__ss.__fp);
+    write!(writer, "lr: 0x{:016x} ", mcontext.__ss.__lr);
+    write!(writer, "pc: 0x{:016x} ", mcontext.__ss.__pc);
+
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn write_crash<W: Write>(writer: &mut BufWriter<W>, signal: Signal, ucontext: &ucontext_t) -> Result<(), std::io::Error> {
+    writeln!(
+        writer,
+        "Received signal {} at {:#016x}, fault address: {:#016x}",
+        signal, ucontext.uc_mcontext.gregs[libc::REG_RIP as usize], ucontext.uc_mcontext.gregs[libc::REG_CR2 as usize]
+    )?;
+
+    Ok(())
+}
+
+#[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+fn write_crash<W: Write>(writer: &mut BufWriter<W>, signal: Signal, ucontext: &ucontext_t) -> Result<(), std::io::Error> {
+    writeln!(
+        writer,
+        "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",
+        signal, ucontext.uc_mcontext.pc, ucontext.uc_mcontext.fault_address
+    )?;
+
+    Ok(())
+}
+
+#[cfg(all(target_vendor = "apple", target_arch = "aarch64"))]
+fn write_crash<W: Write>(writer: &mut BufWriter<W>, signal: Signal, ucontext: &ucontext_t) -> Result<(), std::io::Error> {
+    let mcontext = *ucontext.uc_mcontext;
+    writeln!(
+        writer,
+        "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",
+        signal, mcontext.__ss.__pc, mcontext.__es.__far
+    )?;
+
+    Ok(())
+}
+
+/// Generates a mini-BSOD given a signal and context.
+#[cfg(unix)]
+pub fn generate_minibsod<W: Write>(writer: &mut BufWriter<W>, signal: Signal, _siginfo: &siginfo_t, ucontext: &ucontext_t) -> Result<(), std::io::Error> {
+    writeln!(writer, "{:━^100}", " CRASH ")?;
+    write_crash(writer, signal, ucontext)?;
+    writeln!(writer, "{:━^100}", " REGISTERS ")?;
+    dump_registers(writer, ucontext)?;
+    writeln!(writer, "{:━^100}", " BACKTRACE ")?;
+    writeln!(writer, "{:?}", backtrace::Backtrace::new())?;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        writeln!(writer, "{:━^100}", " MAPS ")?;
+
+        match std::fs::read_to_string("/proc/self/maps") {
+            Ok(maps) => writer.write_all(maps.as_bytes())?,
+            Err(e) => writeln!(writer, "Couldn't load mappings: {:?}", e)?,
+        };
+    }
+
+    Ok(())
+}

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -9,7 +9,7 @@ use crate::bolts::os::unix_signals::Signal;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
-    ucontext: &ucontext_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     use libc::{
         REG_EFL, REG_R10, REG_R11, REG_R12, REG_R13, REG_R14, REG_R15, REG_R8, REG_R9, REG_RAX,
@@ -46,7 +46,7 @@ fn dump_registers<W: Write>(
 ))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
-    ucontext: &ucontext_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     for reg in 0..31 {
         write!(
@@ -66,7 +66,7 @@ fn dump_registers<W: Write>(
 #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))]
 fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
-    ucontext: &ucontext_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     let mcontext = unsafe { *ucontext.uc_mcontext };
     for reg in 0..29 {
@@ -90,7 +90,7 @@ fn dump_registers<W: Write>(
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
     _writer: &mut BufWriter<W>,
-    _ucontext: &ucontext_t,
+    _ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     Ok(())
 }
@@ -99,7 +99,7 @@ fn dump_registers<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: &ucontext_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(
         writer,
@@ -119,7 +119,7 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: &ucontext_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(
         writer,
@@ -134,7 +134,7 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    ucontext: &ucontext_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     let mcontext = unsafe { *ucontext.uc_mcontext };
     writeln!(
@@ -150,7 +150,7 @@ fn write_crash<W: Write>(
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    _ucontext: &ucontext_t,
+    _ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(writer, "Received signal {}", signal,)?;
 
@@ -162,8 +162,8 @@ fn write_crash<W: Write>(
 pub fn generate_minibsod<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,
-    _siginfo: &siginfo_t,
-    ucontext: &ucontext_t,
+    _siginfo: siginfo_t,
+    ucontext: ucontext_t,
 ) -> Result<(), std::io::Error> {
     writeln!(writer, "{:━^100}", " CRASH ")?;
     write_crash(writer, signal, ucontext)?;

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -177,7 +177,6 @@ fn write_crash<W: Write>(
     Ok(())
 }
 
-
 /// Generates a mini-BSOD given a signal and context.
 #[cfg(unix)]
 pub fn generate_minibsod<W: Write>(

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -86,6 +86,14 @@ fn dump_registers<W: Write>(
     Ok(())
 }
 
+#[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
+fn dump_registers<W: Write>(
+    writer: &mut BufWriter<W>,
+    ucontext: &ucontext_t,
+) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
@@ -133,6 +141,18 @@ fn write_crash<W: Write>(
         "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",
         signal, mcontext.__ss.__pc, mcontext.__es.__far
     )?;
+
+    Ok(())
+}
+
+#[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
+fn write_crash<W: Write>(
+    writer: &mut BufWriter<W>,
+    signal: Signal,
+    ucontext: &ucontext_t,
+) -> Result<(), std::io::Error> {
+    let mcontext = *ucontext.uc_mcontext;
+    writeln!(writer, "Received signal {}", signal,)?;
 
     Ok(())
 }

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -92,7 +92,16 @@ fn dump_registers<W: Write>(
     _writer: &mut BufWriter<W>,
     _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
-    Ok(())
+    todo!("implement dump registers");
+}
+
+#[allow(clippy::unnecessary_wraps)]
+#[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+fn dump_registers<W: Write>(
+    _writer: &mut BufWriter<W>,
+    _ucontext: &ucontext_t,
+) -> Result<(), std::io::Error> {
+    todo!("implement dump registers");
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -156,6 +165,18 @@ fn write_crash<W: Write>(
 
     Ok(())
 }
+
+#[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
+fn write_crash<W: Write>(
+    writer: &mut BufWriter<W>,
+    signal: Signal,
+    _ucontext: &ucontext_t,
+) -> Result<(), std::io::Error> {
+    writeln!(writer, "Received signal {}", signal,)?;
+
+    Ok(())
+}
+
 
 /// Generates a mini-BSOD given a signal and context.
 #[cfg(unix)]

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -86,6 +86,7 @@ fn dump_registers<W: Write>(
     Ok(())
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
 fn dump_registers<W: Write>(
     _writer: &mut BufWriter<W>,

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -53,12 +53,12 @@ fn dump_registers<W: Write>(
             writer,
             "x{:02}: 0x{:016x} ",
             reg, ucontext.uc_mcontext.regs[reg as usize]
-        );
+        )?;
         if reg % 4 == 3 {
-            writeln!(writer, "");
+            writeln!(writer)?;
         }
     }
-    writeln!(writer, "pc : 0x{:016x} ", ucontext.uc_mcontext.pc);
+    writeln!(writer, "pc : 0x{:016x} ", ucontext.uc_mcontext.pc)?;
 
     Ok(())
 }
@@ -76,7 +76,7 @@ fn dump_registers<W: Write>(
             reg, mcontext.__ss.__x[reg as usize]
         );
         if reg % 4 == 3 {
-            writeln!(writer, "");
+            writeln!(writer);
         }
     }
     write!(writer, "fp: 0x{:016x} ", mcontext.__ss.__fp);

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -68,7 +68,7 @@ fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
     ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
-    let mcontext = *ucontext.uc_mcontext;
+    let mcontext = unsafe { *ucontext.uc_mcontext };
     for reg in 0..29 {
         writeln!(
             writer,
@@ -135,7 +135,7 @@ fn write_crash<W: Write>(
     signal: Signal,
     ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
-    let mcontext = *ucontext.uc_mcontext;
+    let mcontext = unsafe { *ucontext.uc_mcontext };
     writeln!(
         writer,
         "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -119,10 +119,15 @@ fn dump_registers<W: Write>(
 #[allow(clippy::unnecessary_wraps)]
 #[cfg(not(any(target_vendor = "apple", target_os = "linux", target_os = "android")))]
 fn dump_registers<W: Write>(
-    _writer: &mut BufWriter<W>,
+    writer: &mut BufWriter<W>,
     _ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
     // TODO: Implement dump registers
+    writeln!(
+        writer,
+        "< Dumping registers is not yet supported on platform {:?}. Please add it to `minibsod.rs` >",
+        std::env::consts::OS
+    )?;
     Ok(())
 }
 
@@ -178,6 +183,7 @@ fn write_crash<W: Write>(
 }
 
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
+#[allow(clippy::similar_names)]
 fn write_crash<W: Write>(
     writer: &mut BufWriter<W>,
     signal: Signal,

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -9,7 +9,7 @@ pub mod fs;
 #[cfg(feature = "std")]
 pub mod launcher;
 pub mod llmp;
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", unix))]
 pub mod minibsod;
 pub mod os;
 pub mod ownedref;

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -9,6 +9,7 @@ pub mod fs;
 #[cfg(feature = "std")]
 pub mod launcher;
 pub mod llmp;
+#[cfg(feature = "std")]
 pub mod minibsod;
 pub mod os;
 pub mod ownedref;

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -9,6 +9,7 @@ pub mod fs;
 #[cfg(feature = "std")]
 pub mod launcher;
 pub mod llmp;
+pub mod minibsod;
 pub mod os;
 pub mod ownedref;
 pub mod rands;

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -508,7 +508,7 @@ mod unix_signal_handler {
                         &mut writer,
                         signal,
                         &_info,
-                        &_context,
+                        _context,
                     )
                     .unwrap();
                     writer.flush().unwrap();
@@ -542,7 +542,7 @@ mod unix_signal_handler {
             {
                 let mut writer = std::io::BufWriter::new(std::io::stderr());
                 writeln!(writer, "input: {:?}", input.generate_name(0)).unwrap();
-                crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, &_context)
+                crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, _context)
                     .unwrap();
                 writer.flush().unwrap();
             }

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -316,10 +316,10 @@ pub fn inprocess_get_executor<'a, E>() -> Option<&'a mut E> {
 mod unix_signal_handler {
     use alloc::vec::Vec;
     use core::{mem::transmute, ptr};
-    use std::time::Duration;
     use libc::siginfo_t;
     #[cfg(feature = "std")]
     use std::io::{stdout, Write};
+    use std::time::Duration;
 
     use crate::{
         bolts::os::unix_signals::{ucontext_t, Handler, Signal},
@@ -505,7 +505,13 @@ mod unix_signal_handler {
                 #[cfg(all(feature = "std", unix))]
                 {
                     let mut writer = std::io::BufWriter::new(std::io::stderr());
-                    crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, &_context).unwrap();
+                    crate::bolts::minibsod::generate_minibsod(
+                        &mut writer,
+                        signal,
+                        &_info,
+                        &_context,
+                    )
+                    .unwrap();
                     writer.flush().unwrap();
                 }
             }
@@ -537,12 +543,12 @@ mod unix_signal_handler {
             {
                 let mut writer = std::io::BufWriter::new(std::io::stderr());
                 writeln!(writer, "input: {:?}", input.generate_name(0)).unwrap();
-                crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, &_context).unwrap();
+                crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, &_context)
+                    .unwrap();
                 writer.flush().unwrap();
 
                 std::thread::sleep(Duration::from_secs(30));
             }
-
 
             let interesting = fuzzer
                 .objective_mut()

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -319,7 +319,6 @@ mod unix_signal_handler {
     use libc::siginfo_t;
     #[cfg(feature = "std")]
     use std::io::{stdout, Write};
-    use std::time::Duration;
 
     use crate::{
         bolts::os::unix_signals::{ucontext_t, Handler, Signal},
@@ -546,8 +545,6 @@ mod unix_signal_handler {
                 crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, &_context)
                     .unwrap();
                 writer.flush().unwrap();
-
-                std::thread::sleep(Duration::from_secs(30));
             }
 
             let interesting = fuzzer

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -515,7 +515,7 @@ mod unix_signal_handler {
                     writer.flush().unwrap();
                 }
             }
-            panic!("COREDUMPME!");
+
             #[cfg(feature = "std")]
             {
                 println!("Type QUIT to restart the child");

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -482,7 +482,7 @@ mod unix_signal_handler {
         unix_remove_timeout();
 
         #[cfg(all(target_os = "android", target_arch = "aarch64"))]
-        let _context = *(((_context as *mut _ as *mut libc::c_void as usize) + 128)
+        let _context = &mut *(((_context as *mut _ as *mut libc::c_void as usize) + 128)
             as *mut libc::c_void as *mut ucontext_t);
 
         #[cfg(feature = "std")]

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -504,13 +504,8 @@ mod unix_signal_handler {
                 #[cfg(all(feature = "std", unix))]
                 {
                     let mut writer = std::io::BufWriter::new(std::io::stderr());
-                    crate::bolts::minibsod::generate_minibsod(
-                        &mut writer,
-                        signal,
-                        _info,
-                        _context,
-                    )
-                    .unwrap();
+                    crate::bolts::minibsod::generate_minibsod(&mut writer, signal, _info, _context)
+                        .unwrap();
                     writer.flush().unwrap();
                 }
             }

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -507,7 +507,7 @@ mod unix_signal_handler {
                     crate::bolts::minibsod::generate_minibsod(
                         &mut writer,
                         signal,
-                        &_info,
+                        _info,
                         _context,
                     )
                     .unwrap();
@@ -542,7 +542,7 @@ mod unix_signal_handler {
             {
                 let mut writer = std::io::BufWriter::new(std::io::stderr());
                 writeln!(writer, "input: {:?}", input.generate_name(0)).unwrap();
-                crate::bolts::minibsod::generate_minibsod(&mut writer, signal, &_info, _context)
+                crate::bolts::minibsod::generate_minibsod(&mut writer, signal, _info, _context)
                     .unwrap();
                 writer.flush().unwrap();
             }


### PR DESCRIPTION
Add's the minibsod bolt, which provides `mini-Blue Screen of Death` output on crashes, including register dump, backtrace and mappings.