### PR TITLE
[libafl_qemu] fix i386 Regs values

### DIFF
--- a/libafl_qemu/src/i386.rs
+++ b/libafl_qemu/src/i386.rs
@@ -10,13 +10,13 @@ pub use syscall_numbers::x86::*;
 #[repr(i32)]
 pub enum Regs {
     Eax = 0,
-    Ebx = 1,
-    Ecx = 2,
-    Edx = 3,
-    Esi = 4,
-    Edi = 5,
-    Ebp = 6,
-    Esp = 7,
+    Ecx = 1,
+    Edx = 2,
+    Ebx = 3,
+    Esp = 4,
+    Ebp = 5,
+    Esi = 6,
+    Edi = 7,
     Eip = 8,
     Eflags = 9,
 }


### PR DESCRIPTION
The `Regs` enum was defined out of order, leading to incorrect results from `emu.read_reg` for i386. I found the correct ordering defined [here](https://github.com/AFLplusplus/qemu-libafl-bridge/blob/cabf9862e42ffeab9de9b1bfa12cddaf125c53e8/target/i386/cpu.h#L46-L54).