### PR TITLE
Enable additional rustc errors in test only

### DIFF
--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -27,7 +27,7 @@ Welcome to `LibAFL`
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![cfg_attr(debug_assertions, warn(
+#![cfg_attr(not(test), warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -37,7 +37,7 @@ Welcome to `LibAFL`
     unused_qualifications,
     //unused_results
 ))]
-#![cfg_attr(not(debug_assertions), deny(
+#![cfg_attr(test, deny(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -50,7 +50,7 @@ Welcome to `LibAFL`
     //unused_results
 ))]
 #![cfg_attr(
-    not(debug_assertions),
+    test,
     deny(
         bad_style,
         const_err,
@@ -70,9 +70,6 @@ Welcome to `LibAFL`
         while_true
     )
 )]
-// Till they fix this buggy lint in clippy
-#![allow(clippy::borrow_as_ptr)]
-#![allow(clippy::borrow_deref_ref)]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -15,7 +15,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![cfg_attr(debug_assertions, warn(
+#![cfg_attr(not(test), warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -25,7 +25,7 @@
     unused_qualifications,
     //unused_results
 ))]
-#![cfg_attr(not(debug_assertions), deny(
+#![cfg_attr(test, deny(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -33,10 +33,12 @@
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
+    unused_must_use,
+    missing_docs,
     //unused_results
 ))]
 #![cfg_attr(
-    not(debug_assertions),
+    test,
     deny(
         bad_style,
         const_err,

--- a/libafl_derive/src/lib.rs
+++ b/libafl_derive/src/lib.rs
@@ -16,7 +16,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![cfg_attr(debug_assertions, warn(
+#![cfg_attr(not(test), warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -26,7 +26,7 @@
     unused_qualifications,
     //unused_results
 ))]
-#![cfg_attr(not(debug_assertions), deny(
+#![cfg_attr(test, deny(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -34,10 +34,12 @@
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
+    unused_must_use,
+    missing_docs,
     //unused_results
 ))]
 #![cfg_attr(
-    not(debug_assertions),
+    test,
     deny(
         bad_style,
         const_err,

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -18,7 +18,7 @@ It can report coverage and, on supported architecutres, even reports memory acce
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![cfg_attr(debug_assertions, warn(
+#![cfg_attr(not(test), warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -28,7 +28,7 @@ It can report coverage and, on supported architecutres, even reports memory acce
     unused_qualifications,
     //unused_results
 ))]
-#![cfg_attr(not(debug_assertions), deny(
+#![cfg_attr(test, deny(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -36,10 +36,12 @@ It can report coverage and, on supported architecutres, even reports memory acce
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
+    unused_must_use,
+    missing_docs,
     //unused_results
 ))]
 #![cfg_attr(
-    not(debug_assertions),
+    test,
     deny(
         bad_style,
         const_err,

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -15,7 +15,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![cfg_attr(debug_assertions, warn(
+#![cfg_attr(not(test), warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -25,7 +25,7 @@
     unused_qualifications,
     //unused_results
 ))]
-#![cfg_attr(not(debug_assertions), deny(
+#![cfg_attr(test, deny(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -33,10 +33,12 @@
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
+    unused_must_use,
+    missing_docs,
     //unused_results
 ))]
 #![cfg_attr(
-    not(debug_assertions),
+    test,
     deny(
         bad_style,
         const_err,

--- a/libafl_targets/src/lib.rs
+++ b/libafl_targets/src/lib.rs
@@ -17,7 +17,7 @@
     clippy::module_name_repetitions,
     clippy::unreadable_literal
 )]
-#![cfg_attr(debug_assertions, warn(
+#![cfg_attr(not(test), warn(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -27,7 +27,7 @@
     unused_qualifications,
     //unused_results
 ))]
-#![cfg_attr(not(debug_assertions), deny(
+#![cfg_attr(test, deny(
     missing_debug_implementations,
     missing_docs,
     //trivial_casts,
@@ -35,10 +35,12 @@
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
+    unused_must_use,
+    missing_docs,
     //unused_results
 ))]
 #![cfg_attr(
-    not(debug_assertions),
+    test,
     deny(
         bad_style,
         const_err,


### PR DESCRIPTION
This should make sure compilation doesn't brake with future Rust versions