### PR TITLE
extended inmemory; added exit to qemu

### DIFF
--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -286,6 +286,7 @@ where
                             iters,
                         )?;
                         mgr.on_restart(&mut state)?;
+                        std::process::exit(0);
                     } else {
                         fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)?;
                     }
@@ -306,6 +307,7 @@ where
                             iters,
                         )?;
                         mgr.on_restart(&mut state)?;
+                        std::process::exit(0);
                     } else {
                         fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)?;
                     }
@@ -377,6 +379,7 @@ where
                             iters,
                         )?;
                         mgr.on_restart(&mut state)?;
+                        std::process::exit(0);
                     } else {
                         fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)?;
                     }
@@ -397,6 +400,7 @@ where
                             iters,
                         )?;
                         mgr.on_restart(&mut state)?;
+                        std::process::exit(0);
                     } else {
                         fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)?;
                     }


### PR DESCRIPTION
closes #498 

same changes, different sugar

i didn't have a good way to test this quickly. tried generic_inmemory compiled to .so via afl-gcc-fast with ctypes, but then couldn't resolve symbols at runtime on the python side. Aside from that, the api can be called, params passed in, etc. 

I poked around afl++ directory for the proper libs to link etc, but ran out of time.  Leaving it here for now 

```
import ctypes

from pylibafl import sugar

fuzz_so = ctypes.CDLL("./fuzz.so")
toi = fuzz_so["LLVMFuzzerTestOneInput"]


def harness(buffer):
    toi(buffer, len(buffer))


sugar.InMemoryBytesCoverageSugar(
    ["corpus"], "crashes", 1336, [0], iterations=1, use_cmplog=True
).run(harness)
```