### PR TITLE
Reorder type parameters in the correct order

### DIFF
--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -282,7 +282,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<'a, C, E, I, S, SC, SP, MT, Z> EventProcessor<E, I, S, Z>
+impl<'a, C, E, I, MT, S, SC, SP, Z> EventProcessor<E, I, S, Z>
     for SimpleRestartingEventManager<'a, C, I, MT, S, SC, SP>
 where
     C: Corpus<I>,
@@ -297,7 +297,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<'a, C, E, I, S, SC, SP, MT, Z> EventManager<E, I, S, Z>
+impl<'a, C, E, I, MT, S, SC, SP, Z> EventManager<E, I, S, Z>
     for SimpleRestartingEventManager<'a, C, I, MT, S, SC, SP>
 where
     C: Corpus<I>,

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -1030,7 +1030,7 @@ where
 }
 
 #[cfg(all(feature = "std", unix))]
-impl<'a, EM, H, I, OT, S, Z, SP> Executor<EM, I, S, Z>
+impl<'a, EM, H, I, OT, S, SP, Z> Executor<EM, I, S, Z>
     for InProcessForkExecutor<'a, H, I, OT, S, SP>
 where
     H: FnMut(&I) -> ExitKind,

--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -16,7 +16,7 @@ pub struct WithObservers<E: Debug, OT: Debug> {
     observers: OT,
 }
 
-impl<EM, I, S, Z, E, OT> Executor<EM, I, S, Z> for WithObservers<E, OT>
+impl<E, EM, I, OT, S, Z> Executor<EM, I, S, Z> for WithObservers<E, OT>
 where
     I: Input,
     E: Executor<EM, I, S, Z>,
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<I, S, E: Debug, OT: Debug> HasObservers<I, OT, S> for WithObservers<E, OT>
+impl<I, E: Debug, OT: Debug, S> HasObservers<I, OT, S> for WithObservers<E, OT>
 where
     I: Input,
     OT: ObserversTuple<I, S>,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -139,7 +139,7 @@ where
 
 /// A cobined feedback consisting of ultiple [`Feedback`]s
 #[derive(Debug)]
-pub struct CombinedFeedback<A, B, FL, I, S>
+pub struct CombinedFeedback<A, B, I, S, FL>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,
@@ -155,7 +155,7 @@ where
     phantom: PhantomData<(I, S, FL)>,
 }
 
-impl<A, B, FL, I, S> Named for CombinedFeedback<A, B, FL, I, S>
+impl<A, B, I, S, FL> Named for CombinedFeedback<A, B, I, S, FL>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,
@@ -168,7 +168,7 @@ where
     }
 }
 
-impl<A, B, FL, I, S> CombinedFeedback<A, B, FL, I, S>
+impl<A, B, I, S, FL> CombinedFeedback<A, B, I, S, FL>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,
@@ -188,7 +188,7 @@ where
     }
 }
 
-impl<A, B, FL, I, S> Feedback<I, S> for CombinedFeedback<A, B, FL, I, S>
+impl<A, B, I, S, FL> Feedback<I, S> for CombinedFeedback<A, B, I, S, FL>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -139,7 +139,7 @@ where
 
 /// A cobined feedback consisting of ultiple [`Feedback`]s
 #[derive(Debug)]
-pub struct CombinedFeedback<A, B, I, S, FL>
+pub struct CombinedFeedback<A, B, FL, I, S>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,
@@ -155,7 +155,7 @@ where
     phantom: PhantomData<(I, S, FL)>,
 }
 
-impl<A, B, I, S, FL> Named for CombinedFeedback<A, B, I, S, FL>
+impl<A, B, FL, I, S> Named for CombinedFeedback<A, B, FL, I, S>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,
@@ -168,7 +168,7 @@ where
     }
 }
 
-impl<A, B, I, S, FL> CombinedFeedback<A, B, I, S, FL>
+impl<A, B, FL, I, S> CombinedFeedback<A, B, FL, I, S>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,
@@ -188,7 +188,7 @@ where
     }
 }
 
-impl<A, B, I, S, FL> Feedback<I, S> for CombinedFeedback<A, B, I, S, FL>
+impl<A, B, FL, I, S> Feedback<I, S> for CombinedFeedback<A, B, FL, I, S>
 where
     A: Feedback<I, S>,
     B: Feedback<I, S>,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -532,21 +532,21 @@ where
 
 /// Combine two feedbacks with an eager AND operation,
 /// will call all feedbacks functions even if not necessery to conclude the result
-pub type EagerAndFeedback<A, B, I, S> = CombinedFeedback<A, B, I, S, LogicEagerAnd>;
+pub type EagerAndFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicEagerAnd, I, S>;
 
 /// Combine two feedbacks with an fast AND operation,
 /// might skip calling feedbacks functions if not necessery to conclude the result
-pub type FastAndFeedback<A, B, I, S> = CombinedFeedback<A, B, I, S, LogicFastAnd>;
+pub type FastAndFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicFastAnd, I, S>;
 
 /// Combine two feedbacks with an eager OR operation,
 /// will call all feedbacks functions even if not necessery to conclude the result
-pub type EagerOrFeedback<A, B, I, S> = CombinedFeedback<A, B, I, S, LogicEagerOr>;
+pub type EagerOrFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicEagerOr, I, S>;
 
 /// Combine two feedbacks with an fast OR operation,
 /// might skip calling feedbacks functions if not necessery to conclude the result
 /// This means any feedback that is not first might be skipped, use caution when using with
 /// `TimeFeedback`
-pub type FastOrFeedback<A, B, I, S> = CombinedFeedback<A, B, I, S, LogicFastOr>;
+pub type FastOrFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicFastOr, I, S>;
 
 /// Compose feedbacks with an `NOT` operation
 #[derive(Clone)]


### PR DESCRIPTION
this pr sorts the type parameters

I skimmed through every impl and that was a pita 🥙 