### PR TITLE
Fix Autotokens

### DIFF
--- a/libafl_targets/src/coverage.rs
+++ b/libafl_targets/src/coverage.rs
@@ -46,7 +46,6 @@ pub use __afl_area_ptr as EDGES_MAP_PTR;
 pub fn autotokens() -> Result<Tokens, Error> {
     unsafe {
         if __token_start.is_null() || __token_stop.is_null() {
-            println!("AutoTokens section not found, likely the target is not compiled with AutoTokens. Or there are simply no tokens.");
             Ok(Tokens::default())
         } else {
             // we can safely unwrap

--- a/libafl_targets/src/coverage.rs
+++ b/libafl_targets/src/coverage.rs
@@ -46,9 +46,8 @@ pub use __afl_area_ptr as EDGES_MAP_PTR;
 pub fn autotokens() -> Result<Tokens, Error> {
     unsafe {
         if __token_start.is_null() || __token_stop.is_null() {
-            Err(Error::illegal_state(
-                "AutoTokens section not found, likely the target is not compiled with AutoTokens",
-            ))
+            println!("AutoTokens section not found, likely the target is not compiled with AutoTokens. Or there are simply no tokens.");
+            Ok(Tokens::default())
         } else {
             // we can safely unwrap
             Tokens::from_ptrs(__token_start, __token_stop)


### PR DESCRIPTION
I think I was confused when I pushed #703 

#614 intends to fix runtime error when there're no token, but with #703 I changed the LLVM Pass back to the original state, then now it fails again when there're no tokens.

So this time just return Tokens::default(), no Err