### PR TITLE
Expose OUT_DIR for compiler passes to other components

### DIFF
--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -10,6 +10,9 @@ use std::{
 
 use crate::{CompilerWrapper, Error, LIB_EXT, LIB_PREFIX};
 
+/// The `OUT_DIR` for `LLVM` compiler passes
+pub const OUT_DIR: &str = env!("OUT_DIR");
+
 fn dll_extension<'a>() -> &'a str {
     if cfg!(target_os = "windows") {
         "dll"


### PR DESCRIPTION
This makes it possible to copy&paste clang.rs and edit it for custom compiler wrappers, without copying everything.