### PR TITLE
Remove clang download from windows CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,193 +10,193 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  common:
-    strategy:
-      matrix:
-          os: [ubuntu-latest, windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-      - uses: Swatinem/rust-cache@v1
-      - name: install mdbook
-        uses: baptiste0928/cargo-install@v1.3.0
-        with:
-          crate: mdbook
-      - name: install linkcheck
-        uses: baptiste0928/cargo-install@v1.3.0
-        with:
-          crate: mdbook-linkcheck
-      - uses: actions/checkout@v2
-      - name: Build libafl debug
-        run: cargo build -p libafl
-      - name: Build the book
-        run: cd docs && mdbook build
-      - name: Test the book
-        # TODO: fix books test fail with updated windows-rs
-        if: runner.os != 'Windows'
-        run: cd docs && mdbook test -L ../target/debug/deps
-      - name: Run tests
-        run: cargo test
-      - name: Test libafl no_std
-        run: cd libafl && cargo test --no-default-features
-      - name: Test libafl_targets no_std
-        run: cd libafl_targets && cargo test --no-default-features
-     
-  ubuntu:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: Swatinem/rust-cache@v1
-    - name: set mold linker as default linker
-      uses: rui314/setup-mold@v1
-    - name: Install and cache deps
-      uses: awalsh128/cache-apt-pkgs-action@v1.1.0
-      with:
-        packages: llvm llvm-dev clang ninja-build clang-format-13 shellcheck libgtk-3-dev gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
-    - name: get clang version
-      run: command -v llvm-config && clang -v
-    - name: Install cargo-hack
-      run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
-    - name: Add nightly rustfmt and clippy
-      run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
-    - uses: actions/checkout@v2
+  #common:
+  #  strategy:
+  #    matrix:
+  #        os: [ubuntu-latest, windows-latest, macOS-latest]
+  #  runs-on: ${{ matrix.os }}
+  #  steps:
+  #    - uses: actions-rs/toolchain@v1
+  #      with:
+  #        profile: minimal
+  #        toolchain: nightly
+  #    - uses: Swatinem/rust-cache@v1
+  #    - name: install mdbook
+  #      uses: baptiste0928/cargo-install@v1.3.0
+  #      with:
+  #        crate: mdbook
+  #    - name: install linkcheck
+  #      uses: baptiste0928/cargo-install@v1.3.0
+  #      with:
+  #        crate: mdbook-linkcheck
+  #    - uses: actions/checkout@v2
+  #    - name: Build libafl debug
+  #      run: cargo build -p libafl
+  #    - name: Build the book
+  #      run: cd docs && mdbook build
+  #    - name: Test the book
+  #      # TODO: fix books test fail with updated windows-rs
+  #      if: runner.os != 'Windows'
+  #      run: cd docs && mdbook test -L ../target/debug/deps
+  #    - name: Run tests
+  #      run: cargo test
+  #    - name: Test libafl no_std
+  #      run: cd libafl && cargo test --no-default-features
+  #    - name: Test libafl_targets no_std
+  #      run: cd libafl_targets && cargo test --no-default-features
+  #   
+  #ubuntu:
+  #  runs-on: ubuntu-22.04
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: stable
+  #  - uses: Swatinem/rust-cache@v1
+  #  - name: set mold linker as default linker
+  #    uses: rui314/setup-mold@v1
+  #  - name: Install and cache deps
+  #    uses: awalsh128/cache-apt-pkgs-action@v1.1.0
+  #    with:
+  #      packages: llvm llvm-dev clang ninja-build clang-format-13 shellcheck libgtk-3-dev gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
+  #  - name: get clang version
+  #    run: command -v llvm-config && clang -v
+  #  - name: Install cargo-hack
+  #    run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+  #  - name: Add nightly rustfmt and clippy
+  #    run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
+  #  - uses: actions/checkout@v2
 
-    # ---- format check ----
-    # pcguard edges and pcguard hitcounts are not compatible and we need to build them seperately
-    - name: Check pcguard edges
-      run: cargo check --features=sancov_pcguard_edges
-    - name: Format
-      run: cargo fmt -- --check
-    - name: Run clang-format style check for C/C++ programs.
-      run: clang-format-13 -n -Werror --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
-    - name: run shellcheck
-      run: shellcheck ./scripts/*.sh
-    - name: Run clippy
-      run: ./scripts/clippy.sh
-      
-    # ---- doc check ----
-    - name: Build Docs
-      run: cargo doc
-    - name: Test Docs
-      run: cargo +nightly test --doc --all-features
+  #  # ---- format check ----
+  #  # pcguard edges and pcguard hitcounts are not compatible and we need to build them seperately
+  #  - name: Check pcguard edges
+  #    run: cargo check --features=sancov_pcguard_edges
+  #  - name: Format
+  #    run: cargo fmt -- --check
+  #  - name: Run clang-format style check for C/C++ programs.
+  #    run: clang-format-13 -n -Werror --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
+  #  - name: run shellcheck
+  #    run: shellcheck ./scripts/*.sh
+  #  - name: Run clippy
+  #    run: ./scripts/clippy.sh
+  #    
+  #  # ---- doc check ----
+  #  - name: Build Docs
+  #    run: cargo doc
+  #  - name: Test Docs
+  #    run: cargo +nightly test --doc --all-features
 
-    # ---- build and feature check ----
-    - name: Run a normal build
-      run: cargo build --verbose
-    # cargo-hack tests/checks each crate in the workspace
-    #- name: Run tests
-    #  run: cargo hack test --all-features
-    # cargo-hack's --feature-powerset would be nice here but libafl has a too many knobs
-    - name: Check each feature
-      # Skipping python as it has to be built with the `maturin` tool
-      run: cargo hack check --feature-powerset --depth=2 --exclude-features=agpl,nautilus,python,sancov_pcguard_edges,arm,aarch64,i386 --no-dev-deps    
-    - name: Build examples
-      run: cargo build --examples --verbose
+  #  # ---- build and feature check ----
+  #  - name: Run a normal build
+  #    run: cargo build --verbose
+  #  # cargo-hack tests/checks each crate in the workspace
+  #  #- name: Run tests
+  #  #  run: cargo hack test --all-features
+  #  # cargo-hack's --feature-powerset would be nice here but libafl has a too many knobs
+  #  - name: Check each feature
+  #    # Skipping python as it has to be built with the `maturin` tool
+  #    run: cargo hack check --feature-powerset --depth=2 --exclude-features=agpl,nautilus,python,sancov_pcguard_edges,arm,aarch64,i386 --no-dev-deps    
+  #  - name: Build examples
+  #    run: cargo build --examples --verbose
 
-  ubuntu-concolic:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: Swatinem/rust-cache@v1
-    - uses: actions/checkout@v2
-    - name: Install smoke test deps
-      run: sudo ./libafl_concolic/test/smoke_test_ubuntu_deps.sh 
-    - name: Run smoke test
-      run: ./libafl_concolic/test/smoke_test.sh 
+  #ubuntu-concolic:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: stable
+  #  - uses: Swatinem/rust-cache@v1
+  #  - uses: actions/checkout@v2
+  #  - name: Install smoke test deps
+  #    run: sudo ./libafl_concolic/test/smoke_test_ubuntu_deps.sh 
+  #  - name: Run smoke test
+  #    run: ./libafl_concolic/test/smoke_test.sh 
 
-  bindings:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: Swatinem/rust-cache@v1
-    - name: set mold linker as default linker
-      uses: rui314/setup-mold@v1
-    - name: Install deps
-      run: sudo apt-get install -y llvm llvm-dev clang ninja-build python3-dev python3-pip python3-venv
-    - name: Install maturin
-      run: python3 -m pip install maturin
-    - uses: actions/checkout@v2
-    - name: Run a maturin build
-      run: cd ./bindings/pylibafl && maturin build
+  #bindings:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: stable
+  #  - uses: Swatinem/rust-cache@v1
+  #  - name: set mold linker as default linker
+  #    uses: rui314/setup-mold@v1
+  #  - name: Install deps
+  #    run: sudo apt-get install -y llvm llvm-dev clang ninja-build python3-dev python3-pip python3-venv
+  #  - name: Install maturin
+  #    run: python3 -m pip install maturin
+  #  - uses: actions/checkout@v2
+  #  - name: Run a maturin build
+  #    run: cd ./bindings/pylibafl && maturin build
 
-  fuzzers:
-    strategy:
-      matrix:
-          os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - name: set mold linker as default linker
-      if: runner.os == 'Linux' # mold only support linux until now
-      uses: rui314/setup-mold@v1
-    - name: enable mult-thread for `make`
-      run: export MAKEFLAGS="-j$(expr $(nproc) \+ 1)"
-    - uses: Swatinem/rust-cache@v1
-    - name: Add nightly rustfmt and clippy
-      run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
-    - uses: lyricwulf/abc@v1
-      with: 
-        # todo: remove afl++-clang when nyx support samcov_pcguard
-        linux: llvm llvm-dev clang nasm ninja-build gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libgtk-3-dev afl++-clang pax-utils
-        # update bash for macos to support `declare -A` command`
-        macos: llvm libpng nasm coreutils z3 bash
-    - name: pip install
-      run: python3 -m pip install msgpack jinja2
-    - name: install cargo-make
-      uses: baptiste0928/cargo-install@v1.3.0
-      with:
-        crate: cargo-make
-    - uses: actions/checkout@v2
-      with:
-        submodules: true # recursively checkout submodules
-    - name: Build and run example fuzzers
-      if: runner.os == 'Linux'
-      run: ./scripts/test_all_fuzzers.sh
-    - name: Build and run example fuzzers
-      if: runner.os == 'macOS' # use bash v4
-      run: /usr/local/bin/bash ./scripts/test_all_fuzzers.sh
+  #fuzzers:
+  #  strategy:
+  #    matrix:
+  #        os: [ubuntu-latest, macos-latest]
+  #  runs-on: ${{ matrix.os }}
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: stable
+  #  - name: set mold linker as default linker
+  #    if: runner.os == 'Linux' # mold only support linux until now
+  #    uses: rui314/setup-mold@v1
+  #  - name: enable mult-thread for `make`
+  #    run: export MAKEFLAGS="-j$(expr $(nproc) \+ 1)"
+  #  - uses: Swatinem/rust-cache@v1
+  #  - name: Add nightly rustfmt and clippy
+  #    run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
+  #  - uses: lyricwulf/abc@v1
+  #    with: 
+  #      # todo: remove afl++-clang when nyx support samcov_pcguard
+  #      linux: llvm llvm-dev clang nasm ninja-build gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libgtk-3-dev afl++-clang pax-utils
+  #      # update bash for macos to support `declare -A` command`
+  #      macos: llvm libpng nasm coreutils z3 bash
+  #  - name: pip install
+  #    run: python3 -m pip install msgpack jinja2
+  #  - name: install cargo-make
+  #    uses: baptiste0928/cargo-install@v1.3.0
+  #    with:
+  #      crate: cargo-make
+  #  - uses: actions/checkout@v2
+  #    with:
+  #      submodules: true # recursively checkout submodules
+  #  - name: Build and run example fuzzers
+  #    if: runner.os == 'Linux'
+  #    run: ./scripts/test_all_fuzzers.sh
+  #  - name: Build and run example fuzzers
+  #    if: runner.os == 'macOS' # use bash v4
+  #    run: /usr/local/bin/bash ./scripts/test_all_fuzzers.sh
 
-  nostd-build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-    - uses: Swatinem/rust-cache@v1
-    - name: Add nightly rustfmt and clippy
-      run: rustup toolchain install nightly && rustup target add --toolchain nightly aarch64-unknown-none && rustup component add --toolchain nightly rust-src && rustup target add thumbv6m-none-eabi
-    - uses: actions/checkout@v2
-    - name: Build aarch64-unknown-none
-      run: cd ./fuzzers/baby_no_std && cargo +nightly build -Zbuild-std=core,alloc --target aarch64-unknown-none -v --release && cd ../..
-    - name: run x86_64 until panic!
-      run: cd ./fuzzers/baby_no_std && cargo +nightly run || test $? -ne 0 || exit 1
-    - name: no_std tests
-      run: cd ./libafl && cargo test --no-default-features 
-    - name: libafl armv6m-none-eabi (32 bit no_std) clippy
-      run: cd ./libafl && cargo clippy --target thumbv6m-none-eabi --no-default-features
+  #nostd-build:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: nightly
+  #  - uses: Swatinem/rust-cache@v1
+  #  - name: Add nightly rustfmt and clippy
+  #    run: rustup toolchain install nightly && rustup target add --toolchain nightly aarch64-unknown-none && rustup component add --toolchain nightly rust-src && rustup target add thumbv6m-none-eabi
+  #  - uses: actions/checkout@v2
+  #  - name: Build aarch64-unknown-none
+  #    run: cd ./fuzzers/baby_no_std && cargo +nightly build -Zbuild-std=core,alloc --target aarch64-unknown-none -v --release && cd ../..
+  #  - name: run x86_64 until panic!
+  #    run: cd ./fuzzers/baby_no_std && cargo +nightly run || test $? -ne 0 || exit 1
+  #  - name: no_std tests
+  #    run: cd ./libafl && cargo test --no-default-features 
+  #  - name: libafl armv6m-none-eabi (32 bit no_std) clippy
+  #    run: cd ./libafl && cargo clippy --target thumbv6m-none-eabi --no-default-features
 
-  build-docker:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build docker
-      run: docker build -t libafl .
+  #build-docker:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - name: Build docker
+  #    run: docker build -t libafl .
 
   windows:
     runs-on: windows-latest
@@ -215,11 +215,11 @@ jobs:
         command: clippy
     - name: Build docs
       run: cargo doc
-    - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
-      uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-      with:
-        version: "12.0"
-        directory: ${{ runner.temp }}/llvm
+    #- name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
+    #  uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
+    #  with:
+    #    version: "12.0"
+    #    directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - name: install cargo-make
@@ -228,89 +228,89 @@ jobs:
     - name: Build frida
       run: cd fuzzers/frida_libpng/ && cargo make test
       
-  macos:
-    runs-on: macOS-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: Swatinem/rust-cache@v1
-    - name: Add nightly rustfmt and clippy
-      run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
-    - name: Install deps
-      run: brew install z3 gtk+3
-    - uses: actions/checkout@v2
-    - name: MacOS Build
-      run: cargo build --verbose
-    - name: Run clippy
-      run: ./scripts/clippy.sh
-    - name: Increase map sizes
-      run: ./scripts/shmem_limits_macos.sh
-    - name: Run Tests
-      run: cargo test
+  #macos:
+  #  runs-on: macOS-latest
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: stable
+  #  - uses: Swatinem/rust-cache@v1
+  #  - name: Add nightly rustfmt and clippy
+  #    run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
+  #  - name: Install deps
+  #    run: brew install z3 gtk+3
+  #  - uses: actions/checkout@v2
+  #  - name: MacOS Build
+  #    run: cargo build --verbose
+  #  - name: Run clippy
+  #    run: ./scripts/clippy.sh
+  #  - name: Increase map sizes
+  #    run: ./scripts/shmem_limits_macos.sh
+  #  - name: Run Tests
+  #    run: cargo test
 
-  other_targets:
-    runs-on: macOS-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - uses: Swatinem/rust-cache@v1
-    - uses: nttld/setup-ndk@v1
-      with:
-        ndk-version: r21e
-    - name: install ios
-      run: rustup target add aarch64-apple-ios
-    - name: install android
-      run: rustup target add aarch64-linux-android
-    - name: install cargo ndk
-      run: cargo install cargo-ndk
-    - uses: actions/checkout@v2
-    - name: Build iOS
-      run: cargo build --target aarch64-apple-ios
-    - name: Build Android
-      run: cargo ndk -t arm64-v8a build --release 
-    #run: cargo build --target aarch64-linux-android
-    # TODO: Figure out how to properly build stuff with clang
-    #- name: Add clang path to $PATH env
-    #  if: runner.os == 'Windows'
-    #  run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    #- name: Try if clang works
-    #  run: clang -v
-    #- name: Windows Test
-    #  run: C:\Rust\.cargo\bin\cargo.exe test --verbose
+  #other_targets:
+  #  runs-on: macOS-latest
+  #  steps:
+  #  - uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: stable
+  #  - uses: Swatinem/rust-cache@v1
+  #  - uses: nttld/setup-ndk@v1
+  #    with:
+  #      ndk-version: r21e
+  #  - name: install ios
+  #    run: rustup target add aarch64-apple-ios
+  #  - name: install android
+  #    run: rustup target add aarch64-linux-android
+  #  - name: install cargo ndk
+  #    run: cargo install cargo-ndk
+  #  - uses: actions/checkout@v2
+  #  - name: Build iOS
+  #    run: cargo build --target aarch64-apple-ios
+  #  - name: Build Android
+  #    run: cargo ndk -t arm64-v8a build --release 
+  #  #run: cargo build --target aarch64-linux-android
+  #  # TODO: Figure out how to properly build stuff with clang
+  #  #- name: Add clang path to $PATH env
+  #  #  if: runner.os == 'Windows'
+  #  #  run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+  #  #- name: Try if clang works
+  #  #  run: clang -v
+  #  #- name: Windows Test
+  #  #  run: C:\Rust\.cargo\bin\cargo.exe test --verbose
 
-  freebsd:
-    runs-on: macos-12
-    name: Simple build in FreeBSD
-    steps:
-    - uses: actions/checkout@v2
-    - name: Test in FreeBSD
-      id: test
-      uses: vmactions/freebsd-vm@v0
-      with:
-        usesh: true
-        sync: rsync
-        copyback: false
-        mem: 2048
-        release: 13.1
-        prepare: |
-          pkg install -y curl bash sudo llvm14
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
+  #freebsd:
+  #  runs-on: macos-12
+  #  name: Simple build in FreeBSD
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - name: Test in FreeBSD
+  #    id: test
+  #    uses: vmactions/freebsd-vm@v0
+  #    with:
+  #      usesh: true
+  #      sync: rsync
+  #      copyback: false
+  #      mem: 2048
+  #      release: 13.1
+  #      prepare: |
+  #        pkg install -y curl bash sudo llvm14
+  #        curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-        run: |
-          freebsd-version
-          . "$HOME/.cargo/env"
-          rustup toolchain install nightly
-          export LLVM_CONFIG=/usr/local/bin/llvm-config14
-          pwd
-          ls -lah
-          echo "local/bin"
-          ls -lah /usr/local/bin/
-          which llvm-config
-          chmod +x ./scripts/clippy.sh
-          bash ./scripts/shmem_limits_fbsd.sh
-          bash ./scripts/clippy.sh
-          cargo test
+  #      run: |
+  #        freebsd-version
+  #        . "$HOME/.cargo/env"
+  #        rustup toolchain install nightly
+  #        export LLVM_CONFIG=/usr/local/bin/llvm-config14
+  #        pwd
+  #        ls -lah
+  #        echo "local/bin"
+  #        ls -lah /usr/local/bin/
+  #        which llvm-config
+  #        chmod +x ./scripts/clippy.sh
+  #        bash ./scripts/shmem_limits_fbsd.sh
+  #        bash ./scripts/clippy.sh
+  #        cargo test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,193 +10,193 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  #common:
-  #  strategy:
-  #    matrix:
-  #        os: [ubuntu-latest, windows-latest, macOS-latest]
-  #  runs-on: ${{ matrix.os }}
-  #  steps:
-  #    - uses: actions-rs/toolchain@v1
-  #      with:
-  #        profile: minimal
-  #        toolchain: nightly
-  #    - uses: Swatinem/rust-cache@v1
-  #    - name: install mdbook
-  #      uses: baptiste0928/cargo-install@v1.3.0
-  #      with:
-  #        crate: mdbook
-  #    - name: install linkcheck
-  #      uses: baptiste0928/cargo-install@v1.3.0
-  #      with:
-  #        crate: mdbook-linkcheck
-  #    - uses: actions/checkout@v2
-  #    - name: Build libafl debug
-  #      run: cargo build -p libafl
-  #    - name: Build the book
-  #      run: cd docs && mdbook build
-  #    - name: Test the book
-  #      # TODO: fix books test fail with updated windows-rs
-  #      if: runner.os != 'Windows'
-  #      run: cd docs && mdbook test -L ../target/debug/deps
-  #    - name: Run tests
-  #      run: cargo test
-  #    - name: Test libafl no_std
-  #      run: cd libafl && cargo test --no-default-features
-  #    - name: Test libafl_targets no_std
-  #      run: cd libafl_targets && cargo test --no-default-features
-  #   
-  #ubuntu:
-  #  runs-on: ubuntu-22.04
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: stable
-  #  - uses: Swatinem/rust-cache@v1
-  #  - name: set mold linker as default linker
-  #    uses: rui314/setup-mold@v1
-  #  - name: Install and cache deps
-  #    uses: awalsh128/cache-apt-pkgs-action@v1.1.0
-  #    with:
-  #      packages: llvm llvm-dev clang ninja-build clang-format-13 shellcheck libgtk-3-dev gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
-  #  - name: get clang version
-  #    run: command -v llvm-config && clang -v
-  #  - name: Install cargo-hack
-  #    run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
-  #  - name: Add nightly rustfmt and clippy
-  #    run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
-  #  - uses: actions/checkout@v2
+  common:
+    strategy:
+      matrix:
+          os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@v1
+      - name: install mdbook
+        uses: baptiste0928/cargo-install@v1.3.0
+        with:
+          crate: mdbook
+      - name: install linkcheck
+        uses: baptiste0928/cargo-install@v1.3.0
+        with:
+          crate: mdbook-linkcheck
+      - uses: actions/checkout@v2
+      - name: Build libafl debug
+        run: cargo build -p libafl
+      - name: Build the book
+        run: cd docs && mdbook build
+      - name: Test the book
+        # TODO: fix books test fail with updated windows-rs
+        if: runner.os != 'Windows'
+        run: cd docs && mdbook test -L ../target/debug/deps
+      - name: Run tests
+        run: cargo test
+      - name: Test libafl no_std
+        run: cd libafl && cargo test --no-default-features
+      - name: Test libafl_targets no_std
+        run: cd libafl_targets && cargo test --no-default-features
+     
+  ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v1
+    - name: set mold linker as default linker
+      uses: rui314/setup-mold@v1
+    - name: Install and cache deps
+      uses: awalsh128/cache-apt-pkgs-action@v1.1.0
+      with:
+        packages: llvm llvm-dev clang ninja-build clang-format-13 shellcheck libgtk-3-dev gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
+    - name: get clang version
+      run: command -v llvm-config && clang -v
+    - name: Install cargo-hack
+      run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+    - name: Add nightly rustfmt and clippy
+      run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
+    - uses: actions/checkout@v2
 
-  #  # ---- format check ----
-  #  # pcguard edges and pcguard hitcounts are not compatible and we need to build them seperately
-  #  - name: Check pcguard edges
-  #    run: cargo check --features=sancov_pcguard_edges
-  #  - name: Format
-  #    run: cargo fmt -- --check
-  #  - name: Run clang-format style check for C/C++ programs.
-  #    run: clang-format-13 -n -Werror --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
-  #  - name: run shellcheck
-  #    run: shellcheck ./scripts/*.sh
-  #  - name: Run clippy
-  #    run: ./scripts/clippy.sh
-  #    
-  #  # ---- doc check ----
-  #  - name: Build Docs
-  #    run: cargo doc
-  #  - name: Test Docs
-  #    run: cargo +nightly test --doc --all-features
+    # ---- format check ----
+    # pcguard edges and pcguard hitcounts are not compatible and we need to build them seperately
+    - name: Check pcguard edges
+      run: cargo check --features=sancov_pcguard_edges
+    - name: Format
+      run: cargo fmt -- --check
+    - name: Run clang-format style check for C/C++ programs.
+      run: clang-format-13 -n -Werror --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
+    - name: run shellcheck
+      run: shellcheck ./scripts/*.sh
+    - name: Run clippy
+      run: ./scripts/clippy.sh
+      
+    # ---- doc check ----
+    - name: Build Docs
+      run: cargo doc
+    - name: Test Docs
+      run: cargo +nightly test --doc --all-features
 
-  #  # ---- build and feature check ----
-  #  - name: Run a normal build
-  #    run: cargo build --verbose
-  #  # cargo-hack tests/checks each crate in the workspace
-  #  #- name: Run tests
-  #  #  run: cargo hack test --all-features
-  #  # cargo-hack's --feature-powerset would be nice here but libafl has a too many knobs
-  #  - name: Check each feature
-  #    # Skipping python as it has to be built with the `maturin` tool
-  #    run: cargo hack check --feature-powerset --depth=2 --exclude-features=agpl,nautilus,python,sancov_pcguard_edges,arm,aarch64,i386 --no-dev-deps    
-  #  - name: Build examples
-  #    run: cargo build --examples --verbose
+    # ---- build and feature check ----
+    - name: Run a normal build
+      run: cargo build --verbose
+    # cargo-hack tests/checks each crate in the workspace
+    #- name: Run tests
+    #  run: cargo hack test --all-features
+    # cargo-hack's --feature-powerset would be nice here but libafl has a too many knobs
+    - name: Check each feature
+      # Skipping python as it has to be built with the `maturin` tool
+      run: cargo hack check --feature-powerset --depth=2 --exclude-features=agpl,nautilus,python,sancov_pcguard_edges,arm,aarch64,i386 --no-dev-deps    
+    - name: Build examples
+      run: cargo build --examples --verbose
 
-  #ubuntu-concolic:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: stable
-  #  - uses: Swatinem/rust-cache@v1
-  #  - uses: actions/checkout@v2
-  #  - name: Install smoke test deps
-  #    run: sudo ./libafl_concolic/test/smoke_test_ubuntu_deps.sh 
-  #  - name: Run smoke test
-  #    run: ./libafl_concolic/test/smoke_test.sh 
+  ubuntu-concolic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v2
+    - name: Install smoke test deps
+      run: sudo ./libafl_concolic/test/smoke_test_ubuntu_deps.sh 
+    - name: Run smoke test
+      run: ./libafl_concolic/test/smoke_test.sh 
 
-  #bindings:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: stable
-  #  - uses: Swatinem/rust-cache@v1
-  #  - name: set mold linker as default linker
-  #    uses: rui314/setup-mold@v1
-  #  - name: Install deps
-  #    run: sudo apt-get install -y llvm llvm-dev clang ninja-build python3-dev python3-pip python3-venv
-  #  - name: Install maturin
-  #    run: python3 -m pip install maturin
-  #  - uses: actions/checkout@v2
-  #  - name: Run a maturin build
-  #    run: cd ./bindings/pylibafl && maturin build
+  bindings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v1
+    - name: set mold linker as default linker
+      uses: rui314/setup-mold@v1
+    - name: Install deps
+      run: sudo apt-get install -y llvm llvm-dev clang ninja-build python3-dev python3-pip python3-venv
+    - name: Install maturin
+      run: python3 -m pip install maturin
+    - uses: actions/checkout@v2
+    - name: Run a maturin build
+      run: cd ./bindings/pylibafl && maturin build
 
-  #fuzzers:
-  #  strategy:
-  #    matrix:
-  #        os: [ubuntu-latest, macos-latest]
-  #  runs-on: ${{ matrix.os }}
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: stable
-  #  - name: set mold linker as default linker
-  #    if: runner.os == 'Linux' # mold only support linux until now
-  #    uses: rui314/setup-mold@v1
-  #  - name: enable mult-thread for `make`
-  #    run: export MAKEFLAGS="-j$(expr $(nproc) \+ 1)"
-  #  - uses: Swatinem/rust-cache@v1
-  #  - name: Add nightly rustfmt and clippy
-  #    run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
-  #  - uses: lyricwulf/abc@v1
-  #    with: 
-  #      # todo: remove afl++-clang when nyx support samcov_pcguard
-  #      linux: llvm llvm-dev clang nasm ninja-build gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libgtk-3-dev afl++-clang pax-utils
-  #      # update bash for macos to support `declare -A` command`
-  #      macos: llvm libpng nasm coreutils z3 bash
-  #  - name: pip install
-  #    run: python3 -m pip install msgpack jinja2
-  #  - name: install cargo-make
-  #    uses: baptiste0928/cargo-install@v1.3.0
-  #    with:
-  #      crate: cargo-make
-  #  - uses: actions/checkout@v2
-  #    with:
-  #      submodules: true # recursively checkout submodules
-  #  - name: Build and run example fuzzers
-  #    if: runner.os == 'Linux'
-  #    run: ./scripts/test_all_fuzzers.sh
-  #  - name: Build and run example fuzzers
-  #    if: runner.os == 'macOS' # use bash v4
-  #    run: /usr/local/bin/bash ./scripts/test_all_fuzzers.sh
+  fuzzers:
+    strategy:
+      matrix:
+          os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - name: set mold linker as default linker
+      if: runner.os == 'Linux' # mold only support linux until now
+      uses: rui314/setup-mold@v1
+    - name: enable mult-thread for `make`
+      run: export MAKEFLAGS="-j$(expr $(nproc) \+ 1)"
+    - uses: Swatinem/rust-cache@v1
+    - name: Add nightly rustfmt and clippy
+      run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
+    - uses: lyricwulf/abc@v1
+      with: 
+        # todo: remove afl++-clang when nyx support samcov_pcguard
+        linux: llvm llvm-dev clang nasm ninja-build gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libgtk-3-dev afl++-clang pax-utils
+        # update bash for macos to support `declare -A` command`
+        macos: llvm libpng nasm coreutils z3 bash
+    - name: pip install
+      run: python3 -m pip install msgpack jinja2
+    - name: install cargo-make
+      uses: baptiste0928/cargo-install@v1.3.0
+      with:
+        crate: cargo-make
+    - uses: actions/checkout@v2
+      with:
+        submodules: true # recursively checkout submodules
+    - name: Build and run example fuzzers
+      if: runner.os == 'Linux'
+      run: ./scripts/test_all_fuzzers.sh
+    - name: Build and run example fuzzers
+      if: runner.os == 'macOS' # use bash v4
+      run: /usr/local/bin/bash ./scripts/test_all_fuzzers.sh
 
-  #nostd-build:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: nightly
-  #  - uses: Swatinem/rust-cache@v1
-  #  - name: Add nightly rustfmt and clippy
-  #    run: rustup toolchain install nightly && rustup target add --toolchain nightly aarch64-unknown-none && rustup component add --toolchain nightly rust-src && rustup target add thumbv6m-none-eabi
-  #  - uses: actions/checkout@v2
-  #  - name: Build aarch64-unknown-none
-  #    run: cd ./fuzzers/baby_no_std && cargo +nightly build -Zbuild-std=core,alloc --target aarch64-unknown-none -v --release && cd ../..
-  #  - name: run x86_64 until panic!
-  #    run: cd ./fuzzers/baby_no_std && cargo +nightly run || test $? -ne 0 || exit 1
-  #  - name: no_std tests
-  #    run: cd ./libafl && cargo test --no-default-features 
-  #  - name: libafl armv6m-none-eabi (32 bit no_std) clippy
-  #    run: cd ./libafl && cargo clippy --target thumbv6m-none-eabi --no-default-features
+  nostd-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+    - uses: Swatinem/rust-cache@v1
+    - name: Add nightly rustfmt and clippy
+      run: rustup toolchain install nightly && rustup target add --toolchain nightly aarch64-unknown-none && rustup component add --toolchain nightly rust-src && rustup target add thumbv6m-none-eabi
+    - uses: actions/checkout@v2
+    - name: Build aarch64-unknown-none
+      run: cd ./fuzzers/baby_no_std && cargo +nightly build -Zbuild-std=core,alloc --target aarch64-unknown-none -v --release && cd ../..
+    - name: run x86_64 until panic!
+      run: cd ./fuzzers/baby_no_std && cargo +nightly run || test $? -ne 0 || exit 1
+    - name: no_std tests
+      run: cd ./libafl && cargo test --no-default-features 
+    - name: libafl armv6m-none-eabi (32 bit no_std) clippy
+      run: cd ./libafl && cargo clippy --target thumbv6m-none-eabi --no-default-features
 
-  #build-docker:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #  - name: Build docker
-  #    run: docker build -t libafl .
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build docker
+      run: docker build -t libafl .
 
   windows:
     runs-on: windows-latest
@@ -215,102 +215,99 @@ jobs:
         command: clippy
     - name: Build docs
       run: cargo doc
-    #- name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
-    #  uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-    #  with:
-    #    version: "12.0"
-    #    directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - name: install cargo-make
       run: cargo install --force cargo-make
     - uses: ilammy/msvc-dev-cmd@v1
-    - name: Build frida
+    - name: Build fuzzers/frida_libpng
       run: cd fuzzers/frida_libpng/ && cargo make test
+    - name: Build fuzzers/frida_gdiplus
+      run: cd fuzzers/frida_gdiplus/ && cargo make test
       
-  #macos:
-  #  runs-on: macOS-latest
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: stable
-  #  - uses: Swatinem/rust-cache@v1
-  #  - name: Add nightly rustfmt and clippy
-  #    run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
-  #  - name: Install deps
-  #    run: brew install z3 gtk+3
-  #  - uses: actions/checkout@v2
-  #  - name: MacOS Build
-  #    run: cargo build --verbose
-  #  - name: Run clippy
-  #    run: ./scripts/clippy.sh
-  #  - name: Increase map sizes
-  #    run: ./scripts/shmem_limits_macos.sh
-  #  - name: Run Tests
-  #    run: cargo test
+  macos:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v1
+    - name: Add nightly rustfmt and clippy
+      run: rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
+    - name: Install deps
+      run: brew install z3 gtk+3
+    - uses: actions/checkout@v2
+    - name: MacOS Build
+      run: cargo build --verbose
+    - name: Run clippy
+      run: ./scripts/clippy.sh
+    - name: Increase map sizes
+      run: ./scripts/shmem_limits_macos.sh
+    - name: Run Tests
+      run: cargo test
 
-  #other_targets:
-  #  runs-on: macOS-latest
-  #  steps:
-  #  - uses: actions-rs/toolchain@v1
-  #    with:
-  #      profile: minimal
-  #      toolchain: stable
-  #  - uses: Swatinem/rust-cache@v1
-  #  - uses: nttld/setup-ndk@v1
-  #    with:
-  #      ndk-version: r21e
-  #  - name: install ios
-  #    run: rustup target add aarch64-apple-ios
-  #  - name: install android
-  #    run: rustup target add aarch64-linux-android
-  #  - name: install cargo ndk
-  #    run: cargo install cargo-ndk
-  #  - uses: actions/checkout@v2
-  #  - name: Build iOS
-  #    run: cargo build --target aarch64-apple-ios
-  #  - name: Build Android
-  #    run: cargo ndk -t arm64-v8a build --release 
-  #  #run: cargo build --target aarch64-linux-android
-  #  # TODO: Figure out how to properly build stuff with clang
-  #  #- name: Add clang path to $PATH env
-  #  #  if: runner.os == 'Windows'
-  #  #  run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-  #  #- name: Try if clang works
-  #  #  run: clang -v
-  #  #- name: Windows Test
-  #  #  run: C:\Rust\.cargo\bin\cargo.exe test --verbose
+  other_targets:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v1
+    - uses: nttld/setup-ndk@v1
+      with:
+        ndk-version: r21e
+    - name: install ios
+      run: rustup target add aarch64-apple-ios
+    - name: install android
+      run: rustup target add aarch64-linux-android
+    - name: install cargo ndk
+      run: cargo install cargo-ndk
+    - uses: actions/checkout@v2
+    - name: Build iOS
+      run: cargo build --target aarch64-apple-ios
+    - name: Build Android
+      run: cargo ndk -t arm64-v8a build --release 
+    #run: cargo build --target aarch64-linux-android
+    # TODO: Figure out how to properly build stuff with clang
+    #- name: Add clang path to $PATH env
+    #  if: runner.os == 'Windows'
+    #  run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+    #- name: Try if clang works
+    #  run: clang -v
+    #- name: Windows Test
+    #  run: C:\Rust\.cargo\bin\cargo.exe test --verbose
 
-  #freebsd:
-  #  runs-on: macos-12
-  #  name: Simple build in FreeBSD
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #  - name: Test in FreeBSD
-  #    id: test
-  #    uses: vmactions/freebsd-vm@v0
-  #    with:
-  #      usesh: true
-  #      sync: rsync
-  #      copyback: false
-  #      mem: 2048
-  #      release: 13.1
-  #      prepare: |
-  #        pkg install -y curl bash sudo llvm14
-  #        curl https://sh.rustup.rs -sSf | sh -s -- -y
+  freebsd:
+    runs-on: macos-12
+    name: Simple build in FreeBSD
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test in FreeBSD
+      id: test
+      uses: vmactions/freebsd-vm@v0
+      with:
+        usesh: true
+        sync: rsync
+        copyback: false
+        mem: 2048
+        release: 13.1
+        prepare: |
+          pkg install -y curl bash sudo llvm14
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-  #      run: |
-  #        freebsd-version
-  #        . "$HOME/.cargo/env"
-  #        rustup toolchain install nightly
-  #        export LLVM_CONFIG=/usr/local/bin/llvm-config14
-  #        pwd
-  #        ls -lah
-  #        echo "local/bin"
-  #        ls -lah /usr/local/bin/
-  #        which llvm-config
-  #        chmod +x ./scripts/clippy.sh
-  #        bash ./scripts/shmem_limits_fbsd.sh
-  #        bash ./scripts/clippy.sh
-  #        cargo test
+        run: |
+          freebsd-version
+          . "$HOME/.cargo/env"
+          rustup toolchain install nightly
+          export LLVM_CONFIG=/usr/local/bin/llvm-config14
+          pwd
+          ls -lah
+          echo "local/bin"
+          ls -lah /usr/local/bin/
+          which llvm-config
+          chmod +x ./scripts/clippy.sh
+          bash ./scripts/shmem_limits_fbsd.sh
+          bash ./scripts/clippy.sh
+          cargo test


### PR DESCRIPTION
Remove clang download from windows CI since there is [already one installed](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#language-and-runtime)