### PR TITLE
Add custom GDB commands to libafl_qemu

### DIFF
--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -155,9 +155,15 @@ where
                 .unwrap()
                 .history_map;
 
-            for j in 0..map_len {
-                if map_first[j] != map[j] && history_map[j] != O::Entry::max_value() {
-                    history_map[j] = O::Entry::max_value();
+            if history_map.len() < map_len {
+                history_map.resize(map_len, O::Entry::default());
+            }
+
+            for (first, (cur, history)) in
+                map_first.iter().zip(map.iter().zip(history_map.iter_mut()))
+            {
+                if *first != *cur && *history != O::Entry::max_value() {
+                    *history = O::Entry::max_value();
                     unstable_entries += 1;
                 };
             }

--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -3,7 +3,7 @@ use which::which;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "d840462c2e4cdda4428d99cd4003ddda95c5a2dc";
+const QEMU_REVISION: &str = "6a9a929222cbc8b10adfb048aa24f73486e0a886";
 
 fn build_dep_check(tools: &[&str]) {
     for tool in tools {
@@ -141,80 +141,21 @@ pub fn build() {
     let build_dir = qemu_path.join("build");
     let output_lib = build_dir.join(&format!("libqemu-{}.so", cpu_target));
     if !output_lib.is_file() {
-        drop(
+        /*drop(
             Command::new("make")
                 .current_dir(&qemu_path)
                 .arg("distclean")
                 .status(),
-        );
+        );*/
         Command::new("./configure")
             .current_dir(&qemu_path)
             //.arg("--as-static-lib")
             .arg("--as-shared-lib")
             .arg(&format!("--target-list={}-linux-user", cpu_target))
             .args(&[
-                "--audio-drv-list=",
                 "--disable-blobs",
-                "--disable-bochs",
-                "--disable-brlapi",
                 "--disable-bsd-user",
-                "--disable-bzip2",
-                "--disable-cap-ng",
-                "--disable-cloop",
-                "--disable-curl",
-                "--disable-curses",
-                "--disable-dmg",
                 "--disable-fdt",
-                "--disable-gcrypt",
-                "--disable-glusterfs",
-                "--disable-gnutls",
-                "--disable-gtk",
-                "--disable-guest-agent",
-                "--disable-iconv",
-                "--disable-libiscsi",
-                "--disable-libnfs",
-                "--disable-libssh",
-                "--disable-libusb",
-                "--disable-linux-aio",
-                "--disable-live-block-migration",
-                "--disable-lzo",
-                "--disable-nettle",
-                "--disable-numa",
-                "--disable-opengl",
-                "--disable-parallels",
-                "--disable-plugins",
-                "--disable-qcow1",
-                "--disable-qed",
-                "--disable-rbd",
-                "--disable-rdma",
-                "--disable-replication",
-                "--disable-sdl",
-                "--disable-seccomp",
-                "--disable-smartcard",
-                "--disable-snappy",
-                "--disable-spice",
-                "--disable-system",
-                "--disable-tools",
-                "--disable-tpm",
-                "--disable-usb-redir",
-                "--disable-vde",
-                "--disable-vdi",
-                "--disable-vhost-crypto",
-                "--disable-vhost-kernel",
-                "--disable-vhost-net",
-                "--disable-vhost-scsi",
-                "--disable-vhost-user",
-                "--disable-vhost-vdpa",
-                "--disable-vhost-vsock",
-                "--disable-virglrenderer",
-                "--disable-virtfs",
-                "--disable-vnc",
-                "--disable-vnc-jpeg",
-                "--disable-vnc-sasl",
-                "--disable-vte",
-                "--disable-vvfat",
-                "--disable-xen",
-                "--disable-xen-pci-passthrough",
             ])
             .status()
             .expect("Configure failed");

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -323,7 +323,8 @@ static mut GDB_COMMANDS: Vec<FatPtr> = vec![];
 
 extern "C" fn gdb_cmd(buf: *const u8, len: usize, data: *const ()) -> i32 {
     unsafe {
-        let closure: &mut Box<dyn FnMut(&str) -> bool> = core::mem::transmute(data);
+        let closure =
+            &mut *(data as *mut std::boxed::Box<dyn for<'r> std::ops::FnMut(&'r str) -> bool>);
         let cmd = std::str::from_utf8_unchecked(std::slice::from_raw_parts(buf, len));
         if closure(cmd) {
             1

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -3,7 +3,7 @@
 use core::{
     convert::Into,
     ffi::c_void,
-    mem::{transmute, MaybeUninit},
+    mem::MaybeUninit,
     ptr::{addr_of, addr_of_mut, copy_nonoverlapping, null},
 };
 use libc::c_int;
@@ -475,7 +475,7 @@ impl Emulator {
 
     #[must_use]
     pub fn g2h<T>(&self, addr: GuestAddr) -> *mut T {
-        unsafe { transmute(addr as usize + guest_base) }
+        unsafe { (addr as usize + guest_base) as *mut T }
     }
 
     #[must_use]
@@ -858,7 +858,7 @@ pub mod pybind {
         }
 
         fn h2g(&self, addr: u64) -> GuestAddr {
-            self.emu.h2g(unsafe { transmute::<_, *const u8>(addr) })
+            self.emu.h2g(addr as *const u8)
         }
 
         fn binary_path(&self) -> String {

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -747,7 +747,6 @@ impl Emulator {
 #[cfg(feature = "python")]
 pub mod pybind {
     use super::{GuestAddr, GuestUsize, MmapPerms, SyscallHookResult};
-    use core::mem::transmute;
     use pyo3::exceptions::PyValueError;
     use pyo3::{prelude::*, types::PyInt};
     use std::convert::TryFrom;

--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -14,14 +14,10 @@ use libafl::{executors::inprocess::inprocess_get_state, inputs::Input};
 
 pub use crate::emu::SyscallHookResult;
 use crate::{
-    emu::{Emulator, SKIP_EXEC_HOOK},
+    emu::{Emulator, FatPtr, SKIP_EXEC_HOOK},
     helper::{QemuHelper, QemuHelperTuple},
     GuestAddr,
 };
-
-#[repr(C)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-struct FatPtr(*const c_void, *const c_void);
 
 // all kinds of hooks
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -7,6 +7,8 @@
     allow(clippy::useless_conversion)
 )]
 #![allow(clippy::needless_pass_by_value)]
+// Till they fix this buggy lint in clippy
+#![allow(clippy::borrow_deref_ref)]
 
 use std::env;
 


### PR DESCRIPTION
The use case is to allow a frontend fuzzer to expose commands such as `monitor input-location 0xababcafe 42` and `monitor start-fuzzing` to avoid to write an harness and fuzz from GDB connected to qemu user. 