### PR TITLE
Make ByteNegMutator negate, not flip

### DIFF
--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -271,7 +271,7 @@ where
             Ok(MutationResult::Skipped)
         } else {
             let byte = state.rand_mut().choose(input.bytes_mut());
-            *byte = !*byte;
+            *byte = (-(*byte as i16)) as u8;
             Ok(MutationResult::Mutated)
         }
     }


### PR DESCRIPTION
Change the ByteNegMutator to negate a byte, not flip it. Flipping a byte is already implemented in ByteFlipMutator.

See issue: https://github.com/AFLplusplus/LibAFL/issues/674