### PR TITLE
stacktrace: Use unresolved backtrace call

### DIFF
--- a/libafl/src/observers/stacktrace.rs
+++ b/libafl/src/observers/stacktrace.rs
@@ -26,7 +26,7 @@ use crate::{
 /// ([`Debug`] is currently used for dev purposes, symbols hash will be used eventually)
 #[must_use]
 pub fn collect_backtrace() -> u64 {
-    let b = Backtrace::new();
+    let b = Backtrace::new_unresolved();
     if b.frames().is_empty() {
         return 0;
     }


### PR DESCRIPTION
As far as I've been able to see we don't use the symbols anyway, and it makes the call *way* faster. (On the system we're using it's the difference between 200 exec/sec and 0.5 exec/sec.)

Happy to make it an option if that's preferred?