### PR TITLE
dump_registers and write_crash for armv7

### DIFF
--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -208,7 +208,7 @@ fn write_crash<W: Write>(
     signal: Signal,
     ucontext: &ucontext_t,
 ) -> Result<(), std::io::Error> {
-        writeln!(
+    writeln!(
         writer,
         "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",
         signal, ucontext.uc_mcontext.arm_pc, ucontext.uc_mcontext.fault_address

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -69,6 +69,34 @@ pub fn dump_registers<W: Write>(
 }
 
 /// Write the contens of all important registers
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+pub fn dump_registers<W: Write>(
+    writer: &mut BufWriter<W>,
+    ucontext: &ucontext_t,
+) -> Result<(), std::io::Error> {
+    write!(writer, "r0 : {:#016x}, ", ucontext.uc_mcontext.arm_r0)?;
+    write!(writer, "r1 : {:#016x}, ", ucontext.uc_mcontext.arm_r1)?;
+    write!(writer, "r2: {:#016x}, ", ucontext.uc_mcontext.arm_r2)?;
+    writeln!(writer, "r3: {:#016x}, ", ucontext.uc_mcontext.arm_r3)?;
+    write!(writer, "r4: {:#016x}, ", ucontext.uc_mcontext.arm_r4)?;
+    write!(writer, "r5: {:#016x}, ", ucontext.uc_mcontext.arm_r5)?;
+    write!(writer, "r6: {:#016x}, ", ucontext.uc_mcontext.arm_r6)?;
+    writeln!(writer, "r7: {:#016x}, ", ucontext.uc_mcontext.arm_r7)?;
+    write!(writer, "r8: {:#016x}, ", ucontext.uc_mcontext.arm_r8)?;
+    write!(writer, "r9: {:#016x}, ", ucontext.uc_mcontext.arm_r9)?;
+    write!(writer, "r10: {:#016x}, ", ucontext.uc_mcontext.arm_r10)?;
+    writeln!(writer, "fp: {:#016x}, ", ucontext.uc_mcontext.arm_fp)?;
+    write!(writer, "ip: {:#016x}, ", ucontext.uc_mcontext.arm_ip)?;
+    write!(writer, "sp: {:#016x}, ", ucontext.uc_mcontext.arm_sp)?;
+    write!(writer, "lr: {:#016x}, ", ucontext.uc_mcontext.arm_lr)?;
+    writeln!(writer, "cpsr: {:#016x}, ", ucontext.uc_mcontext.arm_cpsr)?;
+
+    writeln!(writer, "pc : 0x{:016x} ", ucontext.uc_mcontext.arm_pc)?;
+
+    Ok(())
+}
+
+/// Write the contens of all important registers
 #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))]
 pub fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
@@ -169,6 +197,21 @@ fn write_crash<W: Write>(
         writer,
         "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",
         signal, ucontext.uc_mcontext.pc, ucontext.uc_mcontext.fault_address
+    )?;
+
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+fn write_crash<W: Write>(
+    writer: &mut BufWriter<W>,
+    signal: Signal,
+    ucontext: &ucontext_t,
+) -> Result<(), std::io::Error> {
+        writeln!(
+        writer,
+        "Received signal {} at 0x{:016x}, fault address: 0x{:016x}",
+        signal, ucontext.uc_mcontext.arm_pc, ucontext.uc_mcontext.fault_address
     )?;
 
     Ok(())

--- a/libafl/src/bolts/os/unix_signals.rs
+++ b/libafl/src/bolts/os/unix_signals.rs
@@ -18,6 +18,8 @@ use std::ffi::CString;
 pub use libc::c_ulong;
 
 #[cfg(target_arch = "arm")]
+#[allow(non_camel_case_types)]
+#[repr(C)]
 pub struct mcontext_t {
     pub trap_no: c_ulong,
     pub error_code: c_ulong,
@@ -43,6 +45,8 @@ pub struct mcontext_t {
 }
 
 #[cfg(target_arch = "arm")]
+#[allow(non_camel_case_types)]
+#[repr(C)]
 pub struct ucontext_t {
     pub uc_flags: u32,
     pub uc_link: *mut ucontext_t,


### PR DESCRIPTION
Implements the missing helper functions for dumping on crash for 32 bit ARM.