### PR TITLE
Fix exits which may cause double-free corruption

### DIFF
--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -87,7 +87,7 @@ pub unsafe fn shutdown_handler<SP>(
         std::ptr::drop_in_place(sr);
     }
     log::info!("Bye!");
-    std::process::exit(0);
+    libc::_exit(0);
 }
 
 #[cfg(all(unix, feature = "std"))]

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -1536,7 +1536,7 @@ where
                         .post_exec_child_all(state, input, &ExitKind::Ok)
                         .expect("Failed to run post_exec on observers");
 
-                    std::process::exit(0);
+                    libc::_exit(0);
 
                     Ok(ExitKind::Ok)
                 }
@@ -1613,7 +1613,7 @@ where
                         .post_exec_child_all(state, input, &ExitKind::Ok)
                         .expect("Failed to run post_exec on observers");
 
-                    std::process::exit(0);
+                    libc::_exit(0);
 
                     Ok(ExitKind::Ok)
                 }


### PR DESCRIPTION
This fixes issues where std::process::exit was used erroneously instead of _exit.