### PR TITLE
Fix cfg directives for frida-asan

### DIFF
--- a/libafl_frida/src/asan_rt.rs
+++ b/libafl_frida/src/asan_rt.rs
@@ -64,6 +64,7 @@ const ANONYMOUS_FLAG: MapFlags = MapFlags::MAP_ANONYMOUS;
 #[cfg(target_arch = "x86_64")]
 pub const ASAN_SAVE_REGISTER_COUNT: usize = 19;
 
+#[cfg(target_arch = "x86_64")]
 pub const ASAN_SAVE_REGISTER_NAMES: [&str; ASAN_SAVE_REGISTER_COUNT] = [
     "rax",
     "rbx",
@@ -86,7 +87,7 @@ pub const ASAN_SAVE_REGISTER_NAMES: [&str; ASAN_SAVE_REGISTER_COUNT] = [
     "actual rip",
 ];
 
-#[cfg(tareget_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")]
 pub const ASAN_SAVE_REGISTER_COUNT: usize = 32;
 
 /// The frida address sanitizer runtime, providing address sanitization.
@@ -1959,7 +1960,7 @@ impl AsanRuntime {
                 3,
             )
             .unwrap();
-        let instructions = instructions.iter().collect::<Vec<Insn>>();
+        let instructions = instructions.iter().collect::<Vec<&Insn>>();
         let mut insn = instructions.first().unwrap();
         if insn.mnemonic().unwrap() == "msr" && insn.op_str().unwrap() == "nzcv, x0" {
             insn = instructions.get(2).unwrap();

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -62,12 +62,13 @@ enum CmplogOperandType {
     Mem(capstone::RegId, capstone::RegId, i32, u32),
 }
 
+#[cfg(all(feature = "cmplog", target_arch = "aarch64"))]
 enum SpecialCmpLogCase {
     Tbz,
     Tbnz,
 }
 
-#[cfg(any(target_vendor = "apple"))]
+#[cfg(target_vendor = "apple")]
 const ANONYMOUS_FLAG: MapFlags = MapFlags::MAP_ANON;
 #[cfg(not(any(target_vendor = "apple", target_os = "windows")))]
 const ANONYMOUS_FLAG: MapFlags = MapFlags::MAP_ANONYMOUS;

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -836,7 +836,6 @@ impl<'a> FridaInstrumentationHelper<'a> {
         ));
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[inline]
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::too_many_arguments)]

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -836,6 +836,7 @@ impl<'a> FridaInstrumentationHelper<'a> {
         ));
     }
 
+    #[cfg(target_arch = "x86_64")]
     #[inline]
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Fixes missing/broken cfg directives from @tokatoka's frida-asan-x86_64 PR.