### PR TITLE
Improve prompt of edges map size

### DIFF
--- a/libafl_targets/src/sancov_pcguard.rs
+++ b/libafl_targets/src/sancov_pcguard.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn __sanitizer_cov_trace_pc_guard_init(mut start: *mut u32
         #[cfg(not(feature = "pointer_maps"))]
         {
             MAX_EDGES_NUM = MAX_EDGES_NUM.wrapping_add(1);
-            assert!((MAX_EDGES_NUM <= EDGES_MAP.len()), "The number of edges reported by SanitizerCoverage exceed the size of the edges map ({}). Use the LIBAFL_EDGES_MAP_SIZE env to increase it at compile time.", EDGES_MAP.len());
+            assert!((MAX_EDGES_NUM <= EDGES_MAP.len()), "The number of edges reported by SanitizerCoverage ({}) exceeds the size of the edges map ({}). Use the LIBAFL_EDGES_MAP_SIZE env to increase it at compile time.", MAX_EDGES_NUM, EDGES_MAP.len());
         }
     }
 }


### PR DESCRIPTION
The value of `MAX_EDGES_NUM` will help the user to set `LIBAFL_EDGES_MAP_SIZE`