### PR TITLE
Add ability to use virtual dispatch to stagesTuple

### DIFF
--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -151,7 +151,7 @@ where
     I: Input,
     EM: ProgressReporter<I>,
     S: HasExecutions + HasClientPerfMonitor + HasMetadata,
-    ST: ?Sized
+    ST: ?Sized,
 {
     /// Fuzz for a single iteration.
     /// Returns the index of the last fuzzed corpus item.

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -151,6 +151,7 @@ where
     I: Input,
     EM: ProgressReporter<I>,
     S: HasExecutions + HasClientPerfMonitor + HasMetadata,
+    ST: ?Sized
 {
     /// Fuzz for a single iteration.
     /// Returns the index of the last fuzzed corpus item.
@@ -521,7 +522,7 @@ where
     I: Input,
     S: HasClientPerfMonitor + HasExecutions + HasMetadata,
     OF: Feedback<I, S>,
-    ST: StagesTuple<E, EM, S, Self>,
+    ST: StagesTuple<E, EM, S, Self> + ?Sized,
 {
     fn fuzz_one(
         &mut self,


### PR DESCRIPTION
I often find myself trying out different configurations on every aspect of the fuzzing. Especially ObserversTuple, StagesTuple, but I think there could be a discussion over more generic parts of the code.

With this change, I could configure stages at run-time (with CLI flags in my case):

```rs
let concrete_stages = tuple_list!(
  ...
);

let mut stages = Box<dyn StagesTuple<_,_,_,_>>;

if args.is_present("flag") {
  // Con-style stages
  stages = Box::new((AdditionalStage::new(), concrete_stages));
else {
  stages = Box::new(concrete_stages);
}

fuzzer.fuzz_loop(stages.as_mut(), &mut executor, &mut state, &mut mgr);
```

I would like to add this to more parts of the code, because I want to run quick sanity-checks.

Note that my main issue is that I have to write out full types if I have to e.g. extract a function which passes or returns ObserversTuple. I am trying to wrap my head around alternative solutions, but this is the first which seems manageable, and does not seem to impact performance.

What do you think? Also, should I extract the broader issue (about other types) for discussion?