### PR TITLE
Add HitcountsIterableMapObserver, rename AsMutIter to AsIterMut

### DIFF
--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -54,7 +54,7 @@ pub trait AsIter<'it> {
     type IntoIter: Iterator<Item = &'it Self::Item>;
 
     /// Create an interator from &self
-    fn as_ref_iter(&'it self) -> Self::IntoIter;
+    fn as_iter(&'it self) -> Self::IntoIter;
 }
 
 /// Create an `Iterator` from a mutable reference
@@ -65,7 +65,7 @@ pub trait AsIterMut<'it> {
     type IntoIter: Iterator<Item = &'it mut Self::Item>;
 
     /// Create an interator from &mut self
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter;
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter;
 }
 
 /// Has a length field

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -47,7 +47,7 @@ pub trait AsMutSlice<T> {
 }
 
 /// Create an `Iterator` from a reference
-pub trait AsRefIterator<'it> {
+pub trait AsIter<'it> {
     /// The item type
     type Item: 'it;
     /// The iterator type
@@ -58,7 +58,7 @@ pub trait AsRefIterator<'it> {
 }
 
 /// Create an `Iterator` from a mutable reference
-pub trait AsMutIterator<'it> {
+pub trait AsIterMut<'it> {
     /// The item type
     type Item: 'it;
     /// The iterator type

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -664,11 +664,7 @@ where
 
         let history_map = map_state.history_map.as_mut_slice();
 
-        for (i, (item, history)) in observer
-            .as_ref_iter()
-            .zip(history_map.iter_mut())
-            .enumerate()
-        {
+        for (i, (item, history)) in observer.as_iter().zip(history_map.iter_mut()).enumerate() {
             let reduced = R::reduce(*history, *item);
             if N::is_novel(*history, reduced) {
                 *history = reduced;
@@ -763,7 +759,7 @@ where
         let observer = observers.match_name::<O>(&self.name).unwrap();
         let mut hit_target: bool = false;
         //check if we've hit any targets.
-        for (i, &elem) in observer.as_ref_iter().enumerate() {
+        for (i, &elem) in observer.as_iter().enumerate() {
             if elem > 0 {
                 self.target_idx.push(i);
                 hit_target = true;

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -10,7 +10,7 @@ use num_traits::PrimInt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    bolts::{tuples::Named, AsMutSlice, AsRefIterator, AsSlice, HasRefCnt},
+    bolts::{tuples::Named, AsIter, AsMutSlice, AsSlice, HasRefCnt},
     corpus::Testcase,
     events::{Event, EventFirer},
     executors::ExitKind,
@@ -323,7 +323,7 @@ where
     T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
     R: Reducer<T>,
     O: MapObserver<Entry = T>,
-    for<'it> O: AsRefIterator<'it, Item = T>,
+    for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     S: HasNamedMetadata,
 {
@@ -346,7 +346,7 @@ where
     T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
     R: Reducer<T>,
     O: MapObserver<Entry = T>,
-    for<'it> O: AsRefIterator<'it, Item = T>,
+    for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     I: Input,
     S: HasNamedMetadata + HasClientPerfMonitor + Debug,
@@ -417,7 +417,7 @@ where
 impl<I, O, S> Feedback<I, S> for MapFeedback<I, DifferentIsNovel, O, MaxReducer, S, u8>
 where
     O: MapObserver<Entry = u8> + AsSlice<u8>,
-    for<'it> O: AsRefIterator<'it, Item = u8>,
+    for<'it> O: AsIter<'it, Item = u8>,
     I: Input,
     S: HasNamedMetadata + HasClientPerfMonitor + Debug,
 {
@@ -539,7 +539,7 @@ where
     R: Reducer<T>,
     N: IsNovel<T>,
     O: MapObserver<Entry = T>,
-    for<'it> O: AsRefIterator<'it, Item = T>,
+    for<'it> O: AsIter<'it, Item = T>,
     S: HasNamedMetadata,
 {
     #[inline]
@@ -554,7 +554,7 @@ where
     R: Reducer<T>,
     N: IsNovel<T>,
     O: MapObserver<Entry = T>,
-    for<'it> O: AsRefIterator<'it, Item = T>,
+    for<'it> O: AsIter<'it, Item = T>,
     S: HasNamedMetadata,
 {
     #[inline]
@@ -572,7 +572,7 @@ where
     T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
     R: Reducer<T>,
     O: MapObserver<Entry = T>,
-    for<'it> O: AsRefIterator<'it, Item = T>,
+    for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     I: Input,
     S: HasNamedMetadata + HasClientPerfMonitor + Debug,
@@ -716,7 +716,7 @@ pub struct ReachabilityFeedback<O> {
 impl<O> ReachabilityFeedback<O>
 where
     O: MapObserver<Entry = usize>,
-    for<'it> O: AsRefIterator<'it, Item = usize>,
+    for<'it> O: AsIter<'it, Item = usize>,
 {
     /// Creates a new [`ReachabilityFeedback`] for a [`MapObserver`].
     #[must_use]
@@ -743,7 +743,7 @@ impl<I, O, S> Feedback<I, S> for ReachabilityFeedback<O>
 where
     I: Input,
     O: MapObserver<Entry = usize>,
-    for<'it> O: AsRefIterator<'it, Item = usize>,
+    for<'it> O: AsIter<'it, Item = usize>,
     S: HasClientPerfMonitor,
 {
     #[allow(clippy::wrong_self_convention)]
@@ -793,7 +793,7 @@ where
 impl<O> Named for ReachabilityFeedback<O>
 where
     O: MapObserver<Entry = usize>,
-    for<'it> O: AsRefIterator<'it, Item = usize>,
+    for<'it> O: AsIter<'it, Item = usize>,
 {
     #[inline]
     fn name(&self) -> &str {

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -1226,6 +1226,9 @@ where
 }
 
 /// The Multi Map Observer merge different maps into one observer
+///
+/// # Safety
+/// If using this Observer inside a `HitcountsMapObserver`, sub-maps needs to be even-length.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -208,7 +208,7 @@ where
     type Item = T;
     type IntoIter = Iter<'it, T>;
 
-    fn as_ref_iter(&'it self) -> Self::IntoIter {
+    fn as_iter(&'it self) -> Self::IntoIter {
         let cnt = self.usable_count();
         self.as_slice()[..cnt].iter()
     }
@@ -228,7 +228,7 @@ where
     type Item = T;
     type IntoIter = IterMut<'it, T>;
 
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
         let cnt = self.usable_count();
         self.as_mut_slice()[..cnt].iter_mut()
     }
@@ -503,7 +503,7 @@ where
     type Item = T;
     type IntoIter = Iter<'it, T>;
 
-    fn as_ref_iter(&'it self) -> Self::IntoIter {
+    fn as_iter(&'it self) -> Self::IntoIter {
         let cnt = self.usable_count();
         self.as_slice()[..cnt].iter()
     }
@@ -523,7 +523,7 @@ where
     type Item = T;
     type IntoIter = IterMut<'it, T>;
 
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
         let cnt = self.usable_count();
         self.as_mut_slice()[..cnt].iter_mut()
     }
@@ -774,7 +774,7 @@ where
     type Item = T;
     type IntoIter = Iter<'it, T>;
 
-    fn as_ref_iter(&'it self) -> Self::IntoIter {
+    fn as_iter(&'it self) -> Self::IntoIter {
         let cnt = self.usable_count();
         self.as_slice()[..cnt].iter()
     }
@@ -794,7 +794,7 @@ where
     type Item = T;
     type IntoIter = IterMut<'it, T>;
 
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
         let cnt = self.usable_count();
         self.as_mut_slice()[..cnt].iter_mut()
     }
@@ -1045,7 +1045,7 @@ where
         let len = self.len();
         if (len & 1) == 0 {
             // Aligned map. Let's go.
-            for item in self.as_mut_iter().step_by(2) {
+            for item in self.as_iter_mut().step_by(2) {
                 unsafe {
                     let u16_ptr = item as *mut _ as *mut u16;
                     *u16_ptr = *COUNT_CLASS_LOOKUP_16.get_unchecked((*u16_ptr) as usize);
@@ -1053,7 +1053,7 @@ where
             }
         } else {
             // we need special handling for the odd last element
-            for (i, item) in self.as_mut_iter().step_by(2).enumerate() {
+            for (i, item) in self.as_iter_mut().step_by(2).enumerate() {
                 if i * 2 == len - 1 {
                     // last element.
                     *item = unsafe { *COUNT_CLASS_LOOKUP.get_unchecked((*item) as usize) };
@@ -1182,8 +1182,8 @@ where
     type Item = u8;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
 
-    fn as_ref_iter(&'it self) -> Self::IntoIter {
-        self.base.as_ref_iter()
+    fn as_iter(&'it self) -> Self::IntoIter {
+        self.base.as_iter()
     }
 }
 
@@ -1194,8 +1194,8 @@ where
     type Item = u8;
     type IntoIter = <M as AsIterMut<'it>>::IntoIter;
 
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter {
-        self.base.as_mut_iter()
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+        self.base.as_iter_mut()
     }
 }
 
@@ -1444,7 +1444,7 @@ where
     type Item = T;
     type IntoIter = Flatten<Iter<'it, OwnedSliceMut<'a, T>>>;
 
-    fn as_ref_iter(&'it self) -> Self::IntoIter {
+    fn as_iter(&'it self) -> Self::IntoIter {
         self.maps.iter().flatten()
     }
 }
@@ -1457,7 +1457,7 @@ where
     type Item = T;
     type IntoIter = Flatten<IterMut<'it, OwnedSliceMut<'a, T>>>;
 
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
         self.maps.iter_mut().flatten()
     }
 }
@@ -1538,7 +1538,7 @@ where
     type Item = T;
     type IntoIter = Iter<'it, T>;
 
-    fn as_ref_iter(&'it self) -> Self::IntoIter {
+    fn as_iter(&'it self) -> Self::IntoIter {
         self.as_slice().iter()
     }
 }
@@ -1550,7 +1550,7 @@ where
     type Item = T;
     type IntoIter = IterMut<'it, T>;
 
-    fn as_mut_iter(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
         self.as_mut_slice().iter_mut()
     }
 }
@@ -1951,8 +1951,8 @@ pub mod pybind {
                 type Item = $datatype;
                 type IntoIter = Iter<'it, $datatype>;
 
-                fn as_ref_iter(&'it self) -> Self::IntoIter {
-                    mapob_unwrap_me!($wrapper_name, self.wrapper, m, { unsafe { std::mem::transmute::<_, Self::IntoIter>(m.as_ref_iter()) } })
+                fn as_iter(&'it self) -> Self::IntoIter {
+                    mapob_unwrap_me!($wrapper_name, self.wrapper, m, { unsafe { std::mem::transmute::<_, Self::IntoIter>(m.as_iter()) } })
                 }
             }
 
@@ -1960,8 +1960,8 @@ pub mod pybind {
                 type Item = $datatype;
                 type IntoIter = IterMut<'it, $datatype>;
 
-                fn as_mut_iter(&'it mut self) -> Self::IntoIter {
-                    mapob_unwrap_me_mut!($wrapper_name, self.wrapper, m, { unsafe { std::mem::transmute::<_, Self::IntoIter>(m.as_mut_iter()) } })
+                fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+                    mapob_unwrap_me_mut!($wrapper_name, self.wrapper, m, { unsafe { std::mem::transmute::<_, Self::IntoIter>(m.as_iter_mut()) } })
                 }
             }
 

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -1041,19 +1041,17 @@ where
     #[allow(clippy::cast_ptr_alignment)]
     fn post_exec(&mut self, state: &mut S, input: &I, exit_kind: &ExitKind) -> Result<(), Error> {
         let len = self.len();
-        let len_is_odd = if (len & 1) != 0 { true } else { false };
+        let len_is_odd = (len & 1) != 0;
 
         for (i, item) in self.as_mut_iter().enumerate().step_by(2) {
-            if len_is_odd {
-                if i == len - 1 {
-                    // last element.
-                    *item = unsafe { *COUNT_CLASS_LOOKUP.get_unchecked((*item) as usize) };
-                }
+            if i == len - 1 && len_is_odd {
+                // last element.
+                *item = unsafe { *COUNT_CLASS_LOOKUP.get_unchecked((*item) as usize) };
             }
 
             unsafe {
                 let u16_ptr = item as *mut _ as *mut u16;
-                *u16_ptr = *COUNT_CLASS_LOOKUP_16.get_unchecked((*u16_ptr) as usize)
+                *u16_ptr = *COUNT_CLASS_LOOKUP_16.get_unchecked((*u16_ptr) as usize);
             }
         }
 

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -1,7 +1,7 @@
 //! The calibration stage. The fuzzer measures the average exec time and the bitmap size.
 
 use crate::{
-    bolts::{current_time, tuples::Named, AsRefIterator},
+    bolts::{current_time, tuples::Named, AsIter},
     corpus::{Corpus, SchedulerTestcaseMetaData},
     events::{EventFirer, LogSeverity},
     executors::{Executor, ExitKind, HasObservers},
@@ -240,7 +240,7 @@ where
         O::Entry:
             PartialEq + Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
         R: Reducer<O::Entry>,
-        for<'it> O: AsRefIterator<'it, Item = O::Entry>,
+        for<'it> O: AsIter<'it, Item = O::Entry>,
         N: IsNovel<O::Entry>,
     {
         Self {


### PR DESCRIPTION
This brings back iterators to HitcountsMapObserver.
I would be surprised if it were a lot slower, @tokatoka pleas check :)