### PR TITLE
New hooks for libafl_qemu

### DIFF
--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -332,7 +332,7 @@ fn fuzz(
         ExitKind::Ok
     };
 
-    let hooks = QemuHooks::new(
+    let mut hooks = QemuHooks::new(
         &emu,
         tuple_list!(
             QemuEdgeCoverageHelper::default(),
@@ -343,7 +343,7 @@ fn fuzz(
     );
 
     let executor = QemuExecutor::new(
-        hooks,
+        &mut hooks,
         &mut harness,
         tuple_list!(edges_observer, time_observer),
         &mut fuzzer,

--- a/fuzzers/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_launcher/src/fuzzer.rs
@@ -157,7 +157,7 @@ pub fn fuzz() {
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
-        let hooks = QemuHooks::new(&emu, tuple_list!(QemuEdgeCoverageHelper::default(),));
+        let mut hooks = QemuHooks::new(&emu, tuple_list!(QemuEdgeCoverageHelper::default()));
 
         // Create a QEMU in-process executor
         let executor = QemuExecutor::new(

--- a/fuzzers/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_launcher/src/fuzzer.rs
@@ -161,7 +161,7 @@ pub fn fuzz() {
 
         // Create a QEMU in-process executor
         let executor = QemuExecutor::new(
-            hooks,
+            &mut hooks,
             &mut harness,
             tuple_list!(edges_observer, time_observer),
             &mut fuzzer,

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["std", "derive", "llmp_compression", "rand_trait", "fork", "introspection"]
+default = ["std", "derive", "llmp_compression", "rand_trait", "fork"]
 std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "bincode", "wait-timeout", "regex", "byteorder", "once_cell", "uuid", "tui_monitor", "ctor", "backtrace", "num_cpus"] # print, env, launcher ... support
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
 fork = [] # uses the fork() syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on Windows, no_std).

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -72,6 +72,7 @@ Welcome to `LibAFL`
 )]
 // Till they fix this buggy lint in clippy
 #![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::borrow_deref_ref)]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -71,7 +71,7 @@ Welcome to `LibAFL`
     )
 )]
 // Till they fix this buggy lint in clippy
-#![allow(clippy::borrow_deref_ref)]
+#![allow(clippy::borrow_as_ptr)]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -132,12 +132,14 @@ impl TuiUI {
         let tabs = Tabs::new(titles)
             .block(
                 Block::default()
-                    .title(Span::styled(
-                        "charts (`g` switch)",
-                        Style::default()
-                            .fg(Color::LightCyan)
-                            .add_modifier(Modifier::BOLD),
-                    ))
+                    .title(
+                        Span::styled(
+                            "charts (`g` switch)",
+                            Style::default()
+                                .fg(Color::LightCyan)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    )
                     .borders(Borders::ALL),
             )
             .highlight_style(Style::default().fg(Color::LightYellow))
@@ -275,12 +277,14 @@ impl TuiUI {
         let chart = Chart::new(datasets)
             .block(
                 Block::default()
-                    .title(Span::styled(
-                        title,
-                        Style::default()
-                            .fg(Color::LightCyan)
-                            .add_modifier(Modifier::BOLD),
-                    ))
+                    .title(
+                        Span::styled(
+                            title,
+                            Style::default()
+                                .fg(Color::LightCyan)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    )
                     .borders(Borders::ALL),
             )
             .x_axis(
@@ -357,12 +361,14 @@ impl TuiUI {
         let table = Table::new(items)
             .block(
                 Block::default()
-                    .title(Span::styled(
-                        "generic",
-                        Style::default()
-                            .fg(Color::LightCyan)
-                            .add_modifier(Modifier::BOLD),
-                    ))
+                    .title(
+                        Span::styled(
+                            "generic",
+                            Style::default()
+                                .fg(Color::LightCyan)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    )
                     .borders(Borders::ALL),
             )
             .widths(&[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]);
@@ -468,18 +474,19 @@ impl TuiUI {
                 };
             }
 
-            let table = Table::new(items)
-                .block(
-                    Block::default()
-                        .title(Span::styled(
-                            "introspection",
-                            Style::default()
-                                .fg(Color::LightCyan)
-                                .add_modifier(Modifier::BOLD),
-                        ))
-                        .borders(Borders::ALL),
-                )
-                .widths(&[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]);
+            let table =
+                Table::new(items)
+                    .block(
+                        Block::default()
+                            .title(Span::styled(
+                                "introspection",
+                                Style::default()
+                                    .fg(Color::LightCyan)
+                                    .add_modifier(Modifier::BOLD),
+                            ))
+                            .borders(Borders::ALL),
+                    )
+                    .widths(&[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]);
             f.render_widget(table, client_chunks[1]);
         }
     }
@@ -496,12 +503,14 @@ impl TuiUI {
             .map(|msg| ListItem::new(Span::raw(msg)))
             .collect();
         let logs = List::new(logs).block(
-            Block::default().borders(Borders::ALL).title(Span::styled(
-                "clients logs (`t` to show/hide)",
-                Style::default()
-                    .fg(Color::LightCyan)
-                    .add_modifier(Modifier::BOLD),
-            )),
+            Block::default().borders(Borders::ALL).title(
+                Span::styled(
+                    "clients logs (`t` to show/hide)",
+                    Style::default()
+                        .fg(Color::LightCyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ),
         );
         f.render_widget(logs, area);
     }

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -38,6 +38,7 @@ strum_macros = "0.21"
 syscall-numbers = "2.0"
 bio = "0.39"
 thread_local = "1.1.3"
+capstone = "0.10"
 #pyo3 = { version = "0.15", features = ["extension-module"], optional = true }
 pyo3 = { version = "0.15", optional = true }
 

--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -3,7 +3,7 @@ use which::which;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "c2f33d3ee0311e598583971989f490bd5b58437f";
+const QEMU_REVISION: &str = "052fd818b44718f0e2b729af59e184f329ad0c6e";
 
 fn build_dep_check(tools: &[&str]) {
     for tool in tools {

--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -3,7 +3,7 @@ use which::which;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "6a9a929222cbc8b10adfb048aa24f73486e0a886";
+const QEMU_REVISION: &str = "74390ee1b17b908f40106593382099a4148059ed";
 
 fn build_dep_check(tools: &[&str]) {
     for tool in tools {

--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -3,7 +3,7 @@ use which::which;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "ac7bfe4325c84d66c9d839891a45f081506f9b02";
+const QEMU_REVISION: &str = "03e283c85800496b60fb757d68a7df2821fb7a90";
 
 fn build_dep_check(tools: &[&str]) {
     for tool in tools {

--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -3,7 +3,7 @@ use which::which;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "052fd818b44718f0e2b729af59e184f329ad0c6e";
+const QEMU_REVISION: &str = "ac7bfe4325c84d66c9d839891a45f081506f9b02";
 
 fn build_dep_check(tools: &[&str]) {
     for tool in tools {

--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -3,7 +3,7 @@ use which::which;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "74390ee1b17b908f40106593382099a4148059ed";
+const QEMU_REVISION: &str = "c2f33d3ee0311e598583971989f490bd5b58437f";
 
 fn build_dep_check(tools: &[&str]) {
     for tool in tools {

--- a/libafl_qemu/src/aarch64.rs
+++ b/libafl_qemu/src/aarch64.rs
@@ -59,3 +59,8 @@ impl IntoPy<PyObject> for Regs {
         n.into_py(py)
     }
 }
+
+/// Return an ARM64 ArchCapstoneBuilder
+pub fn capstone() -> capstone::arch::arm64::ArchCapstoneBuilder {
+    capstone::Capstone::new().arm()
+}

--- a/libafl_qemu/src/arm.rs
+++ b/libafl_qemu/src/arm.rs
@@ -47,3 +47,8 @@ impl IntoPy<PyObject> for Regs {
         n.into_py(py)
     }
 }
+
+/// Return an ARM ArchCapstoneBuilder
+pub fn capstone() -> capstone::arch::arm::ArchCapstoneBuilder {
+    capstone::Capstone::new().arm()
+}

--- a/libafl_qemu/src/asan.rs
+++ b/libafl_qemu/src/asan.rs
@@ -1,6 +1,6 @@
 use libafl::{inputs::Input, state::HasMetadata};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use std::{env, fs, pin::Pin, ptr};
+use std::{env, fs, ptr};
 
 use crate::{
     emu::{Emulator, SyscallHookResult},
@@ -413,7 +413,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -444,7 +444,7 @@ where
 }
 
 pub fn gen_readwrite_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     pc: u64,
     _size: usize,
@@ -462,7 +462,7 @@ where
 }
 
 pub fn trace_read1_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -476,7 +476,7 @@ pub fn trace_read1_asan<I, QT, S>(
 }
 
 pub fn trace_read2_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -490,7 +490,7 @@ pub fn trace_read2_asan<I, QT, S>(
 }
 
 pub fn trace_read4_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -504,7 +504,7 @@ pub fn trace_read4_asan<I, QT, S>(
 }
 
 pub fn trace_read8_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -518,7 +518,7 @@ pub fn trace_read8_asan<I, QT, S>(
 }
 
 pub fn trace_read_n_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -533,7 +533,7 @@ pub fn trace_read_n_asan<I, QT, S>(
 }
 
 pub fn trace_write1_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -547,7 +547,7 @@ pub fn trace_write1_asan<I, QT, S>(
 }
 
 pub fn trace_write2_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -561,7 +561,7 @@ pub fn trace_write2_asan<I, QT, S>(
 }
 
 pub fn trace_write4_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -575,7 +575,7 @@ pub fn trace_write4_asan<I, QT, S>(
 }
 
 pub fn trace_write8_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -589,7 +589,7 @@ pub fn trace_write8_asan<I, QT, S>(
 }
 
 pub fn trace_write_n_asan<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,

--- a/libafl_qemu/src/asan.rs
+++ b/libafl_qemu/src/asan.rs
@@ -413,7 +413,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {

--- a/libafl_qemu/src/asan.rs
+++ b/libafl_qemu/src/asan.rs
@@ -417,19 +417,23 @@ where
     where
         QT: QemuHelperTuple<I, S>,
     {
-        //hooks.read_generation(gen_readwrite_asan::<I, QT, S>);
-        hooks.read8_execution(trace_read8_asan::<I, QT, S>);
-        hooks.read4_execution(trace_read4_asan::<I, QT, S>);
-        hooks.read2_execution(trace_read2_asan::<I, QT, S>);
-        hooks.read1_execution(trace_read1_asan::<I, QT, S>);
-        hooks.read_n_execution(trace_read_n_asan::<I, QT, S>);
+        hooks.reads(
+            Some(gen_readwrite_asan::<I, QT, S>),
+            Some(trace_read1_asan::<I, QT, S>),
+            Some(trace_read2_asan::<I, QT, S>),
+            Some(trace_read4_asan::<I, QT, S>),
+            Some(trace_read8_asan::<I, QT, S>),
+            Some(trace_read_n_asan::<I, QT, S>),
+        );
 
-        //hooks.write_generation(gen_readwrite_asan::<I, QT, S>);
-        hooks.write8_execution(trace_write8_asan::<I, QT, S>);
-        hooks.write4_execution(trace_write4_asan::<I, QT, S>);
-        hooks.write2_execution(trace_write2_asan::<I, QT, S>);
-        hooks.write1_execution(trace_write1_asan::<I, QT, S>);
-        hooks.write_n_execution(trace_write_n_asan::<I, QT, S>);
+        hooks.writes(
+            Some(gen_readwrite_asan::<I, QT, S>),
+            Some(trace_write1_asan::<I, QT, S>),
+            Some(trace_write2_asan::<I, QT, S>),
+            Some(trace_write4_asan::<I, QT, S>),
+            Some(trace_write8_asan::<I, QT, S>),
+            Some(trace_write_n_asan::<I, QT, S>),
+        );
 
         hooks.syscalls(qasan_fake_syscall::<I, QT, S>);
     }
@@ -439,11 +443,8 @@ where
     }
 }
 
-/*
-// TODO add pc to generation hooks
 pub fn gen_readwrite_asan<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     pc: u64,
     _size: usize,
@@ -452,18 +453,16 @@ where
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
     if h.must_instrument(pc) {
         Some(pc)
     } else {
         None
     }
 }
-*/
 
 pub fn trace_read1_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -471,13 +470,13 @@ pub fn trace_read1_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.read_1(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.read_1(&emulator, addr);
 }
 
 pub fn trace_read2_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -485,13 +484,13 @@ pub fn trace_read2_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.read_2(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.read_2(&emulator, addr);
 }
 
 pub fn trace_read4_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -499,13 +498,13 @@ pub fn trace_read4_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.read_4(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.read_4(&emulator, addr);
 }
 
 pub fn trace_read8_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -513,13 +512,13 @@ pub fn trace_read8_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.read_8(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.read_8(&emulator, addr);
 }
 
 pub fn trace_read_n_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -528,13 +527,13 @@ pub fn trace_read_n_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.read_n(emulator, addr, size);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.read_n(&emulator, addr, size);
 }
 
 pub fn trace_write1_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -542,13 +541,13 @@ pub fn trace_write1_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.write_1(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.write_1(&emulator, addr);
 }
 
 pub fn trace_write2_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -556,13 +555,13 @@ pub fn trace_write2_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.write_2(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.write_2(&emulator, addr);
 }
 
 pub fn trace_write4_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -570,13 +569,13 @@ pub fn trace_write4_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.write_4(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.write_4(&emulator, addr);
 }
 
 pub fn trace_write8_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -584,13 +583,13 @@ pub fn trace_write8_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.write_8(emulator, addr);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.write_8(&emulator, addr);
 }
 
 pub fn trace_write_n_asan<I, QT, S>(
-    emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -599,8 +598,9 @@ pub fn trace_write_n_asan<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers.match_first_type_mut::<QemuAsanHelper>().unwrap();
-    h.read_n(emulator, addr, size);
+    let emulator = hooks.emulator().clone();
+    let h = hooks.match_helper_mut::<QemuAsanHelper>().unwrap();
+    h.read_n(&emulator, addr, size);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -36,7 +36,7 @@ impl QemuCallTracerHelper {
     }
 
     pub fn reset(&mut self) {
-        self.callstack.clear()
+        self.callstack.clear();
     }
 }
 

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -5,13 +5,14 @@ use crate::{
     capstone,
     helper::{QemuHelper, QemuHelperTuple, QemuInstrumentationFilter},
     hooks::QemuHooks,
-    GuestAddr,
+    GuestAddr, Regs,
 };
 
 #[derive(Debug)]
 pub struct QemuCallTracerHelper {
     filter: QemuInstrumentationFilter,
     cs: Capstone,
+    callstack: Vec<GuestAddr>,
 }
 
 impl QemuCallTracerHelper {
@@ -20,12 +21,21 @@ impl QemuCallTracerHelper {
         Self {
             filter,
             cs: capstone().detail(true).build().unwrap(),
+            callstack: vec![],
         }
     }
 
     #[must_use]
     pub fn must_instrument(&self, addr: u64) -> bool {
         self.filter.allowed(addr)
+    }
+
+    pub fn callstack(&self) -> &[GuestAddr] {
+        &self.callstack
+    }
+
+    pub fn reset(&self) {
+        self.callstack.clear()
     }
 }
 
@@ -45,28 +55,67 @@ where
     {
         hooks.blocks(Some(gen_blocks_calls::<I, QT, S>), None);
     }
+
+    fn pre_exec(&mut self, _emulator: &Emulator, _input: &I) {
+        self.reset();
+    }
 }
 
-pub fn on_call<I, QT, S>(hooks: &mut QemuHooks<'_, I, QT, S>, _state: Option<&mut S>, pc: GuestAddr)
+/*pub fn on_call<I, QT, S>(hooks: &mut QemuHooks<'_, I, QT, S>, _state: Option<&mut S>, pc: GuestAddr)
 where
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    //eprintln!("CALL @ 0x{:#x}", pc)
-}
+}*/
 
 pub fn on_ret<I, QT, S>(hooks: &mut QemuHooks<'_, I, QT, S>, _state: Option<&mut S>, pc: GuestAddr)
 where
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    //eprintln!("RET @ 0x{:#x}", pc)
+    #[cfg(cpu_target = "x86_64")]
+    let ret_addr = {
+        let emu = hooks.emulator();
+        let stack_ptr: GuestAddr = emu.read_reg(Regs::Rsp).unwrap();
+        let mut ret_addr = [0; 8];
+        unsafe { emu.read_mem(stack_ptr, &mut ret_addr) };
+        GuestAddr::from_le_bytes(ret_addr)
+    };
+
+    #[cfg(cpu_target = "i386")]
+    let ret_addr = {
+        let emu = hooks.emulator();
+        let stack_ptr: GuestAddr = emu.read_reg(Regs::Esp).unwrap();
+        let mut ret_addr = [0; 4];
+        unsafe { emu.read_mem(stack_ptr, &mut ret_addr) };
+        GuestAddr::from_le_bytes(ret_addr)
+    };
+
+    #[cfg(any(cpu_target = "arm", cpu_target = "aarch64"))]
+    let ret_addr = {
+        let emu = hooks.emulator();
+        let ret_addr: GuestAddr = emu.read_reg(Regs::Lr).unwrap();
+        ret_addr
+    };
+
+    // eprintln!("RET @ 0x{:#x}", ret_addr);
+
+    if let Some(h) = hooks
+        .helpers_mut()
+        .match_first_type_mut::<QemuCallTracerHelper>()
+    {
+        while let Some(addr) = h.callstack.pop() {
+            if addr == ret_addr {
+                break;
+            }
+        }
+    }
 }
 
 pub fn gen_blocks_calls<I, QT, S>(
     hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
-    pc: u64,
+    pc: GuestAddr,
 ) -> Option<u64>
 where
     I: Input,
@@ -90,7 +139,18 @@ where
             for detail in insn_detail.groups() {
                 match detail.0 as u32 {
                     capstone::InsnGroupType::CS_GRP_CALL => {
-                        hooks.instruction(insn.address() as GuestAddr, on_call, false);
+                        // hooks.instruction_closure(insn.address() as GuestAddr, on_call, false);
+                        let call_len = insn.bytes().len() as GuestAddr;
+                        let call_cb = move |_, _, pc| {
+                            // eprintln!("CALL @ 0x{:#x}", pc + call_len);
+                        };
+                        unsafe {
+                            hooks.instruction_closure(
+                                insn.address() as GuestAddr,
+                                Box::new(call_cb),
+                                false,
+                            );
+                        }
                     }
                     capstone::InsnGroupType::CS_GRP_RET => {
                         hooks.instruction(insn.address() as GuestAddr, on_ret, false);
@@ -98,7 +158,8 @@ where
                     }
                     capstone::InsnGroupType::CS_GRP_INVALID
                     | capstone::InsnGroupType::CS_GRP_JUMP
-                    | capstone::InsnGroupType::CS_GRP_IRET => {
+                    | capstone::InsnGroupType::CS_GRP_IRET
+                    | capstone::InsnGroupType::CS_GRP_PRIVILEGE => {
                         break 'disasm;
                     }
                     _ => {}

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -5,7 +5,7 @@ use crate::{
     capstone,
     helper::{QemuHelper, QemuHelperTuple, QemuInstrumentationFilter},
     hooks::QemuHooks,
-    GuestAddr, Regs,
+    Emulator, GuestAddr, Regs,
 };
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl QemuCallTracerHelper {
         &self.callstack
     }
 
-    pub fn reset(&self) {
+    pub fn reset(&mut self) {
         self.callstack.clear()
     }
 }
@@ -68,7 +68,7 @@ where
 {
 }*/
 
-pub fn on_ret<I, QT, S>(hooks: &mut QemuHooks<'_, I, QT, S>, _state: Option<&mut S>, pc: GuestAddr)
+pub fn on_ret<I, QT, S>(hooks: &mut QemuHooks<'_, I, QT, S>, _state: Option<&mut S>, _pc: GuestAddr)
 where
     I: Input,
     QT: QemuHelperTuple<I, S>,
@@ -141,7 +141,7 @@ where
                     capstone::InsnGroupType::CS_GRP_CALL => {
                         // hooks.instruction_closure(insn.address() as GuestAddr, on_call, false);
                         let call_len = insn.bytes().len() as GuestAddr;
-                        let call_cb = move |hooks, _, pc| {
+                        let call_cb = move |hooks: &mut QemuHooks<'_, I, QT, S>, _, pc| {
                             // eprintln!("CALL @ 0x{:#x}", pc + call_len);
                             if let Some(h) = hooks
                                 .helpers_mut()

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -30,6 +30,7 @@ impl QemuCallTracerHelper {
         self.filter.allowed(addr)
     }
 
+    #[must_use]
     pub fn callstack(&self) -> &[GuestAddr] {
         &self.callstack
     }
@@ -137,7 +138,7 @@ where
             let insn = insns.first().unwrap();
             let insn_detail: InsnDetail = h.cs.insn_detail(insn).unwrap();
             for detail in insn_detail.groups() {
-                match detail.0 as u32 {
+                match u32::from(detail.0) {
                     capstone::InsnGroupType::CS_GRP_CALL => {
                         // hooks.instruction_closure(insn.address() as GuestAddr, on_call, false);
                         let call_len = insn.bytes().len() as GuestAddr;

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -1,0 +1,109 @@
+use capstone::prelude::*;
+use libafl::{inputs::Input, state::HasMetadata};
+use std::pin::Pin;
+
+use crate::{
+    capstone,
+    emu::Emulator,
+    helper::{QemuHelper, QemuHelperTuple, QemuInstrumentationFilter},
+    hooks::QemuHooks,
+    GuestAddr,
+};
+
+#[derive(Debug)]
+pub struct QemuCallTracerHelper {
+    filter: QemuInstrumentationFilter,
+    cs: Capstone,
+}
+
+impl QemuCallTracerHelper {
+    #[must_use]
+    pub fn new(filter: QemuInstrumentationFilter) -> Self {
+        Self {
+            filter,
+            cs: capstone().detail(true).build().unwrap(),
+        }
+    }
+
+    #[must_use]
+    pub fn must_instrument(&self, addr: u64) -> bool {
+        self.filter.allowed(addr)
+    }
+}
+
+impl Default for QemuCallTracerHelper {
+    fn default() -> Self {
+        Self::new(QemuInstrumentationFilter::None)
+    }
+}
+
+impl<I, S> QemuHelper<I, S> for QemuCallTracerHelper
+where
+    I: Input,
+    S: HasMetadata,
+{
+    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    where
+        QT: QemuHelperTuple<I, S>,
+    {
+        hooks.block_generation(gen_blocks_calls::<I, QT, S>);
+    }
+}
+
+extern "C" fn on_call(pc: u64) {
+    eprintln!("CALL @ 0x{:#x}", pc)
+}
+
+extern "C" fn on_ret(pc: u64) {
+    eprintln!("RET @ 0x{:#x}", pc)
+}
+
+pub fn gen_blocks_calls<I, QT, S>(
+    emulator: &Emulator,
+    helpers: &mut QT,
+    _state: Option<&mut S>,
+    pc: u64,
+) -> Option<u64>
+where
+    I: Input,
+    QT: QemuHelperTuple<I, S>,
+{
+    if let Some(h) = helpers.match_first_type::<QemuCallTracerHelper>() {
+        if !h.must_instrument(pc) {
+            return None;
+        }
+
+        let mut code = unsafe { std::slice::from_raw_parts(emulator.g2h(pc), 512) };
+        let mut iaddr = pc;
+
+        'disasm: while let Ok(insns) = h.cs.disasm_count(code, iaddr, 1) {
+            if insns.is_empty() {
+                break;
+            }
+            let insn = insns.first().unwrap();
+            let insn_detail: InsnDetail = h.cs.insn_detail(insn).unwrap();
+            for detail in insn_detail.groups() {
+                match detail.0 as u32 {
+                    capstone::InsnGroupType::CS_GRP_CALL => {
+                        emulator.set_hook(insn.address() as GuestAddr, on_call, insn.address());
+                    }
+                    capstone::InsnGroupType::CS_GRP_RET => {
+                        emulator.set_hook(insn.address() as GuestAddr, on_ret, insn.address());
+                        break 'disasm;
+                    }
+                    capstone::InsnGroupType::CS_GRP_INVALID
+                    | capstone::InsnGroupType::CS_GRP_JUMP
+                    | capstone::InsnGroupType::CS_GRP_IRET => {
+                        break 'disasm;
+                    }
+                    _ => {}
+                }
+            }
+
+            iaddr += insn.bytes().len() as u64;
+            code = unsafe { std::slice::from_raw_parts(emulator.g2h(iaddr), 512) };
+        }
+    }
+
+    None
+}

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -141,8 +141,14 @@ where
                     capstone::InsnGroupType::CS_GRP_CALL => {
                         // hooks.instruction_closure(insn.address() as GuestAddr, on_call, false);
                         let call_len = insn.bytes().len() as GuestAddr;
-                        let call_cb = move |_, _, pc| {
+                        let call_cb = move |hooks, _, pc| {
                             // eprintln!("CALL @ 0x{:#x}", pc + call_len);
+                            if let Some(h) = hooks
+                                .helpers_mut()
+                                .match_first_type_mut::<QemuCallTracerHelper>()
+                            {
+                                h.callstack.push(pc + call_len);
+                            }
                         };
                         unsafe {
                             hooks.instruction_closure(

--- a/libafl_qemu/src/cmplog.rs
+++ b/libafl_qemu/src/cmplog.rs
@@ -57,7 +57,7 @@ where
     I: Input,
     S: HasMetadata,
 {
-    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -101,7 +101,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {

--- a/libafl_qemu/src/cmplog.rs
+++ b/libafl_qemu/src/cmplog.rs
@@ -1,4 +1,3 @@
-use core::pin::Pin;
 use hashbrown::HashMap;
 use libafl::{inputs::Input, state::HasMetadata};
 pub use libafl_targets::{
@@ -58,7 +57,7 @@ where
     I: Input,
     S: HasMetadata,
 {
-    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -102,7 +101,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -117,7 +116,7 @@ where
 }
 
 pub fn gen_unique_cmp_ids<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     state: Option<&mut S>,
     pc: u64,
     _size: usize,
@@ -149,7 +148,7 @@ where
 }
 
 pub fn gen_hashed_cmp_ids<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     pc: u64,
     _size: usize,

--- a/libafl_qemu/src/edges.rs
+++ b/libafl_qemu/src/edges.rs
@@ -70,7 +70,7 @@ where
     I: Input,
     S: HasMetadata,
 {
-    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -132,7 +132,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {

--- a/libafl_qemu/src/edges.rs
+++ b/libafl_qemu/src/edges.rs
@@ -4,7 +4,7 @@ pub use libafl_targets::{
     edges_max_num, EDGES_MAP, EDGES_MAP_PTR, EDGES_MAP_PTR_SIZE, EDGES_MAP_SIZE, MAX_EDGES_NUM,
 };
 use serde::{Deserialize, Serialize};
-use std::{cell::UnsafeCell, cmp::max, pin::Pin};
+use std::{cell::UnsafeCell, cmp::max};
 
 use crate::{
     emu::GuestAddr,
@@ -70,7 +70,7 @@ where
     I: Input,
     S: HasMetadata,
 {
-    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -132,7 +132,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -153,7 +153,7 @@ where
 thread_local!(static PREV_LOC : UnsafeCell<u64> = UnsafeCell::new(0));
 
 pub fn gen_unique_edge_ids<I, QT, S>(
-    hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     state: Option<&mut S>,
     src: GuestAddr,
     dest: GuestAddr,
@@ -211,7 +211,7 @@ pub extern "C" fn trace_edge_single(id: u64, _data: u64) {
 }
 
 pub fn gen_hashed_edge_ids<I, QT, S>(
-    hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     src: GuestAddr,
     dest: GuestAddr,
@@ -246,7 +246,7 @@ pub extern "C" fn trace_edge_single_ptr(id: u64, _data: u64) {
 }
 
 pub fn gen_addr_block_ids<I, QT, S>(
-    _hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    _hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     pc: GuestAddr,
 ) -> Option<u64>
@@ -258,7 +258,7 @@ where
 }
 
 pub fn gen_hashed_block_ids<I, QT, S>(
-    _hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    _hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     pc: GuestAddr,
 ) -> Option<u64>

--- a/libafl_qemu/src/edges.rs
+++ b/libafl_qemu/src/edges.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 use std::{cell::UnsafeCell, cmp::max, pin::Pin};
 
 use crate::{
-    emu::Emulator,
+    emu::GuestAddr,
     helper::{hash_me, QemuHelper, QemuHelperTuple, QemuInstrumentationFilter},
     hooks::QemuHooks,
 };
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct QemuEdgesMapMetadata {
-    pub map: HashMap<(u64, u64), u64>,
+    pub map: HashMap<(GuestAddr, GuestAddr), u64>,
     pub current_id: u64,
 }
 
@@ -74,11 +74,16 @@ where
     where
         QT: QemuHelperTuple<I, S>,
     {
-        hooks.edge_generation(gen_unique_edge_ids::<I, QT, S>);
         if self.use_hitcounts {
-            hooks.emulator().set_exec_edge_hook(trace_edge_hitcount);
+            hooks.edges_raw(
+                Some(gen_unique_edge_ids::<I, QT, S>),
+                Some(trace_edge_hitcount),
+            );
         } else {
-            hooks.emulator().set_exec_edge_hook(trace_edge_single);
+            hooks.edges_raw(
+                Some(gen_unique_edge_ids::<I, QT, S>),
+                Some(trace_edge_single),
+            );
         }
     }
 }
@@ -131,11 +136,16 @@ where
     where
         QT: QemuHelperTuple<I, S>,
     {
-        hooks.edge_generation(gen_hashed_edge_ids::<I, QT, S>);
         if self.use_hitcounts {
-            hooks.emulator().set_exec_edge_hook(trace_edge_hitcount_ptr);
+            hooks.edges_raw(
+                Some(gen_hashed_edge_ids::<I, QT, S>),
+                Some(trace_edge_hitcount_ptr),
+            );
         } else {
-            hooks.emulator().set_exec_edge_hook(trace_edge_single_ptr);
+            hooks.edges_raw(
+                Some(gen_hashed_edge_ids::<I, QT, S>),
+                Some(trace_edge_single_ptr),
+            );
         }
     }
 }
@@ -143,18 +153,17 @@ where
 thread_local!(static PREV_LOC : UnsafeCell<u64> = UnsafeCell::new(0));
 
 pub fn gen_unique_edge_ids<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     state: Option<&mut S>,
-    src: u64,
-    dest: u64,
+    src: GuestAddr,
+    dest: GuestAddr,
 ) -> Option<u64>
 where
     S: HasMetadata,
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    if let Some(h) = helpers.match_first_type::<QemuEdgeCoverageHelper>() {
+    if let Some(h) = hooks.helpers().match_first_type::<QemuEdgeCoverageHelper>() {
         if !h.must_instrument(src) && !h.must_instrument(dest) {
             return None;
         }
@@ -189,45 +198,47 @@ where
     }
 }
 
-pub extern "C" fn trace_edge_hitcount(id: u64) {
+pub extern "C" fn trace_edge_hitcount(id: u64, _data: u64) {
     unsafe {
         EDGES_MAP[id as usize] = EDGES_MAP[id as usize].wrapping_add(1);
     }
 }
 
-pub extern "C" fn trace_edge_single(id: u64) {
+pub extern "C" fn trace_edge_single(id: u64, _data: u64) {
     unsafe {
         EDGES_MAP[id as usize] = 1;
     }
 }
 
 pub fn gen_hashed_edge_ids<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
-    src: u64,
-    dest: u64,
+    src: GuestAddr,
+    dest: GuestAddr,
 ) -> Option<u64>
 where
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    if let Some(h) = helpers.match_first_type::<QemuEdgeCoverageChildHelper>() {
+    if let Some(h) = hooks
+        .helpers()
+        .match_first_type::<QemuEdgeCoverageChildHelper>()
+    {
         if !h.must_instrument(src) && !h.must_instrument(dest) {
             return None;
         }
     }
-    Some((hash_me(src) ^ hash_me(dest)) & (unsafe { EDGES_MAP_PTR_SIZE } as u64 - 1))
+    Some((hash_me(src as u64) ^ hash_me(dest as u64)) & (unsafe { EDGES_MAP_PTR_SIZE } as u64 - 1))
 }
 
-pub extern "C" fn trace_edge_hitcount_ptr(id: u64) {
+pub extern "C" fn trace_edge_hitcount_ptr(id: u64, _data: u64) {
     unsafe {
         let ptr = EDGES_MAP_PTR.add(id as usize);
         *ptr = (*ptr).wrapping_add(1);
     }
 }
 
-pub extern "C" fn trace_edge_single_ptr(id: u64) {
+pub extern "C" fn trace_edge_single_ptr(id: u64, _data: u64) {
     unsafe {
         let ptr = EDGES_MAP_PTR.add(id as usize);
         *ptr = 1;
@@ -235,24 +246,30 @@ pub extern "C" fn trace_edge_single_ptr(id: u64) {
 }
 
 pub fn gen_addr_block_ids<I, QT, S>(
-    _emulator: &Emulator,
-    _helpers: &mut QT,
+    _hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
-    pc: u64,
-) -> Option<u64> {
-    Some(pc)
+    pc: GuestAddr,
+) -> Option<u64>
+where
+    I: Input,
+    QT: QemuHelperTuple<I, S>,
+{
+    Some(pc as u64)
 }
 
 pub fn gen_hashed_block_ids<I, QT, S>(
-    _emulator: &Emulator,
-    _helpers: &mut QT,
+    _hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
-    pc: u64,
-) -> Option<u64> {
-    Some(hash_me(pc))
+    pc: GuestAddr,
+) -> Option<u64>
+where
+    I: Input,
+    QT: QemuHelperTuple<I, S>,
+{
+    Some(hash_me(pc as u64))
 }
 
-pub extern "C" fn trace_block_transition_hitcount(id: u64) {
+pub extern "C" fn trace_block_transition_hitcount(id: u64, _data: u64) {
     unsafe {
         PREV_LOC.with(|prev_loc| {
             let x = ((*prev_loc.get() ^ id) as usize) & (EDGES_MAP_PTR_SIZE - 1);
@@ -263,7 +280,7 @@ pub extern "C" fn trace_block_transition_hitcount(id: u64) {
     }
 }
 
-pub extern "C" fn trace_block_transition_single(id: u64) {
+pub extern "C" fn trace_block_transition_single(id: u64, _data: u64) {
     unsafe {
         PREV_LOC.with(|prev_loc| {
             let x = ((*prev_loc.get() ^ id) as usize) & (EDGES_MAP_PTR_SIZE - 1);

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -189,7 +189,7 @@ extern "C" {
     fn libafl_qemu_set_breakpoint(addr: u64) -> i32;
     fn libafl_qemu_remove_breakpoint(addr: u64) -> i32;
     fn libafl_flush_jit();
-    fn libafl_qemu_set_hook(addr: u64, callback: extern "C" fn(u64), val: u64) -> usize;
+    fn libafl_qemu_set_hook(addr: u64, callback: extern "C" fn(u64), data: u64) -> usize;
     fn libafl_qemu_remove_hook(addr: u64) -> i32;
     fn libafl_qemu_run() -> i32;
     fn libafl_load_addr() -> u64;
@@ -231,25 +231,54 @@ extern "C" {
         data: u64,
     );
 
-    static mut libafl_exec_read_hook1: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_read_hook2: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_read_hook4: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_read_hook8: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_read_hookN: unsafe extern "C" fn(u64, u64, u32);
-    static mut libafl_gen_read_hook: unsafe extern "C" fn(u32) -> u64;
+    // void libafl_add_read_hook(uint64_t (*gen)(target_ulong pc, size_t size, uint64_t data),
+    //                      void (*exec1)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec2)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec4)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec8)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec_n)(uint64_t id, target_ulong addr, size_t size, uint64_t data),
+    //                      uint64_t data);
+    fn libafl_add_read_hook(
+        gen: Option<extern "C" fn(GuestAddr, usize, u64) -> u64>,
+        exec1: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec2: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec4: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec8: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec_n: Option<extern "C" fn(u64, GuestAddr, usize, u64)>,
+        data: u64,
+    );
 
-    static mut libafl_exec_write_hook1: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_write_hook2: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_write_hook4: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_write_hook8: unsafe extern "C" fn(u64, u64);
-    static mut libafl_exec_write_hookN: unsafe extern "C" fn(u64, u64, u32);
-    static mut libafl_gen_write_hook: unsafe extern "C" fn(u32) -> u64;
+    // void libafl_add_write_hook(uint64_t (*gen)(target_ulong pc, size_t size, uint64_t data),
+    //                      void (*exec1)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec2)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec4)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec8)(uint64_t id, target_ulong addr, uint64_t data),
+    //                      void (*exec_n)(uint64_t id, target_ulong addr, size_t size, uint64_t data),
+    //                      uint64_t data);
+    fn libafl_add_write_hook(
+        gen: Option<extern "C" fn(GuestAddr, usize, u64) -> u64>,
+        exec1: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec2: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec4: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec8: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec_n: Option<extern "C" fn(u64, GuestAddr, usize, u64)>,
+        data: u64,
+    );
 
-    static mut libafl_exec_cmp_hook1: unsafe extern "C" fn(u64, u8, u8);
-    static mut libafl_exec_cmp_hook2: unsafe extern "C" fn(u64, u16, u16);
-    static mut libafl_exec_cmp_hook4: unsafe extern "C" fn(u64, u32, u32);
-    static mut libafl_exec_cmp_hook8: unsafe extern "C" fn(u64, u64, u64);
-    static mut libafl_gen_cmp_hook: unsafe extern "C" fn(u64, u32) -> u64;
+    // void libafl_add_cmp_hook(uint64_t (*gen)(target_ulong pc, size_t size, uint64_t data),
+    //                      void (*exec1)(uint64_t id, uint8_t v0, uint8_t v1, uint64_t data),
+    //                      void (*exec2)(uint64_t id, uint16_t v0, uint16_t v1, uint64_t data),
+    //                      void (*exec4)(uint64_t id, uint32_t v0, uint32_t v1, uint64_t data),
+    //                      void (*exec8)(uint64_t id, uint64_t v0, uint64_t v1, uint64_t data),
+    //                      uint64_t data);
+    fn libafl_add_cmp_hook(
+        gen: Option<extern "C" fn(GuestAddr, usize, u64) -> u64>,
+        exec1: Option<extern "C" fn(u64, u8, u8, u64)>,
+        exec2: Option<extern "C" fn(u64, u16, u16, u64)>,
+        exec4: Option<extern "C" fn(u64, u32, u32, u64)>,
+        exec8: Option<extern "C" fn(u64, u64, u64, u64)>,
+        data: u64,
+    );
 
     static mut libafl_on_thread_hook: unsafe extern "C" fn(u32);
 
@@ -344,7 +373,7 @@ extern "C" fn gdb_cmd(buf: *const u8, len: usize, data: *const ()) -> i32 {
 
 static mut EMULATOR_IS_INITIALIZED: bool = false;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Emulator {
     _private: (),
 }
@@ -461,9 +490,9 @@ impl Emulator {
         }
     }
 
-    pub fn set_hook(&self, addr: GuestAddr, callback: extern "C" fn(u64), val: u64) {
+    pub fn set_hook(&self, addr: GuestAddr, callback: extern "C" fn(u64), data: u64) {
         unsafe {
-            libafl_qemu_set_hook(addr.into(), callback, val);
+            libafl_qemu_set_hook(addr.into(), callback, data);
         }
     }
 
@@ -603,107 +632,42 @@ impl Emulator {
         unsafe { libafl_add_block_hook(gen, exec, data) }
     }
 
-    pub fn set_exec_read1_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_read_hook1 = hook;
-        }
+    pub fn add_read_hooks(
+        &self,
+        gen: Option<extern "C" fn(GuestAddr, usize, u64) -> u64>,
+        exec1: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec2: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec4: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec8: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec_n: Option<extern "C" fn(u64, GuestAddr, usize, u64)>,
+        data: u64,
+    ) {
+        unsafe { libafl_add_read_hook(gen, exec1, exec2, exec4, exec8, exec_n, data) }
     }
 
-    pub fn set_exec_read2_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_read_hook2 = hook;
-        }
+    pub fn add_write_hooks(
+        &self,
+        gen: Option<extern "C" fn(GuestAddr, usize, u64) -> u64>,
+        exec1: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec2: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec4: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec8: Option<extern "C" fn(u64, GuestAddr, u64)>,
+        exec_n: Option<extern "C" fn(u64, GuestAddr, usize, u64)>,
+        data: u64,
+    ) {
+        unsafe { libafl_add_write_hook(gen, exec1, exec2, exec4, exec8, exec_n, data) }
     }
 
-    pub fn set_exec_read4_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_read_hook4 = hook;
-        }
-    }
-
-    pub fn set_exec_read8_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_read_hook8 = hook;
-        }
-    }
-
-    pub fn set_exec_read_n_hook(&self, hook: extern "C" fn(id: u64, addr: u64, size: u32)) {
-        unsafe {
-            libafl_exec_read_hookN = hook;
-        }
-    }
-
-    pub fn set_gen_read_hook(&self, hook: extern "C" fn(size: u32) -> u64) {
-        unsafe {
-            libafl_gen_read_hook = hook;
-        }
-    }
-
-    pub fn set_exec_write1_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_write_hook1 = hook;
-        }
-    }
-
-    pub fn set_exec_write2_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_write_hook2 = hook;
-        }
-    }
-
-    pub fn set_exec_write4_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_write_hook4 = hook;
-        }
-    }
-
-    pub fn set_exec_write8_hook(&self, hook: extern "C" fn(id: u64, addr: u64)) {
-        unsafe {
-            libafl_exec_write_hook8 = hook;
-        }
-    }
-
-    pub fn set_exec_write_n_hook(&self, hook: extern "C" fn(id: u64, addr: u64, size: u32)) {
-        unsafe {
-            libafl_exec_write_hookN = hook;
-        }
-    }
-
-    // TODO add pc arg
-    pub fn set_gen_write_hook(&self, hook: extern "C" fn(size: u32) -> u64) {
-        unsafe {
-            libafl_gen_write_hook = hook;
-        }
-    }
-
-    pub fn set_exec_cmp1_hook(&self, hook: extern "C" fn(id: u64, v0: u8, v1: u8)) {
-        unsafe {
-            libafl_exec_cmp_hook1 = hook;
-        }
-    }
-
-    pub fn set_exec_cmp2_hook(&self, hook: extern "C" fn(id: u64, v0: u16, v1: u16)) {
-        unsafe {
-            libafl_exec_cmp_hook2 = hook;
-        }
-    }
-
-    pub fn set_exec_cmp4_hook(&self, hook: extern "C" fn(id: u64, v0: u32, v1: u32)) {
-        unsafe {
-            libafl_exec_cmp_hook4 = hook;
-        }
-    }
-
-    pub fn set_exec_cmp8_hook(&self, hook: extern "C" fn(id: u64, v0: u64, v1: u64)) {
-        unsafe {
-            libafl_exec_cmp_hook8 = hook;
-        }
-    }
-
-    pub fn set_gen_cmp_hook(&self, hook: extern "C" fn(pc: u64, size: u32) -> u64) {
-        unsafe {
-            libafl_gen_cmp_hook = hook;
-        }
+    pub fn add_cmp_hooks(
+        &self,
+        gen: Option<extern "C" fn(GuestAddr, usize, u64) -> u64>,
+        exec1: Option<extern "C" fn(u64, u8, u8, u64)>,
+        exec2: Option<extern "C" fn(u64, u16, u16, u64)>,
+        exec4: Option<extern "C" fn(u64, u32, u32, u64)>,
+        exec8: Option<extern "C" fn(u64, u64, u64, u64)>,
+        data: u64,
+    ) {
+        unsafe { libafl_add_cmp_hook(gen, exec1, exec2, exec4, exec8, data) }
     }
 
     pub fn set_on_thread_hook(&self, hook: extern "C" fn(tid: u32)) {

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -896,11 +896,11 @@ pub mod pybind {
             }
         }
 
-        fn remove_hook(&self, addr: GuestAddr) {
+        fn remove_hook(&self, addr: GuestAddr) -> usize {
             unsafe {
                 PY_GENERIC_HOOKS.retain(|(a, _)| *a != addr);
             }
-            self.emu.remove_hook(addr, true);
+            self.emu.remove_hook(addr, true)
         }
     }
 }

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -195,7 +195,7 @@ extern "C" {
         data: u64,
         invalidate_block: i32,
     ) -> usize;
-    fn libafl_qemu_remove_hook(num: usize, invalidate_block: i32) -> i32;
+    // fn libafl_qemu_remove_hook(num: usize, invalidate_block: i32) -> i32;
     fn libafl_qemu_remove_hooks_at(addr: GuestAddr, invalidate_block: i32) -> usize;
     fn libafl_qemu_run() -> i32;
     fn libafl_load_addr() -> u64;

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -503,11 +503,12 @@ impl Emulator {
         data: u64,
         invalidate_block: bool,
     ) -> usize {
-        unsafe { libafl_qemu_set_hook(addr.into(), callback, data, invalidate_block as i32) }
+        unsafe { libafl_qemu_set_hook(addr.into(), callback, data, i32::from(invalidate_block)) }
     }
 
+    #[must_use]
     pub fn remove_hook(&self, addr: GuestAddr, invalidate_block: bool) -> usize {
-        unsafe { libafl_qemu_remove_hooks_at(addr.into(), invalidate_block as i32) }
+        unsafe { libafl_qemu_remove_hooks_at(addr.into(), i32::from(invalidate_block)) }
     }
 
     /// This function will run the emulator until the next breakpoint, or until finish.

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -763,7 +763,7 @@ pub mod pybind {
         )
     }
 
-    extern "C" fn py_generic_hook_wrapper(idx: u64) {
+    extern "C" fn py_generic_hook_wrapper(pc: GuestAddr, idx: u64) {
         let obj = unsafe { &PY_GENERIC_HOOKS[idx as usize].1 };
         Python::with_gil(|py| {
             obj.call0(py).expect("Error in the hook");
@@ -890,7 +890,8 @@ pub mod pybind {
             unsafe {
                 let idx = PY_GENERIC_HOOKS.len();
                 PY_GENERIC_HOOKS.push((addr, hook));
-                self.emu.set_hook(addr, py_generic_hook_wrapper, idx as u64);
+                self.emu
+                    .set_hook(addr, py_generic_hook_wrapper, idx as u64, true);
             }
         }
 
@@ -898,7 +899,7 @@ pub mod pybind {
             unsafe {
                 PY_GENERIC_HOOKS.retain(|(a, _)| *a != addr);
             }
-            self.emu.remove_hook(addr);
+            self.emu.remove_hook(addr, true);
         }
     }
 }

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -763,7 +763,7 @@ pub mod pybind {
         )
     }
 
-    extern "C" fn py_generic_hook_wrapper(pc: GuestAddr, idx: u64) {
+    extern "C" fn py_generic_hook_wrapper(_pc: GuestAddr, idx: u64) {
         let obj = unsafe { &PY_GENERIC_HOOKS[idx as usize].1 };
         Python::with_gil(|py| {
             obj.call0(py).expect("Error in the hook");

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -1,8 +1,5 @@
 //! A `QEMU`-based executor for binary-only instrumentation in `LibAFL`
-use core::{
-    fmt::{self, Debug, Formatter},
-    pin::Pin,
-};
+use core::fmt::{self, Debug, Formatter};
 
 use libafl::{
     bolts::shmem::ShMemProvider,
@@ -26,7 +23,7 @@ where
     OT: ObserversTuple<I, S>,
     QT: QemuHelperTuple<I, S>,
 {
-    hooks: Pin<Box<QemuHooks<'a, I, QT, S>>>,
+    hooks: Box<QemuHooks<'a, I, QT, S>>,
     inner: InProcessExecutor<'a, H, I, OT, S>,
 }
 
@@ -53,7 +50,7 @@ where
     QT: QemuHelperTuple<I, S>,
 {
     pub fn new<EM, OF, Z>(
-        hooks: Pin<Box<QemuHooks<'a, I, QT, S>>>,
+        hooks: Box<QemuHooks<'a, I, QT, S>>,
         harness_fn: &'a mut H,
         observers: OT,
         fuzzer: &mut Z,
@@ -80,11 +77,11 @@ where
         &mut self.inner
     }
 
-    pub fn hooks(&self) -> &Pin<Box<QemuHooks<'a, I, QT, S>>> {
+    pub fn hooks(&self) -> &QemuHooks<'a, I, QT, S> {
         &self.hooks
     }
 
-    pub fn hooks_mut(&mut self) -> &mut Pin<Box<QemuHooks<'a, I, QT, S>>> {
+    pub fn hooks_mut(&mut self) -> &mut QemuHooks<'a, I, QT, S> {
         &mut self.hooks
     }
 
@@ -108,21 +105,9 @@ where
         input: &I,
     ) -> Result<ExitKind, Error> {
         let emu = Emulator::new_empty();
-        unsafe {
-            self.hooks
-                .as_mut()
-                .get_unchecked_mut()
-                .helpers_mut()
-                .pre_exec_all(&emu, input);
-        }
+        self.hooks.helpers_mut().pre_exec_all(&emu, input);
         let r = self.inner.run_target(fuzzer, state, mgr, input);
-        unsafe {
-            self.hooks
-                .as_mut()
-                .get_unchecked_mut()
-                .helpers_mut()
-                .post_exec_all(&emu, input);
-        }
+        self.hooks.helpers_mut().post_exec_all(&emu, input);
         r
     }
 }
@@ -153,7 +138,7 @@ where
     QT: QemuHelperTuple<I, S>,
     SP: ShMemProvider,
 {
-    hooks: Pin<Box<QemuHooks<'a, I, QT, S>>>,
+    hooks: Box<QemuHooks<'a, I, QT, S>>,
     inner: InProcessForkExecutor<'a, H, I, OT, S, SP>,
 }
 
@@ -182,7 +167,7 @@ where
     SP: ShMemProvider,
 {
     pub fn new<EM, OF, Z>(
-        hooks: Pin<Box<QemuHooks<'a, I, QT, S>>>,
+        hooks: Box<QemuHooks<'a, I, QT, S>>,
         harness_fn: &'a mut H,
         observers: OT,
         fuzzer: &mut Z,
@@ -219,11 +204,11 @@ where
         &mut self.inner
     }
 
-    pub fn hooks(&self) -> &Pin<Box<QemuHooks<'a, I, QT, S>>> {
+    pub fn hooks(&self) -> &QemuHooks<'a, I, QT, S> {
         &self.hooks
     }
 
-    pub fn hooks_mut(&mut self) -> &mut Pin<Box<QemuHooks<'a, I, QT, S>>> {
+    pub fn hooks_mut(&mut self) -> &mut QemuHooks<'a, I, QT, S> {
         &mut self.hooks
     }
 
@@ -249,21 +234,9 @@ where
         input: &I,
     ) -> Result<ExitKind, Error> {
         let emu = Emulator::new_empty();
-        unsafe {
-            self.hooks
-                .as_mut()
-                .get_unchecked_mut()
-                .helpers_mut()
-                .pre_exec_all(&emu, input);
-        }
+        self.hooks.helpers_mut().pre_exec_all(&emu, input);
         let r = self.inner.run_target(fuzzer, state, mgr, input);
-        unsafe {
-            self.hooks
-                .as_mut()
-                .get_unchecked_mut()
-                .helpers_mut()
-                .post_exec_all(&emu, input);
-        }
+        self.hooks.helpers_mut().post_exec_all(&emu, input);
         r
     }
 }

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -23,7 +23,7 @@ where
     OT: ObserversTuple<I, S>,
     QT: QemuHelperTuple<I, S>,
 {
-    hooks: Box<QemuHooks<'a, I, QT, S>>,
+    hooks: &'a mut QemuHooks<'a, I, QT, S>,
     inner: InProcessExecutor<'a, H, I, OT, S>,
 }
 
@@ -50,7 +50,7 @@ where
     QT: QemuHelperTuple<I, S>,
 {
     pub fn new<EM, OF, Z>(
-        hooks: Box<QemuHooks<'a, I, QT, S>>,
+        hooks: &'a mut QemuHooks<'a, I, QT, S>,
         harness_fn: &'a mut H,
         observers: OT,
         fuzzer: &mut Z,
@@ -78,11 +78,11 @@ where
     }
 
     pub fn hooks(&self) -> &QemuHooks<'a, I, QT, S> {
-        &self.hooks
+        self.hooks
     }
 
     pub fn hooks_mut(&mut self) -> &mut QemuHooks<'a, I, QT, S> {
-        &mut self.hooks
+        self.hooks
     }
 
     pub fn emulator(&self) -> &Emulator {
@@ -138,7 +138,7 @@ where
     QT: QemuHelperTuple<I, S>,
     SP: ShMemProvider,
 {
-    hooks: Box<QemuHooks<'a, I, QT, S>>,
+    hooks: &'a mut QemuHooks<'a, I, QT, S>,
     inner: InProcessForkExecutor<'a, H, I, OT, S, SP>,
 }
 
@@ -167,7 +167,7 @@ where
     SP: ShMemProvider,
 {
     pub fn new<EM, OF, Z>(
-        hooks: Box<QemuHooks<'a, I, QT, S>>,
+        hooks: &'a mut QemuHooks<'a, I, QT, S>,
         harness_fn: &'a mut H,
         observers: OT,
         fuzzer: &mut Z,
@@ -205,11 +205,11 @@ where
     }
 
     pub fn hooks(&self) -> &QemuHooks<'a, I, QT, S> {
-        &self.hooks
+        self.hooks
     }
 
     pub fn hooks_mut(&mut self) -> &mut QemuHooks<'a, I, QT, S> {
-        &mut self.hooks
+        self.hooks
     }
 
     pub fn emulator(&self) -> &Emulator {

--- a/libafl_qemu/src/helper.rs
+++ b/libafl_qemu/src/helper.rs
@@ -11,7 +11,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = true;
 
-    fn init_hooks<'a, QT>(&self, _hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, _hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -28,7 +28,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool;
 
-    fn init_hooks_all<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks_all<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>;
 
@@ -43,7 +43,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks_all<'a, QT>(&self, _hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks_all<QT>(&self, _hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -62,7 +62,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = Head::HOOKS_DO_SIDE_EFFECTS || Tail::HOOKS_DO_SIDE_EFFECTS;
 
-    fn init_hooks_all<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks_all<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {

--- a/libafl_qemu/src/helper.rs
+++ b/libafl_qemu/src/helper.rs
@@ -1,4 +1,4 @@
-use core::{fmt::Debug, ops::Range, pin::Pin};
+use core::{fmt::Debug, ops::Range};
 use libafl::{bolts::tuples::MatchFirstType, inputs::Input};
 
 use crate::{emu::Emulator, hooks::QemuHooks};
@@ -11,7 +11,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = true;
 
-    fn init_hooks<'a, QT>(&self, _hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, _hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -28,7 +28,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool;
 
-    fn init_hooks_all<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks_all<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>;
 
@@ -43,7 +43,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_hooks_all<'a, QT>(&self, _hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks_all<'a, QT>(&self, _hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -62,7 +62,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = Head::HOOKS_DO_SIDE_EFFECTS || Tail::HOOKS_DO_SIDE_EFFECTS;
 
-    fn init_hooks_all<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks_all<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {

--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -758,7 +758,7 @@ where
     pub unsafe fn instruction_closure(
         &self,
         addr: GuestAddr,
-        hook: Box<dyn FnMut(&mut Self, Option<&mut S>, GuestAddr)>,
+        hook: Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr)>,
         invalidate_block: bool,
     ) {
         let index = GENERIC_HOOKS.len();
@@ -807,9 +807,9 @@ where
     pub unsafe fn edges_closures(
         &self,
         generation_hook: Option<
-            Box<dyn FnMut(&mut Self, Option<&mut S>, GuestAddr, GuestAddr) -> Option<u64>>,
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr, GuestAddr) -> Option<u64>>,
         >,
-        execution_hook: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64)>>,
+        execution_hook: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64)>>,
     ) {
         let index = EDGE_HOOKS.len();
         self.emulator.add_edge_hooks(
@@ -896,9 +896,9 @@ where
     pub unsafe fn blocks_closures(
         &self,
         generation_hook: Option<
-            Box<dyn FnMut(&mut Self, Option<&mut S>, GuestAddr) -> Option<u64>>,
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr) -> Option<u64>>,
         >,
-        execution_hook: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64)>>,
+        execution_hook: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64)>>,
     ) {
         let index = BLOCK_HOOKS.len();
         self.emulator.add_block_hooks(
@@ -1023,13 +1023,15 @@ where
     pub unsafe fn reads_closures(
         &self,
         generation_hook: Option<
-            Box<dyn FnMut(&mut Self, Option<&mut S>, GuestAddr, usize) -> Option<u64>>,
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr, usize) -> Option<u64>>,
         >,
-        execution_hook1: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook2: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook4: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook8: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook_n: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr, usize)>>,
+        execution_hook1: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook2: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook4: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook8: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook_n: Option<
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr, usize)>,
+        >,
     ) {
         let index = READ_HOOKS.len();
         self.emulator.add_read_hooks(
@@ -1200,13 +1202,15 @@ where
     pub unsafe fn writes_closures(
         &self,
         generation_hook: Option<
-            Box<dyn FnMut(&mut Self, Option<&mut S>, GuestAddr, usize) -> Option<u64>>,
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr, usize) -> Option<u64>>,
         >,
-        execution_hook1: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook2: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook4: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook8: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr)>>,
-        execution_hook_n: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, GuestAddr, usize)>>,
+        execution_hook1: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook2: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook4: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook8: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>>,
+        execution_hook_n: Option<
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr, usize)>,
+        >,
     ) {
         let index = WRITE_HOOKS.len();
         self.emulator.add_write_hooks(
@@ -1366,12 +1370,12 @@ where
     pub unsafe fn cmps_closures(
         &self,
         generation_hook: Option<
-            Box<dyn FnMut(&mut Self, Option<&mut S>, GuestAddr, usize) -> Option<u64>>,
+            Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr, usize) -> Option<u64>>,
         >,
-        execution_hook1: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, u8, u8)>>,
-        execution_hook2: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, u16, u16)>>,
-        execution_hook4: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, u32, u32)>>,
-        execution_hook8: Option<Box<dyn FnMut(&mut Self, Option<&mut S>, u64, u64, u64)>>,
+        execution_hook1: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, u8, u8)>>,
+        execution_hook2: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, u16, u16)>>,
+        execution_hook4: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, u32, u32)>>,
+        execution_hook8: Option<Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u64, u64, u64)>>,
     ) {
         let index = CMP_HOOKS.len();
         self.emulator.add_cmp_hooks(
@@ -1467,7 +1471,7 @@ where
 
     pub fn thread_creation_closure(
         &self,
-        hook: Box<dyn FnMut(&mut Self, Option<&mut S>, u32) + 'a>,
+        hook: Box<dyn FnMut(&'a mut Self, Option<&'a mut S>, u32) + 'a>,
     ) {
         unsafe {
             ON_THREAD_HOOKS.push(Hook::Closure(transmute(hook)));

--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -794,12 +794,12 @@ where
                 index as u64,
             );
             EDGE_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
             ));
         }
     }
@@ -826,12 +826,8 @@ where
             index as u64,
         );
         EDGE_HOOKS.push((
-            generation_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
+            generation_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
         ));
     }
 
@@ -854,9 +850,9 @@ where
                 index as u64,
             );
             EDGE_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
                 Hook::Empty,
             ));
         }
@@ -883,12 +879,12 @@ where
                 index as u64,
             );
             BLOCK_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
             ));
         }
     }
@@ -915,12 +911,8 @@ where
             index as u64,
         );
         BLOCK_HOOKS.push((
-            generation_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
+            generation_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
         ));
     }
 
@@ -941,9 +933,9 @@ where
                 index as u64,
             );
             BLOCK_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
                 Hook::Empty,
             ));
         }
@@ -998,24 +990,24 @@ where
                 index as u64,
             );
             READ_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook1
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook2
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook4
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook8
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook_n
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook1.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook2.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook4.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook8.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook_n.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
             ));
         }
     }
@@ -1068,24 +1060,12 @@ where
             index as u64,
         );
         READ_HOOKS.push((
-            generation_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook1
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook2
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook4
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook8
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook_n
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
+            generation_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook1.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook2.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook4.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook8.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook_n.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
         ));
     }
 
@@ -1116,9 +1096,9 @@ where
                 index as u64,
             );
             READ_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
                 Hook::Empty,
                 Hook::Empty,
                 Hook::Empty,
@@ -1177,24 +1157,24 @@ where
                 index as u64,
             );
             WRITE_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook1
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook2
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook4
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook8
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook_n
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook1.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook2.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook4.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook8.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook_n.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
             ));
         }
     }
@@ -1247,24 +1227,12 @@ where
             index as u64,
         );
         WRITE_HOOKS.push((
-            generation_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook1
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook2
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook4
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook8
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook_n
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
+            generation_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook1.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook2.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook4.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook8.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook_n.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
         ));
     }
 
@@ -1295,9 +1263,9 @@ where
                 index as u64,
             );
             WRITE_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
                 Hook::Empty,
                 Hook::Empty,
                 Hook::Empty,
@@ -1348,21 +1316,21 @@ where
                 index as u64,
             );
             CMP_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook1
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook2
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook4
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
-                execution_hook8
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook1.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook2.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook4.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
+                execution_hook8.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
             ));
         }
     }
@@ -1407,21 +1375,11 @@ where
             index as u64,
         );
         CMP_HOOKS.push((
-            generation_hook
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook1
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook2
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook4
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
-            execution_hook8
-                .map(|hook| Hook::Closure(transmute(hook)))
-                .unwrap_or(Hook::Empty),
+            generation_hook.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook1.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook2.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook4.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
+            execution_hook8.map_or(Hook::Empty, |hook| Hook::Closure(transmute(hook))),
         ));
     }
 
@@ -1450,9 +1408,9 @@ where
                 index as u64,
             );
             CMP_HOOKS.push((
-                generation_hook
-                    .map(|hook| Hook::Function(hook as *const libc::c_void))
-                    .unwrap_or(Hook::Empty),
+                generation_hook.map_or(Hook::Empty, |hook| {
+                    Hook::Function(hook as *const libc::c_void)
+                }),
                 Hook::Empty,
                 Hook::Empty,
                 Hook::Empty,

--- a/libafl_qemu/src/i386.rs
+++ b/libafl_qemu/src/i386.rs
@@ -4,6 +4,8 @@ pub use strum_macros::EnumIter;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+use capstone::arch::BuildsCapstone;
+
 pub use syscall_numbers::x86::*;
 
 #[derive(IntoPrimitive, TryFromPrimitive, Debug, Clone, Copy, EnumIter)]
@@ -34,4 +36,11 @@ impl IntoPy<PyObject> for Regs {
         let n: i32 = self.into();
         n.into_py(py)
     }
+}
+
+/// Return an X86 ArchCapstoneBuilder
+pub fn capstone() -> capstone::arch::x86::ArchCapstoneBuilder {
+    capstone::Capstone::new()
+        .x86()
+        .mode(capstone::arch::x86::ArchMode::Mode32)
 }

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -50,6 +50,8 @@ pub use snapshot::QemuSnapshotHelper;
 pub mod asan;
 pub use asan::{init_with_asan, QemuAsanHelper};
 
+// pub mod calls;
+
 pub mod executor;
 pub use executor::{QemuExecutor, QemuForkExecutor};
 

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -7,8 +7,12 @@
     allow(clippy::useless_conversion)
 )]
 #![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::transmute_ptr_to_ptr)]
+#![allow(clippy::too_many_arguments)]
 // Till they fix this buggy lint in clippy
 #![allow(clippy::borrow_as_ptr)]
+// Allow only ATM, it will be evetually removed
+#![allow(clippy::missing_safety_doc)]
 
 use std::env;
 

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![allow(clippy::needless_pass_by_value)]
 // Till they fix this buggy lint in clippy
-#![allow(clippy::borrow_deref_ref)]
+#![allow(clippy::borrow_as_ptr)]
 
 use std::env;
 

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -50,7 +50,7 @@ pub use snapshot::QemuSnapshotHelper;
 pub mod asan;
 pub use asan::{init_with_asan, QemuAsanHelper};
 
-// pub mod calls;
+pub mod calls;
 
 pub mod executor;
 pub use executor::{QemuExecutor, QemuForkExecutor};

--- a/libafl_qemu/src/snapshot.rs
+++ b/libafl_qemu/src/snapshot.rs
@@ -3,7 +3,6 @@ use libafl::{inputs::Input, state::HasMetadata};
 use std::{
     cell::UnsafeCell,
     collections::{HashMap, HashSet},
-    pin::Pin,
     sync::Mutex,
 };
 use thread_local::ThreadLocal;
@@ -197,7 +196,7 @@ where
     I: Input,
     S: HasMetadata,
 {
-    fn init_hooks<'a, QT>(&self, hooks: Pin<&QemuHooks<'a, I, QT, S>>)
+    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {
@@ -223,7 +222,7 @@ where
 }
 
 pub fn trace_write1_snapshot<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -236,7 +235,7 @@ pub fn trace_write1_snapshot<I, QT, S>(
 }
 
 pub fn trace_write2_snapshot<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -249,7 +248,7 @@ pub fn trace_write2_snapshot<I, QT, S>(
 }
 
 pub fn trace_write4_snapshot<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -262,7 +261,7 @@ pub fn trace_write4_snapshot<I, QT, S>(
 }
 
 pub fn trace_write8_snapshot<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -275,7 +274,7 @@ pub fn trace_write8_snapshot<I, QT, S>(
 }
 
 pub fn trace_write_n_snapshot<I, QT, S>(
-    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
+    hooks: &mut QemuHooks<'_, I, QT, S>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,

--- a/libafl_qemu/src/snapshot.rs
+++ b/libafl_qemu/src/snapshot.rs
@@ -201,11 +201,14 @@ where
     where
         QT: QemuHelperTuple<I, S>,
     {
-        hooks.write8_execution(trace_write8_snapshot::<I, QT, S>);
-        hooks.write4_execution(trace_write4_snapshot::<I, QT, S>);
-        hooks.write2_execution(trace_write2_snapshot::<I, QT, S>);
-        hooks.write1_execution(trace_write1_snapshot::<I, QT, S>);
-        hooks.write_n_execution(trace_write_n_snapshot::<I, QT, S>);
+        hooks.writes(
+            None,
+            Some(trace_write1_snapshot::<I, QT, S>),
+            Some(trace_write2_snapshot::<I, QT, S>),
+            Some(trace_write4_snapshot::<I, QT, S>),
+            Some(trace_write8_snapshot::<I, QT, S>),
+            Some(trace_write_n_snapshot::<I, QT, S>),
+        );
 
         hooks.after_syscalls(trace_mmap_snapshot::<I, QT, S>);
     }
@@ -220,8 +223,7 @@ where
 }
 
 pub fn trace_write1_snapshot<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -229,15 +231,12 @@ pub fn trace_write1_snapshot<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers
-        .match_first_type_mut::<QemuSnapshotHelper>()
-        .unwrap();
+    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
     h.access(addr, 1);
 }
 
 pub fn trace_write2_snapshot<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -245,15 +244,12 @@ pub fn trace_write2_snapshot<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers
-        .match_first_type_mut::<QemuSnapshotHelper>()
-        .unwrap();
+    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
     h.access(addr, 2);
 }
 
 pub fn trace_write4_snapshot<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -261,15 +257,12 @@ pub fn trace_write4_snapshot<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers
-        .match_first_type_mut::<QemuSnapshotHelper>()
-        .unwrap();
+    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
     h.access(addr, 4);
 }
 
 pub fn trace_write8_snapshot<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -277,15 +270,12 @@ pub fn trace_write8_snapshot<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers
-        .match_first_type_mut::<QemuSnapshotHelper>()
-        .unwrap();
+    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
     h.access(addr, 8);
 }
 
 pub fn trace_write_n_snapshot<I, QT, S>(
-    _emulator: &Emulator,
-    helpers: &mut QT,
+    mut hooks: Pin<&mut QemuHooks<'_, I, QT, S>>,
     _state: Option<&mut S>,
     _id: u64,
     addr: GuestAddr,
@@ -294,9 +284,7 @@ pub fn trace_write_n_snapshot<I, QT, S>(
     I: Input,
     QT: QemuHelperTuple<I, S>,
 {
-    let h = helpers
-        .match_first_type_mut::<QemuSnapshotHelper>()
-        .unwrap();
+    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
     h.access(addr, size);
 }
 

--- a/libafl_qemu/src/snapshot.rs
+++ b/libafl_qemu/src/snapshot.rs
@@ -196,7 +196,7 @@ where
     I: Input,
     S: HasMetadata,
 {
-    fn init_hooks<'a, QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
+    fn init_hooks<QT>(&self, hooks: &QemuHooks<'_, I, QT, S>)
     where
         QT: QemuHelperTuple<I, S>,
     {

--- a/libafl_qemu/src/x86_64.rs
+++ b/libafl_qemu/src/x86_64.rs
@@ -46,7 +46,8 @@ impl IntoPy<PyObject> for Regs {
     }
 }
 
-/// Return an X86 ArchCapstoneBuilder
+/// Return an X86 `ArchCapstoneBuilder`
+#[must_use]
 pub fn capstone() -> capstone::arch::x86::ArchCapstoneBuilder {
     capstone::Capstone::new()
         .x86()

--- a/libafl_qemu/src/x86_64.rs
+++ b/libafl_qemu/src/x86_64.rs
@@ -4,6 +4,8 @@ pub use strum_macros::EnumIter;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+use capstone::arch::BuildsCapstone;
+
 pub use syscall_numbers::x86_64::*;
 
 #[derive(IntoPrimitive, TryFromPrimitive, Debug, Clone, Copy, EnumIter)]
@@ -42,4 +44,11 @@ impl IntoPy<PyObject> for Regs {
         let n: i32 = self.into();
         n.into_py(py)
     }
+}
+
+/// Return an X86 ArchCapstoneBuilder
+pub fn capstone() -> capstone::arch::x86::ArchCapstoneBuilder {
+    capstone::Capstone::new()
+        .x86()
+        .mode(capstone::arch::x86::ArchMode::Mode64)
 }

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -207,7 +207,7 @@ where
             };
 
             if self.use_cmplog.unwrap_or(false) {
-                let hooks = QemuHooks::new(
+                let mut hooks = QemuHooks::new(
                     emulator,
                     tuple_list!(
                         QemuEdgeCoverageHelper::default(),
@@ -316,7 +316,7 @@ where
                     }
                 }
             } else {
-                let hooks =
+                let mut hooks =
                     QemuHooks::new(emulator, tuple_list!(QemuEdgeCoverageHelper::default()));
 
                 let executor = QemuExecutor::new(

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -216,7 +216,7 @@ where
                 );
 
                 let executor = QemuExecutor::new(
-                    hooks,
+                    &mut hooks,
                     &mut harness,
                     tuple_list!(edges_observer, time_observer),
                     &mut fuzzer,
@@ -320,7 +320,7 @@ where
                     QemuHooks::new(emulator, tuple_list!(QemuEdgeCoverageHelper::default()));
 
                 let executor = QemuExecutor::new(
-                    hooks,
+                    &mut hooks,
                     &mut harness,
                     tuple_list!(edges_observer, time_observer),
                     &mut fuzzer,


### PR DESCRIPTION
The new hook system will allow multiple generation hooks (translation time). This will open the window to generation hooks that analyze the code and insert generic hooks to single instruction, for instance for call stack tracking.