### PR TITLE
Remove unused trait bounds from BytesSwapMutator

### DIFF
--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -855,7 +855,7 @@ pub struct BytesSwapMutator;
 impl<I, S> Mutator<I, S> for BytesSwapMutator
 where
     I: Input + HasBytesVec,
-    S: HasRand + HasCorpus<I> + HasMaxSize,
+    S: HasRand,
 {
     fn mutate(
         &mut self,


### PR DESCRIPTION
Only a small change but it still broke my application so it would be nice to have it upstream