### PR TITLE
Clippy for Cargo

### DIFF
--- a/fuzzers/libfuzzer_stb_image_sugar/Cargo.toml
+++ b/fuzzers/libfuzzer_stb_image_sugar/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.1"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"
 build = "build.rs"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
 default = ["std"]

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
 edition = "2021"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
 default = ["std", "derive", "llmp_compression", "rand_trait", "fork"]
@@ -63,7 +64,7 @@ intervaltree = { version = "0.2.7", default-features = false, features = ["serde
 backtrace = {version = "0.3", optional = true} # Used to get the stacktrace in StacktraceObserver
 
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
-miniz_oxide = { version = "0.5", optional = true}
+miniz_oxide = { version = "0.4.4", optional = true}
 core_affinity = { version = "0.5", git = "https://github.com/s1341/core_affinity_rs", rev = "6648a7a", optional = true }
 hostname = { version = "^0.3", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.5.1", optional = true } # This dependency allows us to export our RomuRand as rand::Rng. We cannot update to the latest version because it breaks compatibility to microsoft lain.

--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -206,6 +206,14 @@ impl TryFrom<&Vec<u8>> for TcpRequest {
     }
 }
 
+impl TryFrom<Vec<u8>> for TcpRequest {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Error> {
+        Ok(postcard::from_bytes(&bytes)?)
+    }
+}
+
 /// Messages for broker 2 broker connection.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TcpRemoteNewMessage {
@@ -224,6 +232,14 @@ impl TryFrom<&Vec<u8>> for TcpRemoteNewMessage {
 
     fn try_from(bytes: &Vec<u8>) -> Result<Self, Error> {
         Ok(postcard::from_bytes(bytes)?)
+    }
+}
+
+impl TryFrom<Vec<u8>> for TcpRemoteNewMessage {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Error> {
+        Ok(postcard::from_bytes(&bytes)?)
     }
 }
 
@@ -260,6 +276,14 @@ impl TryFrom<&Vec<u8>> for TcpResponse {
 
     fn try_from(bytes: &Vec<u8>) -> Result<Self, Error> {
         Ok(postcard::from_bytes(bytes)?)
+    }
+}
+
+impl TryFrom<Vec<u8>> for TcpResponse {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Error> {
+        Ok(postcard::from_bytes(&bytes)?)
     }
 }
 
@@ -1830,7 +1854,7 @@ where
         let mut stream = TcpStream::connect(addr)?;
         println!("B2B: Connected to {:?}", stream);
 
-        match (&recv_tcp_msg(&mut stream)?).try_into()? {
+        match recv_tcp_msg(&mut stream)?.try_into()? {
             TcpResponse::BrokerConnectHello {
                 broker_shmem_description: _,
                 hostname,
@@ -1849,7 +1873,7 @@ where
 
         send_tcp_msg(&mut stream, &TcpRequest::RemoteBrokerHello { hostname })?;
 
-        let broker_id = match (&recv_tcp_msg(&mut stream)?).try_into()? {
+        let broker_id = match recv_tcp_msg(&mut stream)?.try_into()? {
             TcpResponse::RemoteBrokerAccepted { broker_id } => {
                 println!("B2B: Got Connection Ack, broker_id {}", broker_id);
                 broker_id
@@ -2106,7 +2130,7 @@ where
                 // We ignore errors completely as they may be timeout, or stream closings.
                 // Instead, we catch stream close when/if we next try to send.
                 if let Ok(val) = recv_tcp_msg(&mut stream) {
-                    let msg: TcpRemoteNewMessage = (&val).try_into().expect(
+                    let msg: TcpRemoteNewMessage = val.try_into().expect(
                         "Illegal message received from broker 2 broker connection - shutting down.",
                     );
 
@@ -2267,7 +2291,7 @@ where
                                 continue;
                             }
                         };
-                        let req = match (&buf).try_into() {
+                        let req = match buf.try_into() {
                             Ok(req) => req,
                             Err(e) => {
                                 eprintln!("Could not deserialize tcp message: {:?}", e);
@@ -2653,7 +2677,7 @@ where
         let broker_shmem_description = if let TcpResponse::BrokerConnectHello {
             broker_shmem_description,
             hostname: _,
-        } = (&recv_tcp_msg(&mut stream)?).try_into()?
+        } = recv_tcp_msg(&mut stream)?.try_into()?
         {
             broker_shmem_description
         } else {
@@ -2674,7 +2698,7 @@ where
         send_tcp_msg(&mut stream, &client_hello_req)?;
 
         let client_id = if let TcpResponse::LocalClientAccepted { client_id } =
-            (&recv_tcp_msg(&mut stream)?).try_into()?
+            recv_tcp_msg(&mut stream)?.try_into()?
         {
             client_id
         } else {

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -643,12 +643,12 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
 
             if (status & FS_OPT_SHDMEM_FUZZ == FS_OPT_SHDMEM_FUZZ) && map.is_some() {
                 println!("Using SHARED MEMORY FUZZING feature.");
-                send_status = send_status | FS_OPT_SHDMEM_FUZZ;
+                send_status |= FS_OPT_SHDMEM_FUZZ;
             }
 
             if (status & FS_OPT_AUTODICT == FS_OPT_AUTODICT) && self.autotokens.is_some() {
                 println!("Using AUTODICT feature");
-                send_status = send_status | FS_OPT_AUTODICT;
+                send_status |= FS_OPT_AUTODICT;
             }
 
             let send_len = forkserver.write_ctl(send_status)?;
@@ -666,7 +666,7 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
                     ));
                 }
 
-                if dict_size < 2 || dict_size > 0xffffff {
+                if !(2..=0xffffff).contains(&dict_size) {
                     return Err(Error::Forkserver(
                         "Dictionary has an illegal size".to_string(),
                     ));
@@ -801,8 +801,7 @@ impl<'a> ForkserverExecutorBuilder<'a, StdShMemProvider> {
     #[must_use]
     /// Place the input at this position and set the default filename for the input.
     pub fn arg_input_file_std(self) -> Self {
-        let moved = self.arg_input_file(OUTFILE_STD);
-        moved
+        self.arg_input_file(OUTFILE_STD)
     }
 
     #[must_use]
@@ -833,6 +832,12 @@ impl<'a> ForkserverExecutorBuilder<'a, StdShMemProvider> {
             out_filename: self.out_filename,
             shmem_provider: Some(shmem_provider),
         }
+    }
+}
+
+impl<'a> Default for ForkserverExecutorBuilder<'a, StdShMemProvider> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -799,17 +799,15 @@ impl<'a> ForkserverExecutorBuilder<'a, StdShMemProvider> {
             if item.as_ref() == "@@" && use_stdin {
                 use_stdin = false;
                 res.push(OsString::from(".cur_input"));
-            } else {
-                if let Some(name) = &self.out_filename {
-                    if name == item.as_ref() && use_stdin {
-                        use_stdin = false;
-                        res.push(name.clone());
-                    } else {
-                        res.push(item.as_ref().to_os_string());
-                    }
+            } else if let Some(name) = &self.out_filename {
+                if name == item.as_ref() && use_stdin {
+                    use_stdin = false;
+                    res.push(name.clone());
                 } else {
                     res.push(item.as_ref().to_os_string());
                 }
+            } else {
+                res.push(item.as_ref().to_os_string());
             }
         }
 

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -1571,6 +1571,10 @@ pub mod child_signal_handlers {
     }
 
     /// invokes the `post_exec` hook on all observer in case the child process crashes
+    ///
+    /// # Safety
+    /// The function should only be called from a child crash handler.
+    /// It will dereference the `data` pointer and assume it's valid.
     #[cfg(unix)]
     pub unsafe fn child_crash_handler<E, I, OT, S>(
         _signal: Signal,

--- a/libafl/src/feedbacks/concolic.rs
+++ b/libafl/src/feedbacks/concolic.rs
@@ -51,6 +51,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl/src/feedbacks/differential.rs
+++ b/libafl/src/feedbacks/differential.rs
@@ -177,7 +177,7 @@ mod tests {
         fn new(name: &str, value: bool) -> Self {
             Self {
                 name: name.to_string(),
-                value: value,
+                value,
             }
         }
     }

--- a/libafl/src/feedbacks/differential.rs
+++ b/libafl/src/feedbacks/differential.rs
@@ -123,6 +123,7 @@ where
     O1: Observer<I, S> + PartialEq<O2>,
     O2: Observer<I, S>,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -373,6 +373,7 @@ where
     I: Input,
     S: HasFeedbackStates + HasClientPerfMonitor + Debug,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         state: &mut S,
@@ -599,6 +600,7 @@ where
     O: MapObserver<Entry = usize>,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -52,6 +52,7 @@ where
     S: HasClientPerfMonitor,
 {
     /// `is_interesting ` return if an input is worth the addition to the corpus
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         state: &mut S,
@@ -205,6 +206,7 @@ where
     I: Input,
     S: HasClientPerfMonitor + Debug,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         state: &mut S,
@@ -229,6 +231,7 @@ where
     }
 
     #[cfg(feature = "introspection")]
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting_introspection<EM, OT>(
         &mut self,
         state: &mut S,
@@ -592,6 +595,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         state: &mut S,
@@ -707,6 +711,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,
@@ -739,6 +744,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,
@@ -789,6 +795,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,
@@ -844,6 +851,7 @@ where
     I: Input,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -69,6 +69,7 @@ where
     /// It also keeps track of introspection stats.
     #[cfg(feature = "introspection")]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting_introspection<EM, OT>(
         &mut self,
         state: &mut S,

--- a/libafl/src/feedbacks/nautilus.rs
+++ b/libafl/src/feedbacks/nautilus.rs
@@ -78,6 +78,7 @@ impl<'a, S> Feedback<NautilusInput, S> for NautilusFeedback<'a>
 where
     S: HasMetadata + HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl/src/feedbacks/new_hash_feedback.rs
+++ b/libafl/src/feedbacks/new_hash_feedback.rs
@@ -113,6 +113,7 @@ where
     S: HasClientPerfMonitor + HasFeedbackStates,
     O: ObserverWithHashField + Named + Debug,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -8,7 +8,10 @@ Welcome to `LibAFL`
 #![cfg_attr(unstable_feature, feature(specialization))]
 // For `type_id` and owned things
 #![cfg_attr(unstable_feature, feature(intrinsics))]
+#![warn(clippy::cargo)]
+#![deny(clippy::cargo_common_metadata)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::unreadable_literal,

--- a/libafl_cc/Cargo.toml
+++ b/libafl_cc/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "compiler"]
 edition = "2021"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -1,6 +1,7 @@
 //! Compiler Wrapper from `LibAFL`
 
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::unreadable_literal,

--- a/libafl_concolic/symcc_libafl/Cargo.toml
+++ b/libafl_concolic/symcc_libafl/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/AFLplusplus/LibAFL/"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libafl_concolic/symcc_runtime/Cargo.toml
+++ b/libafl_concolic/symcc_runtime/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
 build = "build.rs"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libafl_concolic/symcc_runtime/src/filter/coverage.rs
+++ b/libafl_concolic/symcc_runtime/src/filter/coverage.rs
@@ -70,6 +70,7 @@ impl<THasher: Hasher, THashBuilder: BuildHasher> CallStackCoverage<THasher, THas
         self.pending = true;
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn is_interesting(&self) -> bool {
         self.is_interesting
     }

--- a/libafl_concolic/test/dump_constraints/Cargo.toml
+++ b/libafl_concolic/test/dump_constraints/Cargo.toml
@@ -3,6 +3,13 @@ name = "dump_constraints"
 version = "0.1.0"
 edition = "2021"
 authors = ["Julius Hohnerlein <julihoh@users.noreply.github.com>"]
+description = "Dump Constraints, a lib to see the constraints oof a run"
+documentation = "https://docs.rs/libafl"
+repository = "https://github.com/AFLplusplus/LibAFL/"
+readme = "../README.md"
+license = "MIT OR Apache-2.0"
+keywords = ["fuzzing", "libafl", "ldpreload"]
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libafl_concolic/test/dump_constraints/src/main.rs
+++ b/libafl_concolic/test/dump_constraints/src/main.rs
@@ -112,7 +112,7 @@ fn main() {
                 .enumerate()
                 .filter(|(_, &v)| v != 0)
             {
-                writeln!(&mut f, "{}\t{}", index, count).expect("failed to write coverage file");
+                writeln!(f, "{}\t{}", index, count).expect("failed to write coverage file");
             }
         }
 
@@ -125,7 +125,7 @@ fn main() {
         if opt.plain_text {
             while let Some(message) = reader.next_message() {
                 if let Ok((id, message)) = message {
-                    writeln!(&mut output_file, "{}\t{:?}", id, message)
+                    writeln!(output_file, "{}\t{:?}", id, message)
                         .expect("failed to write to output file");
                 } else {
                     break;

--- a/libafl_concolic/test/runtime_test/Cargo.toml
+++ b/libafl_concolic/test/runtime_test/Cargo.toml
@@ -3,6 +3,13 @@ name = "runtime_test"
 version = "0.1.0"
 edition = "2021"
 authors = ["Julius Hohnerlein <julihoh@users.noreply.github.com>"]
+description = "Runtime test of LibAFL fuzzing with symbolicc execution"
+documentation = "https://docs.rs/libafl"
+repository = "https://github.com/AFLplusplus/LibAFL/"
+readme = "../README.md"
+license = "MIT OR Apache-2.0"
+keywords = ["fuzzing", "libafl", "symbolic", "symcc", "symqemu", "fuzzer"]
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [lib]
 crate-type   = ["cdylib"]

--- a/libafl_derive/Cargo.toml
+++ b/libafl_derive/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing"]
 edition = "2021"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [lib]
 proc-macro = true

--- a/libafl_derive/src/lib.rs
+++ b/libafl_derive/src/lib.rs
@@ -1,6 +1,7 @@
 //! Derives for `LibAFL`
 
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::unreadable_literal,

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "frida", "instrumentation"]
 edition = "2021"
-
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
 default = []

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -615,6 +615,7 @@ where
     I: Input + HasTargetBytes,
     S: HasClientPerfMonitor,
 {
+    #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
         &mut self,
         _state: &mut S,

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -4,6 +4,7 @@ It can report coverage and, on supported architecutres, even reports memory acce
 */
 
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::unreadable_literal,

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "qemu", "instrumentation"]
 edition = "2021"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
 python = ["pyo3", "pyo3-build-config"]

--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["fuzzing"]
 edition = "2021"
 build = "build.rs"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
 python = ["pyo3", "libafl_qemu/python", "pyo3-build-config"]

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -1,6 +1,7 @@
 //! Sugar API to simplify the life of the naive user of `LibAFL`
 
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::unreadable_literal,

--- a/libafl_targets/Cargo.toml
+++ b/libafl_targets/Cargo.toml
@@ -9,6 +9,8 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing"]
 edition = "2021"
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
+
 
 [features]
 default = ["std", "sanitizers_flags"]

--- a/libafl_targets/src/coverage.rs
+++ b/libafl_targets/src/coverage.rs
@@ -43,7 +43,6 @@ pub use __afl_area_ptr as EDGES_MAP_PTR;
 ///
 /// This fn is safe to call, as long as the compilation diid not break, previously
 #[cfg(target_os = "linux")]
-#[must_use]
 pub fn autotokens() -> Result<Tokens, Error> {
     unsafe {
         if __token_start.is_null() || __token_stop.is_null() {

--- a/libafl_targets/src/lib.rs
+++ b/libafl_targets/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //!
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::unreadable_literal,

--- a/scripts/clippy.ps1
+++ b/scripts/clippy.ps1
@@ -1,4 +1,5 @@
 cargo clippy --all --all-features --tests -- `
+   -D clippy::all `
    -D clippy::pedantic `
    -W clippy::similar_names `
    -A clippy::type_repetition_in_bounds `

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -9,6 +9,7 @@ if [ "$1" != "--no-clean" ]; then
    cargo clean -p libafl
 fi
 RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --tests -- -Z macro-backtrace \
+   -D clippy::all \
    -D clippy::pedantic \
    -W clippy::similar_names \
    -A clippy::type_repetition_in_bounds \

--- a/utils/deexit/Cargo.toml
+++ b/utils/deexit/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
+authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 name = "deexit"
 version = "0.1.0"
 edition = "2021"
+description = "DeExit: Replace exits with aborts to catch them during in-process fuzzing"
+documentation = "https://docs.rs/libafl"
+repository = "https://github.com/AFLplusplus/LibAFL/"
+readme = "../../README.md"
+license = "MIT OR Apache-2.0"
+keywords = ["fuzzing", "libafl", "ldpreload"]
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/utils/gramatron/construct_automata/Cargo.toml
+++ b/utils/gramatron/construct_automata/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "construct_automata"
 version = "0.1.0"
-edition = "2021"
+authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+description = "LibAFL Gramatron Gramar Construction"
+documentation = "https://docs.rs/libafl"
+repository = "https://github.com/AFLplusplus/LibAFL/"
+readme = "../../README.md"
+license = "MIT OR Apache-2.0"
+keywords = ["fuzzing", "libafl", "gramatron", "grammar"]
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/utils/gramatron/construct_automata/Cargo.toml
+++ b/utils/gramatron/construct_automata/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "construct_automata"
 version = "0.1.0"
+edition = "2021"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 description = "LibAFL Gramatron Gramar Construction"
 documentation = "https://docs.rs/libafl"

--- a/utils/libafl_benches/Cargo.toml
+++ b/utils/libafl_benches/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
+authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 name = "libafl_benches"
 version = "0.7.1"
 edition = "2021"
+description = "LibAFL Benchmarks"
+documentation = "https://docs.rs/libafl"
+repository = "https://github.com/AFLplusplus/LibAFL/"
+readme = "../../README.md"
+license = "MIT OR Apache-2.0"
+keywords = ["fuzzing", "libafl", "benchmarks"]
+categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [dev-dependencies]
 criterion = "0.3" # Benchmarking


### PR DESCRIPTION
This PR enables Clippy for Cargo, to check the contents of our .toml files.
This found, for example, that categories were not set for our crates.