### PR TITLE
Fix unsafe bracket

### DIFF
--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -83,9 +83,9 @@ where
             self.stalker.deactivate();
         }
         #[cfg(unix)]
-        if unsafe { ASAN_ERRORS.is_some() && !ASAN_ERRORS.as_ref().unwrap().is_empty() } {
-            println!("Crashing target as it had ASAN errors");
-            unsafe {
+        unsafe {
+            if ASAN_ERRORS.is_some() && !ASAN_ERRORS.as_ref().unwrap().is_empty() {
+                println!("Crashing target as it had ASAN errors");
                 libc::raise(libc::SIGABRT);
             }
         }


### PR DESCRIPTION
My VScode's rust-analyzer wants this fix
`this operation is unsafe and requires an unsafe function or block`