### PR TITLE
Various Fixes (windows timeout race & frida options)

### DIFF
--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -812,13 +812,13 @@ mod windows_exception_handler {
                 event_mgr.await_restart_safe();
                 compiler_fence(Ordering::SeqCst);
 
+                ExitProcess(1);
+
                 LeaveCriticalSection(
                     (data.critical as *mut RTL_CRITICAL_SECTION)
                         .as_mut()
                         .unwrap(),
                 );
-
-                ExitProcess(1);
             }
         }
         compiler_fence(Ordering::SeqCst);

--- a/libafl_cc/build.rs
+++ b/libafl_cc/build.rs
@@ -156,7 +156,6 @@ fn main() {
         let _ = Command::new(llvm_bindir.join("clang++"))
             .args(&cxxflags)
             .args(&custom_flags)
-            .arg("-DUSE_NEW_PM")
             .arg(src_dir.join("afl-coverage-pass.cc"))
             .args(&ldflags)
             .args(&["-fPIC", "-shared", "-o"])

--- a/libafl_cc/build.rs
+++ b/libafl_cc/build.rs
@@ -156,6 +156,7 @@ fn main() {
         let _ = Command::new(llvm_bindir.join("clang++"))
             .args(&cxxflags)
             .args(&custom_flags)
+            .arg("-DUSE_NEW_PM")
             .arg(src_dir.join("afl-coverage-pass.cc"))
             .args(&ldflags)
             .args(&["-fPIC", "-shared", "-o"])

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -319,7 +319,7 @@ impl Default for FridaOptions {
             enable_asan: false,
             enable_asan_leak_detection: false,
             enable_asan_continue_after_error: false,
-            enable_asan_allocation_backtraces: true,
+            enable_asan_allocation_backtraces: false,
             asan_max_allocation: 1 << 30,
             asan_max_total_allocation: 1 << 32,
             asan_max_allocation_panics: false,


### PR DESCRIPTION
This pr fixes 
1) a race condition on when crash handler are called right after timer handler finishes its execution

2) set `enable_asan_allocation_backtraces` to false by default. It does not work with amd64 asan
I don't know why, but my guess is alloc() calls _hooked_ malloc() which recursively alloc() (?)