### PR TITLE
token mutations: set MutationResult for CmpValues::Bytes

### DIFF
--- a/fuzzers/frida_libpng/README.md
+++ b/fuzzers/frida_libpng/README.md
@@ -38,7 +38,7 @@ You can also fuzz libpng-1.6.37 on windows with frida mode
 ### To build it with visual studio
 1. Install clang for windows (make sure you add LLVM to the system path!) 
 [https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.1](https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.1)
-2. Download libpng-1.6.37[https://deac-fra.dl.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz] and zlib [https://zlib.net/zlib-1.2.11.tar.gz] into this directory, and rename `zlib-1.2.11` directory to `zlib`.
+2. Download libpng-1.6.37[https://deac-fra.dl.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz] and zlib [https://zlib.net/fossils/zlib-1.2.11.tar.gz] into this directory, and rename `zlib-1.2.11` directory to `zlib`.
 
 3. Build libpng1.6.37 
    - Open libpng-1.6.37/projects/vstudio/vstudio.sln 

--- a/fuzzers/qemu_arm_launcher/Makefile.toml
+++ b/fuzzers/qemu_arm_launcher/Makefile.toml
@@ -20,8 +20,10 @@ windows_alias = "unsupported"
 [tasks.zlib_unix_wget]
 condition = { files_not_exist = [ "./zlib-1.2.12" ] }
 script_runner="@shell"
+# NOTE: There's no specific reason we're using an old version of zlib,
+# but newer versions get moved to fossils/ after a while.
 script='''
-wget http://www.zlib.net/zlib-1.2.12.tar.gz
+wget https://zlib.net/fossils/zlib-1.2.12.tar.gz
 tar -xvf zlib-1.2.12.tar.gz
 '''
 

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -567,6 +567,7 @@ where
                     while size != 0 {
                         if v.0[0..size] == input.bytes()[i..i + size] {
                             buffer_copy(input.bytes_mut(), &v.1, 0, i, size);
+                            result = MutationResult::Mutated;
                             break 'outer;
                         }
                         size -= 1;
@@ -575,6 +576,7 @@ where
                     while size != 0 {
                         if v.1[0..size] == input.bytes()[i..i + size] {
                             buffer_copy(input.bytes_mut(), &v.0, 0, i, size);
+                            result = MutationResult::Mutated;
                             break 'outer;
                         }
                         size -= 1;
@@ -582,8 +584,6 @@ where
                 }
             }
         }
-
-        //println!("{:?}", result);
 
         Ok(result)
     }


### PR DESCRIPTION
I haven't measured this and am not even sure if CmpValues::Bytes is currently populated by any executor, but this seems like an oversight.