### PR TITLE
Call post_exec_all() in calibrate.rs

### DIFF
--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -73,15 +73,12 @@ where
             .clone();
 
         // Run once to get the initial calibration map
-        executor
-            .observers_mut()
-            .match_name_mut::<O>(&self.map_observer_name)
-            .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
-            .reset_map()?;
+        executor.observers_mut().pre_exec_all(state, &input)?;
 
         let mut start = current_time();
 
-        let mut total_time = if executor.run_target(fuzzer, state, mgr, &input)? == ExitKind::Ok {
+        let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
+        let mut total_time = if exit_kind == ExitKind::Ok {
             current_time() - start
         } else {
             mgr.log(
@@ -92,6 +89,8 @@ where
             // assume one second as default time
             Duration::from_secs(1)
         };
+
+        executor.observers_mut().post_exec_all(state, &input, &exit_kind)?;
 
         let map_first = &executor
             .observers()
@@ -113,14 +112,11 @@ where
                 .load_input()?
                 .clone();
 
-            executor
-                .observers_mut()
-                .match_name_mut::<O>(&self.map_observer_name)
-                .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
-                .reset_map()?;
+            executor.observers_mut().pre_exec_all(state, &input)?;
             start = current_time();
 
-            if executor.run_target(fuzzer, state, mgr, &input)? != ExitKind::Ok {
+            let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
+            if exit_kind != ExitKind::Ok {
                 if !has_errors {
                     mgr.log(
                         state,
@@ -137,6 +133,8 @@ where
             };
 
             total_time += current_time() - start;
+
+            executor.observers_mut().post_exec_all(state, &input, &exit_kind)?;
 
             let map = &executor
                 .observers()

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -75,9 +75,9 @@ where
         // Run once to get the initial calibration map
         executor
             .observers_mut()
-            .match_name::<O>(&self.map_observer_name)
+            .match_name_mut::<O>(&self.map_observer_name)
             .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
-            .reset_map();
+            .reset_map()?;
 
         let mut start = current_time();
 
@@ -115,9 +115,9 @@ where
 
             executor
                 .observers_mut()
-                .match_name::<O>(&self.map_observer_name)
+                .match_name_mut::<O>(&self.map_observer_name)
                 .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
-                .reset_map();
+                .reset_map()?;
             start = current_time();
 
             if executor.run_target(fuzzer, state, mgr, &input)? != ExitKind::Ok {

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -90,7 +90,9 @@ where
             Duration::from_secs(1)
         };
 
-        executor.observers_mut().post_exec_all(state, &input, &exit_kind)?;
+        executor
+            .observers_mut()
+            .post_exec_all(state, &input, &exit_kind)?;
 
         let map_first = &executor
             .observers()
@@ -134,7 +136,9 @@ where
 
             total_time += current_time() - start;
 
-            executor.observers_mut().post_exec_all(state, &input, &exit_kind)?;
+            executor
+                .observers_mut()
+                .post_exec_all(state, &input, &exit_kind)?;
 
             let map = &executor
                 .observers()

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -74,7 +74,7 @@ where
 
         // Run once to get the initial calibration map
         executor
-            .observers()
+            .observers_mut()
             .match_name::<O>(&self.map_observer_name)
             .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
             .reset_map();
@@ -114,7 +114,7 @@ where
                 .clone();
 
             executor
-                .observers()
+                .observers_mut()
                 .match_name::<O>(&self.map_observer_name)
                 .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
                 .reset_map();

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -73,7 +73,12 @@ where
             .clone();
 
         // Run once to get the initial calibration map
-        executor.observers_mut().pre_exec_all(state, &input)?;
+        executor
+            .observers()
+            .match_name::<O>(&self.map_observer_name)
+            .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
+            .reset_map();
+
         let mut start = current_time();
 
         let mut total_time = if executor.run_target(fuzzer, state, mgr, &input)? == ExitKind::Ok {
@@ -108,7 +113,11 @@ where
                 .load_input()?
                 .clone();
 
-            executor.observers_mut().pre_exec_all(state, &input)?;
+            executor
+                .observers()
+                .match_name::<O>(&self.map_observer_name)
+                .ok_or_else(|| Error::KeyNotFound("MapObserver not found".to_string()))?
+                .reset_map();
             start = current_time();
 
             if executor.run_target(fuzzer, state, mgr, &input)? != ExitKind::Ok {


### PR DESCRIPTION
use reset_map() , not pre_exec_all() in calibration stage.

I originally thought that post_exec_all() is missing from calibration stage, but adding the post_exec_all() would cost additional cost
What we want is resetting the map every time before running the harness, so I change it to call to reset_map() instead of pre_exec_all()