### PR TITLE
Fixing clippy

### DIFF
--- a/libafl_targets/build.rs
+++ b/libafl_targets/build.rs
@@ -73,9 +73,9 @@ fn main() {
         }
 
         sancov_cmp
-            .define("CMP_MAP_SIZE", Some(&*format!("{}", cmp_map_size)))
-            .define("CMPLOG_MAP_W", Some(&*format!("{}", cmplog_map_w)))
-            .define("CMPLOG_MAP_H", Some(&*format!("{}", cmplog_map_h)))
+            .define("CMP_MAP_SIZE", Some(&*format!("{cmp_map_size}")))
+            .define("CMPLOG_MAP_W", Some(&*format!("{cmplog_map_w}")))
+            .define("CMPLOG_MAP_H", Some(&*format!("{cmplog_map_h}")))
             .file(src_dir.join("sancov_cmp.c"))
             .compile("sancov_cmp");
     }
@@ -105,16 +105,16 @@ fn main() {
 
     cc::Build::new()
         .file(src_dir.join("coverage.c"))
-        .define("EDGES_MAP_SIZE", Some(&*format!("{}", edges_map_size)))
-        .define("ACCOUNTING_MAP_SIZE", Some(&*format!("{}", acc_map_size)))
+        .define("EDGES_MAP_SIZE", Some(&*format!("{edges_map_size}")))
+        .define("ACCOUNTING_MAP_SIZE", Some(&*format!("{acc_map_size}")))
         .compile("coverage");
 
     println!("cargo:rerun-if-changed=src/cmplog.h");
     println!("cargo:rerun-if-changed=src/cmplog.c");
 
     cc::Build::new()
-        .define("CMPLOG_MAP_W", Some(&*format!("{}", cmplog_map_w)))
-        .define("CMPLOG_MAP_H", Some(&*format!("{}", cmplog_map_h)))
+        .define("CMPLOG_MAP_W", Some(&*format!("{cmplog_map_w}")))
+        .define("CMPLOG_MAP_H", Some(&*format!("{cmplog_map_h}")))
         .file(src_dir.join("cmplog.c"))
         .compile("cmplog");
 


### PR DESCRIPTION
Fixing recent clippy complain:
error: variables can be used directly in the `format!` string
  --> libafl_targets/build.rs:76:44
   |
76 |             .define("CMP_MAP_SIZE", Some(&*format!("{}", cmp_map_size)))
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
note: `-D clippy::uninlined-format-args` implied by `-D clippy::pedantic`
...
...