### PR TITLE
[libafl_qemu] prevent unneeded build.rs runs

### DIFF
--- a/libafl_qemu/build.rs
+++ b/libafl_qemu/build.rs
@@ -76,13 +76,8 @@ fn main() {
     let qasan_dir = Path::new("libqasan");
     let qasan_dir = fs::canonicalize(&qasan_dir).unwrap();
     let src_dir = Path::new("src");
-    //let cwd = env::current_dir().unwrap().to_string_lossy().to_string();
 
-    println!("cargo:rerun-if-changed={}/libqasan.so", qasan_dir.display());
-    println!(
-        "cargo:rerun-if-changed={}/libqasan.so",
-        target_dir.display()
-    );
+    println!("cargo:rerun-if-changed=libqasan");
 
     build_dep_check(&["git", "make"]);
 


### PR DESCRIPTION
`libqasan/libqasan.so` never exists during a normal `cargo build` because the .so is built directly to the target_dir, not in the source directory. This missing file was triggering cargo to rerun the build script every time a user of this library made an incremental change to their code.

pointing `rerun-if-changed` to a directory will make cargo rerun build.rs if any file in that directory changes.

Big thanks to bjorn3 and Eric Huss on the rust zulip for helping me track down the reason cargo was rerunning build.rs:

https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/.E2.9C.94.20cargo.20explain.20reason.20for.20running.20build.2Ers.20again.3F