### PR TITLE
libafl: Remove `{update,clear}_hash` from `ObserverWithHashField`

### DIFF
--- a/libafl/src/feedbacks/new_hash_feedback.rs
+++ b/libafl/src/feedbacks/new_hash_feedback.rs
@@ -109,7 +109,7 @@ where
         match observer.hash() {
             Some(hash) => {
                 let res = backtrace_state
-                    .update_hash_set(*hash)
+                    .update_hash_set(hash)
                     .expect("Failed to update the hash state");
                 Ok(res)
             }

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -281,10 +281,6 @@ where
 pub trait ObserverWithHashField {
     /// get the value of the hash field
     fn hash(&self) -> &Option<u64>;
-    /// update the hash field with the given value
-    fn update_hash(&mut self, hash: u64);
-    /// clears the current value of the hash and sets it to None
-    fn clear_hash(&mut self);
 }
 
 /// A trait for [`Observer`]`s` which observe over differential execution.

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -280,7 +280,7 @@ where
 /// A trait for [`Observer`]`s` with a hash field
 pub trait ObserverWithHashField {
     /// get the value of the hash field
-    fn hash(&self) -> &Option<u64>;
+    fn hash(&self) -> Option<u64>;
 }
 
 /// A trait for [`Observer`]`s` which observe over differential execution.

--- a/libafl/src/observers/stacktrace.rs
+++ b/libafl/src/observers/stacktrace.rs
@@ -77,6 +77,16 @@ impl<'a> BacktraceObserver<'a> {
             harness_type,
         }
     }
+
+    /// Updates the hash value of this observer.
+    fn update_hash(&mut self, hash: u64) {
+        *self.hash.as_mut() = Some(hash);
+    }
+
+    /// Clears the current hash value (sets it to `None`)
+    fn clear_hash(&mut self) {
+        *self.hash.as_mut() = None;
+    }
 }
 
 impl<'a> ObserverWithHashField for BacktraceObserver<'a> {
@@ -84,16 +94,6 @@ impl<'a> ObserverWithHashField for BacktraceObserver<'a> {
     #[must_use]
     fn hash(&self) -> &Option<u64> {
         self.hash.as_ref()
-    }
-
-    /// Updates the hash value of this observer.
-    fn update_hash(&mut self, hash: u64) {
-        *self.hash.as_mut() = Some(hash);
-    }
-
-    /// Clears the current hash value
-    fn clear_hash(&mut self) {
-        *self.hash.as_mut() = None;
     }
 }
 
@@ -219,6 +219,11 @@ impl AsanBacktraceObserver {
         });
         self.update_hash(hash);
     }
+
+    /// Updates the hash value of this observer.
+    fn update_hash(&mut self, hash: u64) {
+        self.hash = Some(hash);
+    }
 }
 
 impl ObserverWithHashField for AsanBacktraceObserver {
@@ -226,16 +231,6 @@ impl ObserverWithHashField for AsanBacktraceObserver {
     #[must_use]
     fn hash(&self) -> &Option<u64> {
         &self.hash
-    }
-
-    /// Updates the hash value of this observer.
-    fn update_hash(&mut self, hash: u64) {
-        self.hash = Some(hash);
-    }
-
-    /// Clears the current hash value
-    fn clear_hash(&mut self) {
-        self.hash = None;
     }
 }
 

--- a/libafl/src/observers/stacktrace.rs
+++ b/libafl/src/observers/stacktrace.rs
@@ -92,8 +92,8 @@ impl<'a> BacktraceObserver<'a> {
 impl<'a> ObserverWithHashField for BacktraceObserver<'a> {
     /// Gets the hash value of this observer.
     #[must_use]
-    fn hash(&self) -> &Option<u64> {
-        self.hash.as_ref()
+    fn hash(&self) -> Option<u64> {
+        *self.hash.as_ref()
     }
 }
 
@@ -229,8 +229,8 @@ impl AsanBacktraceObserver {
 impl ObserverWithHashField for AsanBacktraceObserver {
     /// Gets the hash value of this observer.
     #[must_use]
-    fn hash(&self) -> &Option<u64> {
-        &self.hash
+    fn hash(&self) -> Option<u64> {
+        self.hash
     }
 }
 

--- a/libafl/src/observers/value.rs
+++ b/libafl/src/observers/value.rs
@@ -6,12 +6,20 @@ use alloc::{
 };
 use core::fmt::Debug;
 
+#[cfg(feature = "std")]
+use core::hash::Hash;
+#[cfg(feature = "std")]
+use core::hash::Hasher;
+#[cfg(feature = "std")]
+use std::collections::hash_map::DefaultHasher;
+
 use serde::{Deserialize, Serialize};
 
 use super::Observer;
 use crate::{
     bolts::{ownedref::OwnedRef, tuples::Named},
     inputs::UsesInput,
+    observers::ObserverWithHashField,
     Error,
 };
 
@@ -86,5 +94,17 @@ where
 {
     fn name(&self) -> &str {
         &self.name
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a, T: Hash> ObserverWithHashField for ValueObserver<'a, T>
+where
+    T: Debug + Serialize + serde::de::DeserializeOwned,
+{
+    fn hash(&self) -> Option<u64> {
+        let mut s = DefaultHasher::new();
+        Hash::hash(self.value.as_ref(), &mut s);
+        Some(s.finish())
     }
 }


### PR DESCRIPTION
These methods aren't used by `NewHashFeedback`, so there's no compelling reason
to keep them in the interface. They preclude implementations of
`ObserverWithHashField` that calculcate a hash on-the-fly from a value. For
example, my use-case is to store the stdout of a process, and use
`NewHashFeedback` to only collect inputs that result in new messages on stdout.

Both of these methods are pretty suspicious to begin with - why should other
code be able to update the internal state of the observer? What are the
semantics of `update_hash`? If there are compelling reasons to keep these
methods, let's clarify their intent in the documentation.