### PR TITLE
Remove unused deps

### DIFF
--- a/fuzzers/backtrace_baby_fuzzers/command_executor/Cargo.toml
+++ b/fuzzers/backtrace_baby_fuzzers/command_executor/Cargo.toml
@@ -18,6 +18,4 @@ cc = "*"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-ahash = { version = "0.7"} # another hash
-spawn-ptrace = {version= "0.1.2"}
 

--- a/fuzzers/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml
+++ b/fuzzers/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml
@@ -15,4 +15,3 @@ opt-level = 3
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-clap = { version = "4.0", features = ["default"] }

--- a/fuzzers/frida_gdiplus/Cargo.toml
+++ b/fuzzers/frida_gdiplus/Cargo.toml
@@ -25,17 +25,9 @@ reqwest = { version = "0.11.4", features = ["blocking"] }
 
 [dependencies]
 libafl = { path = "../../libafl/", features = [ "std", "llmp_compression", "llmp_bind_public", "frida_cli" ] } #,  "llmp_small_maps", "llmp_debug"]}
-capstone = "0.11.0"
 frida-gum = { version = "0.8.1", features = [ "auto-download", "event-sink", "invocation-listener"] }
 libafl_frida = { path = "../../libafl_frida", features = ["cmplog"] }
 libafl_targets = { path = "../../libafl_targets", features = ["sancov_cmplog"] }
-libc = "0.2"
 libloading = "0.7"
-num-traits = "0.2"
-rangemap = "1"
-clap = { version = "4.0", features = ["derive"] }
-serde = "1.0"
 mimalloc = { version = "*", default-features = false }
-
-backtrace = "0.3"
 color-backtrace = "0.5"

--- a/fuzzers/frida_libpng/Cargo.toml
+++ b/fuzzers/frida_libpng/Cargo.toml
@@ -27,17 +27,9 @@ reqwest = { version = "0.11.4", features = ["blocking"] }
 
 [dependencies]
 libafl = { path = "../../libafl/", features = [ "std", "llmp_compression", "llmp_bind_public", "frida_cli" ] } #,  "llmp_small_maps", "llmp_debug"]}
-capstone = "0.11.0"
 frida-gum = { version = "0.8.1", features = [ "auto-download", "event-sink", "invocation-listener"] }
 libafl_frida = { path = "../../libafl_frida", features = ["cmplog"] }
 libafl_targets = { path = "../../libafl_targets", features = ["sancov_cmplog"] }
-libc = "0.2"
 libloading = "0.7"
-num-traits = "0.2"
-rangemap = "1"
-clap = { version = "4.0", features = ["derive"] }
-serde = "1.0"
 mimalloc = { version = "*", default-features = false }
-
-backtrace = "0.3"
 color-backtrace = "0.5"

--- a/fuzzers/fuzzbench_text/Cargo.toml
+++ b/fuzzers/fuzzbench_text/Cargo.toml
@@ -27,7 +27,6 @@ clap = { version = "4.0", features = ["default"] }
 nix = "0.26"
 mimalloc = { version = "*", default-features = false }
 content_inspector = "0.2.4"
-serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib
 
 [lib]
 name = "fuzzbench"

--- a/fuzzers/tutorial/Cargo.toml
+++ b/fuzzers/tutorial/Cargo.toml
@@ -20,7 +20,6 @@ which = { version = "4.0.2" }
 
 [dependencies]
 libafl = { path = "../../libafl/", features = ["default", "rand_trait"] }
-libafl_derive = { path = "../../libafl_derive/" }
 libafl_targets = { path = "../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog"] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib
 lain = { version = "0.5", features = ["serde_support"], git = "https://github.com/Mrmaxmeier/lain.git", rev = "6c8a786" } # We're using a lain fork with updated rand crate

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -25,11 +25,9 @@ libafl_targets = { path = "../libafl_targets", version = "0.9.0", features = ["s
 nix = "0.26"
 libc = "0.2"
 hashbrown = "0.13"
-libloading = "0.7"
 rangemap = "1.0"
 frida-gum-sys = { version = "0.4.1", features = [ "auto-download", "event-sink", "invocation-listener"] }
 frida-gum = { version = "0.8.1", features = [ "auto-download", "event-sink", "invocation-listener"] }
-regex = "1"
 dynasmrt = "2"
 capstone = "0.11.0"
 color-backtrace ={ version = "0.5", features = [ "resolve-modules" ] }

--- a/libafl_tinyinst/Cargo.toml
+++ b/libafl_tinyinst/Cargo.toml
@@ -12,7 +12,6 @@ description = "TinyInst backend for libafl"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cxx = "1.0"
 libafl = { path = "../libafl", version = "0.9.0", features = [
     "std",
     "libafl_derive",


### PR DESCRIPTION
cargo machete
https://github.com/bnjbvr/cargo-machete
This tool is surprisingly fast btw

```
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in /home/toka/LibAFL:
libafl -- /home/toka/LibAFL/libafl/Cargo.toml:
        async-std
libafl_tinyinst -- /home/toka/LibAFL/libafl_tinyinst/Cargo.toml:
        cxx
libafl_frida -- /home/toka/LibAFL/libafl_frida/Cargo.toml:
        libloading
        regex
command_executor -- /home/toka/LibAFL/fuzzers/backtrace_baby_fuzzers/command_executor/Cargo.toml:
        ahash
        spawn-ptrace
forkserver_executor -- /home/toka/LibAFL/fuzzers/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml:
        clap
fuzzbench_text -- /home/toka/LibAFL/fuzzers/fuzzbench_text/Cargo.toml:
        serde
frida_fuzzer -- /home/toka/LibAFL/fuzzers/frida_libpng/Cargo.toml:
        backtrace
        capstone
        clap
        libc
        num-traits
        rangemap
        serde
tutorial -- /home/toka/LibAFL/fuzzers/tutorial/Cargo.toml:
        libafl_derive
frida_gdiplus -- /home/toka/LibAFL/fuzzers/frida_gdiplus/Cargo.toml:
        backtrace
        capstone
        clap
        libc
        num-traits
        rangemap
        serde
Done!
```
So remove these