### PR TITLE
New Pass Manager Arguments

### DIFF
--- a/libafl_cc/build.rs
+++ b/libafl_cc/build.rs
@@ -204,19 +204,7 @@ pub const LIBAFL_CC_LLVM_VERSION: Option<usize> = None;
         .expect("Could not parse LIBAFL_ACCOUNTING_MAP_SIZE");
     cxxflags.push(format!("-DLIBAFL_ACCOUNTING_MAP_SIZE={}", acc_map_size));
 
-    let llvm_version = match find_llvm_config()
-        .unwrap()
-        .split('-')
-        .collect::<Vec<&str>>()
-        .get(2)
-    {
-        Some(ver) => ver.parse::<usize>().ok(),
-        None => None,
-    };
-    // The approach below causes issues with arguments to optimization passes.
-    // An example is fuzzers/libfuzzer_libpng_accounting which passes -granularity=FUNC.
-    // In CI/CD, the new pass manager is not used. For now, maintain the same behavior.
-    //let llvm_version = find_llvm_version();
+    let llvm_version = find_llvm_version();
 
     if let Some(ver) = llvm_version {
         if ver >= 14 {

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -294,6 +294,14 @@ impl CompilerWrapper for ClangWrapper {
         }
         for pass in &self.passes {
             if self.use_new_pm {
+                // https://github.com/llvm/llvm-project/issues/56137
+                // Need this -Xclang -load -Xclang -<pass>.so thing even with the new PM
+                // to pass the arguments to LLVM Passes
+                args.push("-Xclang".into());
+                args.push("-load".into());
+                args.push("-Xclang".into());
+                args.push(pass.path().into_os_string().into_string().unwrap());
+                args.push("-Xclang".into());
                 args.push(format!(
                     "-fpass-plugin={}",
                     pass.path().into_os_string().into_string().unwrap()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/56137

The new pass manager still needs `-Xclang -load -Xclang -<pass>.so` if we want to load additional arguments