### PR TITLE
libafl: Remove `set_initial`, `initial_mut` from `MapObserver` trait

### DIFF
--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -108,14 +108,6 @@ pub trait MapObserver: HasLen + Named + Serialize + serde::de::DeserializeOwned 
     /// Get the initial value for reset()
     fn initial(&self) -> Self::Entry;
 
-    /// Get the initial value for reset() (mutable)
-    fn initial_mut(&mut self) -> &mut Self::Entry;
-
-    /// Set the initial value for reset()
-    fn set_initial(&mut self, initial: Self::Entry) {
-        *self.initial_mut() = initial;
-    }
-
     /// Reset the map
     fn reset_map(&mut self) -> Result<(), Error>;
 
@@ -387,11 +379,6 @@ where
     #[inline]
     fn initial(&self) -> T {
         self.initial
-    }
-
-    #[inline]
-    fn initial_mut(&mut self) -> &mut T {
-        &mut self.initial
     }
 
     fn to_vec(&self) -> Vec<T> {
@@ -777,11 +764,6 @@ where
     }
 
     #[inline]
-    fn initial_mut(&mut self) -> &mut T {
-        &mut self.initial
-    }
-
-    #[inline]
     fn get(&self, idx: usize) -> &T {
         &self.as_slice()[idx]
     }
@@ -1051,11 +1033,6 @@ where
     }
 
     #[inline]
-    fn initial_mut(&mut self) -> &mut T {
-        &mut self.initial
-    }
-
-    #[inline]
     fn usable_count(&self) -> usize {
         *self.size.as_ref()
     }
@@ -1259,11 +1236,6 @@ where
     #[inline]
     fn initial(&self) -> u8 {
         self.base.initial()
-    }
-
-    #[inline]
-    fn initial_mut(&mut self) -> &mut u8 {
-        self.base.initial_mut()
     }
 
     #[inline]
@@ -1487,11 +1459,6 @@ where
     #[inline]
     fn initial(&self) -> u8 {
         self.base.initial()
-    }
-
-    #[inline]
-    fn initial_mut(&mut self) -> &mut u8 {
-        self.base.initial_mut()
     }
 
     #[inline]
@@ -1732,11 +1699,6 @@ where
     #[inline]
     fn initial(&self) -> T {
         self.initial
-    }
-
-    #[inline]
-    fn initial_mut(&mut self) -> &mut T {
-        &mut self.initial
     }
 
     fn count_bytes(&self) -> u64 {
@@ -2088,16 +2050,6 @@ where
     #[inline]
     fn initial(&self) -> T {
         self.initial
-    }
-
-    #[inline]
-    fn initial_mut(&mut self) -> &mut T {
-        &mut self.initial
-    }
-
-    #[inline]
-    fn set_initial(&mut self, initial: T) {
-        self.initial = initial;
     }
 
     /// Reset the map
@@ -2476,17 +2428,6 @@ pub mod pybind {
                 #[inline]
                 fn initial(&self) -> $datatype {
                     mapob_unwrap_me!($wrapper_name, self.wrapper, m, { m.initial() })
-                }
-
-                #[inline]
-                fn initial_mut(&mut self) -> &mut $datatype {
-                    let ptr = mapob_unwrap_me_mut!($wrapper_name, self.wrapper, m, { m.initial_mut() as *mut $datatype });
-                    unsafe { ptr.as_mut().unwrap() }
-                }
-
-                #[inline]
-                fn set_initial(&mut self, initial: $datatype) {
-                    mapob_unwrap_me_mut!($wrapper_name, self.wrapper, m, { m.set_initial(initial) });
                 }
 
                 #[inline]


### PR DESCRIPTION
These methods force a `MapObserver` to own an initial value, but there's no reason for this to be the case - If you don't need to allow a dynamically-changeable initial value, it might be nice to use  `<<Self as MapObserver>::Entry as Default>::default()` everywhere and have the compiler statically propagate that value.

Not a lot of code used these methods (which seems like a good argument that they aren't a fundamental part of the inteface). In particular, they were apparently intended to be used in `reset`, but `reset` doesn't have a default implementation using them - and I'd argue that's just as well, for the reasons outlined above. It might be desirable to add a sub-trait of `MapObserver` with these methods and an implementation of `reset` in terms of them.

Could probably eliminate `StdMap::initial` entirely and just use `T::default()`.

My motivation is that I'd like to implement a map-like observer and use the map feedbacks (e.g., `MaxMapFeedback`), but these methods would be meaningless on the observer I have in mind and require my type to own an otherwise-unused field.