### PR TITLE
SimpleMonitor optionally with user_monitor stats

### DIFF
--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -195,13 +195,16 @@ fn fuzz(
     let file_null = File::open("/dev/null")?;
 
     // 'While the stats are state, they are usually used in the broker - which is likely never restarted
-    let monitor = SimpleMonitor::with_user_monitor(|s| {
-        #[cfg(unix)]
-        writeln!(&mut stdout_cpy, "{}", s).unwrap();
-        #[cfg(windows)]
-        println!("{}", s);
-        writeln!(log.borrow_mut(), "{:?} {}", current_time(), s).unwrap();
-    }, true);
+    let monitor = SimpleMonitor::with_user_monitor(
+        |s| {
+            #[cfg(unix)]
+            writeln!(&mut stdout_cpy, "{}", s).unwrap();
+            #[cfg(windows)]
+            println!("{}", s);
+            writeln!(log.borrow_mut(), "{:?} {}", current_time(), s).unwrap();
+        },
+        true,
+    );
 
     let mut shmem_provider = StdShMemProvider::new()?;
 

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -195,13 +195,13 @@ fn fuzz(
     let file_null = File::open("/dev/null")?;
 
     // 'While the stats are state, they are usually used in the broker - which is likely never restarted
-    let monitor = SimpleMonitor::new(|s| {
+    let monitor = SimpleMonitor::with_user_monitor(|s| {
         #[cfg(unix)]
         writeln!(&mut stdout_cpy, "{}", s).unwrap();
         #[cfg(windows)]
         println!("{}", s);
         writeln!(log.borrow_mut(), "{:?} {}", current_time(), s).unwrap();
-    });
+    }, true);
 
     let mut shmem_provider = StdShMemProvider::new()?;
 

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -438,7 +438,7 @@ where
         if self.print_user_monitor {
             let client = self.client_stats_mut_for(sender_id);
             for (key, val) in &client.user_monitor {
-                write!(fmt, " , {key}: {val}").unwrap();
+                write!(fmt, ", {key}: {val}").unwrap();
             }
         }
 

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -489,7 +489,7 @@ where
         Self {
             print_fn,
             start_time: current_time(),
-            print_user_monitor: print_user_monitor,
+            print_user_monitor,
             client_stats: vec![],
         }
     }

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -993,6 +993,7 @@ pub mod pybind {
                 inner: SimpleMonitor {
                     print_fn: Box::new(closure),
                     start_time: self.inner.start_time,
+                    print_user_monitor: false,
                     client_stats: self.inner.client_stats.clone(),
                 },
                 print_fn: self.print_fn.clone(),


### PR DESCRIPTION
Currently, the `SimpleMonitor` does not print the user_monitor stats. Especially for the edge coverage, this would be quite useful tho. Therefore, I suggest adding an option flag to enable printing the user_monitor.

Example:
`cargo make run` in `fuzzer/fuzzbench_fork_qemu`

Current state:
```
[Testcase #0] run time: 0h-0m-4s, clients: 1, corpus: 27, objectives: 0, executions: 372, exec/sec: 91.78
[Stats #0] run time: 0h-0m-4s, clients: 1, corpus: 27, objectives: 0, executions: 372, exec/sec: 87.34
[Testcase #0] run time: 0h-0m-4s, clients: 1, corpus: 28, objectives: 0, executions: 393, exec/sec: 92.27
[Stats #0] run time: 0h-0m-5s, clients: 1, corpus: 28, objectives: 0, executions: 393, exec/sec: 78.34
```

With user_monitor:
```
[Testcase #0] run time: 0h-0m-0s, clients: 1, corpus: 7, objectives: 0, executions: 11, exec/sec: 0.000 , edges: 799/65536 (1%)
[Stats #0] run time: 0h-0m-0s, clients: 1, corpus: 7, objectives: 0, executions: 11, exec/sec: 0.000 , edges: 811/65536 (1%)
[Testcase #0] run time: 0h-0m-0s, clients: 1, corpus: 8, objectives: 0, executions: 12, exec/sec: 0.000 , edges: 811/65536 (1%)
[Stats #0] run time: 0h-0m-0s, clients: 1, corpus: 8, objectives: 0, executions: 12, exec/sec: 0.000 , edges: 814/65536 (1%)
```