### PR TITLE
better forkserver example

### DIFF
--- a/fuzzers/forkserver_simple/Cargo.toml
+++ b/fuzzers/forkserver_simple/Cargo.toml
@@ -17,3 +17,4 @@ opt-level = 3
 
 [dependencies]
 libafl = { path = "../../libafl/" }
+clap = { version = "3.0.0-beta.2", features = ["default"] }

--- a/fuzzers/forkserver_simple/README.md
+++ b/fuzzers/forkserver_simple/README.md
@@ -1,7 +1,13 @@
 # Simple Forkserver Fuzzer
 
-This is a simple fuzzer to test the ForkserverExecutor.
-You can test it with the following procedures.
-1. `cargo build --release`
-2. `cp ./target/release/forkserver_simple .`
-3. `taskset -c 1 ./forkserver_simple`
+This is a simple example fuzzer to fuzz a executable instrumented by afl-cc.
+## Usage
+You can build this example by `cargo build --release`.  
+This downloads AFLplusplus/AFLplusplus and compiles the example harness program in src/program.c with afl-cc  
+
+## Run
+After you build it you can run  
+`cp ./target/release/forkserver_simple .` to copy the fuzzer into this directory,  
+and you can run  
+`taskset -c 1 ./forkserver_simple ./target/release/program ./corpus/ -t 1000` to run the fuzzer.
+`taskset` binds this process to a specific core to improve the throughput.  

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -24,9 +24,37 @@ use libafl::{
 };
 use std::path::PathBuf;
 
+use clap::{App, Arg};
+
 #[allow(clippy::similar_names)]
-pub fn main() {
-    let corpus_dirs = vec![PathBuf::from("./corpus")];
+pub fn main() {    
+
+    let res = App::new("forkserver_simple")
+        .about("Example Forkserver fuzer")
+        .arg(
+            Arg::new("executable")
+            .about("The instrumented binary we want to fuzz")
+            .required(true)
+            .index(1)
+            .takes_value(true)
+        )
+        .arg(
+            Arg::new("in")
+            .about("The directory to read initial inputs from ('seeds')")
+            .required(true)
+            .index(2)
+            .takes_value(true),
+        )
+        .arg(
+            Arg::new("timeout")
+            .about("Timeout for each individual execution, in milliseconds")
+            .short('t')
+            .long("timeout")
+            .default_value("1200"),
+        )
+        .get_matches();
+
+    let corpus_dirs = vec![PathBuf::from(res.value_of("in").unwrap().to_string())];
 
     const MAP_SIZE: usize = 65536;
 
@@ -99,13 +127,13 @@ pub fn main() {
     // Create the executor for the forkserver
     let mut executor = TimeoutForkserverExecutor::new(
         ForkserverExecutor::new(
-            "./target/release/program".to_string(),
+            res.value_of("executable").unwrap().to_string(),
             &[],
             true,
             tuple_list!(edges_observer, time_observer),
         )
         .unwrap(),
-        Duration::from_millis(5000),
+        Duration::from_millis(res.value_of("timeout").unwrap().to_string().parse().expect("Could not parse timeout in milliseconds")),
     )
     .expect("Failed to create the executor.");
 

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -27,30 +27,29 @@ use std::path::PathBuf;
 use clap::{App, Arg};
 
 #[allow(clippy::similar_names)]
-pub fn main() {    
-
+pub fn main() {
     let res = App::new("forkserver_simple")
         .about("Example Forkserver fuzer")
         .arg(
             Arg::new("executable")
-            .about("The instrumented binary we want to fuzz")
-            .required(true)
-            .index(1)
-            .takes_value(true)
+                .about("The instrumented binary we want to fuzz")
+                .required(true)
+                .index(1)
+                .takes_value(true),
         )
         .arg(
             Arg::new("in")
-            .about("The directory to read initial inputs from ('seeds')")
-            .required(true)
-            .index(2)
-            .takes_value(true),
+                .about("The directory to read initial inputs from ('seeds')")
+                .required(true)
+                .index(2)
+                .takes_value(true),
         )
         .arg(
             Arg::new("timeout")
-            .about("Timeout for each individual execution, in milliseconds")
-            .short('t')
-            .long("timeout")
-            .default_value("1200"),
+                .about("Timeout for each individual execution, in milliseconds")
+                .short('t')
+                .long("timeout")
+                .default_value("1200"),
         )
         .get_matches();
 
@@ -133,7 +132,13 @@ pub fn main() {
             tuple_list!(edges_observer, time_observer),
         )
         .unwrap(),
-        Duration::from_millis(res.value_of("timeout").unwrap().to_string().parse().expect("Could not parse timeout in milliseconds")),
+        Duration::from_millis(
+            res.value_of("timeout")
+                .unwrap()
+                .to_string()
+                .parse()
+                .expect("Could not parse timeout in milliseconds"),
+        ),
     )
     .expect("Failed to create the executor.");
 


### PR DESCRIPTION
This pr removes hardcoded paths from forkserver example, and use clap to make it look more decent