### PR TITLE
Proposal: replace corpus indices with CorpusIDs

### DIFF
--- a/libafl/src/corpus/cached.rs
+++ b/libafl/src/corpus/cached.rs
@@ -100,7 +100,7 @@ where
     }
 
     fn id_manager(&self) -> &CorpusIDManager {
-        &self.inner.id_manager()
+        self.inner.id_manager()
     }
 }
 

--- a/libafl/src/corpus/cached.rs
+++ b/libafl/src/corpus/cached.rs
@@ -14,7 +14,7 @@ use crate::{
     Error,
 };
 
-use super::{CorpusID, id_manager::CorpusIDManager};
+use super::{id_manager::CorpusIDManager, CorpusID};
 
 /// A corpus that keep in memory a maximun number of testcases. The eviction policy is FIFO.
 #[cfg(feature = "std")]
@@ -81,8 +81,7 @@ where
                     }
                 }
             }
-            self.cached_ids.borrow_mut().push_back(
-                idx);
+            self.cached_ids.borrow_mut().push_back(idx);
         }
         Ok(testcase)
     }

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -2,7 +2,7 @@
 //! indices to allow for a vector-based corpus storage. It is the only component That should be able to create new
 //! CorpusIDs.
 
-use core::fmt::{Formatter, Display};
+use core::fmt::{Formatter, Display, Error};
 use serde::{Serialize, Deserialize};
 use alloc::vec::Vec;
 
@@ -21,7 +21,7 @@ pub struct CorpusID {
     identifier: usize,
 }
 impl Display for CorpusID {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         write!(f, "CorpusID[#{}]", self.identifier)
     }
 }

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -1,0 +1,73 @@
+use core::fmt::{Formatter, Display};
+use serde::{Serialize, Deserialize};
+use alloc::vec::Vec;
+
+use super::Corpus;
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct CorpusID {
+    identifier: usize,
+}
+impl CorpusID {
+    fn new(id: usize) -> CorpusID {
+        CorpusID { identifier: id }
+    }
+}
+impl Display for CorpusID {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "CorpusID[#{}]", self.identifier)
+    }
+}
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CorpusIDManager {
+    next: usize,
+    active_ids_: Vec<CorpusID>,
+}
+
+impl CorpusIDManager {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn active_ids(&self) -> &[CorpusID] {
+        // should always be sorted, since it only increasing values are ever appended!
+        debug_assert!(self.active_ids_.is_sorted());
+        &self.active_ids_
+    }
+
+    fn provide_next(&mut self) -> CorpusID {
+        let val = self.next;
+        self.next = val.checked_add(1).unwrap();
+        let id = CorpusID { identifier: val };
+        self.active_ids_.push(id);
+        id
+    }
+
+    fn invalidate(&mut self, id: CorpusID) {
+        self.active_ids_.retain(|x| x != &id);
+    }
+
+    fn invalidate_multiple(&mut self, ids: &[CorpusID]) {
+        self.active_ids_.retain(|x| !ids.contains(x));
+    }
+
+    fn active_index_for(&self, id: CorpusID) -> Option<usize> {
+        self.active_ids_.iter().position(|x| *x == id)
+    }
+
+    pub fn get(&self, idx: usize) -> Option<CorpusID> {
+        self.active_ids_.get(idx).map(|x| *x)
+    }
+
+    pub fn first_id(&self) -> Option<CorpusID> {
+        self.active_ids_.first().map(|x| *x)
+    }
+    pub fn find_next(&self, id: CorpusID) -> Option<CorpusID> {
+        // it should ALWAYS be sorted since it only ever gets appended to with larger values (next ids)
+        debug_assert!(self.active_ids_.is_sorted());
+
+        self.active_ids_.iter()
+            .find(|x| x.identifier > id.identifier)
+            .map(|x|*x)
+    }
+}

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -37,12 +37,14 @@ pub struct CorpusIDManager {
 impl CorpusIDManager {
 
     /// Creates a new [`CorpusIDManager`].
+    #[must_use]
     pub fn new() -> Self {
-        Default::default()
+        CorpusIDManager::default()
     }
 
     /// Get a slice of the currently active [`CorpusID`]s. The length of this slice should always match the `count()` of
     /// the corpus.
+    #[must_use]
     pub fn active_ids(&self) -> &[CorpusID] {
         // should always be sorted, since it only increasing values are ever appended!
         // debug_assert!(self.active_ids_.is_sorted());

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -41,16 +41,16 @@ impl CorpusIDManager {
         Default::default()
     }
 
-    /// Get a slice of the currently active CorpusIDs. The length of this slice should always match the `count()` of the
+    /// Get a slice of the currently active [`CorpusID`]s. The length of this slice should always match the `count()` of the
     /// corpus.
     pub fn active_ids(&self) -> &[CorpusID] {
         // should always be sorted, since it only increasing values are ever appended!
-        debug_assert!(self.active_ids_.is_sorted());
+        // debug_assert!(self.active_ids_.is_sorted());
         &self.active_ids_
     }
 
-    /// Allocate the next [`CorpusID`] and return it. This returns a CorpusID with an identifer larger than all
-    /// previously issued CorpusIDs. This new [`CorpusID`] is immediately added to the `active_ids`.
+    /// Allocate the next [`CorpusID`] and return it. This returns a [`CorpusID`] with an identifer larger than all
+    /// previously issued `CorpusID`s. This new [`CorpusID`] is immediately added to the `active_ids`.
     pub(super) fn provide_next(&mut self) -> CorpusID {
         let val = self.next;
         self.next = val.checked_add(1).unwrap();
@@ -59,40 +59,45 @@ impl CorpusIDManager {
         id
     }
 
-    /// Invalidate the given [`CorpusID`]. This will cause any future operations and lookups for this CorpusID to fail.
-    /// If the id was valid, returns the index where it was found;
+    /// Invalidate the given [`CorpusID`]. This will cause any future operations and lookups for this [`CorpusID`] to
+    /// fail. If the id was valid, returns the index where it was found;
+    #[must_use]
     pub (crate) fn remove_id(&mut self, id: CorpusID) -> Option<usize> {
-        debug_assert!(self.active_ids_.is_sorted());
+        // debug_assert!(self.active_ids_.is_sorted());
         let idx = self.active_ids_.binary_search(&id).ok()?;
         self.active_ids_.remove(idx);
         Some(idx)
     }
 
     /// Get the corpus index for the given [`CorpusID`]. Should only ever be called by a `Corpus`.
+    #[must_use]
     pub(crate) fn active_index_for(&self, id: CorpusID) -> Option<usize> {
-        debug_assert!(self.active_ids_.is_sorted());
+        // debug_assert!(self.active_ids_.is_sorted());
         self.active_ids_.binary_search(&id).ok()
     }
 
     /// Get the [`CorpusID`] at the given index. If the index is out of bounds, returns `None`.
+    #[must_use]
     pub fn get(&self, idx: usize) -> Option<CorpusID> {
-        self.active_ids_.get(idx).map(|x| *x)
+        self.active_ids_.get(idx).copied()
     }
 
     /// Get the id of the first (oldest) active [`CorpusID`].
+    #[must_use]
     pub fn first_id(&self) -> Option<CorpusID> {
-        self.active_ids_.first().map(|x| *x)
+        self.active_ids_.first().copied()
     }
 
     /// Gets the "next" (least less old) active [`CorpusID`]. This is like incrementing the index.
+    #[must_use]
     pub fn find_next(&self, id: CorpusID) -> Option<CorpusID> {
         // it should ALWAYS be sorted since it only ever gets appended to with larger values (next ids)
-        debug_assert!(self.active_ids_.is_sorted());
+        // debug_assert!(self.active_ids_.is_sorted());
 
         // TODO: change to binary search
         self.active_ids_.iter()
             .find(|x| x.identifier > id.identifier)
-            .map(|x|*x)
+            .copied()
     }
 }
 

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -1,23 +1,33 @@
+//! The CorpusIDManager is responsible for keeping track of active CorpusIDs. It lets the corpus map CorpusIDs to corpus
+//! indices to allow for a vector-based corpus storage. It is the only component That should be able to create new
+//! CorpusIDs.
+
 use core::fmt::{Formatter, Display};
 use serde::{Serialize, Deserialize};
 use alloc::vec::Vec;
 
+use crate::bolts::rands::Rand;
+use crate::inputs::Input;
+use crate::state::{HasRand, HasCorpus};
+
 use super::Corpus;
 
+/// Creates a new [`CorpusID`]. [`CorpusID']s are globally unique for a corpus and monotonically increasing.
+/// They should only ever be created by a [`CorpusIDManager`], everything else must acquire them from one.
+/// [`CorpusID`]s allow us to track a testcase uniquely even when corpora can have testcases be removed or replaced.
+/// Two different testcases should never have the same [`CorpusID`].
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct CorpusID {
     identifier: usize,
-}
-impl CorpusID {
-    fn new(id: usize) -> CorpusID {
-        CorpusID { identifier: id }
-    }
 }
 impl Display for CorpusID {
     fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
         write!(f, "CorpusID[#{}]", self.identifier)
     }
 }
+
+/// A [`CorpusIDManager`] is responsible for keeping track of active [`CorpusID`]s. It creates new ones, ensures that
+/// they are unique, and maps them to their corresponding indices in the corpus. The `active_ids` field
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CorpusIDManager {
     next: usize,
@@ -25,17 +35,23 @@ pub struct CorpusIDManager {
 }
 
 impl CorpusIDManager {
+
+    /// Creates a new [`CorpusIDManager`].
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// Get a slice of the currently active CorpusIDs. The length of this slice should always match the `count()` of the
+    /// corpus.
     pub fn active_ids(&self) -> &[CorpusID] {
         // should always be sorted, since it only increasing values are ever appended!
         debug_assert!(self.active_ids_.is_sorted());
         &self.active_ids_
     }
 
-    fn provide_next(&mut self) -> CorpusID {
+    /// Allocate the next [`CorpusID`] and return it. This returns a CorpusID with an identifer larger than all
+    /// previously issued CorpusIDs. This new [`CorpusID`] is immediately added to the `active_ids`.
+    pub(super) fn provide_next(&mut self) -> CorpusID {
         let val = self.next;
         self.next = val.checked_add(1).unwrap();
         let id = CorpusID { identifier: val };
@@ -43,31 +59,59 @@ impl CorpusIDManager {
         id
     }
 
-    fn invalidate(&mut self, id: CorpusID) {
-        self.active_ids_.retain(|x| x != &id);
+    /// Invalidate the given [`CorpusID`]. This will cause any future operations and lookups for this CorpusID to fail.
+    /// If the id was valid, returns the index where it was found;
+    pub (crate) fn remove_id(&mut self, id: CorpusID) -> Option<usize> {
+        debug_assert!(self.active_ids_.is_sorted());
+        let idx = self.active_ids_.binary_search(&id).ok()?;
+        self.active_ids_.remove(idx);
+        Some(idx)
     }
 
-    fn invalidate_multiple(&mut self, ids: &[CorpusID]) {
-        self.active_ids_.retain(|x| !ids.contains(x));
+    /// Get the corpus index for the given [`CorpusID`]. Should only ever be called by a `Corpus`.
+    pub(crate) fn active_index_for(&self, id: CorpusID) -> Option<usize> {
+        debug_assert!(self.active_ids_.is_sorted());
+        self.active_ids_.binary_search(&id).ok()
     }
 
-    fn active_index_for(&self, id: CorpusID) -> Option<usize> {
-        self.active_ids_.iter().position(|x| *x == id)
-    }
-
+    /// Get the [`CorpusID`] at the given index. If the index is out of bounds, returns `None`.
     pub fn get(&self, idx: usize) -> Option<CorpusID> {
         self.active_ids_.get(idx).map(|x| *x)
     }
 
+    /// Get the id of the first (oldest) active [`CorpusID`].
     pub fn first_id(&self) -> Option<CorpusID> {
         self.active_ids_.first().map(|x| *x)
     }
+
+    /// Gets the "next" (least less old) active [`CorpusID`]. This is like incrementing the index.
     pub fn find_next(&self, id: CorpusID) -> Option<CorpusID> {
         // it should ALWAYS be sorted since it only ever gets appended to with larger values (next ids)
         debug_assert!(self.active_ids_.is_sorted());
 
+        // TODO: change to binary search
         self.active_ids_.iter()
             .find(|x| x.identifier > id.identifier)
             .map(|x|*x)
     }
+}
+
+/// Return a random entry from the corpus of a given state. This function is mainly for encapsulation to make the borrow
+/// checker happy and keep the random index creation confined to one spot.
+pub (crate) fn random_corpus_entry<I, S>(state: &mut S) -> Option<(usize, CorpusID)>
+where
+    S: HasCorpus<I> + HasRand,
+    I: Input
+{
+    let num = state.corpus().count();
+    if num == 0 {
+        return None;
+    }
+    let idx = state.rand_mut().below(num.try_into().unwrap()) as usize;
+    let id = state
+        .corpus()
+        .id_manager()
+        .get(idx)
+        .expect("this should never fail, our random value should always be inbounds");
+    Some((idx, id))
 }

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -2,13 +2,13 @@
 //! [`CorpusID`] to its corresponding corpus index to allow for a vector-based corpus storage. It is the only component
 //! that should be able to create new [`CorpusID`]s.
 
-use core::fmt::{Formatter, Display, Error};
-use serde::{Serialize, Deserialize};
 use alloc::vec::Vec;
+use core::fmt::{Display, Error, Formatter};
+use serde::{Deserialize, Serialize};
 
 use crate::bolts::rands::Rand;
 use crate::inputs::Input;
-use crate::state::{HasRand, HasCorpus};
+use crate::state::{HasCorpus, HasRand};
 
 use super::Corpus;
 
@@ -35,7 +35,6 @@ pub struct CorpusIDManager {
 }
 
 impl CorpusIDManager {
-
     /// Creates a new [`CorpusIDManager`].
     #[must_use]
     pub fn new() -> Self {
@@ -64,7 +63,7 @@ impl CorpusIDManager {
     /// Invalidate the given [`CorpusID`]. This will cause any future operations and lookups for this [`CorpusID`] to
     /// fail. If the id was valid, returns the index where it was found;
     #[must_use]
-    pub (crate) fn remove_id(&mut self, id: CorpusID) -> Option<usize> {
+    pub(crate) fn remove_id(&mut self, id: CorpusID) -> Option<usize> {
         // debug_assert!(self.active_ids_.is_sorted());
         let idx = self.active_ids_.binary_search(&id).ok()?;
         self.active_ids_.remove(idx);
@@ -97,7 +96,8 @@ impl CorpusIDManager {
         // debug_assert!(self.active_ids_.is_sorted());
 
         // TODO: change to binary search
-        self.active_ids_.iter()
+        self.active_ids_
+            .iter()
             .find(|x| x.identifier > id.identifier)
             .copied()
     }
@@ -105,10 +105,10 @@ impl CorpusIDManager {
 
 /// Return a random entry from the corpus of a given state. This function is mainly for encapsulation to make the borrow
 /// checker happy and keep the random index creation confined to one spot.
-pub (crate) fn random_corpus_entry<I, S>(state: &mut S) -> Option<(usize, CorpusID)>
+pub(crate) fn random_corpus_entry<I, S>(state: &mut S) -> Option<(usize, CorpusID)>
 where
     S: HasCorpus<I> + HasRand,
-    I: Input
+    I: Input,
 {
     let num = state.corpus().count();
     if num == 0 {

--- a/libafl/src/corpus/id_manager.rs
+++ b/libafl/src/corpus/id_manager.rs
@@ -1,6 +1,6 @@
-//! The CorpusIDManager is responsible for keeping track of active CorpusIDs. It lets the corpus map CorpusIDs to corpus
-//! indices to allow for a vector-based corpus storage. It is the only component That should be able to create new
-//! CorpusIDs.
+//! The [`CorpusIDManager`] is responsible for keeping track of active [`CorpusID`]s. It lets the corpus map a
+//! [`CorpusID`] to its corresponding corpus index to allow for a vector-based corpus storage. It is the only component
+//! that should be able to create new [`CorpusID`]s.
 
 use core::fmt::{Formatter, Display, Error};
 use serde::{Serialize, Deserialize};
@@ -12,7 +12,7 @@ use crate::state::{HasRand, HasCorpus};
 
 use super::Corpus;
 
-/// Creates a new [`CorpusID`]. [`CorpusID']s are globally unique for a corpus and monotonically increasing.
+/// Creates a new [`CorpusID`]. [`CorpusID`]s are globally unique for a corpus and monotonically increasing.
 /// They should only ever be created by a [`CorpusIDManager`], everything else must acquire them from one.
 /// [`CorpusID`]s allow us to track a testcase uniquely even when corpora can have testcases be removed or replaced.
 /// Two different testcases should never have the same [`CorpusID`].
@@ -41,8 +41,8 @@ impl CorpusIDManager {
         Default::default()
     }
 
-    /// Get a slice of the currently active [`CorpusID`]s. The length of this slice should always match the `count()` of the
-    /// corpus.
+    /// Get a slice of the currently active [`CorpusID`]s. The length of this slice should always match the `count()` of
+    /// the corpus.
     pub fn active_ids(&self) -> &[CorpusID] {
         // should always be sorted, since it only increasing values are ever appended!
         // debug_assert!(self.active_ids_.is_sorted());
@@ -50,7 +50,7 @@ impl CorpusIDManager {
     }
 
     /// Allocate the next [`CorpusID`] and return it. This returns a [`CorpusID`] with an identifer larger than all
-    /// previously issued `CorpusID`s. This new [`CorpusID`] is immediately added to the `active_ids`.
+    /// previously issued [`CorpusID`]s. This new [`CorpusID`] is immediately added to the `active_ids`.
     pub(super) fn provide_next(&mut self) -> CorpusID {
         let val = self.next;
         self.next = val.checked_add(1).unwrap();
@@ -69,7 +69,7 @@ impl CorpusIDManager {
         Some(idx)
     }
 
-    /// Get the corpus index for the given [`CorpusID`]. Should only ever be called by a `Corpus`.
+    /// Get the corpus index for the given [`CorpusID`]. Should only ever be called by a [`Corpus`].
     #[must_use]
     pub(crate) fn active_index_for(&self, id: CorpusID) -> Option<usize> {
         // debug_assert!(self.active_ids_.is_sorted());

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -35,7 +35,7 @@ where
     #[inline]
     fn add(&mut self, testcase: Testcase<I>) -> Result<CorpusID, Error> {
         debug_assert!(self.entries.len() == self.id_manager.active_ids().len());
-        let new_id = self.id_manager.provide_next();
+        let new_id = self.id_manager.provide_next()?;
         self.entries.push(RefCell::new(testcase));
         Ok(new_id)
     }

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{corpus::Corpus, corpus::Testcase, inputs::Input, Error};
 
+use super::CorpusID;
+
 /// A corpus handling all in memory.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "I: serde::de::DeserializeOwned")]
@@ -14,7 +16,7 @@ where
     I: Input,
 {
     entries: Vec<RefCell<Testcase<I>>>,
-    current: Option<usize>,
+    current: Option<CorpusID>,
 }
 
 impl<I> Corpus<I> for InMemoryCorpus<I>
@@ -29,14 +31,14 @@ where
 
     /// Add an entry to the corpus and return its index
     #[inline]
-    fn add(&mut self, testcase: Testcase<I>) -> Result<usize, Error> {
+    fn add(&mut self, testcase: Testcase<I>) -> Result<CorpusID, Error> {
         self.entries.push(RefCell::new(testcase));
         Ok(self.entries.len() - 1)
     }
 
     /// Replaces the testcase at the given idx
     #[inline]
-    fn replace(&mut self, idx: usize, testcase: Testcase<I>) -> Result<(), Error> {
+    fn replace(&mut self, idx: CorpusID, testcase: Testcase<I>) -> Result<(), Error> {
         if idx >= self.entries.len() {
             return Err(Error::key_not_found(format!("Index {} out of bounds", idx)));
         }
@@ -46,7 +48,7 @@ where
 
     /// Removes an entry from the corpus, returning it if it was present.
     #[inline]
-    fn remove(&mut self, idx: usize) -> Result<Option<Testcase<I>>, Error> {
+    fn remove(&mut self, idx: CorpusID) -> Result<Option<Testcase<I>>, Error> {
         if idx >= self.entries.len() {
             Ok(None)
         } else {
@@ -56,19 +58,19 @@ where
 
     /// Get by id
     #[inline]
-    fn get(&self, idx: usize) -> Result<&RefCell<Testcase<I>>, Error> {
+    fn get(&self, idx: CorpusID) -> Result<&RefCell<Testcase<I>>, Error> {
         Ok(&self.entries[idx])
     }
 
     /// Current testcase scheduled
     #[inline]
-    fn current(&self) -> &Option<usize> {
+    fn current(&self) -> &Option<CorpusID> {
         &self.current
     }
 
     /// Current testcase scheduled (mutable)
     #[inline]
-    fn current_mut(&mut self) -> &mut Option<usize> {
+    fn current_mut(&mut self) -> &mut Option<CorpusID> {
         &mut self.current
     }
 }

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -45,7 +45,7 @@ where
     fn replace(&mut self, id: CorpusID, testcase: Testcase<I>) -> Result<(), Error> {
         let old_idx = self.id_manager
             .remove_id(id)
-            .ok_or(Error::key_not_found(format!("ID {:?} is stale", id)))?;
+            .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         self.entries[old_idx] = RefCell::new(testcase);
         Ok(())
     }
@@ -66,7 +66,7 @@ where
     fn get(&self, id: CorpusID) -> Result<&RefCell<Testcase<I>>, Error> {
         let idx = self.id_manager
             .active_index_for(id)
-            .ok_or(Error::key_not_found(format!("ID {:?} is stale", id)))?;
+            .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         Ok(&self.entries[idx])
     }
 
@@ -98,7 +98,7 @@ where
         Self {
             entries: vec![],
             current: None,
-            id_manager: Default::default(),
+            id_manager: CorpusIDManager::new(),
         }
     }
 }

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{corpus::Corpus, corpus::Testcase, inputs::Input, Error};
 
-use super::CorpusID;
 use super::id_manager::CorpusIDManager;
+use super::CorpusID;
 
 /// A corpus handling all in memory.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
@@ -43,7 +43,8 @@ where
     /// Replaces the testcase at the given idx
     #[inline]
     fn replace(&mut self, id: CorpusID, testcase: Testcase<I>) -> Result<(), Error> {
-        let old_idx = self.id_manager
+        let old_idx = self
+            .id_manager
             .remove_id(id)
             .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         self.entries[old_idx] = RefCell::new(testcase);
@@ -55,8 +56,7 @@ where
     fn remove(&mut self, id: CorpusID) -> Result<Option<Testcase<I>>, Error> {
         if let Some(old_idx) = self.id_manager.remove_id(id) {
             Ok(Some(self.entries.remove(old_idx).into_inner()))
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -64,7 +64,8 @@ where
     /// Get by id
     #[inline]
     fn get(&self, id: CorpusID) -> Result<&RefCell<Testcase<I>>, Error> {
-        let idx = self.id_manager
+        let idx = self
+            .id_manager
             .active_index_for(id)
             .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         Ok(&self.entries[idx])

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -5,7 +5,7 @@ use serde::{Serialize, Deserialize};
 pub use testcase::{SchedulerTestcaseMetaData, Testcase};
 
 pub mod id_manager;
-pub use id_manager::CorpusID;
+pub use id_manager::{CorpusID, CorpusIDManager};
 
 pub mod inmemory;
 pub use inmemory::InMemoryCorpus;
@@ -41,7 +41,7 @@ where
 
     /// Returns an immutable reference to the [`CorpusIDManager`]. This should be used to manage the traversal of the
     /// corpus, e.g. in a Scheduler.
-    fn id_manager(&self) -> &id_manager::CorpusIDManager;
+    fn id_manager(&self) -> &CorpusIDManager;
 
     /// Returns true, if no elements are in this corpus yet
     fn is_empty(&self) -> bool {

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -1,7 +1,7 @@
 //! Corpuses contain the testcases, either in memory, on disk, or somewhere else.
 
 pub mod testcase;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 pub use testcase::{SchedulerTestcaseMetaData, Testcase};
 
 pub mod id_manager;

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -1,7 +1,11 @@
 //! Corpuses contain the testcases, either in memory, on disk, or somewhere else.
 
 pub mod testcase;
+use serde::{Serialize, Deserialize};
 pub use testcase::{SchedulerTestcaseMetaData, Testcase};
+
+mod id_manager;
+pub use id_manager::CorpusID;
 
 pub mod inmemory;
 pub use inmemory::InMemoryCorpus;
@@ -17,6 +21,7 @@ pub mod cached;
 pub use cached::CachedOnDiskCorpus;
 
 use core::cell::RefCell;
+use core::fmt::{Display, Formatter};
 
 use crate::{inputs::Input, Error};
 
@@ -28,28 +33,34 @@ where
     /// Returns the number of elements
     fn count(&self) -> usize;
 
+    fn ids(&self) -> &[CorpusID] {
+        self.id_manager().active_ids()
+    }
+
+    fn id_manager(&self) -> &id_manager::CorpusIDManager;
+
     /// Returns true, if no elements are in this corpus yet
     fn is_empty(&self) -> bool {
         self.count() == 0
     }
 
     /// Add an entry to the corpus and return its index
-    fn add(&mut self, testcase: Testcase<I>) -> Result<usize, Error>;
+    fn add(&mut self, testcase: Testcase<I>) -> Result<CorpusID, Error>;
 
     /// Replaces the testcase at the given idx
-    fn replace(&mut self, idx: usize, testcase: Testcase<I>) -> Result<(), Error>;
+    fn replace(&mut self, idx: CorpusID, testcase: Testcase<I>) -> Result<(), Error>;
 
     /// Removes an entry from the corpus, returning it if it was present.
-    fn remove(&mut self, idx: usize) -> Result<Option<Testcase<I>>, Error>;
+    fn remove(&mut self, idx: CorpusID) -> Result<Option<Testcase<I>>, Error>;
 
     /// Get by id
-    fn get(&self, idx: usize) -> Result<&RefCell<Testcase<I>>, Error>;
+    fn get(&self, idx: CorpusID) -> Result<&RefCell<Testcase<I>>, Error>;
 
     /// Current testcase scheduled
-    fn current(&self) -> &Option<usize>;
+    fn current(&self) -> &Option<CorpusID>;
 
     /// Current testcase scheduled (mutable)
-    fn current_mut(&mut self) -> &mut Option<usize>;
+    fn current_mut(&mut self) -> &mut Option<CorpusID>;
 }
 
 /// `Corpus` Python bindings

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -4,7 +4,7 @@ pub mod testcase;
 use serde::{Serialize, Deserialize};
 pub use testcase::{SchedulerTestcaseMetaData, Testcase};
 
-mod id_manager;
+pub mod id_manager;
 pub use id_manager::CorpusID;
 
 pub mod inmemory;
@@ -21,22 +21,26 @@ pub mod cached;
 pub use cached::CachedOnDiskCorpus;
 
 use core::cell::RefCell;
-use core::fmt::{Display, Formatter};
 
 use crate::{inputs::Input, Error};
 
 /// Corpus with all current testcases
-pub trait Corpus<I>: serde::Serialize + for<'de> serde::Deserialize<'de>
+pub trait Corpus<I>: Serialize + for<'de> Deserialize<'de>
 where
     I: Input,
 {
     /// Returns the number of elements
-    fn count(&self) -> usize;
+    fn count(&self) -> usize {
+        self.id_manager().active_ids().len()
+    }
 
+    /// Returns a slice of all currently active [`CorpusID`]s.
     fn ids(&self) -> &[CorpusID] {
         self.id_manager().active_ids()
     }
 
+    /// Returns an immutable reference to the [`CorpusIDManager`]. This should be used to manage the traversal of the
+    /// corpus, e.g. in a Scheduler.
     fn id_manager(&self) -> &id_manager::CorpusIDManager;
 
     /// Returns true, if no elements are in this corpus yet

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -16,7 +16,7 @@ use crate::{
     state::HasMetadata, Error,
 };
 
-use super::{CorpusID, id_manager::CorpusIDManager};
+use super::{id_manager::CorpusIDManager, CorpusID};
 
 /// Options for the the format of the on-disk metadata
 #[cfg(feature = "std")]
@@ -58,7 +58,6 @@ impl<I> Corpus<I> for OnDiskCorpus<I>
 where
     I: Input,
 {
-
     /// Returns the number of elements
     #[inline]
     fn count(&self) -> usize {
@@ -139,7 +138,8 @@ where
     /// Replaces the testcase at the given idx
     #[inline]
     fn replace(&mut self, id: CorpusID, testcase: Testcase<I>) -> Result<(), Error> {
-        let old_idx = self.id_manager
+        let old_idx = self
+            .id_manager
             .remove_id(id)
             .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         self.entries[old_idx] = RefCell::new(testcase);
@@ -151,8 +151,7 @@ where
     fn remove(&mut self, id: CorpusID) -> Result<Option<Testcase<I>>, Error> {
         if let Some(idx) = self.id_manager.active_index_for(id) {
             Ok(Some(self.entries.remove(idx).into_inner()))
-        }
-        else {
+        } else {
             Ok(None)
         }
     }
@@ -160,7 +159,8 @@ where
     /// Get by id
     #[inline]
     fn get(&self, id: CorpusID) -> Result<&RefCell<Testcase<I>>, Error> {
-        let idx = self.id_manager
+        let idx = self
+            .id_manager
             .active_index_for(id)
             .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         Ok(&self.entries[idx])
@@ -200,7 +200,7 @@ where
                 current: None,
                 dir_path,
                 meta_format: None,
-                id_manager: CorpusIDManager::new()
+                id_manager: CorpusIDManager::new(),
             })
         }
         new(dir_path.as_ref().to_path_buf())

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -131,7 +131,7 @@ where
             .expect("Could not save testcase to disk");
         debug_assert!(self.entries.len() == self.id_manager().active_ids().len());
         self.entries.push(RefCell::new(testcase));
-        let id = self.id_manager.provide_next();
+        let id = self.id_manager.provide_next()?;
         Ok(id)
     }
 

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -141,7 +141,7 @@ where
     fn replace(&mut self, id: CorpusID, testcase: Testcase<I>) -> Result<(), Error> {
         let old_idx = self.id_manager
             .remove_id(id)
-            .ok_or(Error::key_not_found(format!("ID {:?} is stale", id)))?;
+            .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         self.entries[old_idx] = RefCell::new(testcase);
         Ok(())
     }
@@ -162,7 +162,7 @@ where
     fn get(&self, id: CorpusID) -> Result<&RefCell<Testcase<I>>, Error> {
         let idx = self.id_manager
             .active_index_for(id)
-            .ok_or(Error::key_not_found(format!("ID {:?} is stale", id)))?;
+            .ok_or_else(|| Error::key_not_found(format!("ID {:?} is stale", id)))?;
         Ok(&self.entries[idx])
     }
 

--- a/libafl/src/feedbacks/owned.rs
+++ b/libafl/src/feedbacks/owned.rs
@@ -26,7 +26,7 @@ impl FeedbackStatesTuple for FeedbackStatesOwnedList {
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         for s in &mut self.list {
             s.perform(fuzzer, executor, state, manager, corpus_idx)?;

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -197,12 +197,6 @@ where
         manager: &mut EM,
         iters: u64,
     ) -> Result<CorpusID, Error> {
-        if iters == 0 {
-            return Err(Error::illegal_argument(
-                "Cannot fuzz for 0 iterations!".to_string(),
-            ));
-        }
-
         let mut ret = None;
         let mut last = current_time();
         let monitor_timeout = STATS_TIMEOUT_DEFAULT;
@@ -217,7 +211,7 @@ where
         // But as the state may grow to a few megabytes,
         // for now we won' and the user has to do it (unless we find a way to do this on `Drop`).
 
-        Ok(ret.expect("iters should not be able to be 0"))
+        ret.ok_or_else(|| Error::illegal_argument("Cannot fuzz for 0 iterations!".to_string()))
     }
 }
 

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bolts::current_time,
-    corpus::{Corpus, Testcase, CorpusID},
+    corpus::{Corpus, CorpusID, Testcase},
     events::{Event, EventConfig, EventFirer, EventManager, ProgressReporter},
     executors::{Executor, ExitKind, HasObservers},
     feedbacks::Feedback,

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -69,6 +69,8 @@ Welcome to `LibAFL`
     )
 )]
 
+#![cfg_attr(debug_assertions, feature(is_sorted))]
+
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -69,8 +69,6 @@ Welcome to `LibAFL`
     )
 )]
 
-#![cfg_attr(debug_assertions, feature(is_sorted))]
-
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;

--- a/libafl/src/mutators/encoded_mutations.rs
+++ b/libafl/src/mutators/encoded_mutations.rs
@@ -321,8 +321,8 @@ where
 
         // We don't want to use the testcase we're already using for splicing
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or(
-                Error::empty(String::from("Corpus is empty"))
+            .ok_or_else(
+                || Error::empty(String::from("Corpus is empty"))
             )?;
         if *state.corpus().current() == Some(chosen_id) {
             return Ok(MutationResult::Skipped);
@@ -397,8 +397,8 @@ where
         }
 
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or(
-                Error::empty(String::from("Corpus is empty"))
+            .ok_or_else(
+                || Error::empty(String::from("Corpus is empty"))
             )?;
         if *state.corpus().current() == Some(chosen_id) {
             return Ok(MutationResult::Skipped);

--- a/libafl/src/mutators/encoded_mutations.rs
+++ b/libafl/src/mutators/encoded_mutations.rs
@@ -1,6 +1,6 @@
 //! Mutations for [`EncodedInput`]s
 //!
-use alloc::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 use core::cmp::{max, min};
 
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
         rands::Rand,
         tuples::{tuple_list, tuple_list_type},
     },
-    corpus::{Corpus, id_manager::random_corpus_entry},
+    corpus::{id_manager::random_corpus_entry, Corpus},
     inputs::EncodedInput,
     mutators::{
         mutations::{buffer_copy, buffer_self_copy, ARITH_MAX},
@@ -321,9 +321,7 @@ where
 
         // We don't want to use the testcase we're already using for splicing
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or_else(
-                || Error::empty(String::from("Corpus is empty"))
-            )?;
+            .ok_or_else(|| Error::empty(String::from("Corpus is empty")))?;
         if *state.corpus().current() == Some(chosen_id) {
             return Ok(MutationResult::Skipped);
         }
@@ -397,9 +395,7 @@ where
         }
 
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or_else(
-                || Error::empty(String::from("Corpus is empty"))
-            )?;
+            .ok_or_else(|| Error::empty(String::from("Corpus is empty")))?;
         if *state.corpus().current() == Some(chosen_id) {
             return Ok(MutationResult::Skipped);
         }

--- a/libafl/src/mutators/gramatron.rs
+++ b/libafl/src/mutators/gramatron.rs
@@ -1,13 +1,13 @@
 //! Gramatron is the rewritten gramatron fuzzer in rust.
 //! See the original gramatron repo [`Gramatron`](https://github.com/HexHive/Gramatron) for more details.
-use alloc::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 use core::cmp::max;
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     bolts::{rands::Rand, tuples::Named},
-    corpus::{Corpus, id_manager::random_corpus_entry},
+    corpus::{id_manager::random_corpus_entry, Corpus},
     generators::GramatronGenerator,
     inputs::{GramatronInput, Terminal},
     mutators::{MutationResult, Mutator},
@@ -106,8 +106,9 @@ where
             return Ok(MutationResult::Skipped);
         }
 
-        let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or_else(|| Error::empty(String::from("Cannot gramatron mutate on an empty corpus")))?;
+        let (_, chosen_id) = random_corpus_entry(state).ok_or_else(|| {
+            Error::empty(String::from("Cannot gramatron mutate on an empty corpus"))
+        })?;
 
         let insert_at = state.rand_mut().below(input.terminals().len() as u64) as usize;
 

--- a/libafl/src/mutators/gramatron.rs
+++ b/libafl/src/mutators/gramatron.rs
@@ -107,7 +107,7 @@ where
         }
 
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or(Error::empty(String::from("Cannot gramatron mutate on an empty corpus")))?;
+            .ok_or_else(|| Error::empty(String::from("Cannot gramatron mutate on an empty corpus")))?;
 
         let insert_at = state.rand_mut().below(input.terminals().len() as u64) as usize;
 

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -23,7 +23,7 @@ pub use nautilus::*;
 use crate::{
     bolts::tuples::{HasConstLen, Named},
     inputs::Input,
-    Error,
+    Error, corpus::CorpusID,
 };
 
 // TODO mutator stats method that produces something that can be sent with the NewTestcase event
@@ -59,7 +59,7 @@ where
         &mut self,
         _state: &mut S,
         _stage_idx: i32,
-        _corpus_idx: Option<usize>,
+        _corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         Ok(())
     }
@@ -83,7 +83,7 @@ where
         &mut self,
         state: &mut S,
         stage_idx: i32,
-        corpus_idx: Option<usize>,
+        corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error>;
 
     /// Gets the [`Mutator`] at the given index and runs the `mutate` function on it.
@@ -101,7 +101,7 @@ where
         index: usize,
         state: &mut S,
         stage_idx: i32,
-        corpus_idx: Option<usize>,
+        corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error>;
 }
 
@@ -122,7 +122,7 @@ where
         &mut self,
         _state: &mut S,
         _stage_idx: i32,
-        _corpus_idx: Option<usize>,
+        _corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         Ok(())
     }
@@ -142,7 +142,7 @@ where
         _index: usize,
         _state: &mut S,
         _stage_idx: i32,
-        _corpus_idx: Option<usize>,
+        _corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         Ok(())
     }
@@ -172,7 +172,7 @@ where
         &mut self,
         state: &mut S,
         stage_idx: i32,
-        corpus_idx: Option<usize>,
+        corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         self.0.post_exec(state, stage_idx, corpus_idx)?;
         self.1.post_exec_all(state, stage_idx, corpus_idx)
@@ -197,7 +197,7 @@ where
         index: usize,
         state: &mut S,
         stage_idx: i32,
-        corpus_idx: Option<usize>,
+        corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         if index == 0 {
             self.0.post_exec(state, stage_idx, corpus_idx)
@@ -258,7 +258,7 @@ pub mod pybind {
             &mut self,
             state: &mut PythonStdState,
             stage_idx: i32,
-            corpus_idx: Option<usize>,
+            corpus_idx: Option<CorpusID>,
         ) -> Result<(), Error> {
             Python::with_gil(|py| -> PyResult<()> {
                 self.inner.call_method1(
@@ -340,7 +340,7 @@ pub mod pybind {
             &mut self,
             state: &mut PythonStdState,
             stage_idx: i32,
-            corpus_idx: Option<usize>,
+            corpus_idx: Option<CorpusID>,
         ) -> Result<(), Error> {
             unwrap_me_mut!(self.wrapper, m, {
                 m.post_exec(state, stage_idx, corpus_idx)

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -22,8 +22,9 @@ pub use nautilus::*;
 
 use crate::{
     bolts::tuples::{HasConstLen, Named},
+    corpus::CorpusID,
     inputs::Input,
-    Error, corpus::CorpusID,
+    Error,
 };
 
 // TODO mutator stats method that produces something that can be sent with the NewTestcase event

--- a/libafl/src/mutators/mopt_mutator.rs
+++ b/libafl/src/mutators/mopt_mutator.rs
@@ -3,7 +3,7 @@ use alloc::{string::ToString, vec::Vec};
 
 use crate::{
     bolts::{current_nanos, rands::Rand, rands::StdRand},
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     inputs::Input,
     mutators::{ComposedByMutations, MutationResult, Mutator, MutatorsTuple, ScheduledMutator},
     state::{HasCorpus, HasMetadata, HasRand, HasSolutions},
@@ -417,7 +417,7 @@ where
         &mut self,
         state: &mut S,
         _stage_idx: i32,
-        _corpus_idx: Option<usize>,
+        _corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         let before = self.finds_before;
         let after = state.corpus().count() + state.solutions().count();

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -912,7 +912,7 @@ where
         let size = input.bytes().len();
 
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or(Error::empty(String::from("Cannot CrossoverInsert mutate on an empty corpus")))?;
+            .ok_or_else(|| Error::empty(String::from("Cannot CrossoverInsert mutate on an empty corpus")))?;
 
         // We don't want to use the testcase we're already using for splicing
         if let Some(cur) = state.corpus().current() {
@@ -991,7 +991,7 @@ where
         }
 
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or(Error::empty(String::from("Cannot CrossoverReplace mutate on an empty corpus")))?;
+            .ok_or_else(|| Error::empty(String::from("Cannot CrossoverReplace mutate on an empty corpus")))?;
 
         // We don't want to use the testcase we're already using for splicing
         if let Some(cur) = state.corpus().current() {
@@ -1072,7 +1072,7 @@ where
     ) -> Result<MutationResult, Error> {
         // We don't want to use the testcase we're already using for splicing
         let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or(Error::empty("Cannot mutate on an empty corpus!".to_owned()))?;
+            .ok_or_else(|| Error::empty("Cannot mutate on an empty corpus!".to_owned()))?;
         if let Some(cur) = state.corpus().current() {
             if chosen_id == *cur {
                 return Ok(MutationResult::Skipped);

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -2,14 +2,14 @@
 
 use crate::{
     bolts::{rands::Rand, tuples::Named},
-    corpus::{Corpus, id_manager::random_corpus_entry},
+    corpus::{id_manager::random_corpus_entry, Corpus},
     inputs::{HasBytesVec, Input},
     mutators::{MutationResult, Mutator},
     state::{HasCorpus, HasMaxSize, HasRand},
     Error,
 };
 
-use alloc::{borrow::ToOwned, vec::Vec, string::String};
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
 use core::{
     cmp::{max, min},
     mem::size_of,
@@ -911,8 +911,11 @@ where
     ) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
 
-        let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or_else(|| Error::empty(String::from("Cannot CrossoverInsert mutate on an empty corpus")))?;
+        let (_, chosen_id) = random_corpus_entry(state).ok_or_else(|| {
+            Error::empty(String::from(
+                "Cannot CrossoverInsert mutate on an empty corpus",
+            ))
+        })?;
 
         // We don't want to use the testcase we're already using for splicing
         if let Some(cur) = state.corpus().current() {
@@ -990,8 +993,11 @@ where
             return Ok(MutationResult::Skipped);
         }
 
-        let (_, chosen_id) = random_corpus_entry(state)
-            .ok_or_else(|| Error::empty(String::from("Cannot CrossoverReplace mutate on an empty corpus")))?;
+        let (_, chosen_id) = random_corpus_entry(state).ok_or_else(|| {
+            Error::empty(String::from(
+                "Cannot CrossoverReplace mutate on an empty corpus",
+            ))
+        })?;
 
         // We don't want to use the testcase we're already using for splicing
         if let Some(cur) = state.corpus().current() {

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -13,7 +13,7 @@ use crate::{
         tuples::{tuple_list, tuple_list_type, NamedTuple},
         AsMutSlice, AsSlice,
     },
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     inputs::Input,
     mutators::{MutationResult, Mutator, MutatorsTuple},
     state::{HasCorpus, HasMetadata, HasRand},
@@ -329,7 +329,7 @@ where
         &mut self,
         state: &mut S,
         _stage_idx: i32,
-        corpus_idx: Option<usize>,
+        corpus_idx: Option<CorpusID>,
     ) -> Result<(), Error> {
         if let Some(idx) = corpus_idx {
             let mut testcase = (*state.corpus_mut().get(idx)?).borrow_mut();
@@ -444,10 +444,10 @@ mod tests {
         // With the current impl, seed of 1 will result in a split at pos 2.
         let mut rand = XkcdRand::with_seed(5);
         let mut corpus: InMemoryCorpus<BytesInput> = InMemoryCorpus::new();
-        corpus.add(Testcase::new(vec![b'a', b'b', b'c'])).unwrap();
-        corpus.add(Testcase::new(vec![b'd', b'e', b'f'])).unwrap();
+        let id_0 = corpus.add(Testcase::new(vec![b'a', b'b', b'c'])).unwrap();
+        let _id_1 = corpus.add(Testcase::new(vec![b'd', b'e', b'f'])).unwrap();
 
-        let testcase = corpus.get(0).expect("Corpus did not contain entries");
+        let testcase = corpus.get(id_0).expect("Corpus did not contain entries");
         let mut input = testcase.borrow_mut().load_input().unwrap().clone();
 
         let mut state =
@@ -471,10 +471,10 @@ mod tests {
         // With the current impl, seed of 1 will result in a split at pos 2.
         let rand = StdRand::with_seed(0x1337);
         let mut corpus: InMemoryCorpus<BytesInput> = InMemoryCorpus::new();
-        corpus.add(Testcase::new(vec![b'a', b'b', b'c'])).unwrap();
-        corpus.add(Testcase::new(vec![b'd', b'e', b'f'])).unwrap();
+        let id_0 = corpus.add(Testcase::new(vec![b'a', b'b', b'c'])).unwrap();
+        let _id_1 = corpus.add(Testcase::new(vec![b'd', b'e', b'f'])).unwrap();
 
-        let testcase = corpus.get(0).expect("Corpus did not contain entries");
+        let testcase = corpus.get(id_0).expect("Corpus did not contain entries");
         let mut input = testcase.borrow_mut().load_input().unwrap().clone();
         let input_prior = input.clone();
 

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bolts::{rands::Rand, AsMutSlice, AsSlice, HasLen, HasRefCnt},
-    corpus::{Corpus, Testcase, CorpusID},
+    corpus::{Corpus, CorpusID, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::Input,
     schedulers::{
@@ -114,7 +114,12 @@ where
         self.inner.on_add(state, idx)
     }
 
-    fn on_replace(&self, state: &mut S, idx: CorpusID, testcase: &Testcase<I>) -> Result<(), Error> {
+    fn on_replace(
+        &self,
+        state: &mut S,
+        idx: CorpusID,
+        testcase: &Testcase<I>,
+    ) -> Result<(), Error> {
         self.inner.on_replace(state, idx, testcase)
     }
 

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     bolts::{rands::Rand, serdeany::SerdeAny, AsSlice, HasRefCnt},
-    corpus::{Corpus, Testcase, CorpusID},
+    corpus::{Corpus, CorpusID, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::Input,
     schedulers::{LenTimeMulTestcaseScore, Scheduler, TestcaseScore},
@@ -87,7 +87,12 @@ where
     }
 
     /// Replaces the testcase at the given idx
-    fn on_replace(&self, state: &mut S, idx: CorpusID, testcase: &Testcase<I>) -> Result<(), Error> {
+    fn on_replace(
+        &self,
+        state: &mut S,
+        idx: CorpusID,
+        testcase: &Testcase<I>,
+    ) -> Result<(), Error> {
         self.base.on_replace(state, idx, testcase)
     }
 

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -26,7 +26,7 @@ pub use powersched::PowerQueueScheduler;
 use alloc::borrow::ToOwned;
 
 use crate::{
-    corpus::{Corpus, Testcase, CorpusID, id_manager::random_corpus_entry},
+    corpus::{id_manager::random_corpus_entry, Corpus, CorpusID, Testcase},
     inputs::Input,
     state::{HasCorpus, HasRand},
     Error,
@@ -78,7 +78,6 @@ where
 {
     /// Gets the next entry at random
     fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
-
         let (_, corpus_id) = random_corpus_entry(state)
             .ok_or_else(|| Error::empty("No entries in corpus".to_owned()))?;
 

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -80,7 +80,7 @@ where
     fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
 
         let (_, corpus_id) = random_corpus_entry(state)
-            .ok_or(Error::empty("No entries in corpus".to_owned()))?;
+            .ok_or_else(|| Error::empty("No entries in corpus".to_owned()))?;
 
         *state.corpus_mut().current_mut() = Some(corpus_id);
         Ok(corpus_id)

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -6,7 +6,7 @@ use alloc::{
 };
 
 use crate::{
-    corpus::{Corpus, SchedulerTestcaseMetaData, CorpusID},
+    corpus::{Corpus, CorpusID, SchedulerTestcaseMetaData},
     inputs::Input,
     schedulers::Scheduler,
     state::{HasCorpus, HasMetadata},
@@ -213,8 +213,7 @@ where
                     Ok(first_id)
                 }
             })
-            .unwrap_or(Ok(first_id))
-            ?;
+            .unwrap_or(Ok(first_id))?;
         *state.corpus_mut().current_mut() = Some(next_id);
 
         // Update the handicap

--- a/libafl/src/schedulers/probabilistic_sampling.rs
+++ b/libafl/src/schedulers/probabilistic_sampling.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     bolts::rands::Rand,
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     inputs::Input,
     schedulers::{Scheduler, TestcaseScore},
     state::{HasCorpus, HasMetadata, HasRand},
@@ -29,7 +29,7 @@ where
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProbabilityMetadata {
     /// corpus index -> probability
-    pub map: HashMap<usize, f64>,
+    pub map: HashMap<CorpusID, f64>,
     /// total probability of all items in the map
     pub total_probability: f64,
 }
@@ -70,7 +70,7 @@ where
     /// Calculate the score and store in `ProbabilityMetadata`
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::unused_self)]
-    pub fn store_probability(&self, state: &mut S, idx: usize) -> Result<(), Error> {
+    pub fn store_probability(&self, state: &mut S, idx: CorpusID) -> Result<(), Error> {
         let factor = F::compute(&mut *state.corpus().get(idx)?.borrow_mut(), state)?;
         if factor == 0.0 {
             return Err(Error::illegal_state(
@@ -94,7 +94,7 @@ where
     I: Input,
     S: HasCorpus<I> + HasMetadata + HasRand,
 {
-    fn on_add(&self, state: &mut S, idx: usize) -> Result<(), Error> {
+    fn on_add(&self, state: &mut S, idx: CorpusID) -> Result<(), Error> {
         if state.metadata().get::<ProbabilityMetadata>().is_none() {
             state.add_metadata(ProbabilityMetadata::new());
         }
@@ -103,7 +103,7 @@ where
 
     /// Gets the next entry
     #[allow(clippy::cast_precision_loss)]
-    fn next(&self, state: &mut S) -> Result<usize, Error> {
+    fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
         if state.corpus().count() == 0 {
             Err(Error::empty(String::from("No entries in corpus")))
         } else {

--- a/libafl/src/schedulers/queue.rs
+++ b/libafl/src/schedulers/queue.rs
@@ -17,9 +17,9 @@ where
     /// Gets the next entry in the queue
     fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
         let id_manager = state.corpus().id_manager();
-        let first_id = id_manager.first_id().ok_or_else (
-            || Error::empty("No entries in corpus".to_owned())
-        )?;
+        let first_id = id_manager
+            .first_id()
+            .ok_or_else(|| Error::empty("No entries in corpus".to_owned()))?;
         let next_id = state
             .corpus()
             .current()

--- a/libafl/src/schedulers/queue.rs
+++ b/libafl/src/schedulers/queue.rs
@@ -17,8 +17,8 @@ where
     /// Gets the next entry in the queue
     fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
         let id_manager = state.corpus().id_manager();
-        let first_id = id_manager.first_id().ok_or(
-            Error::empty("No entries in corpus".to_owned())
+        let first_id = id_manager.first_id().ok_or_else (
+            || Error::empty("No entries in corpus".to_owned())
         )?;
         let next_id = state
             .corpus()

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -82,14 +82,17 @@ where
             .get::<SchedulerMetadata>()
             .ok_or_else(|| Error::key_not_found("SchedulerMetadata not found".to_string()))?;
 
+        let id_manager = state.corpus().id_manager();
+        let corpus_ids = id_manager.active_ids();
+
         let fuzz_mu = if let Some(strat) = psmeta.strat() {
             if strat == PowerSchedule::COE {
                 let corpus = state.corpus();
                 let mut n_paths = 0;
                 let mut v = 0.0;
                 let cur_index = state.corpus().current().unwrap();
-                for idx in 0..corpus.count() {
-                    let n_fuzz_entry = if cur_index == idx {
+                for id in corpus_ids {
+                    let n_fuzz_entry = if cur_index == *id {
                         entry
                             .metadata()
                             .get::<SchedulerTestcaseMetaData>()
@@ -101,7 +104,7 @@ where
                             .n_fuzz_entry()
                     } else {
                         corpus
-                            .get(idx)?
+                            .get(*id)?
                             .borrow()
                             .metadata()
                             .get::<SchedulerTestcaseMetaData>()

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -262,7 +262,7 @@ where
     fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
 
         let (chosen_idx, _chosen_id) = random_corpus_entry(state)
-            .ok_or(Error::empty("No entries in corpus".to_string()))?;
+            .ok_or_else(|| Error::empty("No entries in corpus".to_string()))?;
 
         let corpus_count = state.corpus().count();
 

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -1,14 +1,11 @@
 //! The queue corpus scheduler with weighted queue item selection from aflpp (`https://github.com/AFLplusplus/AFLplusplus/blob/1d4f1e48797c064ee71441ba555b29fc3f467983/src/afl-fuzz-queue.c#L32`)
 //! This queue corpus scheduler needs calibration stage.
 
-use alloc::{
-    string::ToString,
-    vec::Vec,
-};
+use alloc::{string::ToString, vec::Vec};
 
 use crate::{
     bolts::rands::Rand,
-    corpus::{Corpus, SchedulerTestcaseMetaData, CorpusID, id_manager::random_corpus_entry},
+    corpus::{id_manager::random_corpus_entry, Corpus, CorpusID, SchedulerTestcaseMetaData},
     inputs::Input,
     schedulers::{
         powersched::SchedulerMetadata,
@@ -260,7 +257,6 @@ where
 
     #[allow(clippy::similar_names, clippy::cast_precision_loss)]
     fn next(&self, state: &mut S) -> Result<CorpusID, Error> {
-
         let (chosen_idx, _chosen_id) = random_corpus_entry(state)
             .ok_or_else(|| Error::empty("No entries in corpus".to_string()))?;
 
@@ -295,9 +291,7 @@ where
             let psmeta = state
                 .metadata_mut()
                 .get_mut::<SchedulerMetadata>()
-                .ok_or_else(|| {
-                    Error::key_not_found("SchedulerMetadata not found".to_string())
-                })?;
+                .ok_or_else(|| Error::key_not_found("SchedulerMetadata not found".to_string()))?;
             psmeta.set_queue_cycles(psmeta.queue_cycles() + 1);
         }
         let id = state.corpus().ids()[idx];

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bolts::{current_time, tuples::Named, AsRefIterator},
-    corpus::{Corpus, SchedulerTestcaseMetaData},
+    corpus::{Corpus, SchedulerTestcaseMetaData, CorpusID},
     events::{EventFirer, LogSeverity},
     executors::{Executor, ExitKind, HasObservers},
     feedbacks::{
@@ -59,7 +59,7 @@ where
         executor: &mut E,
         state: &mut S,
         mgr: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         // Run this stage only once for each corpus entry
         if state.corpus().get(corpus_idx)?.borrow_mut().fuzz_level() > 0 {

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bolts::{current_time, tuples::Named, AsRefIterator},
-    corpus::{Corpus, SchedulerTestcaseMetaData, CorpusID},
+    corpus::{Corpus, CorpusID, SchedulerTestcaseMetaData},
     events::{EventFirer, LogSeverity},
     executors::{Executor, ExitKind, HasObservers},
     feedbacks::{

--- a/libafl/src/stages/concolic.rs
+++ b/libafl/src/stages/concolic.rs
@@ -9,7 +9,7 @@ use alloc::string::String;
 use alloc::{borrow::ToOwned, string::ToString, vec::Vec};
 
 use crate::{
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     executors::{Executor, HasObservers},
     inputs::Input,
     observers::{concolic::ConcolicObserver, ObserversTuple},
@@ -46,7 +46,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         self.inner
             .perform(fuzzer, executor, state, manager, corpus_idx)?;
@@ -365,7 +365,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         start_timer!(state);
         let testcase = state.corpus().get(corpus_idx)?.clone();

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     bolts::AsSlice,
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     executors::{Executor, HasObservers},
     feedbacks::map::MapNoveltiesMetadata,
     inputs::{GeneralizedInput, GeneralizedItem, HasBytesVec},
@@ -31,7 +31,7 @@ const MAX_GENERALIZED_LEN: usize = 8192;
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct GeneralizedIndexesMetadata {
     /// The set of indexes
-    pub indexes: HashSet<usize>,
+    pub indexes: HashSet<CorpusID>,
 }
 
 crate::impl_serdeany!(GeneralizedIndexesMetadata);
@@ -86,7 +86,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         if state
             .metadata()

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 
 use crate::{
     bolts::rands::Rand,
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     fuzzer::Evaluator,
     inputs::Input,
     mark_feature_time,
@@ -38,7 +38,7 @@ where
     fn mutator_mut(&mut self) -> &mut M;
 
     /// Gets the number of iterations this mutator should run for.
-    fn iterations(&self, state: &mut S, corpus_idx: usize) -> Result<usize, Error>;
+    fn iterations(&self, state: &mut S, corpus_idx: CorpusID) -> Result<usize, Error>;
 
     /// Runs this (mutational) stage for the given testcase
     #[allow(clippy::cast_possible_wrap)] // more than i32 stages on 32 bit system - highly unlikely...
@@ -48,7 +48,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         let num = self.iterations(state, corpus_idx)?;
 
@@ -115,7 +115,7 @@ where
     }
 
     /// Gets the number of iterations as a random number
-    fn iterations(&self, state: &mut S, _corpus_idx: usize) -> Result<usize, Error> {
+    fn iterations(&self, state: &mut S, _corpus_idx: CorpusID) -> Result<usize, Error> {
         Ok(1 + state.rand_mut().below(DEFAULT_MUTATIONAL_MAX_ITERATIONS) as usize)
     }
 }
@@ -135,7 +135,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         let ret = self.perform_mutational(fuzzer, executor, state, manager, corpus_idx);
 

--- a/libafl/src/stages/owned.rs
+++ b/libafl/src/stages/owned.rs
@@ -4,8 +4,9 @@ use alloc::{boxed::Box, vec::Vec};
 
 use crate::{
     bolts::anymap::AsAny,
+    corpus::CorpusID,
     stages::{Stage, StagesTuple},
-    Error, corpus::CorpusID,
+    Error,
 };
 
 /// Combine `Stage` and `AsAny`

--- a/libafl/src/stages/owned.rs
+++ b/libafl/src/stages/owned.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, vec::Vec};
 use crate::{
     bolts::anymap::AsAny,
     stages::{Stage, StagesTuple},
-    Error,
+    Error, corpus::CorpusID,
 };
 
 /// Combine `Stage` and `AsAny`
@@ -26,7 +26,7 @@ impl<E, EM, S, Z> StagesTuple<E, EM, S, Z> for StagesOwnedList<E, EM, S, Z> {
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         for s in &mut self.list {
             s.perform(fuzzer, executor, state, manager, corpus_idx)?;

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use core::{fmt::Debug, marker::PhantomData};
 
 use crate::{
-    corpus::{Corpus, SchedulerTestcaseMetaData, CorpusID},
+    corpus::{Corpus, CorpusID, SchedulerTestcaseMetaData},
     executors::{Executor, HasObservers},
     fuzzer::Evaluator,
     inputs::Input,

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use core::{fmt::Debug, marker::PhantomData};
 
 use crate::{
-    corpus::{Corpus, SchedulerTestcaseMetaData},
+    corpus::{Corpus, SchedulerTestcaseMetaData, CorpusID},
     executors::{Executor, HasObservers},
     fuzzer::Evaluator,
     inputs::Input,
@@ -62,7 +62,7 @@ where
 
     /// Gets the number of iterations as a random number
     #[allow(clippy::cast_sign_loss)]
-    fn iterations(&self, state: &mut S, corpus_idx: usize) -> Result<usize, Error> {
+    fn iterations(&self, state: &mut S, corpus_idx: CorpusID) -> Result<usize, Error> {
         // Update handicap
         let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
         let score = F::compute(&mut *testcase, state)? as usize;
@@ -77,7 +77,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         let num = self.iterations(state, corpus_idx)?;
 
@@ -149,7 +149,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         let ret = self.perform_mutational(fuzzer, executor, state, manager, corpus_idx);
         ret

--- a/libafl/src/stages/push/mod.rs
+++ b/libafl/src/stages/push/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     observers::ObserversTuple,
     schedulers::Scheduler,
     state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasRand},
-    Error, EvaluatorObservers, ExecutionProcessor, HasScheduler,
+    Error, EvaluatorObservers, ExecutionProcessor, HasScheduler, corpus::CorpusID,
 };
 
 /// Send a monitor update all 15 (or more) seconds
@@ -97,7 +97,7 @@ where
     pub errored: bool,
 
     /// The corpus index we're currently working on
-    pub current_corpus_idx: Option<usize>,
+    pub current_corpus_idx: Option<CorpusID>,
 
     /// The input we just ran
     pub current_input: Option<I>, // Todo: Get rid of copy
@@ -195,7 +195,7 @@ where
     fn push_stage_helper_mut(&mut self) -> &mut PushStageHelper<CS, EM, I, OT, S, Z>;
 
     /// Set the current corpus index this stage works on
-    fn set_current_corpus_idx(&mut self, corpus_idx: usize) {
+    fn set_current_corpus_idx(&mut self, corpus_idx: CorpusID) {
         self.push_stage_helper_mut().current_corpus_idx = Some(corpus_idx);
     }
 

--- a/libafl/src/stages/push/mod.rs
+++ b/libafl/src/stages/push/mod.rs
@@ -17,13 +17,14 @@ use core::{
 
 use crate::{
     bolts::current_time,
+    corpus::CorpusID,
     events::{EventFirer, EventRestarter, HasEventManagerId, ProgressReporter},
     executors::ExitKind,
     inputs::Input,
     observers::ObserversTuple,
     schedulers::Scheduler,
     state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasRand},
-    Error, EvaluatorObservers, ExecutionProcessor, HasScheduler, corpus::CorpusID,
+    Error, EvaluatorObservers, ExecutionProcessor, HasScheduler,
 };
 
 /// Send a monitor update all 15 (or more) seconds

--- a/libafl/src/stages/push/mutational.rs
+++ b/libafl/src/stages/push/mutational.rs
@@ -169,12 +169,11 @@ where
     ) -> Result<(), Error> {
         // todo: isintersting, etc.
 
-        let (_exec_result, corpus_id) = fuzzer.process_execution(
-            state, event_mgr, last_input, observers, &exit_kind, true)?;
+        let (_exec_result, corpus_id) =
+            fuzzer.process_execution(state, event_mgr, last_input, observers, &exit_kind, true)?;
 
         start_timer!(state);
-        self.mutator
-            .post_exec(state, self.stage_idx, corpus_id)?;
+        self.mutator.post_exec(state, self.stage_idx, corpus_id)?;
         mark_feature_time!(state, PerfFeature::MutatePostExec);
         self.testcases_done += 1;
 

--- a/libafl/src/stages/sync.rs
+++ b/libafl/src/stages/sync.rs
@@ -14,7 +14,7 @@ use crate::{
     inputs::Input,
     stages::Stage,
     state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasRand},
-    Error,
+    Error, corpus::CorpusID,
 };
 
 /// Metadata used to store information about disk sync time
@@ -63,7 +63,7 @@ where
         executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        _corpus_idx: usize,
+        _corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         let last = state
             .metadata()

--- a/libafl/src/stages/sync.rs
+++ b/libafl/src/stages/sync.rs
@@ -10,11 +10,12 @@ use std::{
 };
 
 use crate::{
+    corpus::CorpusID,
     fuzzer::Evaluator,
     inputs::Input,
     stages::Stage,
     state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasRand},
-    Error, corpus::CorpusID,
+    Error,
 };
 
 /// Metadata used to store information about disk sync time

--- a/libafl/src/stages/tracing.rs
+++ b/libafl/src/stages/tracing.rs
@@ -3,7 +3,7 @@
 use core::{fmt::Debug, marker::PhantomData};
 
 use crate::{
-    corpus::Corpus,
+    corpus::{Corpus, CorpusID},
     executors::{Executor, HasObservers, ShadowExecutor},
     inputs::Input,
     mark_feature_time,
@@ -45,7 +45,7 @@ where
         _executor: &mut E,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         start_timer!(state);
         let input = state
@@ -124,7 +124,7 @@ where
         executor: &mut ShadowExecutor<E, I, S, SOT>,
         state: &mut S,
         manager: &mut EM,
-        corpus_idx: usize,
+        corpus_idx: CorpusID,
     ) -> Result<(), Error> {
         start_timer!(state);
         let input = state


### PR DESCRIPTION
This is a work-in-progress PR with my current implementation of `CorpusID` instead of using straight indices for corpus entries. This has the following benefits:

1. IDs are corpus-unique. That means IDs are safe to store and keep around in metadata and such without having to worry about whether or not they still refer to the same `Testcase`.
2. Accordingly, they handle corpus `remove` and `replace` perfectly well. Accessing a `Testcase` by a stale ID will return None.
3. They allow type-checking of indices into a corpus. You cannot acquire a `CorpusID` from any other source than the corresponding corpus itself. All `CorpusIDs` are guaranteed to have been valid at the time they were issued.

While I have tried to minimize the runtime overhead, some runtime overhead will be incurred (e.g. to internally look up the indices of IDs). Any input on how to further reduce this would be welcome. 

Alternatively, if we choose to make the `Corpus` generic over ID managers, we can simply provide the default implementation with the existing behavior, with all the downsides included. However, I think the added guarantees would be worth it the extra runtime overhead, especially because a lot more tuning can be done. 

I am further along implementing this in my fork, however I thought it'd be good to get feedback from other people before I end up doing a ton of work that will end up not being merged.

Any feedback is welcome, especially on how to make this more performant :)