### PR TITLE
Fix debug_child arg in forkserver_simple example

### DIFF
--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -137,7 +137,7 @@ pub fn main() {
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     // If we should debug the child
-    let debug_child = res.value_of("debug_child").is_some();
+    let debug_child = res.is_present("debug_child");
 
     // Create the executor for the forkserver
     let args = match res.values_of("arguments") {


### PR DESCRIPTION
The `debug_child` command line argument presence was not properly checked,
so it couldn't be set to true. Hence it was not possible to print out
the content of the buffer sent to the harness while fuzzing.