### PR TITLE
Make sure input was loaded to avoid panic on unwrap in MutatedTransform

### DIFF
--- a/libafl/src/inputs/generalized.rs
+++ b/libafl/src/inputs/generalized.rs
@@ -108,7 +108,7 @@ where
     type Post = Self;
 
     fn try_transform_from(
-        base: &Testcase<BytesInput>,
+        base: &mut Testcase<BytesInput>,
         _state: &S,
         corpus_idx: CorpusId,
     ) -> Result<Self, Error> {

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -51,7 +51,7 @@ where
 
     /// Transform the provided testcase into this type
     fn try_transform_from(
-        base: &Testcase<I>,
+        base: &mut Testcase<I>,
         state: &S,
         corpus_idx: CorpusId,
     ) -> Result<Self, Error>;
@@ -69,15 +69,11 @@ where
 
     #[inline]
     fn try_transform_from(
-        base: &Testcase<I>,
+        base: &mut Testcase<I>,
         _state: &S,
         _corpus_idx: CorpusId,
     ) -> Result<Self, Error> {
-        if let Some(i) = base.input().as_ref() {
-            Ok(i.clone())
-        } else {
-            Ok(base.clone().load_input()?.clone())
-        }
+        Ok(base.load_input()?.clone())
     }
 
     #[inline]
@@ -120,8 +116,8 @@ where
         let num = self.iterations(state, corpus_idx)?;
 
         start_timer!(state);
-        let testcase = state.corpus().get(corpus_idx)?.borrow();
-        let Ok(input) = I::try_transform_from(&testcase, state, corpus_idx) else { return Ok(()); };
+        let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
+        let Ok(input) = I::try_transform_from(&mut testcase, state, corpus_idx) else { return Ok(()); };
         drop(testcase);
         mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
 

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -73,7 +73,11 @@ where
         _state: &S,
         _corpus_idx: CorpusId,
     ) -> Result<Self, Error> {
-        Ok(base.input().as_ref().unwrap().clone())
+        if let Some(i) = base.input().as_ref() {
+            Ok(i.clone())
+        } else {
+            Ok(base.clone().load_input()?.clone())
+        }
     }
 
     #[inline]

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -82,8 +82,8 @@ where
     ) -> Result<(), Error> {
         let num = self.iterations(state, corpus_idx)?;
 
-        let testcase = state.corpus().get(corpus_idx)?.borrow();
-        let Ok(input) = I::try_transform_from(&testcase, state, corpus_idx) else { return Ok(()); };
+        let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
+        let Ok(input) = I::try_transform_from(&mut testcase, state, corpus_idx) else { return Ok(()); };
         drop(testcase);
 
         for i in 0..num {


### PR DESCRIPTION
this is my fix for issue #1059 I am not sure about the `base.clone()` though. Seems kind of unnecessary.