### PR TITLE
fix typo in aarch64.rs

### DIFF
--- a/libafl_qemu/src/aarch64.rs
+++ b/libafl_qemu/src/aarch64.rs
@@ -60,5 +60,5 @@ impl IntoPy<PyObject> for Regs {
 
 /// Return an ARM64 ArchCapstoneBuilder
 pub fn capstone() -> capstone::arch::arm64::ArchCapstoneBuilder {
-    capstone::Capstone::new().arm()
+    capstone::Capstone::new().arm64()
 }


### PR DESCRIPTION
Typo lead to fail to compile for arm64