### PR TITLE
Update CorpusWeightTestcaseScore

### DIFF
--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -165,7 +165,7 @@ where
 
     /// Set the `fuzz_level`
     #[inline]
-    pub fn set_fuzz_leve(&mut self, fuzz_level: usize) {
+    pub fn set_fuzz_level(&mut self, fuzz_level: usize) {
         self.fuzz_level = fuzz_level;
     }
 

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -98,12 +98,13 @@ impl SchedulerMetadata {
         self.bitmap_size = val;
     }
 
-    /// The sum of log(bitmap_size)
+    #[must_use]
+    /// The sum of log(`bitmap_size`)
     pub fn bitmap_size_log(&self) -> f64 {
         self.bitmap_size_log
     }
 
-    /// Setts the sum of log(bitmap_size)
+    /// Setts the sum of log(`bitmap_size`)
     pub fn set_bitmap_size_log(&mut self, val: f64) {
         self.bitmap_size_log = val;
     }

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -32,6 +32,8 @@ pub struct SchedulerMetadata {
     cycles: u64,
     /// Size of the observer map
     bitmap_size: u64,
+    /// Sum of log(bitmap_size)
+    bitmap_size_log: f64,
     /// Number of filled map entries
     bitmap_entries: u64,
     /// Queue cycles
@@ -50,6 +52,7 @@ impl SchedulerMetadata {
             exec_time: Duration::from_millis(0),
             cycles: 0,
             bitmap_size: 0,
+            bitmap_size_log: 0.0,
             bitmap_entries: 0,
             queue_cycles: 0,
             n_fuzz: vec![0; N_FUZZ_SIZE],
@@ -93,6 +96,16 @@ impl SchedulerMetadata {
     /// Sets the bitmap size
     pub fn set_bitmap_size(&mut self, val: u64) {
         self.bitmap_size = val;
+    }
+
+    /// The sum of log(bitmap_size)
+    pub fn bitmap_size_log(&self) -> f64 {
+        self.bitmap_size_log
+    }
+
+    /// Setts the sum of log(bitmap_size)
+    pub fn set_bitmap_size_log(&mut self, val: f64) {
+        self.bitmap_size_log = val;
     }
 
     /// The number of filled map entries

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -321,7 +321,7 @@ where
         let favored = entry.has_metadata::<IsFavoredMetadata>();
 
         let avg_exec_us = psmeta.exec_time().as_nanos() as f64 / psmeta.cycles() as f64;
-        let avg_bitmap_size = psmeta.bitmap_size() / psmeta.bitmap_entries();
+        let avg_bitmap_size = psmeta.bitmap_size_log() / psmeta.bitmap_entries() as f64;
 
         let q_bitmap_size = tcmeta.bitmap_size() as f64;
 
@@ -342,7 +342,7 @@ where
         }
 
         weight *= avg_exec_us / q_exec_us;
-        weight *= libm::log2(q_bitmap_size) / (avg_bitmap_size as f64);
+        weight *= libm::log2(q_bitmap_size).max(1.0) / avg_bitmap_size;
 
         let tc_ref = match entry.metadata().get::<MapIndexesMetadata>() {
             Some(meta) => meta.refcnt() as f64,

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -92,7 +92,7 @@ where
     Z: Evaluator<E, EM, State = E::State>,
 {
     #[inline]
-    #[allow(clippy::let_and_return, clippy::too_many_lines)]
+    #[allow(clippy::let_and_return, clippy::too_many_lines, clippy::cast_precision_loss)]
     fn perform(
         &mut self,
         fuzzer: &mut Z,
@@ -219,7 +219,6 @@ where
             i += 1;
         }
 
-        #[allow(clippy::cast_precision_loss)]
         if !unstable_entries.is_empty() {
             // If we see new stable entries executing this new corpus entries, then merge with the existing one
             if state.has_metadata::<UnstableEntriesMetadata>() {

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -261,13 +261,14 @@ where
             psmeta.set_exec_time(psmeta.exec_time() + total_time);
             psmeta.set_cycles(psmeta.cycles() + (iter as u64));
             psmeta.set_bitmap_size(psmeta.bitmap_size() + bitmap_size);
+            psmeta.set_bitmap_size_log(psmeta.bitmap_size_log() + libm::log2(bitmap_size as f64));
             psmeta.set_bitmap_entries(psmeta.bitmap_entries() + 1);
 
             let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
             let fuzz_level = testcase.fuzz_level();
 
             testcase.set_exec_time(total_time / (iter as u32));
-            testcase.set_fuzz_leve(fuzz_level + 1);
+            testcase.set_fuzz_level(fuzz_level + 1);
             // println!("time: {:#?}", testcase.exec_time());
 
             let data = testcase

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -92,7 +92,11 @@ where
     Z: Evaluator<E, EM, State = E::State>,
 {
     #[inline]
-    #[allow(clippy::let_and_return, clippy::too_many_lines, clippy::cast_precision_loss)]
+    #[allow(
+        clippy::let_and_return,
+        clippy::too_many_lines,
+        clippy::cast_precision_loss
+    )]
     fn perform(
         &mut self,
         fuzzer: &mut Z,


### PR DESCRIPTION
Two fixes
1) Probably I was not aware of this commit, https://github.com/AFLplusplus/AFLplusplus/commit/7b8c8cf12fde0feab25a1d794e010a5778cf9be8, so update CorpusWeightTestcaUpdate to make it same as AFL++

2) Sometimes `weight` becomes 0, after this log `weight *= libm::log2(q_bitmap_size) / avg_bitmap_size;` so add max(1.0) to avoid this