### PR TITLE
Observers in the harness function

### DIFF
--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -1048,7 +1048,7 @@ mod tests {
 
         let mut fuzzer = StdFuzzer::new(scheduler, (), ());
 
-        let mut harness = |_buf: &BytesInput| ExitKind::Ok;
+        let mut harness = |_buf: &BytesInput, _: &mut _| ExitKind::Ok;
         let mut executor = InProcessExecutor::new(
             &mut harness,
             tuple_list!(),

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -493,7 +493,7 @@ mod tests {
         let scheduler = RandScheduler::new();
         let mut fuzzer = StdFuzzer::new(scheduler, (), ());
 
-        let mut harness = |_buf: &BytesInput| ExitKind::Ok;
+        let mut harness = |_buf: &BytesInput, _: &mut _| ExitKind::Ok;
         let mut executor = InProcessExecutor::new(
             &mut harness,
             tuple_list!(),


### PR DESCRIPTION
From now on, the harness closure of InProcessExecutor will have a second argument, a mutable ref to the observers tuple

To ignore it:

```
let mut harness = |i: &MyInput, _: &mut _| {
    ...
};
```