### PR TITLE
Fix memory leaks and module instrumentation in frida_gdiplus

### DIFF
--- a/fuzzers/frida_gdiplus/README.md
+++ b/fuzzers/frida_gdiplus/README.md
@@ -6,4 +6,4 @@ Then compile the harness `cl.exe /LD harness.cc /link /dll gdiplus.lib ole32.lib
 
 ## Run
 
-To run the example `target\release\frida_gdiplus.exe -H harness.dll -i corpus -o output`
+To run the example `target\release\frida_gdiplus.exe -H harness.dll -i corpus -o output --libs-to-instrument gdi32.dll --libs-to-instrument gdi32full.dll --libs-to-instrument gdiplus.dll --libs-to-instrument WindowsCodecs.dll`

--- a/fuzzers/frida_gdiplus/harness.cc
+++ b/fuzzers/frida_gdiplus/harness.cc
@@ -16,16 +16,16 @@ GdiplusStartupInput gdiplusStartupInput;
 ULONG_PTR           gdiplusToken;
 
 // Some DLLs are lazily loaded during image loading
-// FridaInstrumentationHelper doesn't instrument DLLs that are loaded after init,
-// so they're manually loaded here
+// FridaInstrumentationHelper doesn't instrument DLLs that are loaded after
+// init, so they're manually loaded here
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
-    switch (fdwReason) {
-        case DLL_PROCESS_ATTACH:
-            LoadLibraryA("gdi32full.dll");
-            LoadLibraryA("WindowsCodecs.dll");
-            break;
-    }
-    return TRUE;
+  switch (fdwReason) {
+    case DLL_PROCESS_ATTACH:
+      LoadLibraryA("gdi32full.dll");
+      LoadLibraryA("WindowsCodecs.dll");
+      break;
+  }
+  return TRUE;
 }
 
 extern "C" __declspec(dllexport) int LLVMFuzzerTestOneInput(const uint8_t *data,

--- a/fuzzers/frida_gdiplus/harness.cc
+++ b/fuzzers/frida_gdiplus/harness.cc
@@ -15,6 +15,19 @@ using namespace Gdiplus;
 GdiplusStartupInput gdiplusStartupInput;
 ULONG_PTR           gdiplusToken;
 
+// Some DLLs are lazily loaded during image loading
+// FridaInstrumentationHelper doesn't instrument DLLs that are loaded after init,
+// so they're manually loaded here
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+    switch (fdwReason) {
+        case DLL_PROCESS_ATTACH:
+            LoadLibraryA("gdi32full.dll");
+            LoadLibraryA("WindowsCodecs.dll");
+            break;
+    }
+    return TRUE;
+}
+
 extern "C" __declspec(dllexport) int LLVMFuzzerTestOneInput(const uint8_t *data,
                                                             size_t size) {
   static DWORD init = 0;
@@ -34,8 +47,6 @@ extern "C" __declspec(dllexport) int LLVMFuzzerTestOneInput(const uint8_t *data,
         Gdiplus::Bitmap *m_pBitmap = Gdiplus::Bitmap::FromStream(pStream);
         pStream->Release();
         if (m_pBitmap) {
-          if (m_pBitmap->GetLastStatus() == Gdiplus::Ok) return true;
-
           delete m_pBitmap;
           m_pBitmap = NULL;
         }


### PR DESCRIPTION
It works until it starts trying to load JPEG files because the JPEG decoder uses exception unwinding (see #830)