### PR TITLE
using wrong commit due to wrong directory

### DIFF
--- a/libafl_nyx/build_nyx_support.sh
+++ b/libafl_nyx/build_nyx_support.sh
@@ -20,7 +20,7 @@ fi
 if [ ! -e ./packer/.git ]; then
     rm -rf ./packer
     git clone https://github.com/syheliel/packer.git || exit 1
-    pushd QEMU-Nyx
+    pushd packer
     git reset --hard 86b159bafc0b2ba8feeaa8761a45b6201d34084f
     popd
 fi


### PR DESCRIPTION
due to the call to pushd on line 23 not being directed at packer, the wrong commit was being used and so that resulted in the wrong init.cpio.gz being generated which hangs when trying to run the libxml2 examples however using the right commit (86b159bafc0b2ba8feeaa8761a45b6201d34084f) fixes this problem.