### PR TITLE
Prevent dropping variables in closure hooks

### DIFF
--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -108,6 +108,9 @@ where
                     let mut func: Box<dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64)> =
                         transmute(*ptr);
                     (func)(&emulator, helpers, inprocess_get_state::<S>(), id);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }
@@ -135,8 +138,13 @@ where
                 let mut func: Box<
                     dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64) -> Option<u64>,
                 > = transmute(*ptr);
-                (func)(&emulator, helpers, inprocess_get_state::<S>(), pc)
-                    .map_or(SKIP_EXEC_HOOK, |id| id)
+                let ret = (func)(&emulator, helpers, inprocess_get_state::<S>(), pc)
+                    .map_or(SKIP_EXEC_HOOK, |id| id);
+
+                // Forget the closure so that drop is not called on captured variables.
+                core::mem::forget(func);
+
+                ret
             }
             _ => SKIP_EXEC_HOOK,
         }
@@ -162,6 +170,9 @@ where
                     let mut func: Box<dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64)> =
                         transmute(*ptr);
                     (func)(&emulator, helpers, inprocess_get_state::<S>(), id);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }
@@ -194,13 +205,18 @@ where
                 let mut func: Box<
                     dyn FnMut(&Emulator, &mut QT, Option<&mut S>, usize) -> Option<u64>,
                 > = transmute(*ptr);
-                (func)(
+                let ret = (func)(
                     &emulator,
                     helpers,
                     inprocess_get_state::<S>(),
                     size as usize,
                 )
-                .map_or(SKIP_EXEC_HOOK, |id| id)
+                .map_or(SKIP_EXEC_HOOK, |id| id);
+
+                // Forget the closure so that drop is not called on captured variables.
+                core::mem::forget(func);
+
+                ret
             }
             _ => SKIP_EXEC_HOOK,
         }
@@ -232,13 +248,18 @@ where
                 let mut func: Box<
                     dyn FnMut(&Emulator, &mut QT, Option<&mut S>, usize) -> Option<u64>,
                 > = transmute(*ptr);
-                (func)(
+                let ret = (func)(
                     &emulator,
                     helpers,
                     inprocess_get_state::<S>(),
                     size as usize,
                 )
-                .map_or(SKIP_EXEC_HOOK, |id| id)
+                .map_or(SKIP_EXEC_HOOK, |id| id);
+
+                // Forget the closure so that drop is not called on captured variables.
+                core::mem::forget(func);
+
+                ret
             }
             _ => SKIP_EXEC_HOOK,
         }
@@ -645,14 +666,19 @@ where
                 let mut func: Box<
                     dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64, usize) -> Option<u64>,
                 > = transmute(*ptr);
-                (func)(
+                let ret = (func)(
                     &emulator,
                     helpers,
                     inprocess_get_state::<S>(),
                     pc,
                     size as usize,
                 )
-                .map_or(SKIP_EXEC_HOOK, |id| id)
+                .map_or(SKIP_EXEC_HOOK, |id| id);
+
+                // Forget the closure so that drop is not called on captured variables.
+                core::mem::forget(func);
+
+                ret
             }
             _ => SKIP_EXEC_HOOK,
         }
@@ -678,6 +704,9 @@ where
                     let mut func: Box<dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64, u8, u8)> =
                         transmute(*ptr);
                     (func)(&emulator, helpers, inprocess_get_state::<S>(), id, v0, v1);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }
@@ -706,6 +735,9 @@ where
                         dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64, u16, u16),
                     > = transmute(*ptr);
                     (func)(&emulator, helpers, inprocess_get_state::<S>(), id, v0, v1);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }
@@ -734,6 +766,9 @@ where
                         dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64, u32, u32),
                     > = transmute(*ptr);
                     (func)(&emulator, helpers, inprocess_get_state::<S>(), id, v0, v1);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }
@@ -762,6 +797,9 @@ where
                         dyn FnMut(&Emulator, &mut QT, Option<&mut S>, u64, u64, u64),
                     > = transmute(*ptr);
                     (func)(&emulator, helpers, inprocess_get_state::<S>(), id, v0, v1);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }
@@ -799,6 +837,9 @@ where
                         ),
                     > = transmute(*ptr);
                     (func)(&emu, hooks, inprocess_get_state::<S>(), tid);
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 Hook::Once(ptr) => {
                     let func: Box<
@@ -907,6 +948,10 @@ where
                         a6,
                         a7,
                     );
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
+
                     if r.skip_syscall {
                         res.skip_syscall = true;
                         res.retval = r.retval;
@@ -1009,6 +1054,9 @@ where
                         a6,
                         a7,
                     );
+
+                    // Forget the closure so that drop is not called on captured variables.
+                    core::mem::forget(func);
                 }
                 _ => (),
             }


### PR DESCRIPTION
Closure hooks are going to be super useful, but I ran into a drop issue when I tried the following change:

```diff
-static mut COV_SOCKET: Option<TcpStream> = None;
-
-/// Send PC over a local TCP socket so that another process can record and format the data
-///
-/// SAFETY: This function must only be called from one thread at a time
-unsafe fn block_exec(_emu: &Emulator, pc: u64) {
-    unsafe {
-        let pc = pc as u32;
-        let mut sock = COV_SOCKET.take().unwrap();
-        sock.write_all(&pc.to_ne_bytes()).unwrap();
-        COV_SOCKET.replace(sock);
-    }
-}
-
 // Useful for crash minimization with afl-tmin (from the stock AFL++ project)
 // Usage:
 //     AFL_NO_FORKSRV=1 AFL_DEBUG=1 \
@@ -650,17 +633,17 @@ pub fn repro(emu: &PreppedEmulator, config: ReproConfig) {
         let hooked_emu = QemuHooks::<BytesInput, _, ()>::new(&emu.emu, tuple_list!());

         // connect the socket
-        let sock = match std::net::TcpStream::connect(("localhost", port)) {
+        let mut sock = match std::net::TcpStream::connect(("localhost", port)) {
             Ok(s) => s,
             Err(e) => panic!("could not connect to localhost:{} due to: {}", port, e),
         };

         // install the basic block hook
-        unsafe {
-            // TODO: when closure hooks are supported, get rid of the global and unsafe blocks
-            COV_SOCKET = Some(sock);
-            hooked_emu.block_execution(|emu, _, _: Option<&mut ()>, pc| block_exec(emu, pc));
-        }
+        hooked_emu.block_execution_closure(Box::new(move |_emu, _, _: Option<&mut ()>, pc| {
+            // Send PC over the socket
+            let pc = pc as u32;
+            sock.write_all(&pc.to_ne_bytes()).unwrap();
+        }));
     }
```

The gist of the change is removing static mut globals used by a function hook, into a closure hook with captured mutable variables.

However, I was getting weird behavior: the first PC is written to the socket fine, but on the next execution of the closure, it panicked with "Bad file descriptor" for the socket. This is because the TcpStream was getting dropped after the first execution.

I verified this was happening with a wrapper type with a custom `impl Drop`:

```rust
        // connect the socket
        let mut sock = match std::net::TcpStream::connect(("localhost", port)) {
            Ok(s) => s,
            Err(e) => panic!("could not connect to localhost:{} due to: {}", port, e),
        };

        struct Test(pub std::net::TcpStream);

        impl Drop for Test {
            fn drop(&mut self) {
                println!("dropping Test!");
            }
        }

        let mut sock = Test(sock);

        // install the basic block hook
        hooked_emu.block_execution_closure(Box::new(move |_emu, _, _: Option<&mut ()>, pc| {
            // Send PC over the socket
            let pc = pc as u32;
            sock.0.write_all(&pc.to_ne_bytes()).unwrap();
        }));
```

And sure enough I saw "dropping Test!" right before the panic. This meant that after the first network write, the TcpStream was dropped, then Test was dropped, then later the closure was called again on the next block execution.

----

The changes in this PR fix this specific issue using `mem::forget`, but there remains the problem that Drop is _never_ called. That's not a soundness issue of course, but it should be possible.