### PR TITLE
Cleanup duplicate package warnings

### DIFF
--- a/fuzzers/baby_fuzzer_gramatron/Cargo.toml
+++ b/fuzzers/baby_fuzzer_gramatron/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_gramatron"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/baby_fuzzer_grimoire/Cargo.toml
+++ b/fuzzers/baby_fuzzer_grimoire/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_grimoire"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/baby_fuzzer_nautilus/Cargo.toml
+++ b/fuzzers/baby_fuzzer_nautilus/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_nautilus"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2018"

--- a/fuzzers/baby_fuzzer_tokens/Cargo.toml
+++ b/fuzzers/baby_fuzzer_tokens/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_tokens"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/backtrace_baby_fuzzers/c_code_with_inprocess_executor/Cargo.toml
+++ b/fuzzers/backtrace_baby_fuzzers/c_code_with_inprocess_executor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "c_code_with_fork_executor"
+name = "c_code_with_inprocess_executor"
 version = "0.0.1"
 edition = "2021"
 

--- a/fuzzers/fuzzbench_text/Cargo.toml
+++ b/fuzzers/fuzzbench_text/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fuzzbench"
+name = "fuzzbench_text"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/fuzzbench_weighted/Cargo.toml
+++ b/fuzzers/fuzzbench_weighted/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fuzzbench"
+name = "fuzzbench_weighted"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/libfuzzer_libmozjpeg/Makefile.toml
+++ b/fuzzers/libfuzzer_libmozjpeg/Makefile.toml
@@ -53,7 +53,7 @@ windows_alias = "unsupported"
 
 [tasks.lib_unix]
 script='''
-cd mozjpeg-4.0.3 && cmake . -DENABLE_SHARED=false -DCMAKE_C_COMPILER="${PROJECT_DIR}/${LIBAFL_CC}" -DCMAKE_CXX_COMPILER="${PROJECT_DIR}/${LIBAFL_CXX}" -G "Unix Makefiles"
+cd mozjpeg-4.0.3 && cmake . -DENABLE_SHARED=false -DPNG_SUPPORTED=false -DCMAKE_C_COMPILER="${PROJECT_DIR}/${LIBAFL_CC}" -DCMAKE_CXX_COMPILER="${PROJECT_DIR}/${LIBAFL_CXX}" -G "Unix Makefiles"
 cd "${PROJECT_DIR}"
 make -C mozjpeg-4.0.3
 '''

--- a/fuzzers/libfuzzer_libpng_accounting/Cargo.toml
+++ b/fuzzers/libfuzzer_libpng_accounting/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libfuzzer_libpng_launcher"
+name = "libfuzzer_libpng_accounting"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/libfuzzer_libpng_accounting/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_accounting/Makefile.toml
@@ -1,6 +1,6 @@
 # Variables
 [env]
-FUZZER_NAME='fuzzer_libpng'
+FUZZER_NAME='fuzzer_libpng_accounting'
 LIBAFL_CC = './target/release/libafl_cc'
 LIBAFL_CXX = './target/release/libafl_cxx'
 FUZZER = './target/release/${FUZZER_NAME}'

--- a/fuzzers/libfuzzer_libpng_ctx/Cargo.toml
+++ b/fuzzers/libfuzzer_libpng_ctx/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libfuzzer_libpng_launcher"
+name = "libfuzzer_libpng_ctx"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/libfuzzer_libpng_ctx/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_ctx/Makefile.toml
@@ -1,6 +1,6 @@
 # Variables
 [env]
-FUZZER_NAME='fuzzer_libpng'
+FUZZER_NAME='fuzzer_libpng_ctx'
 LIBAFL_CC = './target/release/libafl_cc'
 LIBAFL_CXX = './target/release/libafl_cxx'
 FUZZER = './target/release/${FUZZER_NAME}'

--- a/fuzzers/libfuzzer_libpng_launcher/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_launcher/Makefile.toml
@@ -1,6 +1,6 @@
 # Variables
 [env]
-FUZZER_NAME='fuzzer_libpng'
+FUZZER_NAME='fuzzer_libpng_launcher'
 LIBAFL_CC = './target/release/libafl_cc'
 LIBAFL_CXX = './target/release/libafl_cxx'
 FUZZER = './target/release/${FUZZER_NAME}'

--- a/fuzzers/libfuzzer_stb_image_sugar/Cargo.toml
+++ b/fuzzers/libfuzzer_stb_image_sugar/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libfuzzer_stb_image"
+name = "libfuzzer_stb_image_sugar"
 version = "0.8.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/libfuzzer_stb_image_sugar/Makefile.toml
+++ b/fuzzers/libfuzzer_stb_image_sugar/Makefile.toml
@@ -1,6 +1,6 @@
 # Variables
 [env]
-FUZZER_NAME='libfuzzer_stb_image'
+FUZZER_NAME='libfuzzer_stb_image_sugar'
 LIBAFL_CC = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = './target/release/libafl_cc', mapping = {"windows" = '.\\target\\release\\libafl_cc.exe'} }
 LIBAFL_CXX = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = './target/release/libafl_cxx', mapping = {"windows" = '.\\target\\release\\libafl_cxx.exe'} }
 FUZZER = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = './target/release/${FUZZER_NAME}', mapping = {"windows" = '.\\target\\release\\${FUZZER_NAME}.exe'} }


### PR DESCRIPTION
Cargo spits out a bunch of `duplicate package` warnings when scanning the repo checkout of `libafl = { git = "..." }` for `Cargo.toml`s:

```
warning: skipping duplicate package `baby_fuzzer` found at `~/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/c45b6be/fuzzers/baby_fuzzer_nautilus`
warning: skipping duplicate package `fuzzbench` found at `~/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/c45b6be/fuzzers/fuzzbench_text`
[...]
```