### PR TITLE
Fix QAsan

### DIFF
--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -254,23 +254,27 @@ pub fn build() {
     } */
 
     drop(
-        Command::new("make")
+        assert!(Command::new("make")
             .current_dir(&out_dir_path)
             .env("CC", &cross_cc)
             .env("OUT_DIR", &target_dir)
             .arg("-C")
             .arg(&qasan_dir)
             .arg("clean")
-            .status(),
+            .status()
+            .expect("make failed")
+            .success())
     );
     drop(
-        Command::new("make")
+        assert!(Command::new("make")
             .current_dir(&out_dir_path)
             .env("CC", &cross_cc)
             .env("OUT_DIR", &target_dir)
             .arg("-C")
             .arg(&qasan_dir)
-            .status(),
+            .status()
+            .expect("make failed")
+            .success())
     );
 
     cc::Build::new()

--- a/libafl_qemu/libqasan/libqasan.c
+++ b/libafl_qemu/libqasan/libqasan.c
@@ -43,17 +43,16 @@ void __libqasan_print_maps(void) {
   int   i;
   char *line = NULL;
   for (i = 0; i < len; i++) {
-    if (!line) line = { &buf[i];
+    if (!line) line = &buf[i];
+    if (buf[i] == '\n') {
+      buf[i] = 0;
+      QASAN_LOG("%s\n", line);
+      line = NULL;
+    }
   }
-  if (buf[i] == '\n') {
-    buf[i] = 0;
-    QASAN_LOG("%s\n", line);
-    line = NULL;
-  }
-}
 
-if (line) { QASAN_LOG("%s\n", line); }
-QASAN_LOG("\n");
+  if (line) { QASAN_LOG("%s\n", line); }
+  QASAN_LOG("\n");
 }
 
 int __libqasan_is_initialized = 0;


### PR DESCRIPTION
on main: building qasan fails with brackets at wrong locations
```
toka@DESKTOP-6E54AC0:~/LibAFL$ cat fuzzers/fuzzbench_qemu/target/release/build/libafl_qemu-055bd61c23b5850f/stderr
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: fuzzers/fuzzbench_qemu/target/release/build/libafl_qemu-055bd61c23b5850f/stderr
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ ld: missing --end-group; added as last command line option
   2   │ ar: `u' modifier ignored since `D' is the default (see `U')
   3   │ libqasan.c:46:23: error: expected expression
   4   │     if (!line) line = { &buf[i];
   5   │                       ^
   6   │ 1 error generated.
   7   │ make: *** [Makefile:27: libqasan.so] Error 1
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
toka@DESKTOP-6E54AC0:~/LibAFL$
```
probably a mistake in #653 
this pr fixes it
