### PR TITLE
unbreak tui with 1 client

### DIFF
--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -64,7 +64,10 @@ impl TuiUI {
     pub fn on_right(&mut self) {
         if self.clients != 0 {
             // clients_idx never 0
-            self.clients_idx = 1 + self.clients_idx % (self.clients - 1);
+            if self.clients - 1 != 0 {
+                // except for when it is ;)
+                self.clients_idx = 1 + self.clients_idx % (self.clients - 1);
+            }
         }
     }
 
@@ -74,7 +77,10 @@ impl TuiUI {
             if self.clients_idx == 1 {
                 self.clients_idx = self.clients - 1;
             } else {
-                self.clients_idx = 1 + (self.clients_idx - 2) % (self.clients - 1);
+                if self.clients - 1 != 0 {
+                    // dont wanna be dividing by 0
+                    self.clients_idx = 1 + (self.clients_idx - 2) % (self.clients - 1);
+                }
             }
         }
     }

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -76,11 +76,9 @@ impl TuiUI {
             // clients_idx never 0
             if self.clients_idx == 1 {
                 self.clients_idx = self.clients - 1;
-            } else {
-                if self.clients - 1 != 0 {
-                    // dont wanna be dividing by 0
-                    self.clients_idx = 1 + (self.clients_idx - 2) % (self.clients - 1);
-                }
+            } else if self.clients - 1 != 0 {
+                // don't wanna be dividing by 0
+                self.clients_idx = 1 + (self.clients_idx - 2) % (self.clients - 1);
             }
         }
     }


### PR DESCRIPTION
Running libAFL fuzzer (`syheliel`'s nyx-standalone) TUI with 1 client (1 bound cpu) , starts you off on client `#1` screen (when it should be 0, because the fuzzer itself gets clients_idx 0?), so you arrow-left to get to 0, and then any further arrow-left/right cause panic (due to divide by 0)? 

This change stops that from happening. You still start off at fuzzer 1 and need to be on 0, but at least it doesn't panic when you arrow-key around 



