### PR TITLE
libafl_cc fixes clang 16 build.

### DIFF
--- a/libafl_cc/src/common-llvm.h
+++ b/libafl_cc/src/common-llvm.h
@@ -19,6 +19,11 @@ typedef long double max_align_t;
   #define HAVE_VECTOR_INTRINSICS 1
 #endif
 
+#if LLVM_VERSION_MAJOR >= 16
+  #include <optional>
+constexpr std::nullopt_t None = std::nullopt;
+#endif
+
 #ifdef USE_NEW_PM
   #include "llvm/Passes/PassPlugin.h"
   #include "llvm/Passes/PassBuilder.h"


### PR DESCRIPTION
None constant being deprecated, it is recommended
to use the std::nullopt_t type instead.