### PR TITLE
make map debuggable

### DIFF
--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -4,7 +4,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::marker::PhantomData;
+use core::{fmt::Debug, marker::PhantomData};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize};
 
@@ -275,6 +275,7 @@ where
     pub fn with_observer<O>(map_observer: &O) -> Self
     where
         O: MapObserver<T>,
+        T: Debug,
     {
         Self {
             history_map: vec![T::default(); map_observer.len()],
@@ -298,7 +299,7 @@ where
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 pub struct MapFeedback<FT, I, MF, O, R, S, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     R: Reducer<T>,
     O: MapObserver<T>,
     MF: MapFindFilter<T>,
@@ -319,7 +320,7 @@ where
 
 impl<FT, I, MF, O, R, S, T> Feedback<I, S> for MapFeedback<FT, I, MF, O, R, S, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     R: Reducer<T>,
     O: MapObserver<T>,
     MF: MapFindFilter<T>,
@@ -428,7 +429,7 @@ where
 
 impl<FT, I, MF, O, R, S, T> Named for MapFeedback<FT, I, MF, O, R, S, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     R: Reducer<T>,
     MF: MapFindFilter<T>,
     O: MapObserver<T>,
@@ -449,7 +450,8 @@ where
         + 'static
         + serde::Serialize
         + serde::de::DeserializeOwned
-        + PartialOrd,
+        + PartialOrd
+        + Debug,
     R: Reducer<T>,
     MF: MapFindFilter<T>,
     O: MapObserver<T>,

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -6,6 +6,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
+    fmt::Debug,
     hash::Hasher,
     slice::{from_raw_parts, from_raw_parts_mut},
 };
@@ -26,7 +27,7 @@ use crate::{
 /// A [`MapObserver`] observes the static map, as oftentimes used for afl-like coverage information
 pub trait MapObserver<T>: HasLen + Named + serde::Serialize + serde::de::DeserializeOwned
 where
-    T: PrimInt + Default + Copy,
+    T: PrimInt + Default + Copy + Debug,
 {
     /// Get the map if the observer can be represented with a slice
     fn map(&self) -> Option<&[T]>;
@@ -117,7 +118,7 @@ where
 
 impl<'a, I, S, T> Observer<I, S> for StdMapObserver<'a, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     Self: MapObserver<T>,
 {
     #[inline]
@@ -148,7 +149,7 @@ where
 
 impl<'a, T> MapObserver<T> for StdMapObserver<'a, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn map(&self) -> Option<&[T]> {
@@ -232,7 +233,7 @@ where
 
 impl<'a, I, S, T, const N: usize> Observer<I, S> for ConstMapObserver<'a, T, N>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     Self: MapObserver<T>,
 {
     #[inline]
@@ -263,7 +264,7 @@ where
 
 impl<'a, T, const N: usize> MapObserver<T> for ConstMapObserver<'a, T, N>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn usable_count(&self) -> usize {
@@ -354,7 +355,7 @@ where
 
 impl<'a, I, S, T> Observer<I, S> for VariableMapObserver<'a, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     Self: MapObserver<T>,
 {
     #[inline]
@@ -385,7 +386,7 @@ where
 
 impl<'a, T> MapObserver<T> for VariableMapObserver<'a, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn map(&self) -> Option<&[T]> {
@@ -579,7 +580,7 @@ where
 
 impl<'a, I, S, T> Observer<I, S> for MultiMapObserver<'a, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     Self: MapObserver<T>,
 {
     #[inline]
@@ -610,7 +611,7 @@ where
 
 impl<'a, T> MapObserver<T> for MultiMapObserver<'a, T>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn map(&self) -> Option<&[T]> {

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -15,14 +15,14 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{marker::PhantomData, time::Duration};
+use core::{fmt::Debug, marker::PhantomData, time::Duration};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
 pub struct CalibrationStage<C, E, EM, I, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,
@@ -42,7 +42,7 @@ const CAL_STAGE_MAX: usize = 8;
 impl<C, E, EM, I, O, OT, S, T, Z> Stage<E, EM, S, Z>
     for CalibrationStage<C, E, EM, I, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,
@@ -210,7 +210,7 @@ crate::impl_serdeany!(PowerScheduleMetadata);
 
 impl<C, E, I, EM, O, OT, S, T, Z> CalibrationStage<C, E, EM, I, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -1,7 +1,7 @@
 //! The power schedules. This stage should be invoked after the calibration stage.
 
 use alloc::string::{String, ToString};
-use core::marker::PhantomData;
+use core::{fmt::Debug, marker::PhantomData};
 use num_traits::PrimInt;
 
 use crate::{
@@ -34,7 +34,7 @@ const HAVOC_MAX_MULT: f64 = 64.0;
 #[derive(Clone, Debug)]
 pub struct PowerMutationalStage<C, E, EM, I, M, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,
@@ -55,7 +55,7 @@ where
 impl<C, E, EM, I, M, O, OT, S, T, Z> MutationalStage<C, E, EM, I, M, S, Z>
     for PowerMutationalStage<C, E, EM, I, M, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,
@@ -156,7 +156,7 @@ where
 impl<C, E, EM, I, M, O, OT, S, T, Z> Stage<E, EM, S, Z>
     for PowerMutationalStage<C, E, EM, I, M, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,
@@ -183,7 +183,7 @@ where
 
 impl<C, E, EM, I, M, O, OT, S, T, Z> PowerMutationalStage<C, E, EM, I, M, O, OT, S, T, Z>
 where
-    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned,
+    T: PrimInt + Default + Copy + 'static + serde::Serialize + serde::de::DeserializeOwned + Debug,
     C: Corpus<I>,
     E: Executor<EM, I, S, Z> + HasObservers<I, OT, S>,
     I: Input,


### PR DESCRIPTION
As @vanhauser-thc noticed, the map in a map observer is not necessarily debuggable.
Since it needs to be serializable, though, we can always implement debug for it.