### PR TITLE
removed subcommands from FuzzerOptions

### DIFF
--- a/libafl/src/bolts/cli.rs
+++ b/libafl/src/bolts/cli.rs
@@ -125,10 +125,6 @@ fn parse_instrumentation_location(
 )]
 #[allow(clippy::struct_excessive_bools)]
 pub struct FuzzerOptions {
-    /// grouping of subcommands
-    #[clap(subcommand)]
-    pub command: SubCommand,
-
     /// timeout for each target execution (milliseconds)
     #[clap(short, long, takes_value = true, default_value = "1000", parse(try_from_str = parse_timeout), global = true)]
     pub timeout: Duration,
@@ -223,57 +219,46 @@ pub struct FuzzerOptions {
     #[cfg(feature = "qemu_cli")]
     #[clap(last = true, global = true)]
     pub qemu_args: Vec<String>,
-}
 
-/// grouping of default subcommands
-#[derive(Subcommand, Debug)]
-pub enum SubCommand {
-    /// Fuzz mode: mutates the starting corpus indefinitely, looking for crashes
-    Fuzz {
-        /// paths to fuzzer token files (aka 'dictionaries')
-        #[clap(short = 'x', long, multiple_values = true, parse(from_os_str))]
-        tokens: Vec<PathBuf>,
+    /// paths to fuzzer token files (aka 'dictionaries')
+    #[clap(short = 'x', long, multiple_values = true, parse(from_os_str))]
+    pub tokens: Vec<PathBuf>,
 
-        /// input corpus directories
-        #[clap(
+    /// input corpus directories
+    #[clap(
             short,
             long,
             default_values = &["corpus/"],
             multiple_values = true,
             parse(from_os_str)
-        )]
-        input: Vec<PathBuf>,
+    )]
+    pub input: Vec<PathBuf>,
 
-        /// output solutions directory
-        #[clap(short, long, default_value = "solutions/", parse(from_os_str))]
-        output: PathBuf,
+    /// output solutions directory
+    #[clap(short, long, default_value = "solutions/", parse(from_os_str))]
+    pub output: PathBuf,
 
-        /// Spawn a client in each of the provided cores. Use 'all' to select all available
-        /// cores. 'none' to run a client without binding to any core.
-        /// ex: '1,2-4,6' selects the cores 1, 2, 3, 4, and 6.
-        #[clap(short, long, default_value = "0", parse(try_from_str = Cores::from_cmdline))]
-        cores: Cores,
+    /// Spawn a client in each of the provided cores. Use 'all' to select all available
+    /// cores. 'none' to run a client without binding to any core.
+    /// ex: '1,2-4,6' selects the cores 1, 2, 3, 4, and 6.
+    #[clap(short, long, default_value = "0", parse(try_from_str = Cores::from_cmdline))]
+    pub cores: Cores,
 
-        /// port on which the broker should listen
-        #[clap(short = 'p', long, default_value = "1337", name = "PORT")]
-        broker_port: u16,
+    /// port on which the broker should listen
+    #[clap(short = 'p', long, default_value = "1337", name = "PORT")]
+    pub broker_port: u16,
 
-        /// ip:port where a remote broker is already listening
-        #[clap(short = 'a', long, parse(try_from_str), name = "REMOTE")]
-        remote_broker_addr: Option<SocketAddr>,
-    },
+    /// ip:port where a remote broker is already listening
+    #[clap(short = 'a', long, parse(try_from_str), name = "REMOTE")]
+    pub remote_broker_addr: Option<SocketAddr>,
 
-    /// Replay mode: runs a single input file through the fuzz harness
-    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
-    Replay {
-        /// path to file that should be sent to the harness for crash reproduction
-        #[clap(short, long, parse(from_os_str))]
-        input_file: PathBuf,
+    /// path to file that should be sent to the harness for crash reproduction
+    #[clap(short, long, parse(from_os_str))]
+    pub replay: PathBuf,
 
-        /// Run the same input multiple times
-        #[clap(short, long, default_missing_value = "1", min_values = 0)]
-        repeat: Option<usize>,
-    },
+    /// Run the same replay input multiple times
+    #[clap(short = 'R', long, default_missing_value = "1", min_values = 0)]
+    pub repeat: Option<usize>,
 }
 
 impl FuzzerOptions {

--- a/libafl/src/bolts/cli.rs
+++ b/libafl/src/bolts/cli.rs
@@ -327,7 +327,10 @@ pub fn parse_args() -> FuzzerOptions {
     FuzzerOptions::parse()
 }
 
-#[cfg(all(test, any(feature = "qemu_cli", feature = "frida_cli")))]
+#[cfg(all(
+    test,
+    any(feature = "cli", feature = "qemu_cli", feature = "frida_cli")
+))]
 mod tests {
     use super::*;
 
@@ -335,7 +338,7 @@ mod tests {
     /// about; expect the standard option to work normally, and everything after `--` to be
     /// collected into `qemu_args`
     #[test]
-    #[cfg(all(test, feature = "qemu_cli"))]
+    #[cfg(feature = "qemu_cli")]
     fn standard_option_with_trailing_variable_length_args_collected() {
         let parsed = FuzzerOptions::parse_from([
             "some-command",
@@ -355,14 +358,14 @@ mod tests {
 
     /// pass module without @ to `parse_instrumentation_location`, expect error
     #[test]
-    #[cfg(all(test, feature = "frida_cli"))]
+    #[cfg(feature = "frida_cli")]
     fn parse_instrumentation_location_fails_without_at_symbol() {
         assert!(parse_instrumentation_location("mod_name0x12345").is_err());
     }
 
     /// pass module without address to `parse_instrumentation_location`, expect failure
     #[test]
-    #[cfg(all(test, feature = "frida_cli"))]
+    #[cfg(feature = "frida_cli")]
     fn parse_instrumentation_location_failes_without_address() {
         assert!(parse_instrumentation_location("mod_name@").is_err());
     }
@@ -370,7 +373,7 @@ mod tests {
     /// pass location without 0x to `parse_instrumentation_location`, expect value to be parsed
     /// as hex, even without 0x
     #[test]
-    #[cfg(all(test, feature = "frida_cli"))]
+    #[cfg(feature = "frida_cli")]
     fn parse_instrumentation_location_succeeds_without_0x() {
         assert_eq!(
             parse_instrumentation_location("mod_name@12345").unwrap(),
@@ -380,7 +383,7 @@ mod tests {
 
     /// pass location with 0x to `parse_instrumentation_location`, expect value to be parsed as hex
     #[test]
-    #[cfg(all(test, feature = "frida_cli"))]
+    #[cfg(feature = "frida_cli")]
     fn parse_instrumentation_location_succeeds_with_0x() {
         assert_eq!(
             parse_instrumentation_location("mod_name@0x12345").unwrap(),
@@ -390,7 +393,7 @@ mod tests {
 
     /// pass normal value to `parse_timeout` and get back Duration, simple test for happy-path
     #[test]
-    #[cfg(all(test, feature = "cli"))]
+    #[cfg(feature = "cli")]
     fn parse_timeout_gives_correct_values() {
         assert_eq!(parse_timeout("1525").unwrap(), Duration::from_millis(1525));
     }

--- a/libafl/src/bolts/cli.rs
+++ b/libafl/src/bolts/cli.rs
@@ -340,7 +340,6 @@ mod tests {
     fn standard_option_with_trailing_variable_length_args_collected() {
         let parsed = FuzzerOptions::parse_from([
             "some-command",
-            "fuzz",
             "--broker-port",
             "1336",
             "-i",
@@ -351,9 +350,7 @@ mod tests {
             "-L",
             "qemu-bound",
         ]);
-        if let SubCommand::Fuzz { broker_port, .. } = &parsed.command {
-            assert_eq!(*broker_port, 1336);
-            assert_eq!(parsed.qemu_args, ["-L", "qemu-bound"]);
-        }
+        assert_eq!(parsed.qemu_args, ["-L", "qemu-bound"]);
+        assert_eq!(parsed.broker_port, 1336);
     }
 }

--- a/libafl/src/bolts/cli.rs
+++ b/libafl/src/bolts/cli.rs
@@ -268,7 +268,8 @@ pub struct FuzzerOptions {
         long,
         default_missing_value = "1",
         min_values = 0,
-        help_heading = "Replay Options"
+        help_heading = "Replay Options",
+        requires = "replay"
     )]
     pub repeat: Option<usize>,
 }


### PR DESCRIPTION
simplifies ergonomics related to destructuring the SubCommand enum. 

re: https://discord.com/channels/736989425770168422/737602414395260970/937984800239779850

At a glance, this works. ~~I need to update the documentation~~ if this is the route we want to take. Mainly wanted to get a working example for @s1341 to play with for comparison.

With these changes, main can look like 

```rust
fn main() {
    let parsed = parse_args();

    if parsed.replay.is_some() {
        replay(parsed);
    } else {
        fuzz(parsed);
    }
}
```

With signatures being

```rust
fn replay(options: FuzzerOptions) -> Result<(), Error> {}
fn fuzz(options: FuzzerOptions) -> Result<(), Error> {}
```

Leaving this as WIP for now until we know which API we want for the cli. Pinging @evanrichter since he was the main proponent of subcommands. 