### PR TITLE
QEMU target arch selector via feature flag

### DIFF
--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -12,7 +12,11 @@ edition = "2021"
 
 [features]
 python = ["pyo3", "pyo3-build-config"]
-default = []
+default = ["x86_64"]
+x86_64 = []
+i386 = []
+arm = []
+aarch64 = []
 
 [dependencies]
 libafl = { path = "../libafl", version = "0.7.0" }

--- a/libafl_qemu/build.rs
+++ b/libafl_qemu/build.rs
@@ -11,8 +11,44 @@ fn build_dep_check(tools: &[&str]) {
     }
 }
 
+#[macro_export]
+macro_rules! assert_unique_feature {
+    () => {};
+    ($first:tt $(,$rest:tt)*) => {
+        $(
+            #[cfg(all(feature = $first, feature = $rest))]
+            compile_error!(concat!("features \"", $first, "\" and \"", $rest, "\" cannot be used together"));
+        )*
+        assert_unique_feature!($($rest),*);
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn main() {
+    // Make sure we have at least and at most one architecutre feature set
+    assert_unique_feature!("arm", "aarch64", "i386", "i86_64");
+    #[cfg(not(any(
+        feature = "arm",
+        feature = "aarch64",
+        feature = "i368",
+        feature = "x86_64"
+    )))]
+    compile_error!(
+        "No architecture feature enabled for libafl_qemu, supported: arm, aarch64, i368, i86_64"
+    );
+
+    let cpu_target = if cfg!(feature = "arm") {
+        "arm"
+    } else if cfg!(feature = "aarch64") {
+        "aarch64"
+    } else if cfg!(feature = "i368") {
+        "368"
+    } else if cfg!(feature = "x86_64") {
+        "x86_64"
+    } else {
+        panic!("No architecture feture enabled for libafl_qemu");
+    };
+
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/asan-giovese.c");
     println!("cargo:rerun-if-changed=src/asan-giovese.h");
@@ -25,12 +61,9 @@ fn main() {
     }
 
     let jobs = env::var("CARGO_BUILD_JOBS");
-    let cpu_target = env::var("CPU_TARGET").unwrap_or_else(|_| {
-        println!("cargo:warning=CPU_TARGET is not set, default to x86_64");
-        "x86_64".to_owned()
-    });
+
     let cross_cc = env::var("CROSS_CC").unwrap_or_else(|_| {
-        println!("cargo:warning=CROSS_CC is not set, default to cc (things can go wrong if CPU_TARGET is not the host arch)");
+        println!("cargo:warning=CROSS_CC is not set, default to cc (things can go wrong if the selected cpu target ({}) is not the host arch ({}))", cpu_target, env::consts::ARCH);
         "cc".to_owned()
     });
 

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -1,17 +1,23 @@
 use std::env;
 
+#[cfg(feature = "aarch64")]
 pub mod aarch64;
-pub mod arm;
-pub mod i386;
-pub mod x86_64;
-
-#[cfg(cpu_target = "aarch64")]
+#[cfg(feature = "aarch64")]
 pub use aarch64::*;
-#[cfg(cpu_target = "arm")]
+
+#[cfg(feature = "arm")]
+pub mod arm;
+#[cfg(feature = "arm")]
 pub use arm::*;
-#[cfg(cpu_target = "i386")]
+
+#[cfg(feature = "i386")]
+pub mod i386;
+#[cfg(feature = "i386")]
 pub use i386::*;
-#[cfg(cpu_target = "x86_64")]
+
+#[cfg(feature = "x86_64")]
+pub mod x86_64;
+#[cfg(feature = "x86_64")]
 pub use x86_64::*;
 
 pub mod elf;


### PR DESCRIPTION
This allows us to write emulators based on libafl_qemu for a specific target arch