### PR TITLE
Use Instant::now instead of duration

### DIFF
--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -35,7 +35,7 @@ pub use nautilus::*;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
-use create::observers::TimeObserver;
+use crate::observers::TimeObserver;
 
 use crate::{
     bolts::tuples::Named,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     events::EventFirer,
     executors::ExitKind,
     inputs::UsesInput,
-    observers::{ListObserver, ObserversTuple,TimeObserver},
+    observers::{ListObserver, ObserversTuple, TimeObserver},
     state::HasClientPerfMonitor,
     Error,
 };

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -24,19 +24,15 @@ pub use new_hash_feedback::NewHashFeedbackMetadata;
 #[cfg(feature = "nautilus")]
 pub mod nautilus;
 use alloc::string::{String, ToString};
-#[cfg(feature = "std")]
-use core::time::Duration;
 use core::{
     fmt::{self, Debug, Formatter},
     marker::PhantomData,
+    time::Duration,
 };
 
 #[cfg(feature = "nautilus")]
 pub use nautilus::*;
 use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "std")]
-use crate::observers::TimeObserver;
 
 use crate::{
     bolts::tuples::Named,
@@ -44,7 +40,7 @@ use crate::{
     events::EventFirer,
     executors::ExitKind,
     inputs::UsesInput,
-    observers::{ListObserver, ObserversTuple},
+    observers::{ListObserver, ObserversTuple,TimeObserver},
     state::HasClientPerfMonitor,
     Error,
 };
@@ -885,14 +881,12 @@ pub type TimeoutFeedbackFactory = DefaultFeedbackFactory<TimeoutFeedback>;
 /// Nop feedback that annotates execution time in the new testcase, if any
 /// for this Feedback, the testcase is never interesting (use with an OR).
 /// It decides, if the given [`TimeObserver`] value of a run is interesting.
-#[cfg(feature = "std")]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TimeFeedback {
     exec_time: Option<Duration>,
     name: String,
 }
 
-#[cfg(feature = "std")]
 impl<S> Feedback<S> for TimeFeedback
 where
     S: UsesInput + HasClientPerfMonitor,
@@ -936,7 +930,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
 impl Named for TimeFeedback {
     #[inline]
     fn name(&self) -> &str {
@@ -944,7 +937,6 @@ impl Named for TimeFeedback {
     }
 }
 
-#[cfg(feature = "std")]
 impl TimeFeedback {
     /// Creates a new [`TimeFeedback`], deciding if the value of a [`TimeObserver`] with the given `name` of a run is interesting.
     #[must_use]

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -24,12 +24,12 @@ pub use new_hash_feedback::NewHashFeedbackMetadata;
 #[cfg(feature = "nautilus")]
 pub mod nautilus;
 use alloc::string::{String, ToString};
+#[cfg(feature = "std")]
+use core::time::Duration;
 use core::{
     fmt::{self, Debug, Formatter},
     marker::PhantomData,
 };
-#[cfg(feature = "std")]
-use core::time::Duration;
 
 #[cfg(feature = "nautilus")]
 pub use nautilus::*;

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -27,8 +27,9 @@ use alloc::string::{String, ToString};
 use core::{
     fmt::{self, Debug, Formatter},
     marker::PhantomData,
-    time::Duration,
 };
+#[cfg(feature = "std")]
+use core::time::Duration;
 
 #[cfg(feature = "nautilus")]
 pub use nautilus::*;

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -34,13 +34,16 @@ use core::{
 pub use nautilus::*;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "std")]
+use create::observers::TimeObserver;
+
 use crate::{
     bolts::tuples::Named,
     corpus::Testcase,
     events::EventFirer,
     executors::ExitKind,
     inputs::UsesInput,
-    observers::{ListObserver, ObserversTuple, TimeObserver},
+    observers::{ListObserver, ObserversTuple},
     state::HasClientPerfMonitor,
     Error,
 };
@@ -881,12 +884,14 @@ pub type TimeoutFeedbackFactory = DefaultFeedbackFactory<TimeoutFeedback>;
 /// Nop feedback that annotates execution time in the new testcase, if any
 /// for this Feedback, the testcase is never interesting (use with an OR).
 /// It decides, if the given [`TimeObserver`] value of a run is interesting.
+#[cfg(feature = "std")]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TimeFeedback {
     exec_time: Option<Duration>,
     name: String,
 }
 
+#[cfg(feature = "std")]
 impl<S> Feedback<S> for TimeFeedback
 where
     S: UsesInput + HasClientPerfMonitor,
@@ -930,6 +935,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl Named for TimeFeedback {
     #[inline]
     fn name(&self) -> &str {
@@ -937,6 +943,7 @@ impl Named for TimeFeedback {
     }
 }
 
+#[cfg(feature = "std")]
 impl TimeFeedback {
     /// Creates a new [`TimeFeedback`], deciding if the value of a [`TimeObserver`] with the given `name` of a run is interesting.
     #[must_use]

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -418,6 +418,7 @@ pub struct TimeObserver {
     last_runtime: Option<Duration>,
 }
 
+#[cfg(feature = "std")]
 mod instant_serializer {
     use core::time::Duration;
     use std::time::Instant;
@@ -437,11 +438,12 @@ mod instant_serializer {
         D: Deserializer<'de>,
     {
         let duration = Duration::deserialize(deserializer)?;
-        let instant = Instant::now() - duration;
+        let instant = Instant::now().checked_sub(duration).unwrap();
         Ok(instant)
     }
 }
 
+#[cfg(feature = "std")]
 impl TimeObserver {
     /// Creates a new [`TimeObserver`] with the given name.
     #[must_use]
@@ -460,6 +462,7 @@ impl TimeObserver {
     }
 }
 
+#[cfg(feature = "std")]
 impl<S> Observer<S> for TimeObserver
 where
     S: UsesInput,
@@ -481,12 +484,14 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl Named for TimeObserver {
     fn name(&self) -> &str {
         &self.name
     }
 }
 
+#[cfg(feature = "std")]
 impl<OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for TimeObserver
 where
     OTA: ObserversTuple<S>,

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -430,6 +430,7 @@ mod instant_serializer {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S>(instant: &Instant, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -28,7 +28,10 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{fmt::Debug, time::Duration};
+use core::fmt::Debug;
+
+#[cfg(feature = "std")]
+use core::time::Duration;
 
 #[cfg(feature = "std")]
 use std::time::Instant;

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -451,7 +451,7 @@ where
         _input: &S::Input,
         _exit_kind: &ExitKind,
     ) -> Result<(), Error> {
-        self.last_runtime = self.start_time.elapsed();
+        self.last_runtime = Some(self.start_time.elapsed());
         Ok(())
     }
 }

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -28,7 +28,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{fmt::Debug,time::Duration};
+use core::{fmt::Debug, time::Duration};
 
 #[cfg(feature = "std")]
 use std::time::Instant;
@@ -424,7 +424,6 @@ pub struct TimeObserver {
     #[cfg(feature = "no_std")]
     start_time: Duration,
 
-
     last_runtime: Option<Duration>,
 }
 
@@ -490,7 +489,7 @@ where
     }
 
     #[cfg(feature = "no_std")]
-    fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error>{
+    fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
         self.last_runtime = None;
         self.start_time = Duration::from_secs(0);
         Ok(())

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -29,6 +29,8 @@ use alloc::{
     vec::Vec,
 };
 use core::{fmt::Debug, time::Duration};
+
+#[cfg(feature = "std")]
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -29,6 +29,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{fmt::Debug, time::Duration};
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 pub use value::*;
@@ -408,10 +409,11 @@ where
 }
 
 /// A simple observer, just overlooking the runtime of the target.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
 pub struct TimeObserver {
     name: String,
-    start_time: Duration,
+    start_time: Instant,
     last_runtime: Option<Duration>,
 }
 
@@ -421,7 +423,7 @@ impl TimeObserver {
     pub fn new(name: &'static str) -> Self {
         Self {
             name: name.to_string(),
-            start_time: Duration::from_secs(0),
+            start_time: Instant::now(),
             last_runtime: None,
         }
     }
@@ -439,7 +441,7 @@ where
 {
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
         self.last_runtime = None;
-        self.start_time = current_time();
+        self.start_time = Instant::now();
         Ok(())
     }
 
@@ -449,7 +451,7 @@ where
         _input: &S::Input,
         _exit_kind: &ExitKind,
     ) -> Result<(), Error> {
-        self.last_runtime = current_time().checked_sub(self.start_time);
+        self.last_runtime = self.start_time.elapsed();
         Ok(())
     }
 }


### PR DESCRIPTION
Fix #145 

Define custom deserialization and serialization since serde does not support Instant struct by default
https://github.com/serde-rs/serde/issues/1375