### PR TITLE
Disable pita 🥙 compiler in debug mode

### DIFF
--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -18,7 +18,7 @@ Welcome to `LibAFL`
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![deny(
+#![cfg_attr(debug_assertions, warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -27,24 +27,37 @@ Welcome to `LibAFL`
     unused_import_braces,
     unused_qualifications,
     //unused_results
-)]
-#![deny(
-    bad_style,
-    const_err,
-    dead_code,
-    improper_ctypes,
-    non_shorthand_field_patterns,
-    no_mangle_generic_items,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    private_in_public,
-    unconditional_recursion,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_parens,
-    while_true
+))]
+#![cfg_attr(not(debug_assertions), deny(
+    missing_debug_implementations,
+    missing_docs,
+    //trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    //unused_results
+))]
+#![cfg_attr(
+    not(debug_assertions),
+    deny(
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
 )]
 
 #[macro_use]

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -14,7 +14,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![deny(
+#![cfg_attr(debug_assertions, warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -23,24 +23,37 @@
     unused_import_braces,
     unused_qualifications,
     //unused_results
-)]
-#![deny(
-    bad_style,
-    const_err,
-    dead_code,
-    improper_ctypes,
-    non_shorthand_field_patterns,
-    no_mangle_generic_items,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    private_in_public,
-    unconditional_recursion,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_parens,
-    while_true
+))]
+#![cfg_attr(not(debug_assertions), deny(
+    missing_debug_implementations,
+    missing_docs,
+    //trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    //unused_results
+))]
+#![cfg_attr(
+    not(debug_assertions),
+    deny(
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
 )]
 
 use std::{convert::Into, path::Path, process::Command, string::String, vec::Vec};

--- a/libafl_derive/src/lib.rs
+++ b/libafl_derive/src/lib.rs
@@ -14,7 +14,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![deny(
+#![cfg_attr(debug_assertions, warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -23,24 +23,37 @@
     unused_import_braces,
     unused_qualifications,
     //unused_results
-)]
-#![deny(
-    bad_style,
-    const_err,
-    dead_code,
-    improper_ctypes,
-    non_shorthand_field_patterns,
-    no_mangle_generic_items,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    private_in_public,
-    unconditional_recursion,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_parens,
-    while_true
+))]
+#![cfg_attr(not(debug_assertions), deny(
+    missing_debug_implementations,
+    missing_docs,
+    //trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    //unused_results
+))]
+#![cfg_attr(
+    not(debug_assertions),
+    deny(
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
 )]
 
 use proc_macro::TokenStream;

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -17,7 +17,7 @@ It can report coverage and, on supported architecutres, even reports memory acce
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![deny(
+#![cfg_attr(debug_assertions, warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -26,24 +26,37 @@ It can report coverage and, on supported architecutres, even reports memory acce
     unused_import_braces,
     unused_qualifications,
     //unused_results
-)]
-#![deny(
-    bad_style,
-    const_err,
-    dead_code,
-    improper_ctypes,
-    non_shorthand_field_patterns,
-    no_mangle_generic_items,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    private_in_public,
-    unconditional_recursion,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_parens,
-    while_true
+))]
+#![cfg_attr(not(debug_assertions), deny(
+    missing_debug_implementations,
+    missing_docs,
+    //trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    //unused_results
+))]
+#![cfg_attr(
+    not(debug_assertions),
+    deny(
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
 )]
 
 /// The frida-asan allocator

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -14,7 +14,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![deny(
+#![cfg_attr(debug_assertions, warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -23,24 +23,37 @@
     unused_import_braces,
     unused_qualifications,
     //unused_results
-)]
-#![deny(
-    bad_style,
-    const_err,
-    dead_code,
-    improper_ctypes,
-    non_shorthand_field_patterns,
-    no_mangle_generic_items,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    private_in_public,
-    unconditional_recursion,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_parens,
-    while_true
+))]
+#![cfg_attr(not(debug_assertions), deny(
+    missing_debug_implementations,
+    missing_docs,
+    //trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    //unused_results
+))]
+#![cfg_attr(
+    not(debug_assertions),
+    deny(
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
 )]
 
 pub mod inmemory;

--- a/libafl_targets/src/lib.rs
+++ b/libafl_targets/src/lib.rs
@@ -15,7 +15,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![deny(
+#![cfg_attr(debug_assertions, warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -24,24 +24,37 @@
     unused_import_braces,
     unused_qualifications,
     //unused_results
-)]
-#![deny(
-    bad_style,
-    const_err,
-    dead_code,
-    improper_ctypes,
-    non_shorthand_field_patterns,
-    no_mangle_generic_items,
-    overflowing_literals,
-    path_statements,
-    patterns_in_fns_without_body,
-    private_in_public,
-    unconditional_recursion,
-    unused,
-    unused_allocation,
-    unused_comparisons,
-    unused_parens,
-    while_true
+))]
+#![cfg_attr(not(debug_assertions), deny(
+    missing_debug_implementations,
+    missing_docs,
+    //trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    //unused_results
+))]
+#![cfg_attr(
+    not(debug_assertions),
+    deny(
+        bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true
+    )
 )]
 
 #[allow(unused_imports)]


### PR DESCRIPTION
This makes rustc less pedantic for debug builds