### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/src/baby_fuzzer.md
+++ b/docs/src/baby_fuzzer.md
@@ -216,7 +216,7 @@ Now we want to turn our simple fuzzer into a feedback-based one and increase the
 To do that, we need a way to keep track of if a condition is satisfied. The component that feeds the fuzzer with information about properties of a fuzzing run, the satisfied conditions in our case, is the Observer. We use the `StdMapObserver`, the default observer that uses a map to keep track of covered elements. In our fuzzer, each condition is mapped to an entry of such map.
 
 We represent such map as a `static mut` variable.
-As we don't rely on any instrumentation engine, we have to manually track the satisfied conditions in a map modyfing our tested function:
+As we don't rely on any instrumentation engine, we have to manually track the satisfied conditions in a map modifying our tested function:
 
 ```rust
 extern crate libafl;

--- a/libafl/src/bolts/anymap.rs
+++ b/libafl/src/bolts/anymap.rs
@@ -38,8 +38,6 @@ macro_rules! impl_asany {
     };
 }
 
-// yolo
-
 /// Get a `type_id` from its previously unpacked `u64`.
 /// Opposite of [`unpack_type_id(id)`].
 ///

--- a/libafl/src/bolts/anymap.rs
+++ b/libafl/src/bolts/anymap.rs
@@ -8,11 +8,11 @@ use core::{
 
 /// Convert to an Any trait object
 pub trait AsAny: Any {
-    /// returns this as Any trait
+    /// Returns this as Any trait
     fn as_any(&self) -> &dyn Any;
-    /// returns this as mutable Any trait
+    /// Returns this as mutable Any trait
     fn as_any_mut(&mut self) -> &mut dyn Any;
-    /// returns this as boxed Any trait
+    /// Returns this as boxed Any trait
     fn as_any_boxed(self: Box<Self>) -> Box<dyn Any>;
 }
 

--- a/libafl/src/bolts/compress.rs
+++ b/libafl/src/bolts/compress.rs
@@ -16,7 +16,7 @@ pub struct GzipCompressor {
 }
 
 impl GzipCompressor {
-    /// If the buffer is at lest larger as large as the `threshold` value, we compress the buffer.
+    /// If the buffer is at least larger as large as the `threshold` value, we compress the buffer.
     /// When given a `threshold` of `0`, the `GzipCompressor` will always compress.
     #[must_use]
     pub fn new(threshold: usize) -> Self {

--- a/libafl/src/bolts/cpu.rs
+++ b/libafl/src/bolts/cpu.rs
@@ -9,7 +9,7 @@ use crate::bolts::current_nanos;
 
 /// Read a timestamp for measurements.
 ///
-/// This function is a wrapper around different ways to get a timestamp, fast
+/// This function is a wrapper around different ways to get a timestamp, fast.
 /// In this way, an experiment only has to
 /// change this implementation rather than every instead of `read_time_counter`.
 /// It is using `rdtsc` on `x86_64` and `x86`.
@@ -28,7 +28,7 @@ pub fn read_time_counter() -> u64 {
 
 /// Read a timestamp for measurements.
 ///
-/// This function is a wrapper around different ways to get a timestamp, fast
+/// This function is a wrapper around different ways to get a timestamp, fast.
 /// In this way, an experiment only has to
 /// change this implementation rather than every instead of [`read_time_counter`]
 /// On unsupported architectures, it's falling back to normal system time, in millis.

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -55,8 +55,6 @@ For broker2broker communication, all messages are forwarded via network sockets.
 
 Check out the `llmp_test` example in ./examples, or build it with `cargo run --example llmp_test`.
 
-For broker2broker communication, all messages are forwarded via network sockets.
-
 */
 
 use alloc::{string::String, vec::Vec};
@@ -168,7 +166,7 @@ static mut GLOBAL_SIGHANDLER_STATE: LlmpBrokerSignalHandler = LlmpBrokerSignalHa
     shutting_down: false,
 };
 
-/// TAGs used thorughout llmp
+/// TAGs used throughout llmp
 pub type Tag = u32;
 /// The client ID == the sender id.
 pub type ClientId = u32;
@@ -241,7 +239,7 @@ pub enum TcpResponse {
     },
     /// Notify the client on the other side that it has been accepted.
     LocalClientAccepted {
-        /// The ClientId this client should send messages as
+        /// The ClientId this client should send messages as.
         /// Mainly used for client-side deduplication of incoming messages
         client_id: ClientId,
     },
@@ -506,7 +504,7 @@ pub struct LlmpDescription {
 }
 
 #[derive(Copy, Clone, Debug)]
-/// Result of an LLMP Mesasge hook
+/// Result of an LLMP Message hook
 pub enum LlmpMsgHookResult {
     /// This has been handled in the broker. No need to forward.
     Handled,
@@ -520,7 +518,7 @@ pub enum LlmpMsgHookResult {
 pub struct LlmpMsg {
     /// A tag
     pub tag: Tag, //u32
-    /// Sender of this messge
+    /// Sender of this message
     pub sender: ClientId, //u32
     /// ID of another Broker, for b2b messages
     pub broker: BrokerId, //u32
@@ -686,7 +684,7 @@ pub struct LlmpPage {
     pub magic: u64,
     /// The id of the sender
     pub sender: u32,
-    /// Set to != 1 by the receiver, once it got mapped
+    /// Set to != 1 by the receiver, once it got mapped.
     /// It's not safe for the sender to unmap this page before
     /// (The os may have tidied up the memory when the receiver starts to map)
     pub safe_to_unmap: AtomicU16,
@@ -702,7 +700,7 @@ pub struct LlmpPage {
     pub size_total: usize,
     /// How much space is used on this page in bytes
     pub size_used: usize,
-    /// The maximum amount of bytes that ever got allocated on this page in one go
+    /// The maximum amount of bytes that ever got allocated on this page in one go.
     /// An inidactor of what to use as size for future pages
     pub max_alloc_size: usize,
     /// Pointer to the messages, from here on.
@@ -732,7 +730,7 @@ where
     /// Ref to the last message this sender sent on the last page.
     /// If null, a new page (just) started.
     pub last_msg_sent: *const LlmpMsg,
-    /// A vec of page wrappers, each containing an intialized AfShmem
+    /// A vec of page wrappers, each containing an initialized Shmem
     pub out_shmems: Vec<LlmpSharedMap<SP::ShMem>>,
     /// If true, pages will never be pruned.
     /// The broker uses this feature.
@@ -1305,7 +1303,7 @@ where
 {
     /// Id of this provider
     pub id: u32,
-    /// Pointer to the last meg this received
+    /// Pointer to the last message received
     pub last_msg_recvd: *const LlmpMsg,
     /// The shmem provider
     pub shmem_provider: SP,
@@ -1503,7 +1501,7 @@ where
         }
     }
 
-    /// Returns the next message, tag, buf, if avaliable, else None
+    /// Returns the next message, tag, buf, if available, else None
     #[allow(clippy::type_complexity)]
     #[inline]
     pub fn recv_buf(&mut self) -> Result<Option<(ClientId, Tag, &[u8])>, Error> {
@@ -1733,7 +1731,7 @@ where
     /// Broadcast map from broker to all clients
     pub llmp_out: LlmpSender<SP>,
     /// Users of Llmp can add message handlers in the broker.
-    /// This allows us to intercept messages right in the broker
+    /// This allows us to intercept messages right in the broker.
     /// This keeps the out map clean.
     pub llmp_clients: Vec<LlmpReceiver<SP>>,
     /// The ShMemProvider to use
@@ -1974,7 +1972,7 @@ where
             .expect("Error when shutting down broker: Could not send LLMP_TAG_EXITING msg.");
     }
 
-    /// Broadcasts the given buf to all lients
+    /// Broadcasts the given buf to all clients
     pub fn send_buf(&mut self, tag: Tag, buf: &[u8]) -> Result<(), Error> {
         self.llmp_out.send_buf(tag, buf)
     }
@@ -1984,7 +1982,7 @@ where
         self.llmp_out.send_buf_with_flags(tag, flags, buf)
     }
 
-    /// Launches a thread using a tcp listener socket, on which new clients may connect to this broker
+    /// Launches a thread using a tcp listener socket, on which new clients may connect to this broker.
     /// Does so on the given port.
     #[cfg(feature = "std")]
     pub fn launch_tcp_listener_on(&mut self, port: u16) -> Result<thread::JoinHandle<()>, Error> {
@@ -2593,7 +2591,7 @@ where
         self.receiver.recv_blocking()
     }
 
-    /// The current page could have changed in recv (EOP)
+    /// The current page could have changed in recv (EOP).
     /// Alloc the next message, internally handling end of page by allocating a new one.
     /// # Safety
     /// Should be safe, but returns an unsafe ptr
@@ -2602,14 +2600,14 @@ where
         self.sender.alloc_next(buf_len)
     }
 
-    /// Returns the next message, tag, buf, if avaliable, else None
+    /// Returns the next message, tag, buf, if available, else None
     #[allow(clippy::type_complexity)]
     #[inline]
     pub fn recv_buf(&mut self) -> Result<Option<(ClientId, Tag, &[u8])>, Error> {
         self.receiver.recv_buf()
     }
 
-    /// Receives a buf from the broker, looping until a messages becomes avaliable
+    /// Receives a buf from the broker, looping until a message becomes available
     #[inline]
     pub fn recv_buf_blocking(&mut self) -> Result<(ClientId, Tag, &[u8]), Error> {
         self.receiver.recv_buf_blocking()

--- a/libafl/src/bolts/minibsod.rs
+++ b/libafl/src/bolts/minibsod.rs
@@ -1,4 +1,4 @@
-//! Implements a mini-bsod generator
+//! Implements a mini-bsod generator.
 //! It dumps all important registers and prints a stacktrace.
 //! You may use the [`crate::bolts::os::unix_signals::ucontext`]
 //! function to get a [`ucontext_t`].
@@ -8,7 +8,7 @@ use std::io::{BufWriter, Write};
 
 use crate::bolts::os::unix_signals::{ucontext_t, Signal};
 
-/// Write the contens of all important registers
+/// Write the content of all important registers
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[allow(clippy::similar_names)]
 pub fn dump_registers<W: Write>(
@@ -44,7 +44,7 @@ pub fn dump_registers<W: Write>(
     Ok(())
 }
 
-/// Write the contens of all important registers
+/// Write the content of all important registers
 #[cfg(all(
     any(target_os = "linux", target_os = "android"),
     target_arch = "aarch64"
@@ -68,7 +68,7 @@ pub fn dump_registers<W: Write>(
     Ok(())
 }
 
-/// Write the contens of all important registers
+/// Write the content of all important registers
 #[cfg(all(target_os = "linux", target_arch = "arm"))]
 pub fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
@@ -96,7 +96,7 @@ pub fn dump_registers<W: Write>(
     Ok(())
 }
 
-/// Write the contens of all important registers
+/// Write the content of all important registers
 #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))]
 pub fn dump_registers<W: Write>(
     writer: &mut BufWriter<W>,
@@ -120,7 +120,7 @@ pub fn dump_registers<W: Write>(
     Ok(())
 }
 
-/// Write the contens of all important registers
+/// Write the content of all important registers
 #[allow(clippy::unnecessary_wraps, clippy::similar_names)]
 #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))]
 pub fn dump_registers<W: Write>(

--- a/libafl/src/bolts/os/mod.rs
+++ b/libafl/src/bolts/os/mod.rs
@@ -171,10 +171,10 @@ impl Cores {
         Self::from_cmdline("all")
     }
 
-    /// Parses core binding args from user input
+    /// Parses core binding args from user input.
     /// Returns a Vec of CPU IDs.
-    /// `./fuzzer --cores 1,2-4,6` -> clients run in cores 1,2,3,4,6
-    /// ` ./fuzzer --cores all` -> one client runs on each available core
+    /// * `./fuzzer --cores 1,2-4,6`: clients run in cores 1,2,3,4,6
+    /// * `./fuzzer --cores all`: one client runs on each available core
     pub fn from_cmdline(args: &str) -> Result<Self, Error> {
         let mut cores: Vec<CoreId> = vec![];
 
@@ -246,10 +246,10 @@ impl TryFrom<&str> for Cores {
     }
 }
 
-/// Parses core binding args from user input
+/// Parses core binding args from user input.
 /// Returns a Vec of CPU IDs.
-/// `./fuzzer --cores 1,2-4,6` -> clients run in cores 1,2,3,4,6
-/// ` ./fuzzer --cores all` -> one client runs on each available core
+/// * `./fuzzer --cores 1,2-4,6`: clients run in cores 1,2,3,4,6
+/// * `./fuzzer --cores all`: one client runs on each available core
 #[must_use]
 #[cfg(feature = "std")]
 #[deprecated(since = "0.7.1", note = "Use Cores::from_cmdline instead")]

--- a/libafl/src/bolts/ownedref.rs
+++ b/libafl/src/bolts/ownedref.rs
@@ -207,7 +207,7 @@ where
     }
 }
 
-/// Wrap a slice and convert to a Vec on serialize
+/// Wrap a slice and convert to a Vec on serialize.
 /// We use a hidden inner enum so the public API can be safe,
 /// unless the user uses the unsafe [`OwnedSlice::from_raw_parts`]
 #[allow(clippy::unsafe_derive_deserialize)]
@@ -328,7 +328,7 @@ where
     }
 }
 
-/// Wrap a mutable slice and convert to a Vec on serialize
+/// Wrap a mutable slice and convert to a Vec on serialize.
 /// We use a hidden inner enum so the public API can be safe,
 /// unless the user uses the unsafe [`OwnedSliceMut::from_raw_parts_mut`]
 #[derive(Debug)]

--- a/libafl/src/bolts/rands.rs
+++ b/libafl/src/bolts/rands.rs
@@ -16,8 +16,8 @@ const HASH_CONST: u64 = 0xa5b35705;
 /// Not cryptographically secure (which is not what you want during fuzzing ;) )
 pub type StdRand = RomuDuoJrRand;
 
-/// Ways to get random around here
-/// Please note that these are not cryptographically secure
+/// Ways to get random around here.
+/// Please note that these are not cryptographically secure.
 /// Or, even if some might be by accident, at least they are not seeded in a cryptographically secure fashion.
 pub trait Rand: Debug + Serialize + DeserializeOwned {
     /// Sets the seed of this Rand

--- a/libafl/src/bolts/shmem.rs
+++ b/libafl/src/bolts/shmem.rs
@@ -1,5 +1,5 @@
-//! A generic sharememory region to be used by any functions (queues or feedbacks
-// too.)
+//! A generic shared memory region to be used by any functions (queues or feedbacks
+//! too.)
 
 #[cfg(all(unix, feature = "std"))]
 use crate::bolts::os::pipes::Pipe;
@@ -253,7 +253,7 @@ pub trait ShMemProvider: Clone + Default + Debug {
     }
 }
 
-/// A Refernce Counted shared map,
+/// A Reference Counted shared map,
 /// that can use internal mutability.
 /// Useful if the `ShMemProvider` needs to keep local state.
 #[derive(Debug, Clone)]
@@ -299,7 +299,7 @@ impl<T: ShMemProvider> Drop for RcShMem<T> {
     }
 }
 
-/// A Refernce Counted `ShMemProvider`,
+/// A Reference Counted `ShMemProvider`,
 /// that can use internal mutability.
 /// Useful if the `ShMemProvider` needs to keep local state.
 #[derive(Debug, Clone)]

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -365,7 +365,7 @@ where
     }
 }
 
-/// Merge two `TupeList`
+/// Merge two `TupleList`
 pub trait Merge<T> {
     /// The Resulting [`TupleList`], of an [`Merge::merge()`] call
     type MergeResult;

--- a/libafl/src/corpus/cached.rs
+++ b/libafl/src/corpus/cached.rs
@@ -90,7 +90,7 @@ where
         self.inner.current()
     }
 
-    /// Current testcase scheduled (mut)
+    /// Current testcase scheduled (mutable)
     #[inline]
     fn current_mut(&mut self) -> &mut Option<usize> {
         self.inner.current_mut()

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -66,7 +66,7 @@ where
         &self.current
     }
 
-    /// Current testcase scheduled (mut)
+    /// Current testcase scheduled (mutable)
     #[inline]
     fn current_mut(&mut self) -> &mut Option<usize> {
         &mut self.current

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -1,4 +1,4 @@
-//! Corpuses contain the testcases, either in mem, on disk, or somewhere else.
+//! Corpuses contain the testcases, either in memory, on disk, or somewhere else.
 
 pub mod testcase;
 pub use testcase::{PowerScheduleTestcaseMetaData, Testcase};
@@ -70,7 +70,7 @@ where
     /// Current testcase scheduled
     fn current(&self) -> &Option<usize>;
 
-    /// Current testcase scheduled (mut)
+    /// Current testcase scheduled (mutable)
     fn current_mut(&mut self) -> &mut Option<usize>;
 }
 
@@ -145,6 +145,6 @@ impl Default for RandCorpusScheduler {
     }
 }
 
-/// A [`StdCorpusScheduler`] uses the default scheduler in `LibAFL` to schedule [`Testcase`]s
+/// A [`StdCorpusScheduler`] uses the default scheduler in `LibAFL` to schedule [`Testcase`]s.
 /// The current `Std` is a [`RandCorpusScheduler`], although this may change in the future, if another [`CorpusScheduler`] delivers better results.
 pub type StdCorpusScheduler = RandCorpusScheduler;

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -161,7 +161,7 @@ where
         &self.current
     }
 
-    /// Current testcase scheduled (mut)
+    /// Current testcase scheduled (mutable)
     #[inline]
     fn current_mut(&mut self) -> &mut Option<usize> {
         &mut self.current

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -130,7 +130,7 @@ where
         &self.exec_time
     }
 
-    /// Get the execution time of the testcase (mut)
+    /// Get the execution time of the testcase (mutable)
     #[inline]
     pub fn exec_time_mut(&mut self) -> &mut Option<Duration> {
         &mut self.exec_time
@@ -148,7 +148,7 @@ where
         &self.executions
     }
 
-    /// Get the executions (mut)
+    /// Get the executions (mutable)
     #[inline]
     pub fn executions_mut(&mut self) -> &mut usize {
         &mut self.executions

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -521,7 +521,7 @@ where
     }
 }
 
-/// A manager that can restart on the fly, storing states in-between (in `on_resatrt`)
+/// A manager that can restart on the fly, storing states in-between (in `on_restart`)
 #[cfg(feature = "std")]
 #[derive(Debug)]
 pub struct LlmpRestartingEventManager<I, OT, S, SP>
@@ -658,7 +658,7 @@ where
         &self.staterestorer
     }
 
-    /// Get the staterestorer (mut)
+    /// Get the staterestorer (mutable)
     pub fn staterestorer_mut(&mut self) -> &mut StateRestorer<SP> {
         &mut self.staterestorer
     }

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -330,7 +330,7 @@ where
     }
 }
 
-/// [`EventFirer`] fire an event.
+/// [`ProgressReporter`] report progress to the broker.
 pub trait ProgressReporter<I>: EventFirer<I>
 where
     I: Input,

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -66,7 +66,7 @@ impl fmt::Display for LogSeverity {
 /// Indicate if an event worked or not
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub enum BrokerEventResult {
-    /// The broker haneled this. No need to pass it on.
+    /// The broker handled this. No need to pass it on.
     Handled,
     /// Pass this message along to the clients.
     Forward,
@@ -295,10 +295,10 @@ where
     /// In this case, if you `fire` faster than the broker can consume
     /// (for example for each [`Input`], on multiple cores)
     /// the [`llmp`] shared map may fill up and the client will eventually OOM or [`panic`].
-    /// This should not happen for a normal use-cases.
+    /// This should not happen for a normal use-case.
     fn fire<S>(&mut self, state: &mut S, event: Event<I>) -> Result<(), Error>;
 
-    /// Send off an [`Event::Log`] event to the broker
+    /// Send off an [`Event::Log`] event to the broker.
     /// This is a shortcut for [`EventFirer::fire`] with [`Event::Log`] as argument.
     fn log<S>(
         &mut self,
@@ -431,10 +431,10 @@ pub trait EventProcessor<E, I, S, Z> {
 }
 /// The id of this [`EventManager`].
 /// For multi processed [`EventManager`]s,
-/// each connected client sholud have a unique ids.
+/// each connected client should have a unique ids.
 pub trait HasEventManagerId {
     /// The id of this manager. For Multiprocessed [`EventManager`]s,
-    /// each client sholud have a unique ids.
+    /// each client should have a unique ids.
     fn mgr_id(&self) -> EventManagerId;
 }
 

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -144,7 +144,7 @@ where
     /// Create a new in mem executor.
     /// Caution: crash and restart in one of them will lead to odd behavior if multiple are used,
     /// depending on different corpus or state.
-    /// * `harness_fn` - the harness, executiong the function
+    /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
     /// This may return an error on unix, if signal handler setup fails
     pub fn new<EM, OF, Z>(
@@ -217,7 +217,7 @@ where
         &self.handlers
     }
 
-    /// The inprocess handlers, mut
+    /// The inprocess handlers (mutable)
     #[inline]
     pub fn handlers_mut(&mut self) -> &mut InProcessHandlers {
         &mut self.handlers

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -66,7 +66,7 @@ where
     /// Get the linked observers
     fn observers(&self) -> &OT;
 
-    /// Get the linked observers
+    /// Get the linked observers (mutable)
     fn observers_mut(&mut self) -> &mut OT;
 }
 

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -78,7 +78,7 @@ extern "C" {
 #[cfg(all(unix, not(target_os = "linux")))]
 const ITIMER_REAL: c_int = 0;
 
-/// The timeout excutor is a wrapper that sets a timeout before each run
+/// The timeout executor is a wrapper that sets a timeout before each run
 pub struct TimeoutExecutor<E> {
     executor: E,
     #[cfg(target_os = "linux")]

--- a/libafl/src/feedbacks/concolic.rs
+++ b/libafl/src/feedbacks/concolic.rs
@@ -1,4 +1,4 @@
-//! Concoliic feedback for comcolic fuzzing.
+//! Concolic feedback for concolic fuzzing.
 //! It is used to attach concolic tracing metadata to the testcase.
 //! This feedback should be used in combination with another feedback as this feedback always considers testcases
 //! to be not interesting.

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -144,7 +144,7 @@ where
     }
 }
 
-/// A cobined feedback consisting of ultiple [`Feedback`]s
+/// A combined feedback consisting of multiple [`Feedback`]s
 #[derive(Debug)]
 pub struct CombinedFeedback<A, B, FL, I, S>
 where
@@ -271,7 +271,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
-    /// The name of this cobination
+    /// The name of this combination
     fn name() -> &'static str;
 
     /// If the feedback pair is interesting
@@ -538,19 +538,19 @@ where
 }
 
 /// Combine two feedbacks with an eager AND operation,
-/// will call all feedbacks functions even if not necessery to conclude the result
+/// will call all feedbacks functions even if not necessary to conclude the result
 pub type EagerAndFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicEagerAnd, I, S>;
 
 /// Combine two feedbacks with an fast AND operation,
-/// might skip calling feedbacks functions if not necessery to conclude the result
+/// might skip calling feedbacks functions if not necessary to conclude the result
 pub type FastAndFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicFastAnd, I, S>;
 
 /// Combine two feedbacks with an eager OR operation,
-/// will call all feedbacks functions even if not necessery to conclude the result
+/// will call all feedbacks functions even if not necessary to conclude the result
 pub type EagerOrFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicEagerOr, I, S>;
 
 /// Combine two feedbacks with an fast OR operation,
-/// might skip calling feedbacks functions if not necessery to conclude the result
+/// might skip calling feedbacks functions if not necessary to conclude the result.
 /// This means any feedback that is not first might be skipped, use caution when using with
 /// `TimeFeedback`
 pub type FastOrFeedback<A, B, I, S> = CombinedFeedback<A, B, LogicFastOr, I, S>;
@@ -829,7 +829,7 @@ impl Default for TimeoutFeedback {
 }
 
 /// Nop feedback that annotates execution time in the new testcase, if any
-/// for this Feedback, the testcase is never interesting (use with an OR)
+/// for this Feedback, the testcase is never interesting (use with an OR).
 /// It decides, if the given [`TimeObserver`] value of a run is interesting.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TimeFeedback {

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -33,7 +33,7 @@ where
     /// The scheduler
     fn scheduler(&self) -> &CS;
 
-    /// The scheduler (mut)
+    /// The scheduler (mutable)
     fn scheduler_mut(&mut self) -> &mut CS;
 }
 
@@ -47,7 +47,7 @@ where
     /// The feedback
     fn feedback(&self) -> &F;
 
-    /// The feedback (mut)
+    /// The feedback (mutable)
     fn feedback_mut(&mut self) -> &mut F;
 }
 
@@ -61,7 +61,7 @@ where
     /// The objective feedback
     fn objective(&self) -> &OF;
 
-    /// The objective feedback (mut)
+    /// The objective feedback (mutable)
     fn objective_mut(&mut self) -> &mut OF;
 }
 
@@ -85,7 +85,7 @@ where
         EM: EventFirer<I>;
 }
 
-/// Evaluate an input modyfing the state of the fuzzer
+/// Evaluate an input modifying the state of the fuzzer
 pub trait EvaluatorObservers<I, OT, S>: Sized
 where
     I: Input,
@@ -106,7 +106,7 @@ where
         EM: EventManager<E, I, S, Self>;
 }
 
-/// Evaluate an input modyfing the state of the fuzzer
+/// Evaluate an input modifying the state of the fuzzer
 pub trait Evaluator<E, EM, I, S> {
     /// Runs the input and triggers observers and feedback,
     /// returns if is interesting an (option) the index of the new testcase in the corpus
@@ -152,8 +152,8 @@ where
     EM: ProgressReporter<I>,
     S: HasExecutions + HasClientPerfMonitor,
 {
-    /// Fuzz for a single iteration
-    /// Returns the index of the last fuzzed corpus item
+    /// Fuzz for a single iteration.
+    /// Returns the index of the last fuzzed corpus item.
     ///
     /// If you use this fn in a restarting scenario to only run for `n` iterations,
     /// before exiting, make sure you call `event_mgr.on_restart(&mut state)?;`.
@@ -182,8 +182,8 @@ where
         }
     }
 
-    /// Fuzz for n iterations
-    /// Returns the index of the last fuzzed corpus item
+    /// Fuzz for n iterations.
+    /// Returns the index of the last fuzzed corpus item.
     ///
     /// If you use this fn in a restarting scenario to only run for `n` iterations,
     /// before exiting, make sure you call `event_mgr.on_restart(&mut state)?;`.
@@ -225,7 +225,7 @@ where
 pub enum ExecuteInputResult {
     /// No special input
     None,
-    /// This input should be stored ini the corpus
+    /// This input should be stored in the corpus
     Corpus,
     /// This input leads to a solution
     Solution,

--- a/libafl/src/generators/gramatron.rs
+++ b/libafl/src/generators/gramatron.rs
@@ -1,4 +1,4 @@
-//! Gramamtron generator
+//! Gramatron generator
 use alloc::{string::String, vec::Vec};
 use core::marker::PhantomData;
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,7 @@ pub struct Automaton {
 }
 
 #[derive(Clone, Debug)]
-/// Generates random inputs from a grammar automatron
+/// Generates random inputs from a grammar automaton
 pub struct GramatronGenerator<'a, S>
 where
     S: HasRand,

--- a/libafl/src/inputs/bytes.rs
+++ b/libafl/src/inputs/bytes.rs
@@ -1,5 +1,5 @@
 //! The `BytesInput` is the "normal" input, a map of bytes, that can be sent directly to the client
-//! (As opposed to other, more abstract, imputs, like an Grammar-Based AST Input)
+//! (As opposed to other, more abstract, inputs, like an Grammar-Based AST Input)
 
 use ahash::AHasher;
 use alloc::{borrow::ToOwned, rc::Rc, string::String, vec::Vec};
@@ -33,7 +33,7 @@ impl Input for BytesInput {
         write_file_atomic(path, &self.bytes)
     }
 
-    /// Load the contents of this input from a file
+    /// Load the content of this input from a file
     #[cfg(feature = "std")]
     fn from_file<P>(path: P) -> Result<Self, Error>
     where

--- a/libafl/src/inputs/encoded.rs
+++ b/libafl/src/inputs/encoded.rs
@@ -1,5 +1,5 @@
 //! The `EncodedInput` is the "normal" input, a map of codes, that can be sent directly to the client
-//! (As opposed to other, more abstract, imputs, like an Grammar-Based AST Input)
+//! (As opposed to other, more abstract, inputs, like an Grammar-Based AST Input)
 //! See also [the paper on token-level fuzzing](https://www.usenix.org/system/files/sec21-salls.pdf)
 
 use ahash::AHasher;
@@ -32,9 +32,9 @@ pub trait InputDecoder {
     fn decode(&self, input: &EncodedInput, bytes: &mut Vec<u8>) -> Result<(), Error>;
 }
 
-/// Tokenizer is a trait that can tokenize bytes into a ][`Vec`] of tokens
+/// Tokenizer is a trait that can tokenize bytes into a [`Vec`] of tokens
 pub trait Tokenizer {
-    /// Tokanize the given bytes
+    /// Tokenize the given bytes
     fn tokenize(&self, bytes: &[u8]) -> Result<Vec<String>, Error>;
 }
 
@@ -101,13 +101,13 @@ impl Default for TokenInputEncoderDecoder {
     }
 }
 
-/// A native tokenizer struct
+/// A naive tokenizer struct
 #[cfg(feature = "std")]
 #[derive(Clone, Debug)]
 pub struct NaiveTokenizer {
     /// Ident regex
     ident_re: Regex,
-    /// Comement regex
+    /// Comment regex
     comment_re: Regex,
     /// String regex
     string_re: Regex,

--- a/libafl/src/inputs/generalized.rs
+++ b/libafl/src/inputs/generalized.rs
@@ -200,7 +200,7 @@ impl GeneralizedInput {
         self.generalized.as_deref()
     }
 
-    /// Get the generalized input (mut)
+    /// Get the generalized input (mutable)
     pub fn generalized_mut(&mut self) -> &mut Option<Vec<GeneralizedItem>> {
         &mut self.generalized
     }

--- a/libafl/src/inputs/gramatron.rs
+++ b/libafl/src/inputs/gramatron.rs
@@ -91,7 +91,7 @@ impl GramatronInput {
         }
     }
 
-    /// crop the value to the given length
+    /// Crop the value to the given length
     pub fn crop(&self, from: usize, to: usize) -> Result<Self, Error> {
         if from < to && to <= self.terms.len() {
             let mut terms = vec![];

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -61,7 +61,7 @@ pub trait Input: Clone + Serialize + serde::de::DeserializeOwned + Debug + Hash 
         write_file_atomic(path, &postcard::to_allocvec(self)?)
     }
 
-    /// Load the contents of this input from a file
+    /// Load the content of this input from a file
     #[cfg(feature = "std")]
     fn from_file<P>(path: P) -> Result<Self, Error>
     where
@@ -95,8 +95,8 @@ impl HasTargetBytes for NopInput {
 }
 
 // TODO change this to fn target_bytes(&self, buffer: &mut Vec<u8>) -> &[u8];
-/// Can be represented with a vector of bytes
-/// This representation is not necessarily deserializable
+/// Can be represented with a vector of bytes.
+/// This representation is not necessarily deserializable.
 /// Instead, it can be used as bytes input for a target
 pub trait HasTargetBytes {
     /// Target bytes, that can be written to a target

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -1,4 +1,4 @@
-//! Keep stats, and dispaly them to the user. Usually used in a broker, or main node, of some sort.
+//! Keep stats, and display them to the user. Usually used in a broker, or main node, of some sort.
 
 pub mod multi;
 pub use multi::MultiMonitor;
@@ -145,18 +145,18 @@ impl ClientStats {
     }
 }
 
-/// The monitor trait keeps track of all the client's monitor, and offers methods to dispaly them.
+/// The monitor trait keeps track of all the client's monitor, and offers methods to display them.
 pub trait Monitor {
-    /// the client monitor (mut)
+    /// The client monitor (mutable)
     fn client_stats_mut(&mut self) -> &mut Vec<ClientStats>;
 
-    /// the client monitor
+    /// The client monitor
     fn client_stats(&self) -> &[ClientStats];
 
-    /// creation time
+    /// Creation time
     fn start_time(&mut self) -> Duration;
 
-    /// show the monitor to the user
+    /// Show the monitor to the user
     fn display(&mut self, event_msg: String, sender_id: u32);
 
     /// Amount of elements in the corpus (combined for all children)
@@ -212,12 +212,12 @@ pub struct NopMonitor {
 }
 
 impl Monitor for NopMonitor {
-    /// the client monitor, mutable
+    /// The client monitor, mutable
     fn client_stats_mut(&mut self) -> &mut Vec<ClientStats> {
         &mut self.client_stats
     }
 
-    /// the client monitor
+    /// The client monitor
     fn client_stats(&self) -> &[ClientStats] {
         &self.client_stats
     }

--- a/libafl/src/monitors/multi.rs
+++ b/libafl/src/monitors/multi.rs
@@ -1,4 +1,4 @@
-//! Monitor to disply both cumulative and per-client monitor
+//! Monitor to display both cumulative and per-client monitor
 
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;

--- a/libafl/src/mutators/mopt_mutator.rs
+++ b/libafl/src/mutators/mopt_mutator.rs
@@ -15,10 +15,10 @@ use core::{
 };
 use serde::{Deserialize, Serialize};
 
-/// A Struct for managing MOpt-mutator parameters
-/// There are 2 modes for `MOpt` scheduler, the core fuzzing mode and the pilot fuzzing mode
-/// In short, in the pilot fuzzing mode, the fuzzer employs several `swarms` to compute the probability to choose the mutation operator
-/// On the other hand, in the core fuzzing mode, the fuzzer chooses the best `swarms`, which was determined during the pilot fuzzing mode, to compute the probability to choose the operation operator
+/// A Struct for managing MOpt-mutator parameters.
+/// There are 2 modes for `MOpt` scheduler, the core fuzzing mode and the pilot fuzzing mode.
+/// In short, in the pilot fuzzing mode, the fuzzer employs several `swarms` to compute the probability to choose the mutation operator.
+/// On the other hand, in the core fuzzing mode, the fuzzer chooses the best `swarms`, which was determined during the pilot fuzzing mode, to compute the probability to choose the operation operator.
 /// With the current implementation we are always in the pacemaker fuzzing mode.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct MOpt {
@@ -620,7 +620,7 @@ where
         &self.mutations
     }
 
-    // Get the mutations (mut)
+    // Get the mutations (mutable)
     #[inline]
     fn mutations_mut(&mut self) -> &mut MT {
         &mut self.mutations

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -62,7 +62,7 @@ where
     /// Get the mutations
     fn mutations(&self) -> &MT;
 
-    /// Get the mutations (mut)
+    /// Get the mutations (mutable)
     fn mutations_mut(&mut self) -> &mut MT;
 }
 
@@ -78,7 +78,7 @@ where
     /// Get the next mutation to apply
     fn schedule(&self, state: &mut S, input: &I) -> usize;
 
-    /// New default implementation for mutate
+    /// New default implementation for mutate.
     /// Implementations must forward mutate() to this method
     fn scheduled_mutate(
         &mut self,
@@ -158,7 +158,7 @@ where
         &self.mutations
     }
 
-    // Get the mutations (mut)
+    // Get the mutations (mutable)
     #[inline]
     fn mutations_mut(&mut self) -> &mut MT {
         &mut self.mutations

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -1,4 +1,4 @@
-//! Tokens are what afl calls extras or dictionaries.
+//! Tokens are what AFL calls extras or dictionaries.
 //! They may be inserted as part of mutations during fuzzing.
 #[cfg(feature = "std")]
 use crate::mutators::str_decode;
@@ -412,7 +412,7 @@ impl TokenReplace {
 }
 
 /// A `I2SRandReplace` [`Mutator`] replaces a random matching input-2-state comparison operand with the other.
-/// it needs a valid [`CmpValuesMetadata`] in the state.
+/// It needs a valid [`CmpValuesMetadata`] in the state.
 #[derive(Debug, Default)]
 pub struct I2SRandReplace;
 

--- a/libafl/src/observers/cmp.rs
+++ b/libafl/src/observers/cmp.rs
@@ -120,7 +120,7 @@ where
     /// Get the `CmpMap`
     fn cmp_map(&self) -> &CM;
 
-    /// Get the `CmpMap` (mut)
+    /// Get the `CmpMap` (mutable)
     fn cmp_map_mut(&mut self) -> &mut CM;
 
     /// Add [`struct@CmpValuesMetadata`] to the State including the logged values.

--- a/libafl/src/observers/concolic/mod.rs
+++ b/libafl/src/observers/concolic/mod.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 pub type SymExprRef = NonZeroUsize;
 
 /// [`Location`]s are code locations encountered during concolic tracing, that are constructed from pointers, but not always in a meaningful way.
-/// Therefore, a location is an opague value that can only be compared against itself.
+/// Therefore, a location is an opaque value that can only be compared against itself.
 ///
 /// It is possible to get at the underlying value using [`Into::into`], should this restriction be too inflexible for your usecase.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/libafl/src/observers/concolic/serialization_format.rs
+++ b/libafl/src/observers/concolic/serialization_format.rs
@@ -446,7 +446,7 @@ pub const DEFAULT_ENV_NAME: &str = "SHARED_MEMORY_MESSAGES";
 /// The default shared memory size used by the concolic tracing.
 ///
 /// This amounts to 1GiB of memory, which is considered to be enough for any reasonable trace. It is also assumed
-/// that the memory will not be phsyically mapped until accessed, alleviating reource concerns.
+/// that the memory will not be physically mapped until accessed, alleviating resource concerns.
 pub const DEFAULT_SIZE: usize = 1024 * 1024 * 1024;
 
 impl<'buffer> MessageFileReader<Cursor<&'buffer [u8]>> {

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -37,7 +37,7 @@ fn hash_slice<T: PrimInt>(slice: &[T]) -> u64 {
     hasher.finish()
 }
 
-/// A [`MapObserver`] observes the static map, as oftentimes used for afl-like coverage information
+/// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
 pub trait MapObserver: HasLen + Named + Serialize + serde::de::DeserializeOwned + Debug {
     /// Type of each entry in this map
     type Entry: PrimInt + Default + Copy + Debug;
@@ -70,7 +70,7 @@ pub trait MapObserver: HasLen + Named + Serialize + serde::de::DeserializeOwned 
     /// Get the initial value for reset()
     fn initial(&self) -> Self::Entry;
 
-    /// Get the initial value for reset()
+    /// Get the initial value for reset() (mutable)
     fn initial_mut(&mut self) -> &mut Self::Entry;
 
     /// Set the initial value for reset()

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -49,7 +49,7 @@ pub trait Observer<I, S>: Named + Debug {
         Ok(())
     }
 
-    /// Called right after execution finish.
+    /// Called right after execution finishes.
     #[inline]
     fn post_exec(
         &mut self,
@@ -66,7 +66,7 @@ pub trait Observer<I, S>: Named + Debug {
         Ok(())
     }
 
-    /// Called right after execution finish in the child process, if any.
+    /// Called right after execution finishes in the child process, if any.
     #[inline]
     fn post_exec_child(
         &mut self,

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -4,7 +4,7 @@ A well-known [`Stage`], for example, is the mutational stage, running multiple [
 Other stages may enrich [`crate::corpus::Testcase`]s with metadata.
 */
 
-/// Mutational stage is the normal fuzzing stage,
+/// Mutational stage is the normal fuzzing stage.
 pub mod mutational;
 pub use mutational::{MutationalStage, StdMutationalStage};
 
@@ -193,7 +193,7 @@ where
     S: HasClientPerfMonitor + HasCorpus<I> + HasRand + HasExecutions,
     Z: ExecutionProcessor<I, OT, S> + EvaluatorObservers<I, OT, S> + HasCorpusScheduler<CS, I, S>,
 {
-    /// Create a new [`PushStageAdapter`], warpping the given [`PushStage`]
+    /// Create a new [`PushStageAdapter`], wrapping the given [`PushStage`]
     /// to be used as a normal [`Stage`]
     #[must_use]
     pub fn new(push_stage: PS) -> Self {

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -77,7 +77,7 @@ where
     }
 }
 
-/// Default value, how many iterations each stage gets, as an upper bound
+/// Default value, how many iterations each stage gets, as an upper bound.
 /// It may randomly continue earlier.
 pub static DEFAULT_MUTATIONAL_MAX_ITERATIONS: u64 = 128;
 

--- a/libafl/src/stages/push/mod.rs
+++ b/libafl/src/stages/push/mod.rs
@@ -4,7 +4,7 @@
 //! The push stage relies on internal muttability of the supplied `Observers`.
 //!
 
-/// Mutational stage is the normal fuzzing stage,
+/// Mutational stage is the normal fuzzing stage.
 pub mod mutational;
 pub use mutational::StdMutationalPushStage;
 
@@ -93,7 +93,7 @@ where
     /// The shared state, keeping track of the corpus and the fuzzer
     #[allow(clippy::type_complexity)]
     pub shared_state: Rc<RefCell<Option<PushStageSharedState<CS, EM, I, OT, S, Z>>>>,
-    /// If the last iteraation failed
+    /// If the last iteration failed
     pub errored: bool,
 
     /// The corpus index we're currently working on
@@ -191,10 +191,10 @@ where
 {
     /// Gets the [`PushStageHelper`]
     fn push_stage_helper(&self) -> &PushStageHelper<CS, EM, I, OT, S, Z>;
-    /// Gets the [`PushStageHelper`], mut
+    /// Gets the [`PushStageHelper`] (mutable)
     fn push_stage_helper_mut(&mut self) -> &mut PushStageHelper<CS, EM, I, OT, S, Z>;
 
-    /// Set the current corpus index this stagve works on
+    /// Set the current corpus index this stage works on
     fn set_current_corpus_idx(&mut self, corpus_idx: usize) {
         self.push_stage_helper_mut().current_corpus_idx = Some(corpus_idx);
     }

--- a/libafl/src/stages/push/mutational.rs
+++ b/libafl/src/stages/push/mutational.rs
@@ -30,7 +30,7 @@ pub static DEFAULT_MUTATIONAL_MAX_ITERATIONS: u64 = 128;
 /// being applied to the input one by one, between executions.
 /// The push version, in contrast to the normal stage, will return each testcase, instead of executing it.
 ///
-/// Default value, how many iterations each stage gets, as an upper bound
+/// Default value, how many iterations each stage gets, as an upper bound.
 /// It may randomly continue earlier.
 ///
 /// The default mutational push stage

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -26,8 +26,8 @@ use crate::{
 /// The maximum size of a testcase
 pub const DEFAULT_MAX_SIZE: usize = 1_048_576;
 
-/// The [`State`] of the fuzzer
-/// Contains all important information about the current run
+/// The [`State`] of the fuzzer.
+/// Contains all important information about the current run.
 /// Will be used to restart the fuzzing process at any timme.
 pub trait State: Serialize + DeserializeOwned {}
 
@@ -37,7 +37,7 @@ pub trait HasCorpus<I: Input> {
     type Corpus: Corpus<I>;
     /// The testcase corpus
     fn corpus(&self) -> &Self::Corpus;
-    /// The testcase corpus (mut)
+    /// The testcase corpus (mutable)
     fn corpus_mut(&mut self) -> &mut Self::Corpus;
 }
 
@@ -55,7 +55,7 @@ pub trait HasSolutions<I: Input> {
     type Solutions: Corpus<I>;
     /// The solutions corpus
     fn solutions(&self) -> &Self::Solutions;
-    /// The solutions corpus (mut)
+    /// The solutions corpus (mutable)
     fn solutions_mut(&mut self) -> &mut Self::Solutions;
 }
 
@@ -65,7 +65,7 @@ pub trait HasRand {
     type Rand: Rand;
     /// The rand instance
     fn rand(&self) -> &Self::Rand;
-    /// The rand instance (mut)
+    /// The rand instance (mutable)
     fn rand_mut(&mut self) -> &mut Self::Rand;
 }
 
@@ -80,7 +80,7 @@ pub trait HasClientPerfMonitor {
     /// This node's stability
     fn stability(&self) -> &Option<f32>;
 
-    /// This node's stability (mut)
+    /// This node's stability (mutable)
     fn stability_mut(&mut self) -> &mut Option<f32>;
 }
 
@@ -88,7 +88,7 @@ pub trait HasClientPerfMonitor {
 pub trait HasMetadata {
     /// A map, storing all metadata
     fn metadata(&self) -> &SerdeAnyMap;
-    /// A map, storing all metadata (mut)
+    /// A map, storing all metadata (mutable)
     fn metadata_mut(&mut self) -> &mut SerdeAnyMap;
 
     /// Add a metadata to the metadata map
@@ -117,7 +117,7 @@ pub trait HasFeedbackStates {
     /// The feedback states
     fn feedback_states(&self) -> &Self::FeedbackStates;
 
-    /// The feedback states (mut)
+    /// The feedback states (mutable)
     fn feedback_states_mut(&mut self) -> &mut Self::FeedbackStates;
 }
 
@@ -126,7 +126,7 @@ pub trait HasExecutions {
     /// The executions counter
     fn executions(&self) -> &usize;
 
-    /// The executions counter (mut)
+    /// The executions counter (mutable)
     fn executions_mut(&mut self) -> &mut usize;
 }
 
@@ -135,7 +135,7 @@ pub trait HasStartTime {
     /// The starting time
     fn start_time(&self) -> &Duration;
 
-    /// The starting time (mut)
+    /// The starting time (mutable)
     fn start_time_mut(&mut self) -> &mut Duration;
 }
 
@@ -202,7 +202,7 @@ where
         &self.rand
     }
 
-    /// The rand instance (mut)
+    /// The rand instance (mutable)
     #[inline]
     fn rand_mut(&mut self) -> &mut Self::Rand {
         &mut self.rand
@@ -248,7 +248,7 @@ where
         &self.solutions
     }
 
-    /// Returns the solutions corpus (mut)
+    /// Returns the solutions corpus (mutable)
     #[inline]
     fn solutions_mut(&mut self) -> &mut SC {
         &mut self.solutions
@@ -292,7 +292,7 @@ where
         &self.feedback_states
     }
 
-    /// The feedback states (mut)
+    /// The feedback states (mutable)
     #[inline]
     fn feedback_states_mut(&mut self) -> &mut FT {
         &mut self.feedback_states
@@ -313,7 +313,7 @@ where
         &self.executions
     }
 
-    /// The executions counter (mut)
+    /// The executions counter (mutable)
     #[inline]
     fn executions_mut(&mut self) -> &mut usize {
         &mut self.executions
@@ -351,7 +351,7 @@ where
         &self.start_time
     }
 
-    /// The starting time (mut)
+    /// The starting time (mutable)
     #[inline]
     fn start_time_mut(&mut self) -> &mut Duration {
         &mut self.start_time
@@ -367,7 +367,7 @@ where
     FT: FeedbackStatesTuple,
     SC: Corpus<I>,
 {
-    /// loads inputs from a directory
+    /// Loads inputs from a directory.
     /// If `forced` is `true`, the value will be loaded,
     /// even if it's not considered to be `interesting`.
     pub fn load_from_directory<E, EM, Z>(
@@ -602,7 +602,7 @@ where
         &self.stability
     }
 
-    /// This node's stability (mut)
+    /// This node's stability (mutable)
     #[inline]
     fn stability_mut(&mut self) -> &mut Option<f32> {
         &mut self.stability
@@ -632,7 +632,7 @@ where
         &self.stability
     }
 
-    /// This node's stability (mut)
+    /// This node's stability (mutable)
     #[inline]
     fn stability_mut(&mut self) -> &mut Option<f32> {
         &mut self.stability

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -327,7 +327,7 @@ impl AsanRuntime {
         &self.allocator
     }
 
-    /// Gets the allocator, mut
+    /// Gets the allocator (mutable)
     pub fn allocator_mut(&mut self) -> &mut Allocator {
         &mut self.allocator
     }


### PR DESCRIPTION
Fixed typos I found in the documentation (generated by doc comments).

I did my best in 36080e7a727cb848f511e8117bf4d12ab4d460f2 but I bet it could be better.

334b9849bc4369975e83038de047f24be34ca997 can be removed since it is slightly out of the scope of the original work.

There are still some inconsistencies regarding imperative mood, but this is a another kind of issue.