### PR TITLE
fuzzers/qemu_launcher: Use abort instead of exit

### DIFF
--- a/fuzzers/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_launcher/src/fuzzer.rs
@@ -182,7 +182,7 @@ pub fn fuzz() {
                 .load_initial_inputs(&mut fuzzer, &mut executor, &mut mgr, &corpus_dirs)
                 .unwrap_or_else(|_| {
                     println!("Failed to load initial corpus at {:?}", &corpus_dirs);
-                    process::exit(0);
+                    process::abort();
                 });
             println!("We imported {} inputs from disk.", state.corpus().count());
         }


### PR DESCRIPTION
Previously, if you didn't have a corpus and uncommented the line about redirecting stdout to `/dev/null`, you would see:
```
Failed to load initial corpus at ["./corpus"]
thread 'main' panicked at 'Fuzzer-respawner: Storing state in crashed
fuzzer instance did not work, no point to spawn the next client! This
can happen if the child calls `exit()`, in that case make sure it uses
`abort()`, if it got killed unrecoverable (OOM), or if there is a bug in
the fuzzer itself. (Child exited with: 0)',
```