### PR TITLE
libafl_frida: Allow compilation for iOS

### DIFF
--- a/libafl_frida/build.rs
+++ b/libafl_frida/build.rs
@@ -1,7 +1,10 @@
 // build.rs
 
 fn main() {
-    cc::Build::new().file("src/gettls.c").compile("libgettls.a");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os != "ios" {
+        cc::Build::new().file("src/gettls.c").compile("libgettls.a");
+    }
 
     // Force linking against libc++
     #[cfg(unix)]


### PR DESCRIPTION
iOS does not have any TLS, so we don't need to keep track of it. This allows compiling for the `aarch64-apple-ios` target.