### PR TITLE
TUI monitor breaks the terminal if main thread panics

### DIFF
--- a/fuzzers/baby_fuzzer/Cargo.toml
+++ b/fuzzers/baby_fuzzer/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
+tui = []
 std = []
 
 [profile.dev]

--- a/fuzzers/baby_fuzzer/src/main.rs
+++ b/fuzzers/baby_fuzzer/src/main.rs
@@ -12,13 +12,16 @@ use libafl::{
     fuzzer::{Fuzzer, StdFuzzer},
     generators::RandPrintablesGenerator,
     inputs::{BytesInput, HasTargetBytes},
-    monitors::SimpleMonitor,
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
     observers::StdMapObserver,
     schedulers::QueueScheduler,
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
+#[cfg(not(feature = "tui"))]
+use libafl::monitors::SimpleMonitor;
+#[cfg(feature = "tui")]
+use libafl::monitors::tui::TuiMonitor;
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];
@@ -85,7 +88,10 @@ pub fn main() {
     .unwrap();
 
     // The Monitor trait define how the fuzzer stats are displayed to the user
+    #[cfg(not(feature = "tui"))]
     let mon = SimpleMonitor::new(|s| println!("{}", s));
+    #[cfg(feature = "tui")]
+    let mon = TuiMonitor::new(String::from("Baby Fuzzer"), false);
 
     // The event manager handle the various events generated during the fuzzing loop
     // such as the notification of the addition of a new item to the corpus

--- a/fuzzers/baby_fuzzer/src/main.rs
+++ b/fuzzers/baby_fuzzer/src/main.rs
@@ -3,6 +3,10 @@ use std::path::PathBuf;
 #[cfg(windows)]
 use std::ptr::write_volatile;
 
+#[cfg(feature = "tui")]
+use libafl::monitors::tui::TuiMonitor;
+#[cfg(not(feature = "tui"))]
+use libafl::monitors::SimpleMonitor;
 use libafl::{
     bolts::{current_nanos, rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
@@ -18,10 +22,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-#[cfg(not(feature = "tui"))]
-use libafl::monitors::SimpleMonitor;
-#[cfg(feature = "tui")]
-use libafl::monitors::tui::TuiMonitor;
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -1,7 +1,7 @@
 //! Monitor based on tui-rs
 
 use crossterm::{
-    cursor::{Show, EnableBlinking},
+    cursor::{EnableBlinking, Show},
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -29,8 +29,8 @@ use crate::{
 };
 
 // Catching panics because the main thread dies
-use std::panic;
 use alloc::boxed::Box;
+use std::panic;
 
 mod ui;
 use ui::TuiUI;
@@ -377,7 +377,8 @@ fn run_tui_thread(
                 DisableMouseCapture,
                 Show,
                 EnableBlinking,
-            ).unwrap();
+            )
+            .unwrap();
             println!("Custom panic hook");
             old_hook(panic_info);
         }));

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -13,6 +13,7 @@ use std::{
     collections::VecDeque,
     fmt::Write,
     io::{self, BufRead},
+    panic,
     string::String,
     sync::{Arc, RwLock},
     thread,
@@ -28,9 +29,7 @@ use crate::{
     monitors::{ClientStats, Monitor, UserStats},
 };
 
-// Catching panics because the main thread dies
 use alloc::boxed::Box;
-use std::panic;
 
 mod ui;
 use ui::TuiUI;
@@ -379,7 +378,6 @@ fn run_tui_thread(
                 EnableBlinking,
             )
             .unwrap();
-            println!("Custom panic hook");
             old_hook(panic_info);
         }));
 

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -63,15 +63,19 @@ impl TuiUI {
 
     pub fn on_right(&mut self) {
         // never 0
-        self.clients_idx = 1 + self.clients_idx % (self.clients - 1);
+        if self.clients != 0 {
+            self.clients_idx = 1 + self.clients_idx % (self.clients - 1);
+        }
     }
 
     pub fn on_left(&mut self) {
         // never 0
-        if self.clients_idx == 1 {
-            self.clients_idx = self.clients - 1;
-        } else {
-            self.clients_idx = 1 + (self.clients_idx - 2) % (self.clients - 1);
+        if self.clients != 0 {
+            if self.clients_idx == 1 {
+                self.clients_idx = self.clients - 1;
+            } else {
+                self.clients_idx = 1 + (self.clients_idx - 2) % (self.clients - 1);
+            }
         }
     }
 

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -62,15 +62,15 @@ impl TuiUI {
     //pub fn on_down(&mut self) {}
 
     pub fn on_right(&mut self) {
-        // never 0
         if self.clients != 0 {
+            // clients_idx never 0
             self.clients_idx = 1 + self.clients_idx % (self.clients - 1);
         }
     }
 
     pub fn on_left(&mut self) {
-        // never 0
         if self.clients != 0 {
+            // clients_idx never 0
             if self.clients_idx == 1 {
                 self.clients_idx = self.clients - 1;
             } else {


### PR DESCRIPTION
Using the TuiMonitor instead of the SimpleMonitor in the baby_fuzzer breaks the terminal in which the fuzzer runs as soon as the main thread panics and thus kills all threads.

Reproduce:
- Ubuntu 20.04
- GNOME Terminal
- Replace SimpleMonitor by TuiMonitor (see changes to `fuzzer/baby_fuzzer/src/main.rs`)
- Run fuzzer

Minor:
- Check clients != 0 in tui to avoid sub_overflow

