### PR TITLE
Fix overflow on debug build 

### DIFF
--- a/libafl/src/bolts/cli.rs
+++ b/libafl/src/bolts/cli.rs
@@ -135,7 +135,7 @@ pub struct FuzzerOptions {
     /// cores. 'none' to run a client without binding to any core.
     /// ex: '1,2-4,6' selects the cores 1, 2, 3, 4, and 6.
     #[cfg(feature = "frida_cli")]
-    #[clap(short, long, default_value = "0", parse(try_from_str = Cores::from_cmdline), help_heading = "ASAN Options")]
+    #[clap(long, default_value = "0", parse(try_from_str = Cores::from_cmdline), help_heading = "ASAN Options")]
     pub asan_cores: Cores,
 
     /// number of fuzz iterations to perform
@@ -181,7 +181,7 @@ pub struct FuzzerOptions {
     /// cores. 'none' to run a client without binding to any core.
     /// ex: '1,2-4,6' selects the cores 1, 2, 3, 4, and 6.
     #[cfg(feature = "frida_cli")]
-    #[clap(short, long, default_value = "0", parse(try_from_str = Cores::from_cmdline), help_heading = "Frida Options")]
+    #[clap(long, default_value = "0", parse(try_from_str = Cores::from_cmdline), help_heading = "Frida Options")]
     pub cmplog_cores: Cores,
 
     /// enable ASAN leak detection
@@ -278,7 +278,7 @@ pub struct FuzzerOptions {
     /// Spawn a client in each of the provided cores. Use 'all' to select all available
     /// cores. 'none' to run a client without binding to any core.
     /// ex: '1,2-4,6' selects the cores 1, 2, 3, 4, and 6.
-    #[clap(short, long, default_value = "0", parse(try_from_str = Cores::from_cmdline))]
+    #[clap(long, default_value = "0", parse(try_from_str = Cores::from_cmdline))]
     pub cores: Cores,
 
     /// port on which the broker should listen

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -158,9 +158,9 @@ impl CoverageRuntime {
         let bitflip = 0x1cad21f72c81017c ^ 0xdb979082e96dd4de;
         let mut h64 = tmp ^ bitflip;
         h64 = h64.rotate_left(49) & h64.rotate_left(24);
-        h64 *= 0x9FB21C651E98DF25;
+        h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
         h64 ^= (h64 >> 35) + 8;
-        h64 *= 0x9FB21C651E98DF25;
+        h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
         h64 ^= h64 >> 28;
 
         let writer = output.writer();


### PR DESCRIPTION
Closes #631

@s1341 
I had to remove #[clap(short)] on `cmplog_cores` and `cores` because they use the option '-c', but `configuration` also uses '-c', and thus, it fails to build on debug build.
Same for `asan_cores` and `REMOTE`, and I removed #[clap(short)] from `asan_cores`
