### PR TITLE
Linker fix for systemmode libafl_qemu

### DIFF
--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -470,6 +470,8 @@ pub fn build() {
     println!("cargo:rustc-link-lib=z");
     #[cfg(all(feature = "slirp", feature = "systemmode"))]
     println!("cargo:rustc-link-lib=slirp");
+    #[cfg(all(feature = "systemmode"))]
+    println!("cargo:rustc-link-lib=sndio");
 
     if emulation_mode == "systemmode" {
         println!("cargo:rustc-link-lib=pixman-1");


### PR DESCRIPTION
This fixes linking for me.
In case this is a general issue, this should have been caught in CI (we should add a Makefile.toml to fuzzers/qemu_systemmode)