### PR TITLE
Fix scores when using on_replace

### DIFF
--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -94,6 +94,7 @@ where
         idx: usize,
         testcase: &Testcase<<CS::State as UsesInput>::Input>,
     ) -> Result<(), Error> {
+        self.update_score(state, idx)?;
         self.base.on_replace(state, idx, testcase)
     }
 


### PR DESCRIPTION
on_replace may cause a change in the TopRatedsMetadata. This adds it.