### PR TITLE
Fix launcher to work with returning run_client functions

### DIFF
--- a/libafl/src/bolts/launcher.rs
+++ b/libafl/src/bolts/launcher.rs
@@ -180,9 +180,7 @@ where
                             .build()
                             .launch()?;
 
-                        (self.run_client.take().unwrap())(state, mgr, bind_to.id)
-                            .expect("Client closure failed");
-                        break;
+                        return (self.run_client.take().unwrap())(state, mgr, bind_to.id);
                     }
                 };
             }
@@ -250,10 +248,7 @@ where
                     .build()
                     .launch()?;
 
-                (self.run_client.take().unwrap())(state, mgr, core_id)
-                    .expect("Client closure failed");
-
-                unreachable!("Fuzzer client code should never get here!");
+                return (self.run_client.take().unwrap())(state, mgr, core_id);
             }
             Err(std::env::VarError::NotPresent) => {
                 // I am a broker


### PR DESCRIPTION
With that change the Launcher works with run_client functions that return, which is required for e.g. corpus minimization.

@domenukk suggested to either use exit or return, I think by returning the user of the library can implement its own error handling and the library does not panic on each Error?