### PR TITLE
Use Unix timer_* API instead of setitimer

### DIFF
--- a/libafl/src/bolts/os/unix_signals.rs
+++ b/libafl/src/bolts/os/unix_signals.rs
@@ -13,12 +13,12 @@ use nix::errno::{errno, Errno};
 #[cfg(feature = "std")]
 use std::ffi::CString;
 
-#[cfg(target_arch = "arm")]
 /// armv7 `libc` does not feature a `uncontext_t` implementation
+#[cfg(target_arch = "arm")]
 pub use libc::c_ulong;
 
-#[cfg(target_arch = "arm")]
 /// ARMv7-specific representation of a saved context
+#[cfg(target_arch = "arm")]
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
 #[repr(C)]
@@ -67,8 +67,8 @@ pub struct mcontext_t {
     pub fault_address: c_ulong,
 }
 
-#[cfg(target_arch = "arm")]
 /// User Context Struct
+#[cfg(target_arch = "arm")]
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
 #[repr(C)]

--- a/libafl/src/bolts/os/unix_signals.rs
+++ b/libafl/src/bolts/os/unix_signals.rs
@@ -13,46 +13,76 @@ use nix::errno::{errno, Errno};
 #[cfg(feature = "std")]
 use std::ffi::CString;
 
-/// armv7 `libc` does not feature a `uncontext_t` implementation
 #[cfg(target_arch = "arm")]
+/// armv7 `libc` does not feature a `uncontext_t` implementation
 pub use libc::c_ulong;
 
 #[cfg(target_arch = "arm")]
+/// ARMv7-specific representation of a saved context
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct mcontext_t {
+    /// Signal Number
     pub trap_no: c_ulong,
+    /// Error Code
     pub error_code: c_ulong,
+    /// Old signal mask
     pub oldmask: c_ulong,
+    /// GPR R0
     pub arm_r0: c_ulong,
+    /// GPR R1
     pub arm_r1: c_ulong,
+    /// GPR R2
     pub arm_r2: c_ulong,
+    /// GPR R3
     pub arm_r3: c_ulong,
+    /// GPR R4
     pub arm_r4: c_ulong,
+    /// GPR R5
     pub arm_r5: c_ulong,
+    /// GPR R6
     pub arm_r6: c_ulong,
+    /// GPR R7
     pub arm_r7: c_ulong,
+    /// GPR R8
     pub arm_r8: c_ulong,
+    /// GPR R9
     pub arm_r9: c_ulong,
+    /// GPR R10
     pub arm_r10: c_ulong,
+    /// Frame Pointer
     pub arm_fp: c_ulong,
+    /// Intra-Procedure Scratch Register
     pub arm_ip: c_ulong,
+    /// Stack Pointer
     pub arm_sp: c_ulong,
+    /// Link Register
     pub arm_lr: c_ulong,
+    /// Program Counter
     pub arm_pc: c_ulong,
+    /// Current Program Status Register
     pub arm_cpsr: c_ulong,
+    /// Fault Address
     pub fault_address: c_ulong,
 }
 
 #[cfg(target_arch = "arm")]
+/// User Context Struct
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct ucontext_t {
+    /// Flags
     pub uc_flags: u32,
+    /// Pointer to the context that will be resumed when this context returns
     pub uc_link: *mut ucontext_t,
+    /// Stack used by this context
     pub uc_stack: stack_t,
+    /// Machine-specific representation of the saved context
     pub uc_mcontext: mcontext_t,
-    pub uc_sigmask: nix::sys::signal::SigSet,
+    /// Set of signals that are blocked when this context is active
+    pub uc_sigmask: libc::sigset_t,
 }
 
 #[cfg(not(target_arch = "arm"))]

--- a/libafl/src/executors/combined.rs
+++ b/libafl/src/executors/combined.rs
@@ -50,7 +50,10 @@ where
         mgr: &mut EM,
         input: &I,
     ) -> Result<ExitKind, Error> {
-        self.primary.run_target(fuzzer, state, mgr, input)
+        let ret = self.primary.run_target(fuzzer, state, mgr, input);
+        self.primary.post_run_reset();
+        self.secondary.post_run_reset();
+        ret
     }
 }
 

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -35,7 +35,7 @@ use windows::Win32::System::Threading::SetThreadStackGuarantee;
 
 use crate::{
     events::{EventFirer, EventRestarter},
-    executors::{Executor, ExitKind, HasObservers, HasOnCrashReset},
+    executors::{Executor, ExitKind, HasObservers, HasPostRunReset},
     feedbacks::Feedback,
     fuzzer::HasObjective,
     inputs::Input,
@@ -114,14 +114,14 @@ where
     }
 }
 
-impl<'a, H, I, OT, S> HasOnCrashReset for InProcessExecutor<'a, H, I, OT, S>
+impl<'a, H, I, OT, S> HasPostRunReset for InProcessExecutor<'a, H, I, OT, S>
 where
     H: FnMut(&I) -> ExitKind,
     I: Input,
     OT: ObserversTuple<I, S>,
 {
     #[inline]
-    fn reset_on_crash(&self) {}
+    fn post_run_reset(&self) {}
 }
 
 impl<'a, H, I, OT, S> InProcessExecutor<'a, H, I, OT, S>
@@ -278,7 +278,7 @@ impl InProcessHandlers {
     pub fn new<E, EM, I, OF, OT, S, Z>() -> Result<Self, Error>
     where
         I: Input,
-        E: HasObservers<I, OT, S> + HasOnCrashReset,
+        E: HasObservers<I, OT, S> + HasPostRunReset,
         OT: ObserversTuple<I, S>,
         EM: EventFirer<I> + EventRestarter<S>,
         OF: Feedback<I, S>,
@@ -430,7 +430,7 @@ mod unix_signal_handler {
         events::{Event, EventFirer, EventRestarter},
         executors::{
             inprocess::{InProcessExecutorHandlerData, GLOBAL_STATE},
-            ExitKind, HasObservers, HasOnCrashReset,
+            ExitKind, HasObservers, HasPostRunReset,
         },
         feedbacks::Feedback,
         fuzzer::HasObjective,
@@ -572,7 +572,7 @@ mod unix_signal_handler {
         _context: &mut ucontext_t,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        E: HasObservers<I, OT, S> + HasOnCrashReset,
+        E: HasObservers<I, OT, S> + HasPostRunReset,
         EM: EventFirer<I> + EventRestarter<S>,
         OT: ObserversTuple<I, S>,
         OF: Feedback<I, S>,
@@ -622,7 +622,7 @@ mod unix_signal_handler {
         } else {
             let executor = (data.executor_ptr as *const E).as_ref().unwrap();
             // disarms timeout in case of TimeoutExecutor
-            executor.reset_on_crash();
+            executor.post_run_reset();
             let state = (data.state_ptr as *mut S).as_mut().unwrap();
             let event_mgr = (data.event_mgr_ptr as *mut EM).as_mut().unwrap();
             let fuzzer = (data.fuzzer_ptr as *mut Z).as_mut().unwrap();
@@ -699,7 +699,7 @@ mod windows_exception_handler {
         events::{Event, EventFirer, EventRestarter},
         executors::{
             inprocess::{InProcessExecutorHandlerData, GLOBAL_STATE},
-            ExitKind, HasObservers, HasOnCrashReset,
+            ExitKind, HasObservers, HasPostRunReset,
         },
         feedbacks::Feedback,
         fuzzer::HasObjective,
@@ -843,7 +843,7 @@ mod windows_exception_handler {
         exception_pointers: *mut EXCEPTION_POINTERS,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        E: HasObservers<I, OT, S> + HasOnCrashReset,
+        E: HasObservers<I, OT, S> + HasPostRunReset,
         EM: EventFirer<I> + EventRestarter<S>,
         OT: ObserversTuple<I, S>,
         OF: Feedback<I, S>,
@@ -869,7 +869,7 @@ mod windows_exception_handler {
             compiler_fence(Ordering::SeqCst);
 
             let executor = (data.executor_ptr as *const E).as_ref().unwrap();
-            executor.reset_on_crash();
+            executor.post_run_reset();
             data.tp_timer = ptr::null_mut();
         }
 

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -843,7 +843,7 @@ mod windows_exception_handler {
         exception_pointers: *mut EXCEPTION_POINTERS,
         data: &mut InProcessExecutorHandlerData,
     ) where
-        E: HasObservers<I, OT, S>,
+        E: HasObservers<I, OT, S> + HasOnCrashReset,
         EM: EventFirer<I> + EventRestarter<S>,
         OT: ObserversTuple<I, S>,
         OF: Feedback<I, S>,

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -852,7 +852,7 @@ mod windows_exception_handler {
         Z: HasObjective<I, OF, S>,
     {
         // Have we set a timer_before?
-        if let Some(x) =
+        if let Some(_) =
             (data.tp_timer as *mut windows::Win32::System::Threading::TP_TIMER).as_mut()
         {
             /*

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -69,6 +69,12 @@ where
     fn observers_mut(&mut self) -> &mut OT;
 }
 
+/// Allows access to custom Reset Handler
+pub trait HasOnCrashReset {
+    /// Reset the state, e.g., disable timers
+    fn reset(&self);
+}
+
 /// An executor takes the given inputs, and runs the harness/target.
 pub trait Executor<EM, I, S, Z>: Debug
 where
@@ -94,6 +100,11 @@ where
     {
         WithObservers::new(self, observers)
     }
+}
+
+impl<EM, I, S, Z> HasOnCrashReset for dyn Executor<EM, I, S, Z> {
+    #[inline]
+    fn reset(&self) {}
 }
 
 /// A simple executor that does nothing.

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -69,12 +69,6 @@ where
     fn observers_mut(&mut self) -> &mut OT;
 }
 
-/// Allows access to custom Reset Handler
-pub trait HasPostRunReset {
-    /// Reset the state, e.g., disable timers
-    fn post_run_reset(&self);
-}
-
 /// An executor takes the given inputs, and runs the harness/target.
 pub trait Executor<EM, I, S, Z>: Debug
 where
@@ -100,11 +94,9 @@ where
     {
         WithObservers::new(self, observers)
     }
-}
 
-impl<EM, I, S, Z> HasPostRunReset for dyn Executor<EM, I, S, Z> {
-    #[inline]
-    fn post_run_reset(&self) {}
+    /// Custom Reset Handler, e.g., to reset timers
+    fn post_run_reset(&mut self) {}
 }
 
 /// A simple executor that does nothing.
@@ -129,6 +121,8 @@ where
             Ok(ExitKind::Ok)
         }
     }
+
+    fn post_run_reset(&mut self) {}
 }
 
 #[cfg(test)]

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -72,7 +72,7 @@ where
 /// Allows access to custom Reset Handler
 pub trait HasOnCrashReset {
     /// Reset the state, e.g., disable timers
-    fn reset(&self);
+    fn reset_on_crash(&self);
 }
 
 /// An executor takes the given inputs, and runs the harness/target.
@@ -104,7 +104,7 @@ where
 
 impl<EM, I, S, Z> HasOnCrashReset for dyn Executor<EM, I, S, Z> {
     #[inline]
-    fn reset(&self) {}
+    fn reset_on_crash(&self) {}
 }
 
 /// A simple executor that does nothing.

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -70,9 +70,9 @@ where
 }
 
 /// Allows access to custom Reset Handler
-pub trait HasOnCrashReset {
+pub trait HasPostRunReset {
     /// Reset the state, e.g., disable timers
-    fn reset_on_crash(&self);
+    fn post_run_reset(&self);
 }
 
 /// An executor takes the given inputs, and runs the harness/target.
@@ -102,9 +102,9 @@ where
     }
 }
 
-impl<EM, I, S, Z> HasOnCrashReset for dyn Executor<EM, I, S, Z> {
+impl<EM, I, S, Z> HasPostRunReset for dyn Executor<EM, I, S, Z> {
     #[inline]
-    fn reset_on_crash(&self) {}
+    fn post_run_reset(&self) {}
 }
 
 /// A simple executor that does nothing.

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -97,6 +97,7 @@ where
     }
 
     /// Custom Reset Handler, e.g., to reset timers
+    #[inline]
     fn post_run_reset(&mut self) {}
 }
 
@@ -122,8 +123,6 @@ where
             Ok(ExitKind::Ok)
         }
     }
-
-    fn post_run_reset(&mut self) {}
 }
 
 #[cfg(test)]

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -3,7 +3,6 @@
 #[cfg(any(windows, unix))]
 use core::{
     fmt::{self, Debug, Formatter},
-    ptr::{addr_of, addr_of_mut},
     time::Duration,
 };
 
@@ -19,6 +18,9 @@ use crate::executors::inprocess::{HasInProcessHandlers, GLOBAL_STATE};
 
 #[cfg(unix)]
 use core::{mem::zeroed, ptr::null_mut};
+
+#[cfg(target_os = "linux")]
+use core::ptr::{addr_of, addr_of_mut};
 
 #[cfg(all(unix, not(target_os = "linux")))]
 use libc::c_int;

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -151,7 +151,11 @@ impl<E> TimeoutExecutor<E> {
         let mut timerid: libc::timer_t = null_mut();
         unsafe {
             // creates a new per-process interval timer
-            libc::timer_create(libc::CLOCK_MONOTONIC, null_mut(), &mut timerid as *mut _);
+            libc::timer_create(
+                libc::CLOCK_MONOTONIC,
+                null_mut(),
+                std::ptr::addr_of_mut!(timerid),
+            );
         }
         Self {
             executor,
@@ -346,7 +350,12 @@ where
         input: &I,
     ) -> Result<ExitKind, Error> {
         unsafe {
-            libc::timer_settime(self.timerid, 0, &self.itimerspec as *const _, null_mut());
+            libc::timer_settime(
+                self.timerid,
+                0,
+                std::ptr::addr_of_mut!(self.itimerspec),
+                null_mut(),
+            );
             let ret = self.executor.run_target(fuzzer, state, mgr, input);
             // reset timer
             self.post_run_reset();
@@ -357,7 +366,7 @@ where
     fn post_run_reset(&mut self) {
         unsafe {
             let disarmed: libc::itimerspec = zeroed();
-            libc::timer_settime(self.timerid, 0, &disarmed as *const _, null_mut());
+            libc::timer_settime(self.timerid, 0, std::ptr::addr_of!(disarmed), null_mut());
         }
         self.executor.post_run_reset();
     }

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -64,6 +64,14 @@ struct Itimerval {
     pub it_value: Timeval,
 }
 
+#[cfg(all(unix, target_vendor = "apple"))]
+extern "C" {
+    fn setitimer(which: c_int, new_value: *mut Itimerval, old_value: *mut Itimerval) -> c_int;
+}
+
+#[cfg(all(unix, target_vendor = "apple"))]
+const ITIMER_REAL: c_int = 0;
+
 /// The timeout excutor is a wrapper that sets a timeout before each run
 pub struct TimeoutExecutor<E> {
     executor: E,
@@ -305,7 +313,7 @@ where
 
             write_volatile(&mut data.timeout_input_ptr, core::ptr::null_mut());
 
-            self.reset();
+            self.reset_on_crash();
             ret
         }
     }

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use crate::{
-    executors::{Executor, ExitKind, HasObservers, HasPostRunReset},
+    executors::{Executor, ExitKind, HasObservers},
     inputs::Input,
     observers::ObserversTuple,
     Error,
@@ -76,7 +76,7 @@ extern "C" {
 const ITIMER_REAL: c_int = 0;
 
 /// The timeout excutor is a wrapper that sets a timeout before each run
-pub struct TimeoutExecutor<E: HasPostRunReset> {
+pub struct TimeoutExecutor<E> {
     executor: E,
     #[cfg(target_os = "linux")]
     itimerspec: libc::itimerspec,
@@ -92,7 +92,7 @@ pub struct TimeoutExecutor<E: HasPostRunReset> {
     critical: RTL_CRITICAL_SECTION,
 }
 
-impl<E: Debug + HasPostRunReset> Debug for TimeoutExecutor<E> {
+impl<E: Debug> Debug for TimeoutExecutor<E> {
     #[cfg(windows)]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("TimeoutExecutor")
@@ -131,7 +131,7 @@ type PTP_TIMER_CALLBACK = unsafe extern "system" fn(
 );
 
 #[cfg(target_os = "linux")]
-impl<E: HasPostRunReset> TimeoutExecutor<E> {
+impl<E> TimeoutExecutor<E> {
     /// Create a new [`TimeoutExecutor`], wrapping the given `executor` and checking for timeouts.
     /// This should usually be used for `InProcess` fuzzing.
     pub fn new(executor: E, exec_tmout: Duration) -> Self {
@@ -180,7 +180,7 @@ impl<E: HasPostRunReset> TimeoutExecutor<E> {
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
-impl<E: HasPostRunReset> TimeoutExecutor<E> {
+impl<E> TimeoutExecutor<E> {
     /// Create a new [`TimeoutExecutor`], wrapping the given `executor` and checking for timeouts.
     /// This should usually be used for `InProcess` fuzzing.
     pub fn new(executor: E, exec_tmout: Duration) -> Self {
@@ -223,7 +223,7 @@ impl<E: HasPostRunReset> TimeoutExecutor<E> {
 }
 
 #[cfg(windows)]
-impl<E: HasInProcessHandlers + HasPostRunReset> TimeoutExecutor<E> {
+impl<E: HasInProcessHandlers> TimeoutExecutor<E> {
     /// Create a new [`TimeoutExecutor`], wrapping the given `executor` and checking for timeouts.
     pub fn new(executor: E, exec_tmout: Duration) -> Self {
         let milli_sec = exec_tmout.as_millis() as i64;
@@ -265,7 +265,7 @@ impl<E: HasInProcessHandlers + HasPostRunReset> TimeoutExecutor<E> {
 #[cfg(windows)]
 impl<E, EM, I, S, Z> Executor<EM, I, S, Z> for TimeoutExecutor<E>
 where
-    E: Executor<EM, I, S, Z> + HasInProcessHandlers + HasPostRunReset,
+    E: Executor<EM, I, S, Z> + HasInProcessHandlers,
     I: Input,
 {
     #[allow(clippy::cast_sign_loss)]
@@ -320,12 +320,22 @@ where
             ret
         }
     }
+
+    /// Deletes this timer queue
+    /// # Safety
+    /// Will dereference the given `tp_timer` pointer, unchecked.
+    fn post_run_reset(&mut self) {
+        unsafe {
+            CloseThreadpoolTimer(self.tp_timer);
+        }
+        self.executor.post_run_reset();
+    }
 }
 
 #[cfg(target_os = "linux")]
 impl<E, EM, I, S, Z> Executor<EM, I, S, Z> for TimeoutExecutor<E>
 where
-    E: Executor<EM, I, S, Z> + HasPostRunReset,
+    E: Executor<EM, I, S, Z>,
     I: Input,
 {
     fn run_target(
@@ -343,12 +353,20 @@ where
             ret
         }
     }
+
+    fn post_run_reset(&mut self) {
+        unsafe {
+            let disarmed: libc::itimerspec = zeroed();
+            libc::timer_settime(self.timerid, 0, &disarmed as *const _, null_mut());
+        }
+        self.executor.post_run_reset();
+    }
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
 impl<E, EM, I, S, Z> Executor<EM, I, S, Z> for TimeoutExecutor<E>
 where
-    E: Executor<EM, I, S, Z> + HasPostRunReset,
+    E: Executor<EM, I, S, Z>,
     I: Input,
 {
     fn run_target(
@@ -365,11 +383,19 @@ where
             ret
         }
     }
+
+    fn post_run_reset(&mut self) {
+        unsafe {
+            let mut itimerval_zero: Itimerval = zeroed();
+            setitimer(ITIMER_REAL, &mut itimerval_zero, null_mut());
+        }
+        self.executor.post_run_reset();
+    }
 }
 
 impl<E, I, OT, S> HasObservers<I, OT, S> for TimeoutExecutor<E>
 where
-    E: HasObservers<I, OT, S> + HasPostRunReset,
+    E: HasObservers<I, OT, S>,
     OT: ObserversTuple<I, S>,
 {
     #[inline]
@@ -380,42 +406,5 @@ where
     #[inline]
     fn observers_mut(&mut self) -> &mut OT {
         self.executor.observers_mut()
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl<E: HasPostRunReset> HasPostRunReset for TimeoutExecutor<E> {
-    /// Disarm currently running timer
-    fn post_run_reset(&self) {
-        unsafe {
-            let disarmed: libc::itimerspec = zeroed();
-            libc::timer_settime(self.timerid, 0, &disarmed as *const _, null_mut());
-            self.executor.post_run_reset();
-        }
-    }
-}
-
-#[cfg(all(unix, not(target_os = "linux")))]
-impl<E: HasPostRunReset> HasPostRunReset for TimeoutExecutor<E> {
-    /// Disarm currently running timer
-    fn post_run_reset(&self) {
-        unsafe {
-            let mut itimerval_zero: Itimerval = zeroed();
-            setitimer(ITIMER_REAL, &mut itimerval_zero, null_mut());
-            self.executor.post_run_reset();
-        }
-    }
-}
-
-#[cfg(all(windows, feature = "std"))]
-impl<E: HasPostRunReset> HasPostRunReset for TimeoutExecutor<E> {
-    /// Deletes this timer queue
-    /// # Safety
-    /// Will dereference the given `tp_timer` pointer, unchecked.
-    fn post_run_reset(&self) {
-        unsafe {
-            CloseThreadpoolTimer(self.tp_timer);
-            self.executor.post_run_reset();
-        }
     }
 }

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -416,12 +416,3 @@ impl<E> HasPostRunReset for TimeoutExecutor<E> {
         }
     }
 }
-
-#[cfg(windows)]
-impl<E> Drop for TimeoutExecutor<E> {
-    fn drop(&mut self) {
-        unsafe {
-            CloseThreadpoolTimer(self.tp_timer);
-        }
-    }
-}

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -149,6 +149,11 @@ impl CompilerWrapper for ClangWrapper {
             new_args.push("-lBcrypt".into());
             new_args.push("-lAdvapi32".into());
         }
+        // required by timer API (timer_create, timer_settime)
+        #[cfg(target_os = "linux")]
+        if linking {
+            new_args.push("-lrt".into());
+        }
         // MacOS has odd linker behavior sometimes
         #[cfg(target_vendor = "apple")]
         if linking {


### PR DESCRIPTION
Currently, to set and reset timeouts in the _TimeoutExecutor_ the `setitimer` FFI is used.
The function is not exposed in `libc::` and is hence linked in via `extern "C"`, 
required structs are defined manually in LibAFL.
 
As these do not seem to account for different layouts/ pointer sizes, the call fails under armv7
and no alarm is being set (also cf. [this](https://sourceware.org/bugzilla/show_bug.cgi?id=16437)).

While working on this issue, I decided to use the newer timer API (`timer_create, timer_settime`),
as `setitimer` is marked [obsolete](https://linux.die.net/man/2/setitimer).

As this requires global access to a timer_id struct, e.g., in order to disarm timers in the crash handler,
a new trait was introduced for _Executor_s, also streamlining the clock reset between Unix and Windows.

Feedback is welcome. 