### PR TITLE
Bump deps and fix Clippy warns in example fuzzers

### DIFF
--- a/docs/src/advanced_features/nyx.md
+++ b/docs/src/advanced_features/nyx.md
@@ -118,6 +118,6 @@ match Launcher::builder()
 {
     Ok(()) => (),
     Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-    Err(err) => panic!("Failed to run launcher: {:?}", err),
+    Err(err) => panic!("Failed to run launcher: {err:?}"),
 }
 ```

--- a/docs/src/baby_fuzzer/baby_fuzzer.md
+++ b/docs/src/baby_fuzzer/baby_fuzzer.md
@@ -136,7 +136,7 @@ Another required component is the **EventManager**. It handles some events such 
 
 ```rust,ignore
 // The Monitor trait defines how the fuzzer stats are displayed to the user
-let mon = SimpleMonitor::new(|s| println!("{}", s));
+let mon = SimpleMonitor::new(|s| println!("{s}"));
 
 // The event manager handle the various events generated during the fuzzing loop
 // such as the notification of the addition of a new item to the corpus

--- a/fuzzers/baby_fuzzer_swap_differential/Cargo.toml
+++ b/fuzzers/baby_fuzzer_swap_differential/Cargo.toml
@@ -21,7 +21,7 @@ debug = true
 
 [build-dependencies]
 anyhow = "1"
-bindgen = "0.61"
+bindgen = "0.63"
 cc = "1.0"
 
 [dependencies]

--- a/fuzzers/baby_no_std/src/main.rs
+++ b/fuzzers/baby_no_std/src/main.rs
@@ -1,8 +1,6 @@
 #![no_std]
 // Embedded targets: build with no_main
 #![cfg_attr(not(any(windows)), no_main)]
-// Embedded needs alloc error handlers which only work on nightly right now...
-#![cfg_attr(not(any(windows)), feature(default_alloc_error_handler))]
 
 #[cfg(any(windows, unix))]
 extern crate alloc;

--- a/fuzzers/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml
+++ b/fuzzers/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml
@@ -15,4 +15,4 @@ opt-level = 3
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-clap = { version = "3.2", features = ["default"] }
+clap = { version = "4.0", features = ["default"] }

--- a/fuzzers/frida_gdiplus/Cargo.toml
+++ b/fuzzers/frida_gdiplus/Cargo.toml
@@ -15,10 +15,10 @@ opt-level = 3
 debug = true
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.0.42", features = ["parallel"] }
 num_cpus = "1.0"
 which = "4.1"
-xz = "0.1.0"
+xz2 = "0.1.6"
 flate2 = "1.0.22"
 tar = "0.4.37"
 reqwest = { version = "0.11.4", features = ["blocking"] }
@@ -32,7 +32,7 @@ libafl_targets = { path = "../../libafl_targets", features = ["sancov_cmplog"] }
 libc = "0.2"
 libloading = "0.7"
 num-traits = "0.2"
-rangemap = "0.1"
+rangemap = "1"
 clap = { version = "4.0", features = ["derive"] }
 serde = "1.0"
 mimalloc = { version = "*", default-features = false }

--- a/fuzzers/frida_libpng/Cargo.toml
+++ b/fuzzers/frida_libpng/Cargo.toml
@@ -15,9 +15,9 @@ opt-level = 3
 debug = true
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.0.42", features = ["parallel"] }
 which = "4.1"
-xz = "0.1.0"
+xz2 = "0.1.6"
 flate2 = "1.0.22"
 tar = "0.4.37"
 reqwest = { version = "0.11.4", features = ["blocking"] }
@@ -34,7 +34,7 @@ libafl_targets = { path = "../../libafl_targets", features = ["sancov_cmplog"] }
 libc = "0.2"
 libloading = "0.7"
 num-traits = "0.2"
-rangemap = "0.1"
+rangemap = "1"
 clap = { version = "4.0", features = ["derive"] }
 serde = "1.0"
 mimalloc = { version = "*", default-features = false }

--- a/fuzzers/fuzzbench/fuzz.c
+++ b/fuzzers/fuzzbench/fuzz.c
@@ -3,6 +3,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   if (Size >= 8 && *(uint32_t *)Data == 0xaabbccdd) { abort(); }
+  return 0;
 }
 
 /*

--- a/fuzzers/fuzzbench_fork_qemu/Cargo.toml
+++ b/fuzzers/fuzzbench_fork_qemu/Cargo.toml
@@ -14,5 +14,5 @@ debug = true
 [dependencies]
 libafl = { path = "../../libafl/" }
 libafl_qemu = { path = "../../libafl_qemu/", features = ["x86_64", "usermode"] }
-clap = { version = "3.2", features = ["default"] }
+clap = { version = "4.0", features = ["default"] }
 nix = "0.25"

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -70,21 +70,18 @@ pub fn main() {
             Arg::new("out")
                 .help("The directory to place finds in ('corpus')")
                 .long("libafl-out")
-                .required(true)
-                .takes_value(true),
+                .required(true),
         )
         .arg(
             Arg::new("in")
                 .help("The directory to read initial inputs from ('seeds')")
                 .long("libafl-in")
-                .required(true)
-                .takes_value(true),
+                .required(true),
         )
         .arg(
             Arg::new("tokens")
                 .long("libafl-tokens")
-                .help("A file to read tokens from, to be used during fuzzing")
-                .takes_value(true),
+                .help("A file to read tokens from, to be used during fuzzing"),
         )
         .arg(
             Arg::new("logfile")
@@ -158,7 +155,7 @@ fn fuzz(
     let test_one_input_ptr = elf
         .resolve_symbol("LLVMFuzzerTestOneInput", emu.load_addr())
         .expect("Symbol LLVMFuzzerTestOneInput not found");
-    println!("LLVMFuzzerTestOneInput @ {:#x}", test_one_input_ptr);
+    println!("LLVMFuzzerTestOneInput @ {test_one_input_ptr:#x}");
 
     emu.set_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     unsafe { emu.run() };
@@ -170,14 +167,14 @@ fn fuzz(
     unsafe { emu.read_mem(stack_ptr, &mut ret_addr) };
     let ret_addr = u64::from_le_bytes(ret_addr);
 
-    println!("Stack pointer = {:#x}", stack_ptr);
-    println!("Return address = {:#x}", ret_addr);
+    println!("Stack pointer = {stack_ptr:#x}");
+    println!("Return address = {ret_addr:#x}");
 
     emu.remove_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     emu.set_breakpoint(ret_addr); // LLVMFuzzerTestOneInput ret addr
 
     let input_addr = emu.map_private(0, 4096, MmapPerms::ReadWrite).unwrap();
-    println!("Placing input at {:#x}", input_addr);
+    println!("Placing input at {input_addr:#x}");
 
     let log = RefCell::new(
         OpenOptions::new()

--- a/fuzzers/fuzzbench_qemu/Cargo.toml
+++ b/fuzzers/fuzzbench_qemu/Cargo.toml
@@ -14,5 +14,5 @@ debug = true
 [dependencies]
 libafl = { path = "../../libafl/" }
 libafl_qemu = { path = "../../libafl_qemu/", features = ["x86_64", "usermode"] }
-clap = { version = "3.2", features = ["default"] }
+clap = { version = "4.0", features = ["default"] }
 nix = "0.25"

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -78,21 +78,18 @@ pub fn main() {
             Arg::new("out")
                 .help("The directory to place finds in ('corpus')")
                 .long("libafl-out")
-                .required(true)
-                .takes_value(true),
+                .required(true),
         )
         .arg(
             Arg::new("in")
                 .help("The directory to read initial inputs from ('seeds')")
                 .long("libafl-in")
-                .required(true)
-                .takes_value(true),
+                .required(true),
         )
         .arg(
             Arg::new("tokens")
                 .long("libafl-tokens")
-                .help("A file to read tokens from, to be used during fuzzing")
-                .takes_value(true),
+                .help("A file to read tokens from, to be used during fuzzing"),
         )
         .arg(
             Arg::new("logfile")
@@ -183,7 +180,7 @@ fn fuzz(
     let test_one_input_ptr = elf
         .resolve_symbol("LLVMFuzzerTestOneInput", emu.load_addr())
         .expect("Symbol LLVMFuzzerTestOneInput not found");
-    println!("LLVMFuzzerTestOneInput @ {:#x}", test_one_input_ptr);
+    println!("LLVMFuzzerTestOneInput @ {test_one_input_ptr:#x}");
 
     emu.set_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     unsafe { emu.run() };
@@ -195,8 +192,8 @@ fn fuzz(
     unsafe { emu.read_mem(stack_ptr, &mut ret_addr) };
     let ret_addr = u64::from_le_bytes(ret_addr);
 
-    println!("Stack pointer = {:#x}", stack_ptr);
-    println!("Return address = {:#x}", ret_addr);
+    println!("Stack pointer = {stack_ptr:#x}");
+    println!("Return address = {ret_addr:#x}");
 
     emu.remove_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     emu.set_breakpoint(ret_addr); // LLVMFuzzerTestOneInput ret addr
@@ -204,7 +201,7 @@ fn fuzz(
     let input_addr = emu
         .map_private(0, MAX_INPUT_SIZE, MmapPerms::ReadWrite)
         .unwrap();
-    println!("Placing input at {:#x}", input_addr);
+    println!("Placing input at {input_addr:#x}");
 
     let log = RefCell::new(
         OpenOptions::new()
@@ -224,7 +221,7 @@ fn fuzz(
     // 'While the stats are state, they are usually used in the broker - which is likely never restarted
     let monitor = SimpleMonitor::new(|s| {
         #[cfg(unix)]
-        writeln!(&mut stdout_cpy, "{}", s).unwrap();
+        writeln!(&mut stdout_cpy, "{s}").unwrap();
         #[cfg(windows)]
         println!("{s}");
         writeln!(log.borrow_mut(), "{:?} {}", current_time(), s).unwrap();

--- a/fuzzers/fuzzbench_text/fuzz.c
+++ b/fuzzers/fuzzbench_text/fuzz.c
@@ -3,6 +3,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   if (Size >= 8 && *(uint32_t *)Data == 0xaabbccdd) { abort(); }
+  return 0;
 }
 
 /*

--- a/fuzzers/fuzzbench_text/src/lib.rs
+++ b/fuzzers/fuzzbench_text/src/lib.rs
@@ -278,7 +278,7 @@ fn fuzz_binary(
     // 'While the monitor are state, they are usually used in the broker - which is likely never restarted
     let monitor = SimpleMonitor::new(|s| {
         #[cfg(unix)]
-        writeln!(&mut stdout_cpy, "{}", s).unwrap();
+        writeln!(&mut stdout_cpy, "{s}").unwrap();
         #[cfg(windows)]
         println!("{s}");
         writeln!(log.borrow_mut(), "{:?} {}", current_time(), s).unwrap();
@@ -479,7 +479,7 @@ fn fuzz_text(
     // 'While the monitor are state, they are usually used in the broker - which is likely never restarted
     let monitor = SimpleMonitor::new(|s| {
         #[cfg(unix)]
-        writeln!(&mut stdout_cpy, "{}", s).unwrap();
+        writeln!(&mut stdout_cpy, "{s}").unwrap();
         #[cfg(windows)]
         println!("{s}");
         writeln!(log.borrow_mut(), "{:?} {}", current_time(), s).unwrap();

--- a/fuzzers/libafl_atheris/Cargo.toml
+++ b/fuzzers/libafl_atheris/Cargo.toml
@@ -21,7 +21,7 @@ which = { version = "4.0.2" }
 [dependencies]
 libafl = { path = "../../libafl/" }
 libafl_targets = { path = "../../libafl_targets/", features = ["pointer_maps", "sancov_cmplog", "libfuzzer"] }
-clap = { version = "3.2", features = ["default"] }
+clap = { version = "4.0", features = ["default"] }
 
 [lib]
 name = "afl_atheris"

--- a/fuzzers/libafl_atheris/Makefile
+++ b/fuzzers/libafl_atheris/Makefile
@@ -1,8 +1,11 @@
-FUZZER_NAME="fuzzer"
 PROJECT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 UNAME :="$(shell uname)"
 LIB_DIR :="$(PROJECT_DIR)/target/release/libafl_atheris.a"
 DEEXIT_PATH = "$(PROJECT_DIR)/../../target/release/libdeexit.dylib"
+
+ifeq ("$(wildcard $(DEEXIT_PATH))", "")
+	DEEXIT_PATH = "$(PROJECT_DIR)/../../target/release/libdeexit.so"
+endif
 
 PHONY: all
 
@@ -22,7 +25,8 @@ target/release/libafl_atheris.a: src/*
 
 fuzzer: target/release/libafl_atheris.a atheris env
 	(\
-	source env/bin/activate; \
+	. env/bin/activate; \
+	pip install wheel; \
 	cd atheris; \
 	LIBFUZZER_LIB=$(LIB_DIR) pip install .; \
 	)
@@ -30,25 +34,21 @@ fuzzer: target/release/libafl_atheris.a atheris env
 clean:
 	rm env
 
-run: all
-	./$(FUZZER_NAME) --cores 0 &
-
 env:
-	python3 -m pip install --user virtualenv
 	python3 -m venv env
 
 short_test: all
 	(\
 	rm -rf libafl_unix_shmem_server || true; \
-	source env/bin/activate; \
-	LDPRELOAD=$(DEEXIT_PATH) DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=$(DEEXIT_PATH) RUST_BACKTRACE=1 timeout 10s python3 ./atheris/example_fuzzers/fuzzing_example.py --cores 0 -i in -o out || true; \
+	. env/bin/activate; \
+	LD_PRELOAD=$(DEEXIT_PATH) DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=$(DEEXIT_PATH) RUST_BACKTRACE=1 timeout 10s python3 ./atheris/example_fuzzers/fuzzing_example.py --cores 0 -i in -o out || true; \
 	rm -rf out; \
 	)
 
-test: all
+test:
 	(\
 	rm -rf libafl_unix_shmem_server || true; \
-	source env/bin/activate; \
-	LDPRELOAD=$(DEEXIT_PATH) DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=$(DEEXIT_PATH) RUST_BACKTRACE=1 timeout 60s python3 ./atheris/example_fuzzers/fuzzing_example.py --cores 0 -i in -o out || true; \
+	. env/bin/activate; \
+	LD_PRELOAD=$(DEEXIT_PATH) DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=$(DEEXIT_PATH) RUST_BACKTRACE=1 timeout 60s python3 ./atheris/example_fuzzers/fuzzing_example.py --cores 0 -i in -o out || true; \
 	rm -rf out; \
 	)

--- a/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/libfuzzer_libmozjpeg/src/lib.rs
@@ -73,7 +73,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
                 return Ok(());
             }
             Err(err) => {
-                panic!("Failed to setup the restarter: {:?}", err);
+                panic!("Failed to setup the restarter: {err:?}");
             }
         };
 

--- a/fuzzers/libfuzzer_libpng_accounting/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/bin/libafl_cc.rs
@@ -28,7 +28,7 @@ pub fn main() {
             .link_staticlib(&dir, "libfuzzer_libpng")
             .add_arg("-fsanitize-coverage=trace-pc-guard")
             .add_pass(LLVMPasses::CoverageAccounting)
-            .add_passes_arg(format!("-granularity={}", GRANULARITY))
+            .add_passes_arg(format!("-granularity={GRANULARITY}"))
             .run()
             .expect("Failed to run the wrapped compiler")
         {

--- a/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
@@ -253,6 +253,6 @@ pub fn libafl_main() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/libfuzzer_libpng_ctx/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_ctx/src/lib.rs
@@ -242,6 +242,6 @@ pub fn libafl_main() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -247,6 +247,6 @@ pub fn libafl_main() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -20,7 +20,7 @@ use libafl::{
         scheduled::{havoc_mutations, StdScheduledMutator},
         token_mutations::I2SRandReplace,
     },
-    observers::{StdMapObserver, TimeObserver},
+    observers::TimeObserver,
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -145,7 +145,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     if state.must_load_initial_inputs() {
         state
             .load_initial_inputs(&mut fuzzer, &mut executor, &mut restarting_mgr, corpus_dirs)
-            .unwrap_or_else(|_| panic!("Failed to load initial corpus at {:?}", corpus_dirs));
+            .unwrap_or_else(|_| panic!("Failed to load initial corpus at {corpus_dirs:?}"));
         println!("We imported {} inputs from disk.", state.corpus().count());
     }
 

--- a/fuzzers/nautilus_sync/src/bin/libafl_cc.rs
+++ b/fuzzers/nautilus_sync/src/bin/libafl_cc.rs
@@ -4,7 +4,7 @@ use libafl_cc::{ClangWrapper, CompilerWrapper};
 
 fn find_libpython() -> Result<String, String> {
     match Command::new("python3")
-        .args(&["-m", "find_libpython"])
+        .args(["-m", "find_libpython"])
         .output()
     {
         Ok(output) => {

--- a/fuzzers/nautilus_sync/src/lib.rs
+++ b/fuzzers/nautilus_sync/src/lib.rs
@@ -257,6 +257,6 @@ pub fn libafl_main() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/nyx_libxml2_parallel/src/main.rs
+++ b/fuzzers/nyx_libxml2_parallel/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 
     // endregion

--- a/fuzzers/push_harness/src/main.rs
+++ b/fuzzers/push_harness/src/main.rs
@@ -66,7 +66,7 @@ fn input_generator() {
     .unwrap();
 
     // The Monitor trait define how the fuzzer stats are reported to the user
-    let monitor = SimpleMonitor::new(|s| println!("{}", s));
+    let monitor = SimpleMonitor::new(|s| println!("{s}"));
 
     // The event manager handle the various events generated during the fuzzing loop
     // such as the notification of the addition of a new item to the corpus

--- a/fuzzers/push_stage_harness/src/main.rs
+++ b/fuzzers/push_stage_harness/src/main.rs
@@ -60,7 +60,7 @@ pub fn main() {
     .unwrap();
 
     // The Monitor trait define how the fuzzer stats are reported to the user
-    let monitor = SimpleMonitor::new(|s| println!("{}", s));
+    let monitor = SimpleMonitor::new(|s| println!("{s}"));
 
     // The event manager handle the various events generated during the fuzzing loop
     // such as the notification of the addition of a new item to the corpus

--- a/fuzzers/python_qemu/fuzz.c
+++ b/fuzzers/python_qemu/fuzz.c
@@ -5,6 +5,7 @@
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   // printf("Got %ld bytes.\n", Size);
   if (Size >= 4 && *(uint32_t *)Data == 0xaabbccdd) { abort(); }
+  return 0;
 }
 
 int main() {

--- a/fuzzers/qemu_arm_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_arm_launcher/src/fuzzer.rs
@@ -62,7 +62,7 @@ pub fn fuzz() {
     let test_one_input_ptr = elf
         .resolve_symbol("LLVMFuzzerTestOneInput", emu.load_addr())
         .expect("Symbol LLVMFuzzerTestOneInput not found");
-    println!("LLVMFuzzerTestOneInput @ {:#x}", test_one_input_ptr);
+    println!("LLVMFuzzerTestOneInput @ {test_one_input_ptr:#x}");
 
     emu.set_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     unsafe { emu.run() };
@@ -73,14 +73,14 @@ pub fn fuzz() {
     let stack_ptr: u64 = emu.read_reg(Regs::Sp).unwrap();
     let ret_addr: u32 = emu.read_reg(Regs::Lr).unwrap();
 
-    println!("Stack pointer = {:#x}", stack_ptr);
-    println!("Return address = {:#x}", ret_addr);
+    println!("Stack pointer = {stack_ptr:#x}");
+    println!("Return address = {ret_addr:#x}");
 
     emu.remove_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     emu.set_breakpoint(ret_addr); // LLVMFuzzerTestOneInput ret addr
 
     let input_addr = emu.map_private(0, 4096, MmapPerms::ReadWrite).unwrap();
-    println!("Placing input at {:#x}", input_addr);
+    println!("Placing input at {input_addr:#x}");
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |input: &BytesInput| {
@@ -233,6 +233,6 @@ pub fn fuzz() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_launcher/src/fuzzer.rs
@@ -62,7 +62,7 @@ pub fn fuzz() {
     let test_one_input_ptr = elf
         .resolve_symbol("LLVMFuzzerTestOneInput", emu.load_addr())
         .expect("Symbol LLVMFuzzerTestOneInput not found");
-    println!("LLVMFuzzerTestOneInput @ {:#x}", test_one_input_ptr);
+    println!("LLVMFuzzerTestOneInput @ {test_one_input_ptr:#x}");
 
     emu.set_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     unsafe { emu.run() };
@@ -75,8 +75,8 @@ pub fn fuzz() {
     unsafe { emu.read_mem(stack_ptr, &mut ret_addr) };
     let ret_addr = u64::from_le_bytes(ret_addr);
 
-    println!("Stack pointer = {:#x}", stack_ptr);
-    println!("Return address = {:#x}", ret_addr);
+    println!("Stack pointer = {stack_ptr:#x}");
+    println!("Return address = {ret_addr:#x}");
 
     emu.remove_breakpoint(test_one_input_ptr); // LLVMFuzzerTestOneInput
     emu.set_breakpoint(ret_addr); // LLVMFuzzerTestOneInput ret addr
@@ -84,7 +84,7 @@ pub fn fuzz() {
     let input_addr = emu
         .map_private(0, MAX_INPUT_SIZE, MmapPerms::ReadWrite)
         .unwrap();
-    println!("Placing input at {:#x}", input_addr);
+    println!("Placing input at {input_addr:#x}");
 
     // The wrapped harness function, calling out to the LLVM-style harness
     let mut harness = |input: &BytesInput| {
@@ -214,6 +214,6 @@ pub fn fuzz() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/qemu_systemmode/src/fuzzer.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer.rs
@@ -61,12 +61,12 @@ pub fn fuzz() {
             0,
         )
         .expect("Symbol or env FUZZ_INPUT not found") as GuestPhysAddr;
-    println!("FUZZ_INPUT @ {:#x}", input_addr);
+    println!("FUZZ_INPUT @ {input_addr:#x}");
 
     let main_addr = elf
         .resolve_symbol("main", 0)
         .expect("Symbol main not found");
-    println!("main address = {:#x}", main_addr);
+    println!("main address = {main_addr:#x}");
 
     let breakpoint = elf
         .resolve_symbol(
@@ -74,7 +74,7 @@ pub fn fuzz() {
             0,
         )
         .expect("Symbol or env BREAKPOINT not found");
-    println!("Breakpoint address = {:#x}", breakpoint);
+    println!("Breakpoint address = {breakpoint:#x}");
 
     let mut run_client = |state: Option<_>, mut mgr, _core_id| {
         // Initialize QEMU
@@ -248,6 +248,6 @@ pub fn fuzz() {
     {
         Ok(()) => (),
         Err(Error::ShuttingDown) => println!("Fuzzing stopped by user. Good bye."),
-        Err(err) => panic!("Failed to run launcher: {:?}", err),
+        Err(err) => panic!("Failed to run launcher: {err:?}"),
     }
 }

--- a/fuzzers/tutorial/src/input.rs
+++ b/fuzzers/tutorial/src/input.rs
@@ -38,16 +38,12 @@ impl Fixup for PacketData {
     Serialize, Deserialize, Debug, Copy, Clone, FuzzerObject, ToPrimitiveU32, BinarySerialize, Hash,
 )]
 #[repr(u32)]
+#[derive(Default)]
 pub enum PacketType {
+    #[default]
     Read = 0x0,
     Write = 0x1,
     Reset = 0x2,
-}
-
-impl Default for PacketType {
-    fn default() -> Self {
-        PacketType::Read
-    }
 }
 
 impl Input for PacketData {


### PR DESCRIPTION
* Mostly addressing changing the `uninlined_format_args` lint which was changed to warn-by-default in rust clippy 1.67

* Bump dependencies: bindgen:  0.61 -> 0.63
  cc:       1.0 -> 1.0.42 (Exclue versions w/incompat rayon dependency)
  clap:     3.x -> 4.0
  nix:      0.25 -> 0.26
  rangemap: 0.1 -> 1
  xz -> xz2:  move to updated version

* Add fallthrough default return to `LLVMFuzzerTestOneInput` in **/fuzz.c to prevent Clang's -Wreturn-type

* libafl_atheris: Improve POSIX compatibility and reduce warnings
  * Check for .dylib and .so libraries
  * `source` -> `.` for POSIX shells
  * install wheel into the venv to support newer Python packaging standards
  * `LDPRELOAD` -> `LD_PRELOAD`