### PR TITLE
OSX force_load option

### DIFF
--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -264,7 +264,11 @@ impl CompilerWrapper for ClangWrapper {
 
         if cfg!(unix) {
             if cfg!(target_vendor = "apple") {
-                self.add_link_arg(lib_file)
+                // Same as --whole-archive on linux
+                // Without this option, the linker picks the first symbols it finds and does not care if it's a weak or a strong symbol
+                // See: <https://stackoverflow.com/questions/13089166/how-to-make-gcc-link-strong-symbol-in-static-library-to-overwrite-weak-symbol>
+                self.add_link_arg("-Wl,-force_load")
+                    .add_link_arg(lib_file)
             } else {
                 self.add_link_arg("-Wl,--whole-archive")
                     .add_link_arg(lib_file)

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -267,8 +267,7 @@ impl CompilerWrapper for ClangWrapper {
                 // Same as --whole-archive on linux
                 // Without this option, the linker picks the first symbols it finds and does not care if it's a weak or a strong symbol
                 // See: <https://stackoverflow.com/questions/13089166/how-to-make-gcc-link-strong-symbol-in-static-library-to-overwrite-weak-symbol>
-                self.add_link_arg("-Wl,-force_load")
-                    .add_link_arg(lib_file)
+                self.add_link_arg("-Wl,-force_load").add_link_arg(lib_file)
             } else {
                 self.add_link_arg("-Wl,--whole-archive")
                     .add_link_arg(lib_file)


### PR DESCRIPTION
Add force_load option to libafl_cc when linking static libs on macOS.
This option is equivalent to linux's --whole-archive, and it is necessary because the linker does not pick the strongly defined symbol otherwise

https://stackoverflow.com/questions/13089166/how-to-make-gcc-link-strong-symbol-in-static-library-to-overwrite-weak-symbol/37191811#37191811