### PR TITLE
Fix StdErrObserver not implementing needed traits

### DIFF
--- a/libafl/src/observers/stdio.rs
+++ b/libafl/src/observers/stdio.rs
@@ -51,7 +51,7 @@ impl Named for StdOutObserver {
 
 /// An observer that captures stderr of a target.
 /// Only works for supported executors.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StdErrObserver {
     /// The name of the observer.
     pub name: String,


### PR DESCRIPTION
StdFuzzer under the hood requires all attached observers to have Serialize and Deserialize traits. Even StdOutObserver has one.

StdFuzzer needs serialization to implement ExecutionProcessor trait. Sending a newTestcase event requires a serialized ObserversTuple.

I think this might have been a copy pasta bug or otherwise missing trait. Maybe it would be a good idea to require it from each implementation to prevent typos like this.