### PR TITLE
libafl: Cargo feature to avoid regex dependency

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["std", "derive", "llmp_compression", "llmp_small_maps", "llmp_broker_timeouts", "rand_trait", "fork", "prelude", "gzip"]
-std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "bincode", "wait-timeout", "regex", "byteorder", "once_cell", "uuid", "tui_monitor", "ctor", "backtrace", "uds"] # print, env, launcher ... support
+default = ["std", "derive", "llmp_compression", "llmp_small_maps", "llmp_broker_timeouts", "rand_trait", "fork", "prelude", "gzip", "regex"]
+std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "bincode", "wait-timeout", "byteorder", "once_cell", "uuid", "tui_monitor", "ctor", "backtrace", "uds"] # print, env, launcher ... support
 derive = ["libafl_derive"] # provide derive(SerdeAny) macro.
 fork = [] # uses the fork() syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on Windows, no_std).
 rand_trait = ["rand_core"] # If set, libafl's rand implementations will implement `rand::Rng`
@@ -31,6 +31,7 @@ errors_backtrace = ["backtrace"] # Create backtraces at Error creation
 cmin = ["z3"] # for corpus minimisation
 corpus_btreemap = [] # Switches from HashMap to BTreeMap for CorpusId
 gzip = ["miniz_oxide"] # Enables gzip compression in certain parts of the lib
+regex = ["std", "dep:regex"] # enables the NaiveTokenizer and StacktraceObserver
 
 # features hiding dependencies licensed under GPL
 gpl = []

--- a/libafl/src/inputs/encoded.rs
+++ b/libafl/src/inputs/encoded.rs
@@ -15,7 +15,7 @@ use core::{
 
 use ahash::RandomState;
 use hashbrown::HashMap;
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -108,7 +108,7 @@ impl Default for TokenInputEncoderDecoder {
 }
 
 /// A naive tokenizer struct
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 #[derive(Clone, Debug)]
 pub struct NaiveTokenizer {
     /// Ident regex
@@ -119,7 +119,7 @@ pub struct NaiveTokenizer {
     string_re: Regex,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 impl NaiveTokenizer {
     /// Creates a new [`NaiveTokenizer`]
     #[must_use]
@@ -132,7 +132,7 @@ impl NaiveTokenizer {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 impl Default for NaiveTokenizer {
     fn default() -> Self {
         Self {
@@ -146,7 +146,7 @@ impl Default for NaiveTokenizer {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 impl Tokenizer for NaiveTokenizer {
     fn tokenize(&self, bytes: &[u8]) -> Result<Vec<String>, Error> {
         let mut tokens = vec![];
@@ -259,7 +259,7 @@ impl EncodedInput {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 #[cfg(test)]
 mod tests {
     use alloc::borrow::ToOwned;

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -11,9 +11,9 @@ pub mod stdio;
 #[cfg(feature = "std")]
 pub use stdio::{StdErrObserver, StdOutObserver};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 pub mod stacktrace;
-#[cfg(feature = "std")]
+#[cfg(feature = "regex")]
 pub use stacktrace::*;
 
 pub mod concolic;


### PR DESCRIPTION
regex is a large crate, and is only used in a few specific spots. Users should have the ability to avoid this transitive dependency if not using the features in question.