### PR TITLE
Fixes forkersever_simple issue on Macs

### DIFF
--- a/fuzzers/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
+++ b/fuzzers/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
@@ -24,11 +24,11 @@ use libafl::{
     state::StdState,
 };
 use std::path::PathBuf;
-#[cfg(target_vendor = "apple")]
-use libafl::bolts::shmem::UnixShMemProvider;
 
 #[cfg(not(target_vendor = "apple"))]
 use libafl::bolts::shmem::StdShMemProvider;
+#[cfg(target_vendor = "apple")]
+use libafl::bolts::shmem::UnixShMemProvider;
 
 #[allow(clippy::similar_names)]
 pub fn main() {
@@ -97,7 +97,7 @@ pub fn main() {
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
     let mut executor = ForkserverExecutor::builder()
-        .program("./target/release/program".to_string())
+        .program("./target/release/program")
         .arg_input_file_std()
         .shmem_provider(&mut shmem_provider)
         .build(tuple_list!(bt_observer, edges_observer))

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -4,7 +4,7 @@ use libafl::{
     bolts::{
         current_nanos,
         rands::StdRand,
-        shmem::{ShMem, ShMemProvider, StdShMemProvider},
+        shmem::{ShMem, ShMemProvider},
         tuples::{tuple_list, Merge},
         AsMutSlice,
     },
@@ -24,6 +24,12 @@ use libafl::{
 };
 use nix::sys::signal::Signal;
 use std::path::PathBuf;
+
+#[cfg(target_vendor = "apple")]
+use libafl::bolts::shmem::UnixShMemProvider;
+
+#[cfg(not(target_vendor = "apple"))]
+use libafl::bolts::shmem::StdShMemProvider;
 
 #[allow(clippy::similar_names)]
 pub fn main() {
@@ -74,7 +80,12 @@ pub fn main() {
     const MAP_SIZE: usize = 65536;
 
     // The default, OS-specific privider for shared memory
+    #[cfg(target_vendor = "apple")]
+    let mut shmem_provider = UnixShMemProvider::new().unwrap();
+
+    #[cfg(not(target_vendor = "apple"))]
     let mut shmem_provider = StdShMemProvider::new().unwrap();
+
     // The coverage map shared between observer and executor
     let mut shmem = shmem_provider.new_shmem(MAP_SIZE).unwrap();
     // let the forkserver know the shmid

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -822,8 +822,6 @@ impl<'a> ForkserverExecutorBuilder<'a, StdShMemProvider> {
         self
     }
 
-
-
     /// Shmem provider for forkserver's shared memory testcase feature.
     pub fn shmem_provider<SP: ShMemProvider>(
         self,


### PR DESCRIPTION
Fixes #611, an issue where `StdShMemProvider` does not work properly on Macs with targets compiled with `afl-cc`.

Since that particular combination seems to not be used frequently, I fixed the issue by using `UnixShMemProvider` in `forkserver_simple` and `backtrace_baby_fuzzers/forkserver_executor`, controlled by a cfg

One issue I ran into is that `ForkserverExecutorBuilder` only implemented `autotokens` and `parse_afl_cmdline` when ForkserverExecutorBuilder used a `StdShMemProvider` as its generic type (idk if my wording here is proper). All I did was change which impl block those two functions were put in.