### PR TITLE
Add function call level granularity for coverage accounting

### DIFF
--- a/fuzzers/libfuzzer_libpng_accounting/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/bin/libafl_cc.rs
@@ -1,6 +1,8 @@
 use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses};
 use std::env;
 
+const GRANULARITY: &str = "FUNC";
+
 pub fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() > 1 {
@@ -25,6 +27,7 @@ pub fn main() {
             .link_staticlib(&dir, "libfuzzer_libpng")
             .add_arg("-fsanitize-coverage=trace-pc-guard")
             .add_pass(LLVMPasses::CoverageAccounting)
+            .add_passes_arg(format!("-granularity={}", GRANULARITY))
             .run()
             .expect("Failed to run the wrapped compiler")
         {

--- a/fuzzers/libfuzzer_libpng_ctx/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_ctx/src/bin/libafl_cc.rs
@@ -23,8 +23,7 @@ pub fn main() {
             .parse_args(&args)
             .expect("Failed to parse the command line")
             .add_pass(LLVMPasses::AFLCoverage)
-            .add_arg("-mllvm")
-            .add_arg("-ctx") // Context sensitive coverage
+            .add_passes_arg("-ctx") // Context sensitive coverage
             .link_staticlib(&dir, "libfuzzer_libpng")
             .run()
             .expect("Failed to run the wrapped compiler")

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -77,7 +77,7 @@ pub struct ClangWrapper {
     cc_args: Vec<String>,
     link_args: Vec<String>,
     passes: Vec<LLVMPasses>,
-    passes_args: Vec<String>
+    passes_args: Vec<String>,
 }
 
 #[allow(clippy::match_same_arms)] // for the linking = false wip for "shared"
@@ -367,8 +367,8 @@ impl ClangWrapper {
 
     /// Add LLVM pass arguments
     pub fn add_passes_arg<S>(&mut self, arg: S) -> &'_ mut Self
-        where
-            S: AsRef<str>,
+    where
+        S: AsRef<str>,
     {
         self.passes_args.push(arg.as_ref().to_string());
         self

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -77,6 +77,7 @@ pub struct ClangWrapper {
     cc_args: Vec<String>,
     link_args: Vec<String>,
     passes: Vec<LLVMPasses>,
+    passes_args: Vec<String>
 }
 
 #[allow(clippy::match_same_arms)] // for the linking = false wip for "shared"
@@ -264,6 +265,10 @@ impl CompilerWrapper for ClangWrapper {
             args.push("-Xclang".into());
             args.push(pass.path().into_os_string().into_string().unwrap());
         }
+        for passes_arg in &self.passes_args {
+            args.push("-mllvm".into());
+            args.push(passes_arg.into());
+        }
         if self.linking {
             if self.x_set {
                 args.push("-x".into());
@@ -325,6 +330,7 @@ impl ClangWrapper {
             cc_args: vec![],
             link_args: vec![],
             passes: vec![],
+            passes_args: vec![],
             is_silent: false,
         }
     }
@@ -356,6 +362,15 @@ impl ClangWrapper {
     /// Add LLVM pass
     pub fn add_pass(&mut self, pass: LLVMPasses) -> &'_ mut Self {
         self.passes.push(pass);
+        self
+    }
+
+    /// Add LLVM pass arguments
+    pub fn add_passes_arg<S>(&mut self, arg: S) -> &'_ mut Self
+        where
+            S: AsRef<str>,
+    {
+        self.passes_args.push(arg.as_ref().to_string());
         self
     }
 


### PR DESCRIPTION
Implemented [TortoiseFuzz](https://www.ndss-symposium.org/wp-content/uploads/2020/02/24422-paper.pdf)'s function call level granularity for coverage accounting. I'll add loop level granularity in a separate PR. 