### PR TITLE
MapFeedback: Adding support for with_name()

### DIFF
--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -633,7 +633,9 @@ where
         }
     }
 
-    /// Create new `MapFeedback`
+    /// Creating a new `MapFeedback` with a specific name. This is usefully whenever the same
+    /// feedback is needed twice, but with a different history. Using `new()` always results in the
+    /// same name and therefore also the same history.
     #[must_use]
     pub fn with_name(name: &'static str, map_observer: &O) -> Self {
         Self {

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -633,6 +633,19 @@ where
         }
     }
 
+    /// Create new `MapFeedback`
+    #[must_use]
+    pub fn with_name(name: &'static str, map_observer: &O) -> Self {
+        Self {
+            indexes: None,
+            novelties: None,
+            name: name.to_string(),
+            observer_name: map_observer.name().to_string(),
+            stats_name: create_stats_name(name),
+            phantom: PhantomData,
+        }
+    }
+
     /// Create new `MapFeedback` specifying if it must track indexes of used entries and/or novelties
     #[must_use]
     pub fn with_names_tracking(


### PR DESCRIPTION
MapFeedback currently only support `with_names()`. 

Using `with_names()` results in errors like the one below. Even though one could specify the type directly, this is very impractical in my opinion. Therefore I suggest adding `with_name()` and potentially even removing `with_names()`.
```
error[E0284]: type annotations needed for `MapFeedback<libafl::inputs::BytesInput, DifferentIsNovel, O, MaxReducer, libafl::state::StdState<libafl::corpus::InMemoryCorpus<libafl::inputs::BytesInput>, libafl::inputs::BytesInput, RomuDuoJrRand, libafl::corpus::OnDiskCorpus<libafl::inputs::BytesInput>>, T>`
   --> src/fuzzer.rs:165:43
    |
165 |     let mut objective_coverage_feedback = MaxMapFeedback::with_names("objective_coverage_feedback", &edges_observer.name());
    |         -------------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `O`
    |         |
    |         consider giving `objective_coverage_feedback` the explicit type `MapFeedback<_, _, O, _, _, T>`, where the type parameter `O` is specified
    |
    = note: cannot satisfy `<_ as MapObserver>::Entry == _`
note: required by a bound in `MapFeedback::<I, N, O, R, S, T>::with_names`
   --> LibAFL/libafl/src/feedbacks/map.rs:591:20
    |
591 |     O: MapObserver<Entry = T>,
    |                    ^^^^^^^^^ required by this bound in `MapFeedback::<I, N, O, R, S, T>::with_names`

For more information about this error, try `rustc --explain E0284`.
```