### PR TITLE
Expose more options to python qemu sugar

### DIFF
--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -88,7 +88,7 @@ pub fn python_module(py: Python, m: &PyModule) -> PyResult<()> {
     {
         qemu::pybind::register(py, m)?;
     }
-    #[cfg(target_family = "unix")]
+    #[cfg(unix)]
     {
         forkserver::pybind::register(py, m)?;
     }

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -88,5 +88,9 @@ pub fn python_module(py: Python, m: &PyModule) -> PyResult<()> {
     {
         qemu::pybind::register(py, m)?;
     }
+    #[cfg(target_family = "unix")]
+    {
+        forkserver::pybind::register(py, m)?;
+    }
     Ok(())
 }

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -488,7 +488,7 @@ pub mod pybind {
                 .tokens_file(self.tokens_file.clone())
                 .iterations(self.iterations)
                 .build()
-                .run(&emulator.emu)
+                .run(&emulator.emu);
         }
     }
 


### PR DESCRIPTION
re: https://discord.com/channels/736989425770168422/745844821800779786/935105388527902740

Of note: 
- all add'l options are optional, so existing users of the python api shouldn't have breakage
- the TypedBuilder with generics prevented me from doing conditional build steps, so i updated the rust struct to accept Options instead of stripping them off
- for my personal target that i used this on, i needed to call exit(0) after on_restart; i left that off with the expectation that it was just my target
- i registered the forkserver python sugar in lib.rs, lmk if leaving it out was intentional, and i'll remove it