### PR TITLE
Mutator sampling probability fixes

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -100,6 +100,9 @@ z3 = { version = "0.11", features = ["static-link-z3"], optional = true } # for 
 pyo3 = { version = "0.17", optional = true, features = ["serde", "macros"] }
 concat-idents = { version = "1.1.3", optional = true }
 
+# clippy-suggested optimised byte counter
+bytecount = "0.6.3"
+
 # AGPL
 # !!! this create requires nightly
 grammartec = { version = "0.3", optional = true }

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -60,7 +60,7 @@ pub fn buffer_set<T: Clone>(data: &mut [T], from: usize, len: usize, val: T) {
 /// The solution for this is to specify a window length, then pretend we can start at indices that
 /// would lead to invalid ranges. Then, clamp the values.
 ///
-/// This problem corresponds to: https://oeis.org/A059036
+/// This problem corresponds to: <https://oeis.org/A059036>
 #[inline]
 pub fn rand_range<S: HasRand>(state: &mut S, upper: usize, max_len: usize) -> Range<usize> {
     let len = state.rand_mut().next() as usize % max_len + 1;

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1402,7 +1402,7 @@ mod tests {
             }
             assert!(mutated.bytes.len() <= base.bytes.len() + 16);
             assert_eq!(
-                mutated.bytes.iter().filter(|&&v| v == inserted).count(),
+                bytecount::count(&mutated.bytes, inserted),
                 mutated.bytes.len() - base.bytes.len() + 1
             );
             counts[inserted as usize] += 1;
@@ -1447,13 +1447,9 @@ mod tests {
                 }
             }
             assert!(mutated.bytes.len() <= base.bytes.len() + 16);
-            let offset = if (inserted as usize) < base.bytes.len() {
-                1
-            } else {
-                0
-            };
+            let offset = usize::from((inserted as usize) < base.bytes.len());
             assert_eq!(
-                mutated.bytes.iter().filter(|&&v| v == inserted).count(),
+                bytecount::count(&mutated.bytes, inserted),
                 mutated.bytes.len() - base.bytes.len() + offset,
                 "{:?}",
                 mutated.bytes

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1424,7 +1424,7 @@ mod tests {
         Ok(())
     }
 
-    /// This test guarantees that the likelihood of a byte being re-inserted is equally likely
+    /// This test guarantees that the likelihood of a random byte being inserted is equally likely
     #[test]
     fn test_rand_insert() -> Result<(), Error> {
         let base = BytesInput::new((0..10).collect());


### PR DESCRIPTION
Incomplete as of now (still need to update non-bytes mutators), but this fixes some issues with the likelihoods of various bytes being selected for mutation in a variety of mutators. It also introduces `rand_range`, which generally solves the random range selection problem.

This should not be merged until it has been checked for performance against the previous libafl mutations.