### PR TITLE
mopt: seed from state rand instead of current_nanos

### DIFF
--- a/libafl/src/mutators/mopt_mutator.rs
+++ b/libafl/src/mutators/mopt_mutator.rs
@@ -8,10 +8,7 @@ use core::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bolts::{
-        current_nanos,
-        rands::{Rand, StdRand},
-    },
+    bolts::rands::{Rand, StdRand},
     corpus::Corpus,
     mutators::{ComposedByMutations, MutationResult, Mutator, MutatorsTuple, ScheduledMutator},
     state::{HasCorpus, HasMetadata, HasRand, HasSolutions},
@@ -141,9 +138,9 @@ const PERIOD_PILOT_COEF: f64 = 5000.0;
 
 impl MOpt {
     /// Creates a new [`struct@MOpt`] instance.
-    pub fn new(operator_num: usize, swarm_num: usize) -> Result<Self, Error> {
+    pub fn new(operator_num: usize, swarm_num: usize, rand_seed: u64) -> Result<Self, Error> {
         let mut mopt = Self {
-            rand: StdRand::with_seed(current_nanos()),
+            rand: StdRand::with_seed(rand_seed),
             total_finds: 0,
             finds_until_last_swarm: 0,
             w_init: 0.9,
@@ -537,7 +534,8 @@ where
         swarm_num: usize,
     ) -> Result<Self, Error> {
         if !state.has_metadata::<MOpt>() {
-            state.add_metadata::<MOpt>(MOpt::new(mutations.len(), swarm_num)?);
+            let rand_seed = state.rand_mut().next();
+            state.add_metadata::<MOpt>(MOpt::new(mutations.len(), swarm_num, rand_seed)?);
         }
         Ok(Self {
             mode: MOptMode::Pilotfuzzing,


### PR DESCRIPTION
I ran into a non-determinism issue during debugging caused by this.