### PR TITLE
Make weigthed scheduler independent of powersheduler stage

### DIFF
--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -314,10 +314,10 @@ fn fuzz(
     )?;
 
     let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::FAST);
+        StdPowerMutationalStage::new(mutator, &edges_observer);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -313,11 +313,11 @@ fn fuzz(
         5,
     )?;
 
-    let power =
-        StdPowerMutationalStage::new(mutator, &edges_observer);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
+    let scheduler =
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -284,11 +284,11 @@ fn fuzz(
         5,
     )?;
 
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::FAST);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler =
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -301,7 +301,7 @@ fn fuzz(
 
     // A minimization+queue policy to get testcasess from the corpus
     let scheduler =
-        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerQueueScheduler::FAST));
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerQueueSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -301,7 +301,7 @@ fn fuzz(
 
     // A minimization+queue policy to get testcasess from the corpus
     let scheduler =
-        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerQueueSchedule::FAST));
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -297,11 +297,11 @@ fn fuzz(
         5,
     )?;
 
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::FAST);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler =
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerQueueScheduler::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_text/src/lib.rs
+++ b/fuzzers/fuzzbench_text/src/lib.rs
@@ -374,11 +374,11 @@ fn fuzz_binary(
         5,
     )?;
 
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::FAST);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler =
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
@@ -584,8 +584,7 @@ fn fuzz_text(
         5,
     )?;
 
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::FAST);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     let grimoire_mutator = StdScheduledMutator::with_max_stack_pow(
         tuple_list!(
@@ -601,7 +600,8 @@ fn fuzz_text(
     let grimoire = StdMutationalStage::new(grimoire_mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler =
+        IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_weighted/src/lib.rs
+++ b/fuzzers/fuzzbench_weighted/src/lib.rs
@@ -313,8 +313,7 @@ fn fuzz(
         5,
     )?;
 
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::RAND);
+    let power = StdMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
     let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::new());

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -130,8 +130,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
     let calibration = CalibrationStage::new(&edges_observer);
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::COE);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     let mut stages = tuple_list!(calibration, power);
 

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -150,7 +150,7 @@ fn fuzz(
     println!("We're a client, let's fuzz :)");
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -40,7 +40,7 @@ use libafl::{
         },
         StdMapObserver, TimeObserver,
     },
-    schedulers::{IndexesLenTimeMinimizerScheduler, PowerQueueScheduler},
+    schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{
         ConcolicTracingStage, ShadowTracingStage, SimpleConcolicMutationalStage,
         StdMutationalStage, TracingStage,

--- a/fuzzers/tutorial/src/lib.rs
+++ b/fuzzers/tutorial/src/lib.rs
@@ -126,13 +126,12 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mutator = LainMutator::new();
 
     let calibration = CalibrationStage::new(&edges_observer);
-    let power =
-        StdPowerMutationalStage::new(&mut state, mutator, &edges_observer, PowerSchedule::FAST);
+    let power = StdPowerMutationalStage::new(mutator, &edges_observer);
 
     let mut stages = tuple_list!(calibration, power);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = PacketLenMinimizerScheduler::new(PowerQueueScheduler::new());
+    let scheduler = PacketLenMinimizerScheduler::new(PowerQueueScheduler::new(PowerSchedule::FAST));
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -1,7 +1,7 @@
 //! Corpuses contain the testcases, either in memory, on disk, or somewhere else.
 
 pub mod testcase;
-pub use testcase::{PowerScheduleTestcaseMetaData, Testcase};
+pub use testcase::{SchedulerTestcaseMetaData, Testcase};
 
 pub mod inmemory;
 pub use inmemory::InMemoryCorpus;

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -276,7 +276,7 @@ where
 
 /// The Metadata for each testcase used in power schedules.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PowerScheduleTestcaseMetaData {
+pub struct SchedulerTestcaseMetaData {
     /// Number of bits set in bitmap, updated in calibrate_case
     bitmap_size: u64,
     /// Number of queue cycles behind
@@ -287,7 +287,7 @@ pub struct PowerScheduleTestcaseMetaData {
     n_fuzz_entry: usize,
 }
 
-impl PowerScheduleTestcaseMetaData {
+impl SchedulerTestcaseMetaData {
     /// Create new [`struct@PowerScheduleTestcaseMetaData`]
     #[must_use]
     pub fn new(depth: u64) -> Self {
@@ -344,4 +344,4 @@ impl PowerScheduleTestcaseMetaData {
     }
 }
 
-crate::impl_serdeany!(PowerScheduleTestcaseMetaData);
+crate::impl_serdeany!(SchedulerTestcaseMetaData);

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -288,7 +288,7 @@ pub struct SchedulerTestcaseMetaData {
 }
 
 impl SchedulerTestcaseMetaData {
-    /// Create new [`struct@PowerScheduleTestcaseMetaData`]
+    /// Create new [`struct@SchedulerTestcaseMetaData`]
     #[must_use]
     pub fn new(depth: u64) -> Self {
         Self {

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -166,7 +166,9 @@ where
                 .borrow_mut()
                 .metadata_mut()
                 .get_mut::<SchedulerTestcaseMetaData>()
-                .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?
+                .ok_or_else(|| {
+                    Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
+                })?
                 .depth(),
             None => 0,
         };
@@ -203,6 +205,25 @@ where
                 None => 0,
             };
             *state.corpus_mut().current_mut() = Some(id);
+
+            // Update the handicap
+            let mut testcase = state
+                .corpus()
+                .get(id)?
+                .borrow_mut();
+            let tcmeta = testcase
+                .metadata_mut()
+                .get_mut::<SchedulerTestcaseMetaData>()
+                .ok_or_else(|| {
+                    Error::KeyNotFound("PowerScheduleTestcaseMetaData not found".to_string())
+                })?;
+
+            if tcmeta.handicap() >= 4 {
+                tcmeta.set_handicap(tcmeta.handicap() - 4);
+            } else if tcmeta.handicap() > 0 {
+                tcmeta.set_handicap(tcmeta.handicap() - 1);
+            }
+
             Ok(id)
         }
     }

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -23,7 +23,7 @@ crate::impl_serdeany!(SchedulerMetadata);
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SchedulerMetadata {
     /// Powerschedule strategy
-    strat: PowerSchedule,
+    strat: Option<PowerSchedule>,
     /// Measured exec time during calibration
     exec_time: Duration,
     /// Calibration cycles
@@ -42,7 +42,7 @@ pub struct SchedulerMetadata {
 impl SchedulerMetadata {
     /// Creates a new [`struct@SchedulerMetadata`]
     #[must_use]
-    pub fn new(strat: PowerSchedule) -> Self {
+    pub fn new(strat: Option<PowerSchedule>) -> Self {
         Self {
             strat,
             exec_time: Duration::from_millis(0),
@@ -56,7 +56,7 @@ impl SchedulerMetadata {
 
     /// The powerschedule strategy
     #[must_use]
-    pub fn strat(&self) -> PowerSchedule {
+    pub fn strat(&self) -> Option<PowerSchedule> {
         self.strat
     }
 
@@ -132,7 +132,6 @@ impl SchedulerMetadata {
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum PowerSchedule {
-    RAND,
     EXPLORE,
     EXPLOIT,
     FAST,
@@ -155,7 +154,7 @@ where
     /// Add an entry to the corpus and return its index
     fn on_add(&self, state: &mut S, idx: usize) -> Result<(), Error> {
         if !state.has_metadata::<SchedulerMetadata>() {
-            state.add_metadata::<SchedulerMetadata>(SchedulerMetadata::new(self.strat));
+            state.add_metadata::<SchedulerMetadata>(SchedulerMetadata::new(Some(self.strat)));
         }
 
         let current_idx = *state.corpus().current();

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -207,10 +207,7 @@ where
             *state.corpus_mut().current_mut() = Some(id);
 
             // Update the handicap
-            let mut testcase = state
-                .corpus()
-                .get(id)?
-                .borrow_mut();
+            let mut testcase = state.corpus().get(id)?.borrow_mut();
             let tcmeta = testcase
                 .metadata_mut()
                 .get_mut::<SchedulerTestcaseMetaData>()

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -212,7 +212,7 @@ where
                 .metadata_mut()
                 .get_mut::<SchedulerTestcaseMetaData>()
                 .ok_or_else(|| {
-                    Error::KeyNotFound("PowerScheduleTestcaseMetaData not found".to_string())
+                    Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
                 })?;
 
             if tcmeta.handicap() >= 4 {

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -6,7 +6,7 @@ use alloc::{
 };
 
 use crate::{
-    corpus::{Corpus, PowerScheduleTestcaseMetaData},
+    corpus::{Corpus, SchedulerTestcaseMetaData},
     inputs::Input,
     schedulers::Scheduler,
     state::{HasCorpus, HasMetadata},
@@ -165,19 +165,19 @@ where
                 .get(parent_idx)?
                 .borrow_mut()
                 .metadata_mut()
-                .get_mut::<PowerScheduleTestcaseMetaData>()
-                .ok_or_else(|| Error::KeyNotFound("PowerScheduleTestData not found".to_string()))?
+                .get_mut::<SchedulerTestcaseMetaData>()
+                .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?
                 .depth(),
             None => 0,
         };
 
-        // Attach a `PowerScheduleTestData` to the queue entry.
+        // Attach a `SchedulerTestcaseMetaData` to the queue entry.
         depth += 1;
         state
             .corpus()
             .get(idx)?
             .borrow_mut()
-            .add_metadata(PowerScheduleTestcaseMetaData::new(depth));
+            .add_metadata(SchedulerTestcaseMetaData::new(depth));
         Ok(())
     }
 

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -17,11 +17,11 @@ use serde::{Deserialize, Serialize};
 /// The n fuzz size
 pub const N_FUZZ_SIZE: usize = 1 << 21;
 
-crate::impl_serdeany!(PowerScheduleMetadata);
+crate::impl_serdeany!(SchedulerMetadata);
 
 /// The metadata used for power schedules
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct PowerScheduleMetadata {
+pub struct SchedulerMetadata {
     /// Powerschedule strategy
     strat: PowerSchedule,
     /// Measured exec time during calibration
@@ -39,8 +39,8 @@ pub struct PowerScheduleMetadata {
 }
 
 /// The metadata for runs in the calibration stage.
-impl PowerScheduleMetadata {
-    /// Creates a new [`struct@PowerScheduleMetadata`]
+impl SchedulerMetadata {
+    /// Creates a new [`struct@SchedulerMetadata`]
     #[must_use]
     pub fn new(strat: PowerSchedule) -> Self {
         Self {
@@ -143,12 +143,8 @@ pub enum PowerSchedule {
 
 /// A corpus scheduler using power schedules
 #[derive(Clone, Debug)]
-pub struct PowerQueueScheduler;
-
-impl Default for PowerQueueScheduler {
-    fn default() -> Self {
-        Self::new()
-    }
+pub struct PowerQueueScheduler {
+    strat: PowerSchedule,
 }
 
 impl<I, S> Scheduler<I, S> for PowerQueueScheduler
@@ -158,6 +154,10 @@ where
 {
     /// Add an entry to the corpus and return its index
     fn on_add(&self, state: &mut S, idx: usize) -> Result<(), Error> {
+        if !state.has_metadata::<SchedulerMetadata>() {
+            state.add_metadata::<SchedulerMetadata>(SchedulerMetadata::new(self.strat));
+        }
+
         let current_idx = *state.corpus().current();
 
         let mut depth = match current_idx {
@@ -191,9 +191,9 @@ where
                     if *cur + 1 >= state.corpus().count() {
                         let psmeta = state
                             .metadata_mut()
-                            .get_mut::<PowerScheduleMetadata>()
+                            .get_mut::<SchedulerMetadata>()
                             .ok_or_else(|| {
-                                Error::KeyNotFound("PowerScheduleMetadata not found".to_string())
+                                Error::KeyNotFound("SchedulerMetadata not found".to_string())
                             })?;
                         psmeta.set_queue_cycles(psmeta.queue_cycles() + 1);
                         0
@@ -212,7 +212,7 @@ where
 impl PowerQueueScheduler {
     /// Create a new [`PowerQueueScheduler`]
     #[must_use]
-    pub fn new() -> Self {
-        Self
+    pub fn new(strat: PowerSchedule) -> Self {
+        PowerQueueScheduler { strat }
     }
 }

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -142,7 +142,9 @@ where
         let tcmeta = entry
             .metadata()
             .get::<SchedulerTestcaseMetaData>()
-            .ok_or_else(|| Error::key_not_found("SchedulerTestcaseMetaData not found".to_string()))?;
+            .ok_or_else(|| {
+                Error::key_not_found("SchedulerTestcaseMetaData not found".to_string())
+            })?;
 
         if q_exec_us * 0.1 > avg_exec_us {
             perf_score = 10.0;
@@ -317,7 +319,9 @@ where
         let tcmeta = entry
             .metadata()
             .get::<SchedulerTestcaseMetaData>()
-            .ok_or_else(|| Error::key_not_found("SchedulerTestcaseMetaData not found".to_string()))?;
+            .ok_or_else(|| {
+                Error::key_not_found("SchedulerTestcaseMetaData not found".to_string())
+            })?;
 
         // This means that this testcase has never gone through the calibration stage before1,
         // In this case we'll just return the default weight

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -94,7 +94,9 @@ where
                             .metadata()
                             .get::<SchedulerTestcaseMetaData>()
                             .ok_or_else(|| {
-                                Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
+                                Error::KeyNotFound(
+                                    "SchedulerTestcaseMetaData not found".to_string(),
+                                )
                             })?
                             .n_fuzz_entry()
                     } else {
@@ -104,7 +106,9 @@ where
                             .metadata()
                             .get::<SchedulerTestcaseMetaData>()
                             .ok_or_else(|| {
-                                Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
+                                Error::KeyNotFound(
+                                    "SchedulerTestcaseMetaData not found".to_string(),
+                                )
                             })?
                             .n_fuzz_entry()
                     };

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -1,7 +1,7 @@
 //! The `TestcaseScore` is an evaluator providing scores of corpus items.
 use crate::{
     bolts::{HasLen, HasRefCnt},
-    corpus::{Corpus, PowerScheduleTestcaseMetaData, Testcase},
+    corpus::{Corpus, SchedulerTestcaseMetaData, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::Input,
     schedulers::{
@@ -92,9 +92,9 @@ where
                     let n_fuzz_entry = if cur_index == idx {
                         entry
                             .metadata()
-                            .get::<PowerScheduleTestcaseMetaData>()
+                            .get::<SchedulerTestcaseMetaData>()
                             .ok_or_else(|| {
-                                Error::KeyNotFound("PowerScheduleTestData not found".to_string())
+                                Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
                             })?
                             .n_fuzz_entry()
                     } else {
@@ -102,9 +102,9 @@ where
                             .get(idx)?
                             .borrow()
                             .metadata()
-                            .get::<PowerScheduleTestcaseMetaData>()
+                            .get::<SchedulerTestcaseMetaData>()
                             .ok_or_else(|| {
-                                Error::KeyNotFound("PowerScheduleTestData not found".to_string())
+                                Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
                             })?
                             .n_fuzz_entry()
                     };
@@ -137,7 +137,7 @@ where
         let favored = entry.has_metadata::<IsFavoredMetadata>();
         let tcmeta = entry
             .metadata()
-            .get::<PowerScheduleTestcaseMetaData>()
+            .get::<SchedulerTestcaseMetaData>()
             .ok_or_else(|| {
                 Error::KeyNotFound("PowerScheduleTestcaseMetaData not found".to_string())
             })?;
@@ -314,8 +314,8 @@ where
 
         let tcmeta = entry
             .metadata()
-            .get::<PowerScheduleTestcaseMetaData>()
-            .ok_or_else(|| Error::KeyNotFound("PowerScheduleTestData not found".to_string()))?;
+            .get::<SchedulerTestcaseMetaData>()
+            .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?;
 
         // This means that this testcase has never gone through the calibration stage before1,
         // In this case we'll just return the default weight

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -323,7 +323,7 @@ where
 
         // This means that this testcase has never gone through the calibration stage before1,
         // In this case we'll just return the default weight
-        // This methoud is called in corpus's on_add() method. Fuzz_level is zero at that time. 
+        // This methoud is called in corpus's on_add() method. Fuzz_level is zero at that time.
         if entry.fuzz_level() == 0 || psmeta.cycles() == 0 {
             return Ok(weight);
         }

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -142,9 +142,7 @@ where
         let tcmeta = entry
             .metadata()
             .get::<SchedulerTestcaseMetaData>()
-            .ok_or_else(|| {
-                Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
-            })?;
+            .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?;
 
         if q_exec_us * 0.1 > avg_exec_us {
             perf_score = 10.0;

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -82,41 +82,45 @@ where
             .get::<SchedulerMetadata>()
             .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?;
 
-        let fuzz_mu = if psmeta.strat() == PowerSchedule::COE {
-            let corpus = state.corpus();
-            let mut n_paths = 0;
-            let mut v = 0.0;
-            let cur_index = state.corpus().current().unwrap();
-            for idx in 0..corpus.count() {
-                let n_fuzz_entry = if cur_index == idx {
-                    entry
-                        .metadata()
-                        .get::<PowerScheduleTestcaseMetaData>()
-                        .ok_or_else(|| {
-                            Error::KeyNotFound("PowerScheduleTestData not found".to_string())
-                        })?
-                        .n_fuzz_entry()
-                } else {
-                    corpus
-                        .get(idx)?
-                        .borrow()
-                        .metadata()
-                        .get::<PowerScheduleTestcaseMetaData>()
-                        .ok_or_else(|| {
-                            Error::KeyNotFound("PowerScheduleTestData not found".to_string())
-                        })?
-                        .n_fuzz_entry()
-                };
-                v += libm::log2(f64::from(psmeta.n_fuzz()[n_fuzz_entry]));
-                n_paths += 1;
-            }
+        let fuzz_mu = if let Some(strat) = psmeta.strat() {
+            if strat == PowerSchedule::COE {
+                let corpus = state.corpus();
+                let mut n_paths = 0;
+                let mut v = 0.0;
+                let cur_index = state.corpus().current().unwrap();
+                for idx in 0..corpus.count() {
+                    let n_fuzz_entry = if cur_index == idx {
+                        entry
+                            .metadata()
+                            .get::<PowerScheduleTestcaseMetaData>()
+                            .ok_or_else(|| {
+                                Error::KeyNotFound("PowerScheduleTestData not found".to_string())
+                            })?
+                            .n_fuzz_entry()
+                    } else {
+                        corpus
+                            .get(idx)?
+                            .borrow()
+                            .metadata()
+                            .get::<PowerScheduleTestcaseMetaData>()
+                            .ok_or_else(|| {
+                                Error::KeyNotFound("PowerScheduleTestData not found".to_string())
+                            })?
+                            .n_fuzz_entry()
+                    };
+                    v += libm::log2(f64::from(psmeta.n_fuzz()[n_fuzz_entry]));
+                    n_paths += 1;
+                }
 
-            if n_paths == 0 {
-                return Err(Error::Unknown(String::from("Queue state corrput")));
-            }
+                if n_paths == 0 {
+                    return Err(Error::Unknown(String::from("Queue state corrput")));
+                }
 
-            v /= f64::from(n_paths);
-            v
+                v /= f64::from(n_paths);
+                v
+            } else {
+                0.0
+            }
         } else {
             0.0
         };
@@ -191,81 +195,87 @@ where
 
         // COE and Fast schedule are fairly different from what are described in the original thesis,
         // This implementation follows the changes made in this pull request https://github.com/AFLplusplus/AFLplusplus/pull/568
-        match psmeta.strat() {
-            PowerSchedule::EXPLORE | PowerSchedule::RAND => {
-                // Nothing happens in EXPLORE
-            }
-            PowerSchedule::EXPLOIT => {
-                factor = MAX_FACTOR;
-            }
-            PowerSchedule::COE => {
-                if libm::log2(f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()])) > fuzz_mu
-                    && !favored
-                {
-                    // Never skip favorites.
-                    factor = 0.0;
+        if let Some(strat) = psmeta.strat() {
+            match strat {
+                PowerSchedule::EXPLORE => {
+                    // Nothing happens in EXPLORE
                 }
-            }
-            PowerSchedule::FAST => {
-                if entry.fuzz_level() != 0 {
-                    let lg = libm::log2(f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()]));
-
-                    match lg {
-                        f if f < 2.0 => {
-                            factor = 4.0;
-                        }
-                        f if (2.0..4.0).contains(&f) => {
-                            factor = 3.0;
-                        }
-                        f if (4.0..5.0).contains(&f) => {
-                            factor = 2.0;
-                        }
-                        f if (6.0..7.0).contains(&f) => {
-                            if !favored {
-                                factor = 0.8;
-                            }
-                        }
-                        f if (7.0..8.0).contains(&f) => {
-                            if !favored {
-                                factor = 0.6;
-                            }
-                        }
-                        f if f >= 8.0 => {
-                            if !favored {
-                                factor = 0.4;
-                            }
-                        }
-                        _ => {
-                            factor = 1.0;
-                        }
-                    }
-
-                    if favored {
-                        factor *= 1.15;
+                PowerSchedule::EXPLOIT => {
+                    factor = MAX_FACTOR;
+                }
+                PowerSchedule::COE => {
+                    if libm::log2(f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()])) > fuzz_mu
+                        && !favored
+                    {
+                        // Never skip favorites.
+                        factor = 0.0;
                     }
                 }
-            }
-            PowerSchedule::LIN => {
-                factor = (entry.fuzz_level() as f64)
-                    / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
-            }
-            PowerSchedule::QUAD => {
-                factor = ((entry.fuzz_level() * entry.fuzz_level()) as f64)
-                    / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
+                PowerSchedule::FAST => {
+                    if entry.fuzz_level() != 0 {
+                        let lg = libm::log2(f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()]));
+
+                        match lg {
+                            f if f < 2.0 => {
+                                factor = 4.0;
+                            }
+                            f if (2.0..4.0).contains(&f) => {
+                                factor = 3.0;
+                            }
+                            f if (4.0..5.0).contains(&f) => {
+                                factor = 2.0;
+                            }
+                            f if (6.0..7.0).contains(&f) => {
+                                if !favored {
+                                    factor = 0.8;
+                                }
+                            }
+                            f if (7.0..8.0).contains(&f) => {
+                                if !favored {
+                                    factor = 0.6;
+                                }
+                            }
+                            f if f >= 8.0 => {
+                                if !favored {
+                                    factor = 0.4;
+                                }
+                            }
+                            _ => {
+                                factor = 1.0;
+                            }
+                        }
+
+                        if favored {
+                            factor *= 1.15;
+                        }
+                    }
+                }
+                PowerSchedule::LIN => {
+                    factor = (entry.fuzz_level() as f64)
+                        / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
+                }
+                PowerSchedule::QUAD => {
+                    factor = ((entry.fuzz_level() * entry.fuzz_level()) as f64)
+                        / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
+                }
             }
         }
 
-        if psmeta.strat() != PowerSchedule::EXPLORE {
-            if factor > MAX_FACTOR {
-                factor = MAX_FACTOR;
-            }
+        if let Some(strat) = psmeta.strat() {
+            if strat == PowerSchedule::EXPLORE {
+                if factor > MAX_FACTOR {
+                    factor = MAX_FACTOR;
+                }
 
-            perf_score *= factor / POWER_BETA;
+                perf_score *= factor / POWER_BETA;
+            }
         }
 
         // Lower bound if the strat is not COE.
-        if psmeta.strat() == PowerSchedule::COE && perf_score < 1.0 {
-            perf_score = 1.0;
+        if let Some(strat) = psmeta.strat() {
+            if strat == PowerSchedule::COE && perf_score < 1.0 {
+                perf_score = 1.0;
+            }
         }
 
         // Upper bound
@@ -324,15 +334,20 @@ where
 
         let q_bitmap_size = tcmeta.bitmap_size() as f64;
 
-        match psmeta.strat() {
-            PowerSchedule::FAST | PowerSchedule::COE | PowerSchedule::LIN | PowerSchedule::QUAD => {
-                let hits = psmeta.n_fuzz()[tcmeta.n_fuzz_entry()];
-                if hits > 0 {
-                    weight *= libm::log10(f64::from(hits)) + 1.0;
+        if let Some(strat) = psmeta.strat() {
+            match strat {
+                PowerSchedule::FAST
+                | PowerSchedule::COE
+                | PowerSchedule::LIN
+                | PowerSchedule::QUAD => {
+                    let hits = psmeta.n_fuzz()[tcmeta.n_fuzz_entry()];
+                    if hits > 0 {
+                        weight *= libm::log10(f64::from(hits)) + 1.0;
+                    }
                 }
+                // EXPLORE and EXPLOIT fall into this
+                _ => {}
             }
-            // EXPLORE and EXPLOIT fall into this
-            _ => {}
         }
 
         weight *= avg_exec_us / q_exec_us;

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -323,6 +323,7 @@ where
 
         // This means that this testcase has never gone through the calibration stage before1,
         // In this case we'll just return the default weight
+        // This methoud is called in corpus's on_add() method. Fuzz_level is zero at that time. 
         if entry.fuzz_level() == 0 || psmeta.cycles() == 0 {
             return Ok(weight);
         }

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -6,7 +6,7 @@ use crate::{
     inputs::Input,
     schedulers::{
         minimizer::{IsFavoredMetadata, TopRatedsMetadata},
-        powersched::{PowerSchedule, PowerScheduleMetadata},
+        powersched::{PowerSchedule, SchedulerMetadata},
     },
     state::{HasCorpus, HasMetadata},
     Error,
@@ -79,8 +79,8 @@ where
     fn compute(entry: &mut Testcase<I>, state: &S) -> Result<f64, Error> {
         let psmeta = state
             .metadata()
-            .get::<PowerScheduleMetadata>()
-            .ok_or_else(|| Error::KeyNotFound("PowerScheduleMetadata not found".to_string()))?;
+            .get::<SchedulerMetadata>()
+            .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?;
 
         let fuzz_mu = if psmeta.strat() == PowerSchedule::COE {
             let corpus = state.corpus();
@@ -299,8 +299,8 @@ where
         let mut weight = 1.0;
         let psmeta = state
             .metadata()
-            .get::<PowerScheduleMetadata>()
-            .ok_or_else(|| Error::KeyNotFound("PowerScheduleMetadata not found".to_string()))?;
+            .get::<SchedulerMetadata>()
+            .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?;
 
         let tcmeta = entry
             .metadata()

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -143,7 +143,7 @@ where
             .metadata()
             .get::<SchedulerTestcaseMetaData>()
             .ok_or_else(|| {
-                Error::KeyNotFound("PowerScheduleTestcaseMetaData not found".to_string())
+                Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
             })?;
 
         if q_exec_us * 0.1 > avg_exec_us {

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -1,5 +1,5 @@
 //! The queue corpus scheduler with weighted queue item selection from aflpp (`https://github.com/AFLplusplus/AFLplusplus/blob/1d4f1e48797c064ee71441ba555b29fc3f467983/src/afl-fuzz-queue.c#L32`)
-//! This queue corpus scheduler needs calibration stage and the power schedule stage.
+//! This queue corpus scheduler needs calibration stage.
 
 use alloc::{
     string::{String, ToString},

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -11,7 +11,7 @@ use crate::{
     corpus::{Corpus, PowerScheduleTestcaseMetaData},
     inputs::Input,
     schedulers::{
-        powersched::PowerScheduleMetadata,
+        powersched::SchedulerMetadata,
         testcase_score::{CorpusWeightTestcaseScore, TestcaseScore},
         Scheduler,
     },
@@ -279,9 +279,9 @@ where
             if current_cycles > corpus_counts {
                 let psmeta = state
                     .metadata_mut()
-                    .get_mut::<PowerScheduleMetadata>()
+                    .get_mut::<SchedulerMetadata>()
                     .ok_or_else(|| {
-                        Error::KeyNotFound("PowerScheduleMetadata not found".to_string())
+                        Error::KeyNotFound("SchedulerMetadata not found".to_string())
                     })?;
                 psmeta.set_queue_cycles(psmeta.queue_cycles() + 1);
             }

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -16,7 +16,7 @@ use crate::{
         Scheduler,
     },
     state::{HasCorpus, HasMetadata, HasRand},
-    Error,
+    Error, mutators::ScheduledMutator,
 };
 use core::marker::PhantomData;
 use serde::{Deserialize, Serialize};
@@ -213,6 +213,10 @@ where
 {
     /// Add an entry to the corpus and return its index
     fn on_add(&self, state: &mut S, idx: usize) -> Result<(), Error> {
+        if !state.has_metadata::<SchedulerMetadata>() {
+            state.add_metadata(SchedulerMetadata::new(None));
+        }
+
         if !state.has_metadata::<WeightedScheduleMetadata>() {
             state.add_metadata(WeightedScheduleMetadata::new());
         }

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -230,7 +230,9 @@ where
                 .borrow_mut()
                 .metadata_mut()
                 .get_mut::<SchedulerTestcaseMetaData>()
-                .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?
+                .ok_or_else(|| {
+                    Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
+                })?
                 .depth(),
             None => 0,
         };
@@ -284,9 +286,7 @@ where
                 let psmeta = state
                     .metadata_mut()
                     .get_mut::<SchedulerMetadata>()
-                    .ok_or_else(|| {
-                        Error::KeyNotFound("SchedulerMetadata not found".to_string())
-                    })?;
+                    .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?;
                 psmeta.set_queue_cycles(psmeta.queue_cycles() + 1);
             }
             *state.corpus_mut().current_mut() = Some(idx);

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -16,7 +16,7 @@ use crate::{
         Scheduler,
     },
     state::{HasCorpus, HasMetadata, HasRand},
-    Error, mutators::ScheduledMutator,
+    Error,
 };
 use core::marker::PhantomData;
 use serde::{Deserialize, Serialize};
@@ -243,7 +243,7 @@ where
             .borrow_mut()
             .add_metadata(SchedulerTestcaseMetaData::new(depth));
 
-        // Recrate the alias table
+        // Recreate the alias table
         self.create_alias_table(state)?;
         Ok(())
     }

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -288,7 +288,9 @@ where
                 let psmeta = state
                     .metadata_mut()
                     .get_mut::<SchedulerMetadata>()
-                    .ok_or_else(|| Error::key_not_found("SchedulerMetadata not found".to_string()))?;
+                    .ok_or_else(|| {
+                        Error::key_not_found("SchedulerMetadata not found".to_string())
+                    })?;
                 psmeta.set_queue_cycles(psmeta.queue_cycles() + 1);
             }
             *state.corpus_mut().current_mut() = Some(idx);

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -8,7 +8,7 @@ use alloc::{
 
 use crate::{
     bolts::rands::Rand,
-    corpus::{Corpus, PowerScheduleTestcaseMetaData},
+    corpus::{Corpus, SchedulerTestcaseMetaData},
     inputs::Input,
     schedulers::{
         powersched::SchedulerMetadata,
@@ -229,19 +229,19 @@ where
                 .get(parent_idx)?
                 .borrow_mut()
                 .metadata_mut()
-                .get_mut::<PowerScheduleTestcaseMetaData>()
-                .ok_or_else(|| Error::KeyNotFound("PowerScheduleTestData not found".to_string()))?
+                .get_mut::<SchedulerTestcaseMetaData>()
+                .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?
                 .depth(),
             None => 0,
         };
 
-        // Attach a `PowerScheduleTestData` to the queue entry.
+        // Attach a `SchedulerTestcaseMetaData` to the queue entry.
         depth += 1;
         state
             .corpus()
             .get(idx)?
             .borrow_mut()
-            .add_metadata(PowerScheduleTestcaseMetaData::new(depth));
+            .add_metadata(SchedulerTestcaseMetaData::new(depth));
 
         // Recrate the alias table
         self.create_alias_table(state)?;

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -10,7 +10,7 @@ use crate::{
     fuzzer::Evaluator,
     inputs::Input,
     observers::{MapObserver, ObserversTuple},
-    schedulers::powersched::PowerScheduleMetadata,
+    schedulers::powersched::SchedulerMetadata,
     stages::Stage,
     state::{HasClientPerfMonitor, HasCorpus, HasFeedbackStates, HasMetadata},
     Error,
@@ -161,7 +161,7 @@ where
         };
 
         // If power schedule is used, update it
-        let use_powerschedule = state.has_metadata::<PowerScheduleMetadata>()
+        let use_powerschedule = state.has_metadata::<SchedulerMetadata>()
             && state
                 .corpus()
                 .get(corpus_idx)?
@@ -178,7 +178,7 @@ where
 
             let psmeta = state
                 .metadata_mut()
-                .get_mut::<PowerScheduleMetadata>()
+                .get_mut::<SchedulerMetadata>()
                 .unwrap();
             let handicap = psmeta.queue_cycles();
 

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -3,7 +3,7 @@
 use crate::{
     bolts::current_time,
     bolts::tuples::MatchName,
-    corpus::{Corpus, PowerScheduleTestcaseMetaData},
+    corpus::{Corpus, SchedulerTestcaseMetaData},
     events::{EventFirer, LogSeverity},
     executors::{Executor, ExitKind, HasObservers},
     feedbacks::MapFeedbackState,
@@ -160,13 +160,13 @@ where
             }
         };
 
-        // If power schedule is used, update it
+        // If weighted scheduler or powerscheduler is used, update it
         let use_powerschedule = state.has_metadata::<SchedulerMetadata>()
             && state
                 .corpus()
                 .get(corpus_idx)?
                 .borrow()
-                .has_metadata::<PowerScheduleTestcaseMetaData>();
+                .has_metadata::<SchedulerTestcaseMetaData>();
 
         if use_powerschedule {
             let map = executor
@@ -196,8 +196,8 @@ where
 
             let data = testcase
                 .metadata_mut()
-                .get_mut::<PowerScheduleTestcaseMetaData>()
-                .ok_or_else(|| Error::KeyNotFound("PowerScheduleTestData not found".to_string()))?;
+                .get_mut::<SchedulerTestcaseMetaData>()
+                .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?;
 
             data.set_bitmap_size(bitmap_size);
             data.set_handicap(handicap);

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -176,10 +176,7 @@ where
 
             let bitmap_size = map.count_bytes();
 
-            let psmeta = state
-                .metadata_mut()
-                .get_mut::<SchedulerMetadata>()
-                .unwrap();
+            let psmeta = state.metadata_mut().get_mut::<SchedulerMetadata>().unwrap();
             let handicap = psmeta.queue_cycles();
 
             psmeta.set_exec_time(psmeta.exec_time() + total_time);
@@ -197,7 +194,9 @@ where
             let data = testcase
                 .metadata_mut()
                 .get_mut::<SchedulerTestcaseMetaData>()
-                .ok_or_else(|| Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string()))?;
+                .ok_or_else(|| {
+                    Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
+                })?;
 
             data.set_bitmap_size(bitmap_size);
             data.set_handicap(handicap);

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -68,17 +68,6 @@ where
         // Update handicap
         let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
         let score = F::compute(&mut *testcase, state)? as usize;
-        let tcmeta = testcase
-            .metadata_mut()
-            .get_mut::<SchedulerTestcaseMetaData>()
-            .ok_or_else(|| {
-                Error::KeyNotFound("PowerScheduleTestcaseMetaData not found".to_string())
-            })?;
-        if tcmeta.handicap() >= 4 {
-            tcmeta.set_handicap(tcmeta.handicap() - 4);
-        } else if tcmeta.handicap() > 0 {
-            tcmeta.set_handicap(tcmeta.handicap() - 1);
-        }
 
         Ok(score)
     }

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -4,7 +4,6 @@ use alloc::string::{String, ToString};
 use core::{fmt::Debug, marker::PhantomData};
 
 use crate::{
-    bolts::rands::Rand,
     corpus::{Corpus, PowerScheduleTestcaseMetaData},
     executors::{Executor, HasObservers},
     fuzzer::Evaluator,
@@ -12,7 +11,7 @@ use crate::{
     mutators::Mutator,
     observers::{MapObserver, ObserversTuple},
     schedulers::{
-        powersched::{PowerSchedule, SchedulerMetadata},
+        powersched::SchedulerMetadata,
         testcase_score::CorpusPowerTestcaseScore,
         TestcaseScore,
     },
@@ -67,16 +66,6 @@ where
     #[allow(clippy::cast_sign_loss)]
     fn iterations(&self, state: &mut S, corpus_idx: usize) -> Result<usize, Error> {
         // Update handicap
-        let use_random = state
-            .metadata_mut()
-            .get_mut::<SchedulerMetadata>()
-            .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?
-            .strat()
-            == PowerSchedule::RAND;
-        if use_random {
-            return Ok(1 + state.rand_mut().below(128) as usize);
-        }
-
         let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
         let score = F::compute(&mut *testcase, state)? as usize;
         let tcmeta = testcase

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -11,9 +11,7 @@ use crate::{
     mutators::Mutator,
     observers::{MapObserver, ObserversTuple},
     schedulers::{
-        powersched::SchedulerMetadata,
-        testcase_score::CorpusPowerTestcaseScore,
-        TestcaseScore,
+        powersched::SchedulerMetadata, testcase_score::CorpusPowerTestcaseScore, TestcaseScore,
     },
     stages::{MutationalStage, Stage},
     state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasRand},

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use core::{fmt::Debug, marker::PhantomData};
 
 use crate::{
-    corpus::{Corpus, PowerScheduleTestcaseMetaData},
+    corpus::{Corpus, SchedulerTestcaseMetaData},
     executors::{Executor, HasObservers},
     fuzzer::Evaluator,
     inputs::Input,
@@ -70,7 +70,7 @@ where
         let score = F::compute(&mut *testcase, state)? as usize;
         let tcmeta = testcase
             .metadata_mut()
-            .get_mut::<PowerScheduleTestcaseMetaData>()
+            .get_mut::<SchedulerTestcaseMetaData>()
             .ok_or_else(|| {
                 Error::KeyNotFound("PowerScheduleTestcaseMetaData not found".to_string())
             })?;
@@ -128,9 +128,9 @@ where
                     .get(idx)?
                     .borrow_mut()
                     .metadata_mut()
-                    .get_mut::<PowerScheduleTestcaseMetaData>()
+                    .get_mut::<SchedulerTestcaseMetaData>()
                     .ok_or_else(|| {
-                        Error::KeyNotFound("PowerScheduleTestData not found".to_string())
+                        Error::KeyNotFound("SchedulerTestcaseMetaData not found".to_string())
                     })?
                     .set_n_fuzz_entry(hash);
             }

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -12,7 +12,7 @@ use crate::{
     mutators::Mutator,
     observers::{MapObserver, ObserversTuple},
     schedulers::{
-        powersched::{PowerSchedule, PowerScheduleMetadata},
+        powersched::{PowerSchedule, SchedulerMetadata},
         testcase_score::CorpusPowerTestcaseScore,
         TestcaseScore,
     },
@@ -69,8 +69,8 @@ where
         // Update handicap
         let use_random = state
             .metadata_mut()
-            .get_mut::<PowerScheduleMetadata>()
-            .ok_or_else(|| Error::KeyNotFound("PowerScheduleMetadata not found".to_string()))?
+            .get_mut::<SchedulerMetadata>()
+            .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?
             .strat()
             == PowerSchedule::RAND;
         if use_random {
@@ -126,8 +126,8 @@ where
 
             let psmeta = state
                 .metadata_mut()
-                .get_mut::<PowerScheduleMetadata>()
-                .ok_or_else(|| Error::KeyNotFound("PowerScheduleMetadata not found".to_string()))?;
+                .get_mut::<SchedulerMetadata>()
+                .ok_or_else(|| Error::KeyNotFound("SchedulerMetadata not found".to_string()))?;
 
             hash %= psmeta.n_fuzz().len();
             // Update the path frequency
@@ -192,10 +192,7 @@ where
     Z: Evaluator<E, EM, I, S>,
 {
     /// Creates a new [`PowerMutationalStage`]
-    pub fn new(state: &mut S, mutator: M, map_observer_name: &O, strat: PowerSchedule) -> Self {
-        if !state.has_metadata::<PowerScheduleMetadata>() {
-            state.add_metadata::<PowerScheduleMetadata>(PowerScheduleMetadata::new(strat));
-        }
+    pub fn new(mutator: M, map_observer_name: &O) -> Self {
         Self {
             map_observer_name: map_observer_name.name().to_string(),
             mutator,


### PR DESCRIPTION
- Rename PowerSchedulerMetadata to SchedulerMetadata, and PowerSchedulerTestcaseMetadata to SchedulerTestcaseMetadata, as these data are likely to be used in other schedulers.
- Add these metadata in `Scheduler` not in `Stage`