### PR TITLE
fixing freebsd unused import warning in core affinity.

### DIFF
--- a/libafl/src/bolts/core_affinity.rs
+++ b/libafl/src/bolts/core_affinity.rs
@@ -642,7 +642,7 @@ mod freebsd {
     use alloc::vec::Vec;
     use std::{mem, thread::available_parallelism};
 
-    use libc::{cpuset_getaffinity, cpuset_setaffinity, cpuset_t, CPU_SET};
+    use libc::{cpuset_setaffinity, cpuset_t, CPU_SET};
 
     use super::CoreId;
     use crate::Error;
@@ -688,7 +688,7 @@ mod freebsd {
 
         // Try to get current core affinity mask.
         let result = unsafe {
-            cpuset_getaffinity(
+            libc::cpuset_getaffinity(
                 CPU_LEVEL_WHICH,
                 CPU_WHICH_PID,
                 -1, // Defaults to current thread

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -297,10 +297,12 @@ impl CompilerWrapper for ClangWrapper {
             return Ok(args);
         }
 
-        if self.use_new_pm {
-            args.push("-fexperimental-new-pass-manager".into());
-        } else {
-            args.push("-flegacy-pass-manager".into());
+        if !self.passes.is_empty() {
+            if self.use_new_pm {
+                args.push("-fexperimental-new-pass-manager".into());
+            } else {
+                args.push("-flegacy-pass-manager".into());
+            }
         }
         for pass in &self.passes {
             if self.use_new_pm {


### PR DESCRIPTION
fixing clang wrapper test passing llvm pass api support when there are actual passes.