### PR TITLE
CorpusMinimizer opt: don't add to map if it's the initial value (uninteresting)

### DIFF
--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -142,12 +142,14 @@ where
             // Store coverage, mapping coverage map indices to hit counts (if present) and the
             // associated seeds for the map indices with those hit counts.
             for (i, e) in obs.as_iter().copied().enumerate() {
-                cov_map
-                    .entry(i)
-                    .or_insert_with(HashMap::new)
-                    .entry(e)
-                    .or_insert_with(HashSet::new)
-                    .insert(seed_expr.clone());
+                if e != obs.initial() {
+                    cov_map
+                        .entry(i)
+                        .or_insert_with(HashMap::new)
+                        .entry(e)
+                        .or_insert_with(HashSet::new)
+                        .insert(seed_expr.clone());
+                }
             }
 
             // Keep track of that seed's index and weight


### PR DESCRIPTION
Previously, CMin attempted to minimised based on distinct hitcounts; if we had two inputs, one of which had an edge hit and another which did not, it would keep both on the grounds that they were distinct and therefore interesting compared to each other.

This change drops the distinctness requirements for "not hit", which optimises CMin when used with sparse maps at the cost of some potentially interesting inputs by distinctness (notably tested: browser coverage can take several minutes with small corpora before opt).