### PR TITLE
check_for_blobs.sh: respect gitignore

### DIFF
--- a/scripts/check_for_blobs.sh
+++ b/scripts/check_for_blobs.sh
@@ -1,19 +1,30 @@
 #!/bin/bash
 
-blobs=$(find . -type f -exec sh -c '
-  for f; do 
-    mimetype -b "$f" | grep -Eq "application/(x-object|x-executable)" && 
-    printf "%s\n" "$f"
-  done
-' sh {} +)
+declare -a blobs
 
-if [ -z "$blobs" ]
+KNOWN_GOOD_FILE_EXTENSIONS=("rs" "c" "h" "cc" "sh" "py" "toml" "yml" "json" "md" "gitignore" "png")
+
+while read -r file; do
+  # NOTE: mimetype detection spawns a perl process for each file and is pretty slow.
+  # we work around this by skipping files with known-good extensions.
+  ext="${file##*.}"
+  for skipExt in "${KNOWN_GOOD_FILE_EXTENSIONS[@]}"; do
+    if [ "$ext" = "$skipExt" ]; then
+      continue 2
+    fi
+  done
+  if mimetype -b "$file" | grep -Eq "application/(x-object|x-executable)"; then
+    blobs+=("$file");
+  fi
+done < <(git ls-files --exclude-standard --cached --others)
+
+if [ ${#blobs[@]} -eq 0 ]
 then
   echo "No object or executable files in the root directory"
   exit 0
 else
   echo "Hey! There are some object or executable file in the root directory!"
-  echo "$blobs"
+  echo "${blobs[@]}"
   echo "Aborting."
   exit 1
 fi


### PR DESCRIPTION
This should fix the builds that fail due to blobs detected in cached artifacts (#875).
~~The `check_for_blobs.sh` script takes ages locally for me though so I'm not sure what's up with that.~~
I'm not sure how the macOS fuzzer test job broke :/
It's probably related to the `pyo3` update from yesterday, but there's no obvious build system changes:
https://github.com/PyO3/pyo3/releases/tag/v0.17.3