### PR TITLE
Fix mac m1 incompatibility for cmplog in frida mode

### DIFF
--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -187,23 +187,23 @@ impl CmpLogRuntime {
         macro_rules! tbz_masking {
             ($ops:ident) => {dynasm!($ops
                 ; .arch aarch64
-                ; stp x5, x5, [sp, #-0x10]!
+                ; stp x5, xzr, [sp, #-0x10]!
                 ; mov x5, #1
                 ; lsl x5, x5, x1
                 ; eor x5, x5, #255
                 ; orr x1, x0, x5
-                ; ldp x5, x5, [sp], #0x10
+                ; ldp x5, xzr, [sp], #0x10
             );};
         }
 
         macro_rules! tbnz_masking {
             ($ops:ident) => {dynasm!($ops
                 ; .arch aarch64
-                ; stp x5, x5, [sp, #-0x10]!
+                ; stp x5, xzr, [sp, #-0x10]!
                 ; mov x5, #1
                 ; lsl x5, x5, x1
                 ; orr x1, x0, x5
-                ; ldp x5, x5, [sp], #0x10
+                ; ldp x5, xzr, [sp], #0x10
             );};
 
         }


### PR DESCRIPTION
For some reason, Apple's aarch64 processor throws a SIGILL when encountering LDP x5, x5 (or any other repeating register). STP works, but I changed both for symmetry.