### PR TITLE
Fix a typo in gnf_converter.py

### DIFF
--- a/utils/gramatron/gnf_converter.py
+++ b/utils/gramatron/gnf_converter.py
@@ -78,7 +78,7 @@ def remove_left_recursion(grammar):
             for rule in rules:
                 tokens = gettokens(rule)
                 if tokens[0] == lhs:
-                    left_recursion = False
+                    no_left_recursion = False
                     break
             else:
                 continue


### PR DESCRIPTION
This patch addresses the issue in #879, which fixes a typo in the `remove_left_recursion` method.