### PR TITLE
Fix run/exec rounding by using floats + prettify result

### DIFF
--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -164,6 +164,16 @@ impl ClientStats {
         (self.executions as f64) / elapsed
     }
 
+    /// Executions per second
+    fn execs_per_sec_pretty(&mut self, cur_time: Duration) -> String {
+        match self.execs_per_sec(cur_time) {
+            value if value >= 1000.0 => { format!("{}", value) }
+            value if value >= 100.0 => { format!("{:.1}", value) }
+            value if value >= 10.0 => { format!("{:.2}", value) }
+            value => { format!("{:.3}", value) }
+        }
+    }
+
     /// Update the user-defined stat with name and value
     pub fn update_user_stats(&mut self, name: String, value: UserStats) {
         self.user_monitor.insert(name, value);
@@ -225,6 +235,15 @@ pub trait Monitor {
         self.client_stats_mut()
             .iter_mut()
             .fold(0.0, |acc, x| acc + x.execs_per_sec(cur_time))
+    }
+
+    /// Executions per second
+    fn execs_per_sec_pretty(&mut self) -> String {
+        match self.execs_per_sec() {
+            value if value > 1000.0 => { format!("{}", value) }
+            value if value > 100.0 => { format!("{:.1}", value) }
+            value => { format!("{:.2}", value) }
+        }
     }
 
     /// The client monitor for a specific id, creating new if it doesn't exist
@@ -320,7 +339,7 @@ impl Monitor for SimplePrintingMonitor {
 
     fn display(&mut self, event_msg: String, sender_id: u32) {
         println!(
-            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
+            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             event_msg,
             sender_id,
             format_duration_hms(&(current_time() - self.start_time)),
@@ -328,7 +347,7 @@ impl Monitor for SimplePrintingMonitor {
             self.corpus_size(),
             self.objective_size(),
             self.total_execs(),
-            self.execs_per_sec()
+            self.execs_per_sec_pretty()
         );
 
         // Only print perf monitor if the feature is enabled
@@ -389,7 +408,7 @@ where
 
     fn display(&mut self, event_msg: String, sender_id: u32) {
         let fmt = format!(
-            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
+            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             event_msg,
             sender_id,
             format_duration_hms(&(current_time() - self.start_time)),
@@ -397,7 +416,7 @@ where
             self.corpus_size(),
             self.objective_size(),
             self.total_execs(),
-            self.execs_per_sec()
+            self.execs_per_sec_pretty()
         );
         (self.print_fn)(fmt);
 

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -167,10 +167,18 @@ impl ClientStats {
     /// Executions per second
     fn execs_per_sec_pretty(&mut self, cur_time: Duration) -> String {
         match self.execs_per_sec(cur_time) {
-            value if value >= 1000.0 => { format!("{}", value) }
-            value if value >= 100.0 => { format!("{:.1}", value) }
-            value if value >= 10.0 => { format!("{:.2}", value) }
-            value => { format!("{:.3}", value) }
+            value if value >= 1000.0 => {
+                format!("{}", value)
+            }
+            value if value >= 100.0 => {
+                format!("{:.1}", value)
+            }
+            value if value >= 10.0 => {
+                format!("{:.2}", value)
+            }
+            value => {
+                format!("{:.3}", value)
+            }
         }
     }
 
@@ -240,9 +248,18 @@ pub trait Monitor {
     /// Executions per second
     fn execs_per_sec_pretty(&mut self) -> String {
         match self.execs_per_sec() {
-            value if value > 1000.0 => { format!("{}", value) }
-            value if value > 100.0 => { format!("{:.1}", value) }
-            value => { format!("{:.2}", value) }
+            value if value >= 1000.0 => {
+                format!("{}", value)
+            }
+            value if value >= 100.0 => {
+                format!("{:.1}", value)
+            }
+            value if value >= 10.0 => {
+                format!("{:.2}", value)
+            }
+            value => {
+                format!("{:.3}", value)
+            }
         }
     }
 

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -118,22 +118,22 @@ impl ClientStats {
     /// Get the calculated executions per second for this client
     #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
     #[cfg(feature = "afl_exec_sec")]
-    pub fn execs_per_sec(&mut self, cur_time: Duration) -> u64 {
+    pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
-            return 0;
+            return 0.0;
         }
 
         let elapsed = cur_time
             .checked_sub(self.last_window_time)
             .map_or(0.0, |d| d.as_secs_f64());
         if elapsed as u64 == 0 {
-            return self.last_execs_per_sec as u64;
+            return self.last_execs_per_sec;
         }
 
         let cur_avg = ((self.executions - self.last_window_executions) as f64) / elapsed;
         if self.last_window_executions == 0 {
             self.last_execs_per_sec = cur_avg;
-            return self.last_execs_per_sec as u64;
+            return self.last_execs_per_sec;
         }
 
         // If there is a dramatic (5x+) jump in speed, reset the indicator more quickly
@@ -143,7 +143,7 @@ impl ClientStats {
 
         self.last_execs_per_sec =
             self.last_execs_per_sec * (1.0 - 1.0 / 16.0) + cur_avg * (1.0 / 16.0);
-        self.last_execs_per_sec as u64
+        self.last_execs_per_sec
     }
 
     /// Get the calculated executions per second for this client

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -116,7 +116,7 @@ impl ClientStats {
     }
 
     /// Get the calculated executions per second for this client
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     #[cfg(feature = "afl_exec_sec")]
     pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
@@ -147,7 +147,7 @@ impl ClientStats {
     }
 
     /// Get the calculated executions per second for this client
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     #[cfg(not(feature = "afl_exec_sec"))]
     pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
@@ -224,6 +224,7 @@ pub trait Monitor {
     }
 
     /// Executions per second
+    #[allow(clippy::cast_sign_loss)]
     #[inline]
     fn execs_per_sec(&mut self) -> u64 {
         let cur_time = current_time();

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -62,26 +62,25 @@ impl fmt::Display for UserStats {
 /// Prettifies float values for human-readable output
 fn prettify_float(value: f64) -> String {
     let (value, suffix) = match value {
-        value if value >= 1000000.0 => { (value/1000000.0, "M") }
-        value if value >= 1000.0 => { (value/1000.0, "k") }
-        value => { (value, "") }
+        value if value >= 1000000.0 => (value / 1000000.0, "M"),
+        value if value >= 1000.0 => (value / 1000.0, "k"),
+        value => (value, ""),
     };
     match value {
         value if value >= 1000.0 => {
-            format!("{}{}", value, suffix)
+            format!("{value}{suffix}")
         }
         value if value >= 100.0 => {
-            format!("{:.1}{}", value, suffix)
+            format!("{value:.1}{suffix}")
         }
         value if value >= 10.0 => {
-            format!("{:.2}{}", value, suffix)
+            format!("{value:.2}{suffix}")
         }
         value => {
-            format!("{:.3}{}", value, suffix)
+            format!("{value:.3}{suffix}")
         }
     }
 }
-
 
 /// A simple struct to keep track of client monitor
 #[derive(Debug, Clone, Default, Serialize)]

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -116,7 +116,7 @@ impl ClientStats {
     }
 
     /// Get the calculated executions per second for this client
-    #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss)]
     #[cfg(feature = "afl_exec_sec")]
     pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
@@ -147,7 +147,7 @@ impl ClientStats {
     }
 
     /// Get the calculated executions per second for this client
-    #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss)]
     #[cfg(not(feature = "afl_exec_sec"))]
     pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
@@ -164,6 +164,7 @@ impl ClientStats {
         (self.executions as f64) / elapsed
     }
 
+    #[allow(clippy::cast_sign_loss)]
     /// Get the calculated executions per second for this client
     pub fn execs_per_sec(&mut self, cur_time: Duration) -> u64 {
         self.execs_per_sec_f64(cur_time) as u64

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -118,7 +118,7 @@ impl ClientStats {
     /// Get the calculated executions per second for this client
     #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     #[cfg(feature = "afl_exec_sec")]
-    pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
+    pub fn execs_per_sec(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
             return 0.0;
         }
@@ -149,7 +149,7 @@ impl ClientStats {
     /// Get the calculated executions per second for this client
     #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     #[cfg(not(feature = "afl_exec_sec"))]
-    pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
+    pub fn execs_per_sec(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
             return 0.0;
         }
@@ -162,12 +162,6 @@ impl ClientStats {
         }
 
         (self.executions as f64) / elapsed
-    }
-
-    #[allow(clippy::cast_sign_loss)]
-    /// Get the calculated executions per second for this client
-    pub fn execs_per_sec(&mut self, cur_time: Duration) -> u64 {
-        self.execs_per_sec_f64(cur_time) as u64
     }
 
     /// Update the user-defined stat with name and value
@@ -226,11 +220,11 @@ pub trait Monitor {
     /// Executions per second
     #[allow(clippy::cast_sign_loss)]
     #[inline]
-    fn execs_per_sec(&mut self) -> u64 {
+    fn execs_per_sec(&mut self) -> f64 {
         let cur_time = current_time();
         self.client_stats_mut()
             .iter_mut()
-            .fold(0.0, |acc, x| acc + x.execs_per_sec_f64(cur_time)) as u64
+            .fold(0.0, |acc, x| acc + x.execs_per_sec(cur_time))
     }
 
     /// The client monitor for a specific id, creating new if it doesn't exist

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -60,23 +60,7 @@ impl fmt::Display for UserStats {
 }
 
 /// Prettifies float values for human-readable output
-/// ```rust
-/// # use libafl::monitors::prettify;
-/// # fn main() {
-/// assert_eq!(prettify(123423123.0), "123.4M");
-/// assert_eq!(prettify(12342312.3), "12.34M");
-/// assert_eq!(prettify(1234231.23), "1.234M");
-/// assert_eq!(prettify(123423.123), "123.4k");
-/// assert_eq!(prettify(12342.3123), "12.34k");
-/// assert_eq!(prettify(1234.23123), "1.234k");
-/// assert_eq!(prettify(123.423123), "123.4");
-/// assert_eq!(prettify(12.3423123), "12.34");
-/// assert_eq!(prettify(1.23423123), "1.234");
-/// assert_eq!(prettify(0.123423123), "0.123");
-/// assert_eq!(prettify(0.0123423123), "0.012");
-/// # }
-/// ```
-pub fn prettify(value: f64) -> String {
+fn prettify_float(value: f64) -> String {
     let (value, suffix) = match value {
         value if value >= 1000000.0 => { (value/1000000.0, "M") }
         value if value >= 1000.0 => { (value/1000.0, "k") }
@@ -206,7 +190,7 @@ impl ClientStats {
 
     /// Executions per second
     fn execs_per_sec_pretty(&mut self, cur_time: Duration) -> String {
-        prettify(self.execs_per_sec(cur_time))
+        prettify_float(self.execs_per_sec(cur_time))
     }
 
     /// Update the user-defined stat with name and value
@@ -274,7 +258,7 @@ pub trait Monitor {
 
     /// Executions per second
     fn execs_per_sec_pretty(&mut self) -> String {
-        prettify(self.execs_per_sec())
+        prettify_float(self.execs_per_sec())
     }
 
     /// The client monitor for a specific id, creating new if it doesn't exist
@@ -1083,5 +1067,24 @@ pub mod pybind {
         m.add_class::<PythonSimpleMonitor>()?;
         m.add_class::<PythonMonitor>()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::monitors::prettify_float;
+    #[test]
+    fn test_prettify_float() {
+        assert_eq!(prettify_float(123423123.0), "123.4M");
+        assert_eq!(prettify_float(12342312.3), "12.34M");
+        assert_eq!(prettify_float(1234231.23), "1.234M");
+        assert_eq!(prettify_float(123423.123), "123.4k");
+        assert_eq!(prettify_float(12342.3123), "12.34k");
+        assert_eq!(prettify_float(1234.23123), "1.234k");
+        assert_eq!(prettify_float(123.423123), "123.4");
+        assert_eq!(prettify_float(12.3423123), "12.34");
+        assert_eq!(prettify_float(1.23423123), "1.234");
+        assert_eq!(prettify_float(0.123423123), "0.123");
+        assert_eq!(prettify_float(0.0123423123), "0.012");
     }
 }

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -320,7 +320,7 @@ impl Monitor for SimplePrintingMonitor {
 
     fn display(&mut self, event_msg: String, sender_id: u32) {
         println!(
-            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
             event_msg,
             sender_id,
             format_duration_hms(&(current_time() - self.start_time)),
@@ -389,7 +389,7 @@ where
 
     fn display(&mut self, event_msg: String, sender_id: u32) {
         let fmt = format!(
-            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
             event_msg,
             sender_id,
             format_duration_hms(&(current_time() - self.start_time)),

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -149,19 +149,24 @@ impl ClientStats {
     /// Get the calculated executions per second for this client
     #[allow(clippy::cast_sign_loss, clippy::cast_precision_loss)]
     #[cfg(not(feature = "afl_exec_sec"))]
-    pub fn execs_per_sec(&mut self, cur_time: Duration) -> u64 {
+    pub fn execs_per_sec_f64(&mut self, cur_time: Duration) -> f64 {
         if self.executions == 0 {
-            return 0;
+            return 0.0;
         }
 
         let elapsed = cur_time
             .checked_sub(self.last_window_time)
             .map_or(0.0, |d| d.as_secs_f64());
         if elapsed as u64 == 0 {
-            return 0;
+            return 0.0;
         }
 
-        ((self.executions as f64) / elapsed) as u64
+        (self.executions as f64) / elapsed
+    }
+
+    /// Get the calculated executions per second for this client
+    pub fn execs_per_sec(&mut self, cur_time: Duration) -> u64 {
+        self.execs_per_sec_f64(cur_time) as u64
     }
 
     /// Update the user-defined stat with name and value
@@ -223,7 +228,7 @@ pub trait Monitor {
         let cur_time = current_time();
         self.client_stats_mut()
             .iter_mut()
-            .fold(0_u64, |acc, x| acc + x.execs_per_sec(cur_time))
+            .fold(0.0, |acc, x| acc + x.execs_per_sec_f64(cur_time)) as u64
     }
 
     /// The client monitor for a specific id, creating new if it doesn't exist

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -59,6 +59,46 @@ impl fmt::Display for UserStats {
     }
 }
 
+/// Prettifies float values for human-readable output
+/// ```rust
+/// # use libafl::monitors::prettify;
+/// # fn main() {
+/// assert_eq!(prettify(123423123.0), "123.4M");
+/// assert_eq!(prettify(12342312.3), "12.34M");
+/// assert_eq!(prettify(1234231.23), "1.234M");
+/// assert_eq!(prettify(123423.123), "123.4k");
+/// assert_eq!(prettify(12342.3123), "12.34k");
+/// assert_eq!(prettify(1234.23123), "1.234k");
+/// assert_eq!(prettify(123.423123), "123.4");
+/// assert_eq!(prettify(12.3423123), "12.34");
+/// assert_eq!(prettify(1.23423123), "1.234");
+/// assert_eq!(prettify(0.123423123), "0.123");
+/// assert_eq!(prettify(0.0123423123), "0.012");
+/// # }
+/// ```
+pub fn prettify(value: f64) -> String {
+    let (value, suffix) = match value {
+        value if value >= 1000000.0 => { (value/1000000.0, "M") }
+        value if value >= 1000.0 => { (value/1000.0, "k") }
+        value => { (value, "") }
+    };
+    match value {
+        value if value >= 1000.0 => {
+            format!("{}{}", value, suffix)
+        }
+        value if value >= 100.0 => {
+            format!("{:.1}{}", value, suffix)
+        }
+        value if value >= 10.0 => {
+            format!("{:.2}{}", value, suffix)
+        }
+        value => {
+            format!("{:.3}{}", value, suffix)
+        }
+    }
+}
+
+
 /// A simple struct to keep track of client monitor
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ClientStats {
@@ -166,20 +206,7 @@ impl ClientStats {
 
     /// Executions per second
     fn execs_per_sec_pretty(&mut self, cur_time: Duration) -> String {
-        match self.execs_per_sec(cur_time) {
-            value if value >= 1000.0 => {
-                format!("{}", value)
-            }
-            value if value >= 100.0 => {
-                format!("{:.1}", value)
-            }
-            value if value >= 10.0 => {
-                format!("{:.2}", value)
-            }
-            value => {
-                format!("{:.3}", value)
-            }
-        }
+        prettify(self.execs_per_sec(cur_time))
     }
 
     /// Update the user-defined stat with name and value
@@ -247,20 +274,7 @@ pub trait Monitor {
 
     /// Executions per second
     fn execs_per_sec_pretty(&mut self) -> String {
-        match self.execs_per_sec() {
-            value if value >= 1000.0 => {
-                format!("{}", value)
-            }
-            value if value >= 100.0 => {
-                format!("{:.1}", value)
-            }
-            value if value >= 10.0 => {
-                format!("{:.2}", value)
-            }
-            value => {
-                format!("{:.3}", value)
-            }
-        }
+        prettify(self.execs_per_sec())
     }
 
     /// The client monitor for a specific id, creating new if it doesn't exist

--- a/libafl/src/monitors/multi.rs
+++ b/libafl/src/monitors/multi.rs
@@ -49,24 +49,24 @@ where
         };
         let head = format!("{event_msg}{pad} {sender}");
         let global_fmt = format!(
-            "[{}]  (GLOBAL) run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
+            "[{}]  (GLOBAL) run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             head,
             format_duration_hms(&(current_time() - self.start_time)),
             self.client_stats().len(),
             self.corpus_size(),
             self.objective_size(),
             self.total_execs(),
-            self.execs_per_sec()
+            self.execs_per_sec_pretty()
         );
         (self.print_fn)(global_fmt);
 
         let client = self.client_stats_mut_for(sender_id);
         let cur_time = current_time();
-        let exec_sec = client.execs_per_sec(cur_time);
+        let exec_sec = client.execs_per_sec_pretty(cur_time);
 
         let pad = " ".repeat(head.len());
         let mut fmt = format!(
-            " {}   (CLIENT) corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
+            " {}   (CLIENT) corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             pad, client.corpus_size, client.objective_size, client.executions, exec_sec
         );
         for (key, val) in &client.user_monitor {

--- a/libafl/src/monitors/multi.rs
+++ b/libafl/src/monitors/multi.rs
@@ -49,7 +49,7 @@ where
         };
         let head = format!("{event_msg}{pad} {sender}");
         let global_fmt = format!(
-            "[{}]  (GLOBAL) run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            "[{}]  (GLOBAL) run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
             head,
             format_duration_hms(&(current_time() - self.start_time)),
             self.client_stats().len(),
@@ -66,7 +66,7 @@ where
 
         let pad = " ".repeat(head.len());
         let mut fmt = format!(
-            " {}   (CLIENT) corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            " {}   (CLIENT) corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
             pad, client.corpus_size, client.objective_size, client.executions, exec_sec
         );
         for (key, val) in &client.user_monitor {

--- a/libafl/src/monitors/prometheus.rs
+++ b/libafl/src/monitors/prometheus.rs
@@ -139,7 +139,7 @@ where
 
         // display stats in a SimpleMonitor format
         let fmt = format!(
-            "[Prometheus] [{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
+            "[Prometheus] [{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             event_msg,
             sender_id,
             format_duration_hms(&(current_time() - self.start_time)),
@@ -147,7 +147,7 @@ where
             self.corpus_size(),
             self.objective_size(),
             self.total_execs(),
-            self.execs_per_sec()
+            self.execs_per_sec_pretty()
         );
         (self.print_fn)(fmt);
 

--- a/libafl/src/monitors/prometheus.rs
+++ b/libafl/src/monitors/prometheus.rs
@@ -139,7 +139,7 @@ where
 
         // display stats in a SimpleMonitor format
         let fmt = format!(
-            "[Prometheus] [{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            "[Prometheus] [{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
             event_msg,
             sender_id,
             format_duration_hms(&(current_time() - self.start_time)),

--- a/libafl/src/monitors/prometheus.rs
+++ b/libafl/src/monitors/prometheus.rs
@@ -91,6 +91,7 @@ where
         self.start_time
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn display(&mut self, event_msg: String, sender_id: u32) {
         // Update the prometheus metrics
         // Label each metric with the sender / client_id
@@ -115,7 +116,7 @@ where
                 stat: String::new(),
             })
             .set(total_execs);
-        let execs_per_sec = self.execs_per_sec();
+        let execs_per_sec = self.execs_per_sec() as u64;
         self.exec_rate
             .get_or_create(&Labels {
                 client: sender_id,

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -169,13 +169,14 @@ pub struct ClientTuiContext {
     pub corpus: u64,
     pub objectives: u64,
     pub executions: u64,
-    pub exec_sec: f64,
+    /// Float value formatted as String
+    pub exec_sec: String,
 
     pub user_stats: HashMap<String, UserStats>,
 }
 
 impl ClientTuiContext {
-    pub fn grab_data(&mut self, client: &ClientStats, exec_sec: f64) {
+    pub fn grab_data(&mut self, client: &ClientStats, exec_sec: String) {
         self.corpus = client.corpus_size;
         self.objectives = client.objective_size;
         self.executions = client.executions;
@@ -276,7 +277,7 @@ impl Monitor for TuiMonitor {
         }
 
         let client = self.client_stats_mut_for(sender_id);
-        let exec_sec = client.execs_per_sec(cur_time);
+        let exec_sec = client.execs_per_sec_pretty(cur_time);
 
         let sender = format!("#{sender_id}");
         let pad = if event_msg.len() + sender.len() < 13 {
@@ -286,7 +287,7 @@ impl Monitor for TuiMonitor {
         };
         let head = format!("{event_msg}{pad} {sender}");
         let mut fmt = format!(
-            "[{}] corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
+            "[{}] corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             head, client.corpus_size, client.objective_size, client.executions, exec_sec
         );
         for (key, val) in &client.user_monitor {

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -286,7 +286,7 @@ impl Monitor for TuiMonitor {
         };
         let head = format!("{event_msg}{pad} {sender}");
         let mut fmt = format!(
-            "[{}] corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            "[{}] corpus: {}, objectives: {}, executions: {}, exec/sec: {:.2}",
             head, client.corpus_size, client.objective_size, client.executions, exec_sec
         );
         for (key, val) in &client.user_monitor {

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -169,13 +169,13 @@ pub struct ClientTuiContext {
     pub corpus: u64,
     pub objectives: u64,
     pub executions: u64,
-    pub exec_sec: u64,
+    pub exec_sec: f64,
 
     pub user_stats: HashMap<String, UserStats>,
 }
 
 impl ClientTuiContext {
-    pub fn grab_data(&mut self, client: &ClientStats, exec_sec: u64) {
+    pub fn grab_data(&mut self, client: &ClientStats, exec_sec: f64) {
         self.corpus = client.corpus_size;
         self.objectives = client.objective_size;
         self.executions = client.executions;
@@ -256,11 +256,13 @@ impl Monitor for TuiMonitor {
         self.start_time
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn display(&mut self, event_msg: String, sender_id: u32) {
         let cur_time = current_time();
 
         {
-            let execsec = self.execs_per_sec();
+            // TODO implement floating-point support for TimedStat
+            let execsec = self.execs_per_sec() as u64;
             let totalexec = self.total_execs();
             let run_time = cur_time - self.start_time;
 

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -397,7 +397,7 @@ impl TuiUI {
                 ]));
                 client_items.push(Row::new(vec![
                     Cell::from(Span::raw("exec/sec")),
-                    Cell::from(Span::raw(format!("{}", client.exec_sec))),
+                    Cell::from(Span::raw(client.exec_sec.clone())),
                 ]));
                 client_items.push(Row::new(vec![
                     Cell::from(Span::raw("corpus")),

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -397,7 +397,7 @@ impl TuiUI {
                 ]));
                 client_items.push(Row::new(vec![
                     Cell::from(Span::raw("exec/sec")),
-                    Cell::from(Span::raw(format!("{}", client.exec_sec))),
+                    Cell::from(Span::raw(format!("{:.2}", client.exec_sec))),
                 ]));
                 client_items.push(Row::new(vec![
                     Cell::from(Span::raw("corpus")),

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -397,7 +397,7 @@ impl TuiUI {
                 ]));
                 client_items.push(Row::new(vec![
                     Cell::from(Span::raw("exec/sec")),
-                    Cell::from(Span::raw(format!("{:.2}", client.exec_sec))),
+                    Cell::from(Span::raw(format!("{}", client.exec_sec))),
                 ]));
                 client_items.push(Row::new(vec![
                     Cell::from(Span::raw("corpus")),


### PR DESCRIPTION
When running with many cores, or exec/sec is small (around 1), the rounding error can be relatively large for the *global* monitor.

I would also prefer printing a float, not a number. However, this PR does not change the output format. (Only when calculating the global exec/sec from client exec/sec values)

Note that I have not investigated whether TUI module works OK, but even the interfaces did not change.