### PR TITLE
Fixing baby_no_std

### DIFF
--- a/fuzzers/baby_no_std/Cargo.toml
+++ b/fuzzers/baby_no_std/Cargo.toml
@@ -20,5 +20,4 @@ static-alloc = "0.2.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-cstr_core = "0.2.3"
 

--- a/fuzzers/baby_no_std/Makefile.toml
+++ b/fuzzers/baby_no_std/Makefile.toml
@@ -25,6 +25,9 @@ cargo run -Zbuild-std=core,alloc --target x86_64-unknown-linux-gnu || true
 '''
 dependencies = ["build"]
 
+[tasks.build_aarch]
+script = "cargo +nightly build -Zbuild-std=core,alloc --target aarch64-unknown-none -v --release"
+
 # Clean
 [tasks.clean]
 command = "cargo"

--- a/fuzzers/baby_no_std/Makefile.toml
+++ b/fuzzers/baby_no_std/Makefile.toml
@@ -1,0 +1,31 @@
+[env]
+FUZZER_NAME="fuzzer"
+PROJECT_DIR = { script = ["pwd"] }
+
+[tasks.unsupported]
+script_runner="@shell"
+script='''
+echo "Cargo-make not integrated yet on this"
+'''
+
+# Fuzzer
+[tasks.build]
+command = "cargo"
+args = ["build", "--release", "-Zbuild-std=core,alloc", "--target", "x86_64-unknown-linux-gnu"]
+
+# Test
+[tasks.test]
+linux_alias = "test_unix"
+mac_alias = "unsupported"
+windows_alias = "unsupported"
+
+[tasks.test_unix]
+script='''
+cargo run -Zbuild-std=core,alloc --target x86_64-unknown-linux-gnu || true
+'''
+dependencies = ["build"]
+
+# Clean
+[tasks.clean]
+command = "cargo"
+args = ["clean"]

--- a/fuzzers/baby_no_std/build.rs
+++ b/fuzzers/baby_no_std/build.rs
@@ -1,4 +1,5 @@
 fn main() {
-    #[cfg(unix)]
-    println!("cargo:rustc-link-lib=c")
+    if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default() == "unix" {
+        println!("cargo:rustc-link-lib=c");
+    };
 }

--- a/fuzzers/baby_no_std/build.rs
+++ b/fuzzers/baby_no_std/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(unix)]
+    println!("cargo:rustc-link-lib=c")
+}

--- a/fuzzers/baby_no_std/rust-toolchain
+++ b/fuzzers/baby_no_std/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/fuzzers/baby_no_std/src/main.rs
+++ b/fuzzers/baby_no_std/src/main.rs
@@ -26,7 +26,7 @@ use libafl::{
     state::StdState,
 };
 #[cfg(any(windows, unix))]
-use libc::{abort, c_char, printf};
+use libc::{abort, printf};
 use static_alloc::Bump;
 
 #[global_allocator]
@@ -107,14 +107,11 @@ pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     .unwrap();
 
     // The Monitor trait define how the fuzzer stats are reported to the user
-    let monitor = SimpleMonitor::new(|s| {
-        // TODO: Print `s` here, if your target permits it.
+    let monitor = SimpleMonitor::new(|_s| {
+        // TODO: Print `_s` here, if your target permits it.
         #[cfg(any(windows, unix))]
         unsafe {
-            printf(
-                b"%s\n\0".as_ptr() as *const c_char,
-                CString::new(s).unwrap().as_ptr() as *const c_char,
-            );
+            printf(b"%s\n\0".as_ptr() as _, CString::new(_s).unwrap().as_ptr());
         }
     });
 

--- a/fuzzers/baby_no_std/src/main.rs
+++ b/fuzzers/baby_no_std/src/main.rs
@@ -52,7 +52,7 @@ fn signals_set(idx: usize) {
     unsafe { SIGNALS[idx] = 1 };
 }
 
-/// Provide custom time in no_std environment
+/// Provide custom time in `no_std` environment
 /// Use a time provider of your choice
 #[no_mangle]
 pub extern "C" fn external_current_millis() -> u64 {
@@ -60,6 +60,9 @@ pub extern "C" fn external_current_millis() -> u64 {
     1000
 }
 
+/// The main of this program.
+/// # Panics
+/// Will panic once the fuzzer finds the correct conditions.
 #[allow(clippy::similar_names)]
 #[no_mangle]
 pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
@@ -72,6 +75,7 @@ pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
             signals_set(1);
             if buf.len() > 1 && buf[1] == b'b' {
                 signals_set(2);
+                #[allow(clippy::manual_assert)]
                 if buf.len() > 2 && buf[2] == b'c' {
                     panic!("=)");
                 }
@@ -107,11 +111,11 @@ pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     .unwrap();
 
     // The Monitor trait define how the fuzzer stats are reported to the user
-    let monitor = SimpleMonitor::new(|_s| {
-        // TODO: Print `_s` here, if your target permits it.
+    let monitor = SimpleMonitor::new(|s| {
+        // TODO: Print `s` here, if your target permits it.
         #[cfg(any(windows, unix))]
         unsafe {
-            printf(b"%s\n\0".as_ptr() as _, CString::new(_s).unwrap().as_ptr());
+            printf(b"%s\n\0".as_ptr().cast(), CString::new(s).unwrap().as_ptr());
         }
     });
 

--- a/fuzzers/baby_no_std/src/main.rs
+++ b/fuzzers/baby_no_std/src/main.rs
@@ -4,11 +4,13 @@
 // Embedded needs alloc error handlers which only work on nightly right now...
 #![cfg_attr(not(any(windows)), feature(default_alloc_error_handler))]
 
+#[cfg(any(windows, unix))]
+extern crate alloc;
+#[cfg(any(windows, unix))]
+use alloc::ffi::CString;
 #[cfg(not(any(windows)))]
 use core::panic::PanicInfo;
 
-#[cfg(any(windows, unix))]
-use cstr_core::CString;
 use libafl::{
     bolts::{current_nanos, rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::InMemoryCorpus,
@@ -115,7 +117,8 @@ pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
         // TODO: Print `s` here, if your target permits it.
         #[cfg(any(windows, unix))]
         unsafe {
-            printf(b"%s\n\0".as_ptr().cast(), CString::new(s).unwrap().as_ptr());
+            let s = CString::new(s).unwrap();
+            printf(b"%s\n\0".as_ptr().cast(), s.as_ptr());
         }
     });
 

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::testing", "emulators", "embedded", "os", "no-s
 
 [features]
 default = ["std", "derive", "llmp_compression", "rand_trait", "fork", "prelude"]
-std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "bincode", "wait-timeout", "regex", "byteorder", "once_cell", "uuid", "tui_monitor", "ctor", "backtrace"] # print, env, launcher ... support
+std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "bincode", "wait-timeout", "regex", "byteorder", "once_cell", "uuid", "tui_monitor", "ctor", "backtrace", "uds"] # print, env, launcher ... support
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
 fork = [] # uses the fork() syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on Windows, no_std).
 rand_trait = ["rand_core"] # If set, libafl's rand implementations will implement `rand::Rng`
@@ -94,7 +94,7 @@ grammartec = { version = "0.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2" # For (*nix) libc
-uds = "0.2.6"
+uds = { version = "0.2.6", optional = true }
 lock_api = "0.4.7"
 
 [target.'cfg(windows)'.dependencies]

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -452,7 +452,7 @@ impl InProcessExecutorHandlerData {
         self.in_target == 1
     }
 
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     fn is_valid(&self) -> bool {
         !self.current_input_ptr.is_null()
     }


### PR DESCRIPTION
Seems like the baby_nostd example no longer works.
This moves it to a nightly no_std completely, also on unix.

Windows is likely still broken, though