### PR TITLE
Adding fork feature passing from libafl_qemu to libafl crate

### DIFF
--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -12,22 +12,23 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["usermode"]
+default = ["fork"]
 python = ["pyo3", "pyo3-build-config"]
+fork = ["libafl/fork"]
 
 # The following architecture features are mutually exclusive.
 x86_64 = [] # build qemu for x86_64 (default)
 i386 = [] # build qemu for i386
 arm = [] # build qemu for arm
 aarch64 = [] # build qemu for aarch64
-be = []
 
 usermode = []
+systemmode = []
 
 clippy = [] # special feature for clippy, don't use in normal projects§
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.8.1" }
+libafl = { path = "../libafl", version = "0.8.1", default-features = false, features = ["std", "derive", "llmp_compression", "rand_trait"] }
 libafl_targets = { path = "../libafl_targets", version = "0.8.1" }
 
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["usermode"]
+default = ["usermode", "fork"]
 python = ["pyo3", "pyo3-build-config"]
 fork = ["libafl/fork"]
 

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["fork"]
+default = ["usermode"]
 python = ["pyo3", "pyo3-build-config"]
 fork = ["libafl/fork"]
 
@@ -21,9 +21,9 @@ x86_64 = [] # build qemu for x86_64 (default)
 i386 = [] # build qemu for i386
 arm = [] # build qemu for arm
 aarch64 = [] # build qemu for aarch64
+be = []
 
 usermode = []
-systemmode = []
 
 clippy = [] # special feature for clippy, don't use in normal projects§
 

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -28,7 +28,7 @@ usermode = []
 clippy = [] # special feature for clippy, don't use in normal projects§
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.8.1", default-features = false, features = ["std", "derive", "llmp_compression", "rand_trait"] }
+libafl = { path = "../libafl", version = "0.8.1", default-features = false, features = ["std", "derive", "llmp_compression"] }
 libafl_targets = { path = "../libafl_targets", version = "0.8.1" }
 
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -1,10 +1,12 @@
 //! A `QEMU`-based executor for binary-only instrumentation in `LibAFL`
 use core::fmt::{self, Debug, Formatter};
 
+#[cfg(feature = "fork")]
+use libafl::executors::InProcessForkExecutor;
 use libafl::{
     bolts::shmem::ShMemProvider,
     events::{EventFirer, EventRestarter},
-    executors::{Executor, ExitKind, HasObservers, InProcessExecutor, InProcessForkExecutor},
+    executors::{Executor, ExitKind, HasObservers, InProcessExecutor},
     feedbacks::Feedback,
     fuzzer::HasObjective,
     inputs::Input,
@@ -130,6 +132,7 @@ where
     }
 }
 
+#[cfg(feature = "fork")]
 pub struct QemuForkExecutor<'a, H, I, OT, QT, S, SP>
 where
     H: FnMut(&I) -> ExitKind,
@@ -142,6 +145,7 @@ where
     inner: InProcessForkExecutor<'a, H, I, OT, S, SP>,
 }
 
+#[cfg(feature = "fork")]
 impl<'a, H, I, OT, QT, S, SP> Debug for QemuForkExecutor<'a, H, I, OT, QT, S, SP>
 where
     H: FnMut(&I) -> ExitKind,
@@ -158,6 +162,7 @@ where
     }
 }
 
+#[cfg(feature = "fork")]
 impl<'a, H, I, OT, QT, S, SP> QemuForkExecutor<'a, H, I, OT, QT, S, SP>
 where
     H: FnMut(&I) -> ExitKind,
@@ -217,6 +222,7 @@ where
     }
 }
 
+#[cfg(feature = "fork")]
 impl<'a, EM, H, I, OT, QT, S, Z, SP> Executor<EM, I, S, Z>
     for QemuForkExecutor<'a, H, I, OT, QT, S, SP>
 where
@@ -241,6 +247,7 @@ where
     }
 }
 
+#[cfg(feature = "fork")]
 impl<'a, H, I, OT, QT, S, SP> HasObservers<I, OT, S> for QemuForkExecutor<'a, H, I, OT, QT, S, SP>
 where
     H: FnMut(&I) -> ExitKind,

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -62,7 +62,9 @@ pub use asan::{init_with_asan, QemuAsanHelper};
 pub mod calls;
 
 pub mod executor;
-pub use executor::{QemuExecutor, QemuForkExecutor};
+pub use executor::QemuExecutor;
+#[cfg(feature = "fork")]
+pub use executor::QemuForkExecutor;
 
 pub mod emu;
 pub use emu::*;


### PR DESCRIPTION
Problem:
Currently, it is not possible to disable the `fork` feature on `unix` without breaking the `libafl_qemu` build process. This is because `QemuForkExecutor` depends on `InProcessForkExecutor`.

Fix:
Adding `fork` feature to `libafl_qemu` and passing it down to `libafl`.