### PR TITLE
Hook IsProcessorFeaturePresent to crash with STATUS_STACK_BUFFER_OVERRUN exception

### DIFF
--- a/fuzzers/frida_gdiplus/Cargo.toml
+++ b/fuzzers/frida_gdiplus/Cargo.toml
@@ -29,7 +29,6 @@ capstone = "0.11.0"
 frida-gum = { version = "0.8.1", features = [ "auto-download", "event-sink", "invocation-listener"] }
 libafl_frida = { path = "../../libafl_frida", features = ["cmplog"] }
 libafl_targets = { path = "../../libafl_targets", features = ["sancov_cmplog"] }
-lazy_static = "1.4.0"
 libc = "0.2"
 libloading = "0.7"
 num-traits = "0.2"

--- a/libafl/src/bolts/os/windows_exceptions.rs
+++ b/libafl/src/bolts/os/windows_exceptions.rs
@@ -316,7 +316,7 @@ unsafe fn internal_handle_exception(
 }
 
 /// Internal function that is being called whenever an exception arrives (stdcall).
-unsafe extern "system" fn handle_exception(exception_pointers: *mut EXCEPTION_POINTERS) -> c_long {
+pub unsafe extern "system" fn handle_exception(exception_pointers: *mut EXCEPTION_POINTERS) -> c_long {
     let code = exception_pointers
         .as_mut()
         .unwrap()

--- a/libafl/src/bolts/os/windows_exceptions.rs
+++ b/libafl/src/bolts/os/windows_exceptions.rs
@@ -315,7 +315,9 @@ unsafe fn internal_handle_exception(
     }
 }
 
-/// Internal function that is being called whenever an exception arrives (stdcall).
+/// Function that is being called whenever an exception arrives (stdcall).
+/// # Safety
+/// This function is unsafe because it is called by the OS
 pub unsafe extern "system" fn handle_exception(
     exception_pointers: *mut EXCEPTION_POINTERS,
 ) -> c_long {

--- a/libafl/src/bolts/os/windows_exceptions.rs
+++ b/libafl/src/bolts/os/windows_exceptions.rs
@@ -13,7 +13,10 @@ use std::os::raw::{c_long, c_void};
 use num_enum::TryFromPrimitive;
 pub use windows::Win32::{
     Foundation::NTSTATUS,
-    System::Diagnostics::Debug::{AddVectoredExceptionHandler, EXCEPTION_POINTERS},
+    System::{
+        Diagnostics::Debug::{AddVectoredExceptionHandler, EXCEPTION_POINTERS},
+        Threading::{IsProcessorFeaturePresent, PROCESSOR_FEATURE_ID},
+    },
 };
 
 use crate::Error;

--- a/libafl/src/bolts/os/windows_exceptions.rs
+++ b/libafl/src/bolts/os/windows_exceptions.rs
@@ -316,7 +316,9 @@ unsafe fn internal_handle_exception(
 }
 
 /// Internal function that is being called whenever an exception arrives (stdcall).
-pub unsafe extern "system" fn handle_exception(exception_pointers: *mut EXCEPTION_POINTERS) -> c_long {
+pub unsafe extern "system" fn handle_exception(
+    exception_pointers: *mut EXCEPTION_POINTERS,
+) -> c_long {
     let code = exception_pointers
         .as_mut()
         .unwrap()

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -39,4 +39,3 @@ backtrace = { version = "0.3", default-features = false, features = ["std", "ser
 num-traits = "0.2"
 ahash = "0.7"
 paste = "1.0"
-lazy_static = "1.4.0"

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -39,3 +39,4 @@ backtrace = { version = "0.3", default-features = false, features = ["std", "ser
 num-traits = "0.2"
 ahash = "0.7"
 paste = "1.0"
+lazy_static = "1.4.0"

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -149,7 +149,7 @@ where
         }
 
         #[cfg(windows)]
-        initialize(&gum);
+        initialize(&gum).unwrap();
 
         Self {
             base,

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -18,6 +18,9 @@ use libafl::{
 use crate::asan::errors::ASAN_ERRORS;
 use crate::helper::{FridaInstrumentationHelper, FridaRuntimeTuple};
 
+#[cfg(windows)]
+use crate::windows_hooks::initialize;
+
 /// The [`FridaInProcessExecutor`] is an [`Executor`] that executes the target in the same process, usinig [`frida`](https://frida.re/) for binary-only instrumentation.
 pub struct FridaInProcessExecutor<'a, 'b, 'c, H, I, OT, RT, S>
 where
@@ -145,6 +148,9 @@ where
                 range.end - range.start,
             ));
         }
+
+        #[cfg(windows)]
+        initialize();
 
         Self {
             base,

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -149,7 +149,7 @@ where
         }
 
         #[cfg(windows)]
-        initialize(&gum).unwrap();
+        initialize(&gum);
 
         Self {
             base,

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -17,7 +17,6 @@ use libafl::{
 #[cfg(unix)]
 use crate::asan::errors::ASAN_ERRORS;
 use crate::helper::{FridaInstrumentationHelper, FridaRuntimeTuple};
-
 #[cfg(windows)]
 use crate::windows_hooks::initialize;
 

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -149,7 +149,7 @@ where
         }
 
         #[cfg(windows)]
-        initialize();
+        initialize(&gum);
 
         Self {
             base,

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -69,6 +69,10 @@ pub mod alloc;
 #[cfg(unix)]
 pub mod asan;
 
+#[cfg(windows)]
+/// Windows specific hooks to catch __fastfail like exceptions with Frida, see https://github.com/AFLplusplus/LibAFL/issues/395 for more details
+pub mod windows_hooks;
+
 pub mod coverage_rt;
 
 #[cfg(feature = "cmplog")]

--- a/libafl_frida/src/windows_hooks.rs
+++ b/libafl_frida/src/windows_hooks.rs
@@ -1,0 +1,98 @@
+// Based on the example of setting hooks: https://github.com/frida/frida-rust/blob/main/examples/gum/hook_open/src/lib.rs
+use std::{cell::UnsafeCell, sync::Mutex};
+
+use frida_gum::{interceptor::Interceptor, Gum, Module, NativePointer};
+use lazy_static::lazy_static;
+use libafl::bolts::os::windows_exceptions::{handle_exception, EXCEPTION_POINTERS};
+
+type IsProcessorFeaturePresentFunc = unsafe extern "C" fn(feature: u32) -> bool;
+type UnhandledExceptionFilterFunc =
+    unsafe extern "C" fn(exceptioninfo: *mut EXCEPTION_POINTERS) -> i32;
+
+lazy_static! {
+    static ref GUM: Gum = unsafe { Gum::obtain() };
+    static ref IS_PROCESSOR_FEATURE_PRESENT: Mutex<UnsafeCell<Option<IsProcessorFeaturePresentFunc>>> =
+        Mutex::new(UnsafeCell::new(None));
+    static ref UNHANDLED_EXCEPTION_FILTER: Mutex<UnsafeCell<Option<UnhandledExceptionFilterFunc>>> =
+        Mutex::new(UnsafeCell::new(None));
+}
+
+/// Initialize the hooks
+pub fn initialize() {
+    let is_processor_feature_present =
+        Module::find_export_by_name(Some("kernel32.dll"), "IsProcessorFeaturePresent");
+    let is_processor_feature_present = is_processor_feature_present.unwrap();
+    if is_processor_feature_present.is_null() {
+        panic!("IsProcessorFeaturePresent not found");
+    }
+    let unhandled_exception_filter =
+        Module::find_export_by_name(Some("kernel32.dll"), "UnhandledExceptionFilter");
+    let unhandled_exception_filter = unhandled_exception_filter.unwrap();
+    if unhandled_exception_filter.is_null() {
+        panic!("UnhandledExceptionFilter not found");
+    }
+
+    let mut interceptor = Interceptor::obtain(&GUM);
+    use std::ffi::c_void;
+
+    unsafe {
+        *IS_PROCESSOR_FEATURE_PRESENT.lock().unwrap().get_mut() = Some(std::mem::transmute(
+            interceptor
+                .replace(
+                    is_processor_feature_present,
+                    NativePointer(is_processor_feature_present_detour as *mut c_void),
+                    NativePointer(std::ptr::null_mut()),
+                )
+                .unwrap()
+                .0,
+        ));
+        *UNHANDLED_EXCEPTION_FILTER.lock().unwrap().get_mut() = Some(std::mem::transmute(
+            interceptor
+                .replace(
+                    unhandled_exception_filter,
+                    NativePointer(unhandled_exception_filter_detour as *mut c_void),
+                    NativePointer(std::ptr::null_mut()),
+                )
+                .unwrap()
+                .0,
+        ));
+    }
+
+    unsafe extern "C" fn is_processor_feature_present_detour(feature: u32) -> bool {
+        let func = IS_PROCESSOR_FEATURE_PRESENT
+            .lock()
+            .unwrap()
+            .get()
+            .as_ref()
+            .unwrap()
+            .unwrap();
+
+        let result = match feature {
+            0x17 => false,
+            _ => func(feature),
+        };
+        println!(
+            "IsProcessorFeaturePresent({}) returning {}",
+            feature, result
+        );
+        result
+    }
+
+    unsafe extern "C" fn unhandled_exception_filter_detour(
+        exception_pointers: *mut EXCEPTION_POINTERS,
+    ) -> i32 {
+        let func = UNHANDLED_EXCEPTION_FILTER
+            .lock()
+            .unwrap()
+            .get()
+            .as_ref()
+            .unwrap()
+            .unwrap();
+
+        println!("Calling handle_exception");
+        handle_exception(exception_pointers);
+        println!("UnhandledExceptionFilter() calling the orig function...");
+        let result = func(exception_pointers);
+        result
+    }
+}

--- a/libafl_frida/src/windows_hooks.rs
+++ b/libafl_frida/src/windows_hooks.rs
@@ -1,31 +1,22 @@
 // Based on the example of setting hooks: Https://github.com/frida/frida-rust/blob/main/examples/gum/hook_open/src/lib.rs
 use frida_gum::{interceptor::Interceptor, Gum, Module, NativePointer};
-use libafl::{
-    bolts::os::windows_exceptions::{
-        handle_exception, IsProcessorFeaturePresent, EXCEPTION_POINTERS, PROCESSOR_FEATURE_ID,
-    },
-    Error, ErrorBacktrace,
+use libafl::bolts::os::windows_exceptions::{
+    handle_exception, IsProcessorFeaturePresent, EXCEPTION_POINTERS, PROCESSOR_FEATURE_ID,
 };
 
 /// Initialize the hooks
-pub fn initialize(gum: &Gum) -> Result<(), Error> {
+pub fn initialize(gum: &Gum) {
     let is_processor_feature_present =
         Module::find_export_by_name(Some("kernel32.dll"), "IsProcessorFeaturePresent");
     let is_processor_feature_present = is_processor_feature_present.unwrap();
     if is_processor_feature_present.is_null() {
-        return Err(Error::Unknown(
-            "IsProcessorFeaturePresent not found".to_string(),
-            ErrorBacktrace::new(),
-        ));
+        panic!("IsProcessorFeaturePresent not found");
     }
     let unhandled_exception_filter =
         Module::find_export_by_name(Some("kernel32.dll"), "UnhandledExceptionFilter");
     let unhandled_exception_filter = unhandled_exception_filter.unwrap();
     if unhandled_exception_filter.is_null() {
-        return Err(Error::Unknown(
-            "UnhandledExceptionFilter not found".to_string(),
-            ErrorBacktrace::new(),
-        ));
+        panic!("UnhandledExceptionFilter not found");
     }
 
     let mut interceptor = Interceptor::obtain(&gum);
@@ -61,5 +52,4 @@ pub fn initialize(gum: &Gum) -> Result<(), Error> {
         handle_exception(exception_pointers);
         unreachable!("handle_exception should not return");
     }
-    Ok(())
 }

--- a/libafl_frida/src/windows_hooks.rs
+++ b/libafl_frida/src/windows_hooks.rs
@@ -1,16 +1,11 @@
 // Based on the example of setting hooks: https://github.com/frida/frida-rust/blob/main/examples/gum/hook_open/src/lib.rs
 use frida_gum::{interceptor::Interceptor, Gum, Module, NativePointer};
-use lazy_static::lazy_static;
 use libafl::bolts::os::windows_exceptions::{
     handle_exception, IsProcessorFeaturePresent, EXCEPTION_POINTERS, PROCESSOR_FEATURE_ID,
 };
 
-lazy_static! {
-    static ref GUM: Gum = unsafe { Gum::obtain() };
-}
-
 /// Initialize the hooks
-pub fn initialize() {
+pub fn initialize(gum: &Gum) {
     let is_processor_feature_present =
         Module::find_export_by_name(Some("kernel32.dll"), "IsProcessorFeaturePresent");
     let is_processor_feature_present = is_processor_feature_present.unwrap();
@@ -24,7 +19,7 @@ pub fn initialize() {
         panic!("UnhandledExceptionFilter not found");
     }
 
-    let mut interceptor = Interceptor::obtain(&GUM);
+    let mut interceptor = Interceptor::obtain(&gum);
     use std::ffi::c_void;
 
     interceptor

--- a/libafl_frida/src/windows_hooks.rs
+++ b/libafl_frida/src/windows_hooks.rs
@@ -39,24 +39,16 @@ pub fn initialize(gum: &Gum) {
         .unwrap();
 
     unsafe extern "C" fn is_processor_feature_present_detour(feature: u32) -> bool {
-        println!("IsProcessorFeaturePresent called with feature {}", feature);
-
         let result = match feature {
             0x17 => false,
             _ => IsProcessorFeaturePresent(PROCESSOR_FEATURE_ID(feature)).as_bool(),
         };
-        println!(
-            "IsProcessorFeaturePresent({}) returning {}",
-            feature, result
-        );
         result
     }
 
     unsafe extern "C" fn unhandled_exception_filter_detour(
         exception_pointers: *mut EXCEPTION_POINTERS,
     ) -> i32 {
-        println!("Calling handle_exception");
-        handle_exception(exception_pointers);
         unreachable!("handle_exception should not return");
     }
 }


### PR DESCRIPTION
Closes #395

I feel like I just created the architectual crutches by introducing [windows_hooks.rs](https://github.com/AFLplusplus/LibAFL/compare/main...expend20:LibAFL:fastfail-fix?expand=1#diff-039e662e2d4ee92b6b369a86ff38b2bf5e3a8a642e56a42386aff7c89f8efd31) with lazy_static in it. I basically needed the following, but didn't find a good way to do that. I appreciate the review comments
* I need a placeholder for keeping the result of `interceptor.replace` becase the function returns the original (not hooked) function so we could use it from our detour
* The reference for that placeholder can be passed as a parameter to the *_detour functions, now it is passed through a Mutex, but anyway the placeholder should live all the time hook exist