### PR TITLE
Add continous JSON Logging monitor

### DIFF
--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -3,7 +3,6 @@
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;
 use std::{fs::File, io::Write, path::PathBuf};
-#[cfg(serde_json)]
 use std::fs::OpenOptions;
 
 use crate::{
@@ -136,17 +135,17 @@ impl OnDiskTOMLMonitor<NopMonitor> {
     }
 }
 
-#[cfg(serde_json)]
 #[derive(Debug, Clone)]
+/// Wraps a base monitor and continuously appends the current statistics to a JSON file
 pub struct OnDiskJSONMonitor<M> where M: Monitor {
     base: M,
     filename: PathBuf,
     last_update: Duration,
 }
 
-#[cfg(serde_json)]
 impl<M> OnDiskJSONMonitor<M> where M: Monitor {
-    pub fn new(filename: P, base: M) -> Self<M> where P: Into<PathBuf> {
+    /// Create a new [`OnDiskJSONMonitor`]
+    pub fn new<P>(filename: P, base: M) -> Self where P: Into<PathBuf> {
         Self {
             base,
             filename: filename.into(),
@@ -155,7 +154,6 @@ impl<M> OnDiskJSONMonitor<M> where M: Monitor {
     }
 }
 
-#[cfg(serde_json)]
 impl<M> Monitor for OnDiskJSONMonitor<M> where M: Monitor {
     fn client_stats_mut(&mut self) -> &mut Vec<ClientStats> {
         self.base.client_stats_mut()
@@ -172,7 +170,7 @@ impl<M> Monitor for OnDiskJSONMonitor<M> where M: Monitor {
     fn display(&mut self, event_msg: String, sender_id: u32) {
         if (current_time() - self.last_update).as_secs() >= 60 {
             let file = OpenOptions::new().append(true).open(&self.filename).expect("Failed to open JSON file");
-            writeln!(&file, serde_json::to_string(&self.client_stats()).expect("Failed to serialize client stats")).expect("Failed to write JSON to file");
+            writeln!(&file, "{}", serde_json::to_string(&self.client_stats()).expect("Failed to serialize client stats")).expect("Failed to write JSON to file");
             self.last_update = current_time();
         }
         self.base.display(event_msg, sender_id);

--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -2,9 +2,13 @@
 
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;
+use std::{
+    fs::{File, OpenOptions},
+    io::Write,
+    path::PathBuf,
+};
+
 use serde_json::json;
-use std::fs::OpenOptions;
-use std::{fs::File, io::Write, path::PathBuf};
 
 use crate::{
     bolts::{current_time, format_duration_hms},

--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -144,7 +144,7 @@ impl OnDiskTOMLMonitor<NopMonitor> {
 /// Wraps a base monitor and continuously appends the current statistics to a JSON lines file.
 pub struct OnDiskJSONMonitor<F, M>
 where
-    F: Fn(&Duration) -> bool,
+    F: FnMut(&Duration) -> bool,
     M: Monitor,
 {
     base: M,
@@ -155,7 +155,7 @@ where
 
 impl<F, M> OnDiskJSONMonitor<F, M>
 where
-    F: Fn(&Duration) -> bool,
+    F: FnMut(&Duration) -> bool,
     M: Monitor,
 {
     /// Create a new [`OnDiskJSONMonitor`]
@@ -175,7 +175,7 @@ where
 
 impl<F, M> Monitor for OnDiskJSONMonitor<F, M>
 where
-    F: Fn(&Duration) -> bool,
+    F: FnMut(&Duration) -> bool,
     M: Monitor,
 {
     fn client_stats_mut(&mut self) -> &mut Vec<ClientStats> {

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -15,7 +15,7 @@ use alloc::{fmt::Debug, string::String, vec::Vec};
 use core::{fmt, time::Duration};
 
 #[cfg(feature = "std")]
-pub use disk::{OnDiskTOMLMonitor, OnDiskJSONMonitor};
+pub use disk::{OnDiskJSONMonitor, OnDiskTOMLMonitor};
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -15,7 +15,7 @@ use alloc::{fmt::Debug, string::String, vec::Vec};
 use core::{fmt, time::Duration};
 
 #[cfg(feature = "std")]
-pub use disk::OnDiskTOMLMonitor;
+pub use disk::{OnDiskTOMLMonitor, OnDiskJSONMonitor};
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -56,7 +56,7 @@ impl fmt::Display for UserStats {
 }
 
 /// A simple struct to keep track of client monitor
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct ClientStats {
     // monitor (maybe we need a separated struct?)
     /// The corpus size for this client


### PR DESCRIPTION
Add a monitor that appends a single-line JSON object (https://jsonlines.org/) containing the current state every 60 seconds. I want to use it so that I can do some time-related analysis, e.g. how much coverage is found after a certain amount of time etc.