### PR TITLE
Hide prelude behind feature flag

### DIFF
--- a/fuzzers/baby_fuzzer_minimizing/Cargo.toml
+++ b/fuzzers/baby_fuzzer_minimizing/Cargo.toml
@@ -20,4 +20,4 @@ opt-level = 3
 debug = true
 
 [dependencies]
-libafl = { path = "../../libafl/" }
+libafl = { path = "../../libafl/", features = ["prelude"] }

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -20,6 +20,7 @@ rand_trait = ["rand_core"] # If set, libafl's rand implementations will implemen
 introspection = [] # Include performance statistics of the fuzzing pipeline
 concolic_mutation = ["z3"] # include a simple concolic mutator based on z3
 python = ["pyo3"]
+prelude = [] # Expose libafl::prelude for access without additional using directives
 tui_monitor = ["tui", "crossterm"] # enable TuiMonitor with crossterm
 cli = ["clap"]  # expose bolts::cli
 qemu_cli = ["cli"]

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["std", "derive", "llmp_compression", "rand_trait", "fork"]
+default = ["std", "derive", "llmp_compression", "rand_trait", "fork", "prelude"]
 std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "bincode", "wait-timeout", "regex", "byteorder", "once_cell", "uuid", "tui_monitor", "ctor", "backtrace"] # print, env, launcher ... support
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
 fork = [] # uses the fork() syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on Windows, no_std).

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -428,6 +428,7 @@ impl From<pyo3::PyErr> for Error {
 impl std::error::Error for Error {}
 
 /// The purpose of this module is to alleviate imports of many components by adding a glob import.
+#[cfg(feature = "prelude")]
 pub mod prelude {
     pub use super::{
         bolts::{bolts_prelude::*, *},


### PR DESCRIPTION
Auto-importing types oftentimes picks up the prelude, instead of the proper type.
Since prelude is a different use-case, I'd suggest to hide it behind a feature flag.