### PR TITLE
fix the start index of terminal slice to be removed

### DIFF
--- a/libafl/src/mutators/gramatron.rs
+++ b/libafl/src/mutators/gramatron.rs
@@ -229,7 +229,7 @@ where
         self.temp.clear();
         self.temp.extend_from_slice(&input.terminals()[idx_2..]);
 
-        input.terminals_mut().truncate(idx_2);
+        input.terminals_mut().truncate(idx_1);
         input.terminals_mut().extend_from_slice(&self.temp);
 
         Ok(MutationResult::Mutated)


### PR DESCRIPTION
Fix a mistake in `gramatron.rs`.
It seems that a slice truncates to `idx_2` and then extends from `idx_2` makes no sense. Instead truncating to `idx_1` and then extending from `idx_2` is much more reasonable.
