### PR TITLE
Fix fuzz_level related thing, separate on_replace/on_remove from Scheduler & various fixes

### DIFF
--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -385,8 +385,8 @@ fn fuzz(
     #[cfg(unix)]
     {
         let null_fd = file_null.as_raw_fd();
-        // dup2(null_fd, io::stdout().as_raw_fd())?;
-        // dup2(null_fd, io::stderr().as_raw_fd())?;
+        dup2(null_fd, io::stdout().as_raw_fd())?;
+        dup2(null_fd, io::stderr().as_raw_fd())?;
     }
     // reopen file to make sure we're at the end
     log.replace(OpenOptions::new().append(true).create(true).open(logfile)?);

--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -385,8 +385,8 @@ fn fuzz(
     #[cfg(unix)]
     {
         let null_fd = file_null.as_raw_fd();
-        dup2(null_fd, io::stdout().as_raw_fd())?;
-        dup2(null_fd, io::stderr().as_raw_fd())?;
+        // dup2(null_fd, io::stdout().as_raw_fd())?;
+        // dup2(null_fd, io::stderr().as_raw_fd())?;
     }
     // reopen file to make sure we're at the end
     log.replace(OpenOptions::new().append(true).create(true).open(logfile)?);

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -19,7 +19,7 @@ use crate::{
     corpus::Corpus,
     executors::{Executor, HasObservers},
     observers::{MapObserver, ObserversTuple},
-    schedulers::{LenTimeMulTestcaseScore, Scheduler, TestcaseScore},
+    schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasMetadata, UsesState},
     Error, HasScheduler,
 };
@@ -41,7 +41,7 @@ where
     ) -> Result<(), Error>
     where
         E: Executor<EM, Z> + HasObservers,
-        CS: Scheduler<State = E::State>,
+        CS: Scheduler<State = E::State> + RemovableScheduler, // schedulers that has on_remove/on_replace only!
         EM: UsesState<State = E::State>,
         Z: HasScheduler<Scheduler = CS, State = E::State>;
 }
@@ -100,7 +100,7 @@ where
     ) -> Result<(), Error>
     where
         E: Executor<EM, Z> + HasObservers,
-        CS: Scheduler<State = E::State>,
+        CS: Scheduler<State = E::State> + RemovableScheduler,
         EM: UsesState<State = E::State>,
         Z: HasScheduler<Scheduler = CS, State = E::State>,
     {

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -34,9 +34,7 @@ where
     /// Number of executions done at discovery time
     executions: usize,
     /// Number of fuzzing iterations of this particular input updated in perform_mutational
-    fuzz_level: usize,
-    /// If it has been fuzzed
-    fuzzed: bool,
+    fuzz_count: usize,
     /// Parent [`CorpusId`], if known
     parent_id: Option<CorpusId>,
 }
@@ -160,28 +158,16 @@ where
         &mut self.executions
     }
 
-    /// Get the `fuzz_level`
+    /// Get the `fuzz_count`
     #[inline]
-    pub fn fuzz_level(&self) -> usize {
-        self.fuzz_level
+    pub fn fuzz_count(&self) -> usize {
+        self.fuzz_count
     }
 
-    /// Set the `fuzz_level`
+    /// Set the `fuzz_count`
     #[inline]
-    pub fn set_fuzz_level(&mut self, fuzz_level: usize) {
-        self.fuzz_level = fuzz_level;
-    }
-
-    /// Get if it was fuzzed
-    #[inline]
-    pub fn fuzzed(&self) -> bool {
-        self.fuzzed
-    }
-
-    /// Set if it was fuzzed
-    #[inline]
-    pub fn set_fuzzed(&mut self, fuzzed: bool) {
-        self.fuzzed = fuzzed;
+    pub fn set_fuzz_count(&mut self, fuzz_count: usize) {
+        self.fuzz_count = fuzz_count;
     }
 
     /// Create a new Testcase instance given an input
@@ -257,9 +243,8 @@ where
             metadata: SerdeAnyMap::new(),
             exec_time: None,
             cached_len: None,
-            fuzz_level: 0,
+            fuzz_count: 0,
             executions: 0,
-            fuzzed: false,
             parent_id: None,
         }
     }
@@ -486,13 +471,8 @@ pub mod pybind {
         }
 
         #[getter]
-        fn fuzz_level(&self) -> usize {
-            self.inner.as_ref().fuzz_level()
-        }
-
-        #[getter]
-        fn fuzzed(&self) -> bool {
-            self.inner.as_ref().fuzzed()
+        fn fuzz_count(&self) -> usize {
+            self.inner.as_ref().fuzz_count()
         }
 
         fn metadata(&mut self) -> PyObject {

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -34,7 +34,7 @@ where
     /// Number of executions done at discovery time
     executions: usize,
     /// Number of fuzzing iterations of this particular input updated in perform_mutational
-    fuzz_count: usize,
+    scheduled_count: usize,
     /// Parent [`CorpusId`], if known
     parent_id: Option<CorpusId>,
 }
@@ -158,16 +158,16 @@ where
         &mut self.executions
     }
 
-    /// Get the `fuzz_count`
+    /// Get the `scheduled_count`
     #[inline]
-    pub fn fuzz_count(&self) -> usize {
-        self.fuzz_count
+    pub fn scheduled_count(&self) -> usize {
+        self.scheduled_count
     }
 
-    /// Set the `fuzz_count`
+    /// Set the `scheduled_count`
     #[inline]
-    pub fn set_fuzz_count(&mut self, fuzz_count: usize) {
-        self.fuzz_count = fuzz_count;
+    pub fn set_scheduled_count(&mut self, scheduled_count: usize) {
+        self.scheduled_count = scheduled_count;
     }
 
     /// Create a new Testcase instance given an input
@@ -243,7 +243,7 @@ where
             metadata: SerdeAnyMap::new(),
             exec_time: None,
             cached_len: None,
-            fuzz_count: 0,
+            scheduled_count: 0,
             executions: 0,
             parent_id: None,
         }
@@ -471,8 +471,8 @@ pub mod pybind {
         }
 
         #[getter]
-        fn fuzz_count(&self) -> usize {
-            self.inner.as_ref().fuzz_count()
+        fn scheduled_count(&self) -> usize {
+            self.inner.as_ref().scheduled_count()
         }
 
         fn metadata(&mut self) -> PyObject {

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -50,7 +50,7 @@ use crate::{
     fuzzer::HasObjective,
     inputs::UsesInput,
     observers::{ObserversTuple, UsesObservers},
-    state::{HasClientPerfMonitor, HasSolutions, UsesState, HasCorpus},
+    state::{HasClientPerfMonitor, HasCorpus, HasSolutions, UsesState},
     Error,
 };
 
@@ -861,7 +861,7 @@ pub mod windows_asan_handler {
         feedbacks::Feedback,
         fuzzer::HasObjective,
         inputs::UsesInput,
-        state::{HasClientPerfMonitor, HasSolutions},
+        state::{HasClientPerfMonitor, HasCorpus, HasSolutions},
     };
 
     /// # Safety
@@ -970,7 +970,7 @@ mod windows_exception_handler {
         feedbacks::Feedback,
         fuzzer::HasObjective,
         inputs::UsesInput,
-        state::{HasClientPerfMonitor, HasSolutions},
+        state::{HasClientPerfMonitor, HasCorpus, HasSolutions},
     };
 
     pub(crate) type HandlerFuncPtr =

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -50,8 +50,7 @@ use crate::{
     fuzzer::HasObjective,
     inputs::UsesInput,
     observers::{ObserversTuple, UsesObservers},
-    prelude::HasCorpus,
-    state::{HasClientPerfMonitor, HasSolutions, UsesState},
+    state::{HasClientPerfMonitor, HasSolutions, UsesState, HasCorpus},
     Error,
 };
 
@@ -872,7 +871,7 @@ pub mod windows_asan_handler {
         E: Executor<EM, Z> + HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let mut data = &mut GLOBAL_STATE;
@@ -1010,7 +1009,7 @@ mod windows_exception_handler {
         E: HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let old_hook = panic::take_hook();
@@ -1069,7 +1068,7 @@ mod windows_exception_handler {
         E: HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let data: &mut InProcessExecutorHandlerData =
@@ -1130,7 +1129,7 @@ mod windows_exception_handler {
         E: Executor<EM, Z> + HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         // Have we set a timer_before?

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -560,6 +560,7 @@ pub fn run_observers_and_save_state<E, EM, OF, Z>(
     if interesting {
         let mut new_testcase = Testcase::new(input.clone());
         new_testcase.add_metadata(exitkind);
+        new_testcase.set_parent_id_optional(*state.corpus().current());
         fuzzer
             .objective_mut()
             .append_metadata(state, observers, &mut new_testcase)

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -860,7 +860,7 @@ pub mod windows_asan_handler {
         feedbacks::Feedback,
         fuzzer::HasObjective,
         inputs::UsesInput,
-        state::{HasClientPerfMonitor, HasFuzzedCorpusId, HasSolutions},
+        state::{HasClientPerfMonitor, HasSolutions},
     };
 
     /// # Safety
@@ -870,7 +870,7 @@ pub mod windows_asan_handler {
         E: Executor<EM, Z> + HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor + HasFuzzedCorpusId,
+        E::State: HasSolutions + HasClientPerfMonitor,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let mut data = &mut GLOBAL_STATE;
@@ -969,7 +969,7 @@ mod windows_exception_handler {
         feedbacks::Feedback,
         fuzzer::HasObjective,
         inputs::UsesInput,
-        state::{HasClientPerfMonitor, HasFuzzedCorpusId, HasSolutions},
+        state::{HasClientPerfMonitor, HasSolutions},
     };
 
     pub(crate) type HandlerFuncPtr =
@@ -1008,7 +1008,7 @@ mod windows_exception_handler {
         E: HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor + HasFuzzedCorpusId,
+        E::State: HasSolutions + HasClientPerfMonitor,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let old_hook = panic::take_hook();
@@ -1067,7 +1067,7 @@ mod windows_exception_handler {
         E: HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor + HasFuzzedCorpusId,
+        E::State: HasSolutions + HasClientPerfMonitor,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let data: &mut InProcessExecutorHandlerData =
@@ -1128,7 +1128,7 @@ mod windows_exception_handler {
         E: Executor<EM, Z> + HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor + HasFuzzedCorpusId,
+        E::State: HasSolutions + HasClientPerfMonitor,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         // Have we set a timer_before?

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -50,6 +50,7 @@ use crate::{
     fuzzer::HasObjective,
     inputs::UsesInput,
     observers::{ObserversTuple, UsesObservers},
+    prelude::HasCorpus,
     state::{HasClientPerfMonitor, HasSolutions, UsesState},
     Error,
 };
@@ -167,7 +168,7 @@ where
     H: FnMut(&<S as UsesInput>::Input) -> ExitKind + ?Sized,
     HB: BorrowMut<H>,
     OT: ObserversTuple<S>,
-    S: HasSolutions + HasClientPerfMonitor,
+    S: HasSolutions + HasClientPerfMonitor + HasCorpus,
 {
     /// Create a new in mem executor.
     /// Caution: crash and restart in one of them will lead to odd behavior if multiple are used,
@@ -344,7 +345,7 @@ impl InProcessHandlers {
         E: Executor<EM, Z> + HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         #[cfg(unix)]
@@ -543,7 +544,7 @@ pub fn run_observers_and_save_state<E, EM, OF, Z>(
     E: HasObservers,
     EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
     OF: Feedback<E::State>,
-    E::State: HasSolutions + HasClientPerfMonitor,
+    E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
     Z: HasObjective<Objective = OF, State = E::State>,
 {
     let observers = executor.observers_mut();
@@ -610,7 +611,7 @@ mod unix_signal_handler {
         feedbacks::Feedback,
         fuzzer::HasObjective,
         inputs::UsesInput,
-        state::{HasClientPerfMonitor, HasSolutions},
+        state::{HasClientPerfMonitor, HasCorpus, HasSolutions},
     };
 
     pub(crate) type HandlerFuncPtr =
@@ -669,7 +670,7 @@ mod unix_signal_handler {
         E: HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         let old_hook = panic::take_hook();
@@ -710,7 +711,7 @@ mod unix_signal_handler {
         E: HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         if !data.is_valid() {
@@ -753,7 +754,7 @@ mod unix_signal_handler {
         E: Executor<EM, Z> + HasObservers,
         EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
         OF: Feedback<E::State>,
-        E::State: HasSolutions + HasClientPerfMonitor,
+        E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
         Z: HasObjective<Objective = OF, State = E::State>,
     {
         #[cfg(all(target_os = "android", target_arch = "aarch64"))]

--- a/libafl/src/feedbacks/nautilus.rs
+++ b/libafl/src/feedbacks/nautilus.rs
@@ -14,9 +14,8 @@ use crate::{
     executors::ExitKind,
     feedbacks::Feedback,
     generators::NautilusContext,
-    inputs::NautilusInput,
+    inputs::{NautilusInput, UsesInput},
     observers::ObserversTuple,
-    prelude::UsesInput,
     state::{HasClientPerfMonitor, HasMetadata},
     Error,
 };

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -462,7 +462,6 @@ where
         let exit_kind = self.execute_input(state, executor, manager, &input)?;
         let observers = executor.observers();
 
-        self.scheduler.on_evaluation(state, &input, observers)?;
 
         self.process_execution(state, manager, input, observers, &exit_kind, send_events)
     }
@@ -629,6 +628,8 @@ where
         start_timer!(state);
         let exit_kind = executor.run_target(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::TargetExecution);
+
+        self.scheduler.on_execution(state, &input, executor.observers())?;
 
         start_timer!(state);
         executor

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -417,6 +417,7 @@ where
 
                 // The input is a solution, add it to the respective corpus
                 let mut testcase = Testcase::with_executions(input, *state.executions());
+                testcase.set_parent_id_optional(*state.corpus().current());
                 self.objective_mut()
                     .append_metadata(state, observers, &mut testcase)?;
                 state.solutions_mut().add(testcase)?;

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -462,6 +462,8 @@ where
         let exit_kind = self.execute_input(state, executor, manager, &input)?;
         let observers = executor.observers();
 
+        self.scheduler.on_evaluation(state, &input, observers)?;
+
         self.process_execution(state, manager, input, observers, &exit_kind, send_events)
     }
 }
@@ -627,9 +629,6 @@ where
         start_timer!(state);
         let exit_kind = executor.run_target(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::TargetExecution);
-
-        self.scheduler
-            .on_execution(state, input, executor.observers())?;
 
         start_timer!(state);
         executor

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -23,10 +23,7 @@ use crate::{
     schedulers::Scheduler,
     stages::StagesTuple,
     start_timer,
-    state::{
-        HasClientPerfMonitor, HasCorpus, HasExecutions, HasFuzzedCorpusId, HasMetadata,
-        HasSolutions, UsesState,
-    },
+    state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasMetadata, HasSolutions, UsesState},
     Error,
 };
 
@@ -330,7 +327,7 @@ where
     F: Feedback<CS::State>,
     OF: Feedback<CS::State>,
     OT: ObserversTuple<CS::State> + Serialize + DeserializeOwned,
-    CS::State: HasCorpus + HasSolutions + HasClientPerfMonitor + HasExecutions + HasFuzzedCorpusId,
+    CS::State: HasCorpus + HasSolutions + HasClientPerfMonitor + HasExecutions,
 {
     /// Evaluate if a set of observation channels has an interesting state
     fn process_execution<EM>(
@@ -387,7 +384,6 @@ where
 
                 // Add the input to the main corpus
                 let mut testcase = Testcase::with_executions(input.clone(), *state.executions());
-                testcase.set_parent_id_optional(state.fuzzed_corpus_id());
                 self.feedback_mut()
                     .append_metadata(state, observers, &mut testcase)?;
                 let idx = state.corpus_mut().add(testcase)?;
@@ -421,7 +417,6 @@ where
 
                 // The input is a solution, add it to the respective corpus
                 let mut testcase = Testcase::with_executions(input, *state.executions());
-                testcase.set_parent_id_optional(state.fuzzed_corpus_id());
                 self.objective_mut()
                     .append_metadata(state, observers, &mut testcase)?;
                 state.solutions_mut().add(testcase)?;
@@ -447,7 +442,7 @@ where
     OT: ObserversTuple<CS::State> + Serialize + DeserializeOwned,
     F: Feedback<CS::State>,
     OF: Feedback<CS::State>,
-    CS::State: HasCorpus + HasSolutions + HasClientPerfMonitor + HasExecutions + HasFuzzedCorpusId,
+    CS::State: HasCorpus + HasSolutions + HasClientPerfMonitor + HasExecutions,
 {
     /// Process one input, adding to the respective corpora if needed and firing the right events
     #[inline]
@@ -480,7 +475,7 @@ where
     F: Feedback<CS::State>,
     OF: Feedback<CS::State>,
     OT: ObserversTuple<CS::State> + Serialize + DeserializeOwned,
-    CS::State: HasCorpus + HasSolutions + HasClientPerfMonitor + HasExecutions + HasFuzzedCorpusId,
+    CS::State: HasCorpus + HasSolutions + HasClientPerfMonitor + HasExecutions,
 {
     /// Process one input, adding to the respective corpora if needed and firing the right events
     #[inline]
@@ -518,7 +513,6 @@ where
 
         // Add the input to the main corpus
         let mut testcase = Testcase::with_executions(input.clone(), *state.executions());
-        testcase.set_parent_id_optional(state.fuzzed_corpus_id());
         self.feedback_mut()
             .append_metadata(state, observers, &mut testcase)?;
         let idx = state.corpus_mut().add(testcase)?;
@@ -552,7 +546,7 @@ where
     EM: ProgressReporter + EventProcessor<E, Self, State = CS::State>,
     F: Feedback<CS::State>,
     OF: Feedback<CS::State>,
-    CS::State: HasClientPerfMonitor + HasExecutions + HasMetadata + HasFuzzedCorpusId,
+    CS::State: HasClientPerfMonitor + HasExecutions + HasMetadata,
     ST: StagesTuple<E, EM, CS::State, Self>,
 {
     fn fuzz_one(
@@ -577,14 +571,8 @@ where
         #[cfg(feature = "introspection")]
         state.introspection_monitor_mut().reset_stage_index();
 
-        // Set the parent id - all new testcases will have this id as parent in the following stages.
-        state.set_fuzzed_corpus_id(idx);
-
         // Execute all stages
         stages.perform_all(self, executor, state, manager, idx)?;
-
-        // Reset the parent id
-        state.clear_fuzzed_corpus_id();
 
         // Init timer for manager
         #[cfg(feature = "introspection")]

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -462,7 +462,6 @@ where
         let exit_kind = self.execute_input(state, executor, manager, &input)?;
         let observers = executor.observers();
 
-
         self.process_execution(state, manager, input, observers, &exit_kind, send_events)
     }
 }
@@ -629,7 +628,8 @@ where
         let exit_kind = executor.run_target(self, state, event_mgr, input)?;
         mark_feature_time!(state, PerfFeature::TargetExecution);
 
-        self.scheduler.on_execution(state, &input, executor.observers())?;
+        self.scheduler
+            .on_execution(state, input, executor.observers())?;
 
         start_timer!(state);
         executor

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     bolts::{rands::Rand, AsMutSlice, AsSlice, HasLen, HasRefCnt},
-    corpus::{Corpus, CorpusId, Testcase},
+    corpus::{Corpus, CorpusId},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
     schedulers::{
@@ -128,24 +128,6 @@ where
     fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
         self.update_accounting_score(state, idx)?;
         self.inner.on_add(state, idx)
-    }
-
-    fn on_replace(
-        &mut self,
-        state: &mut Self::State,
-        idx: CorpusId,
-        testcase: &Testcase<<Self::State as UsesInput>::Input>,
-    ) -> Result<(), Error> {
-        self.inner.on_replace(state, idx, testcase)
-    }
-
-    fn on_remove(
-        &mut self,
-        state: &mut Self::State,
-        idx: CorpusId,
-        testcase: &Option<Testcase<<Self::State as UsesInput>::Input>>,
-    ) -> Result<(), Error> {
-        self.inner.on_remove(state, idx, testcase)
     }
 
     fn next(&mut self, state: &mut Self::State) -> Result<CorpusId, Error> {
@@ -274,7 +256,7 @@ where
 
         for (_key, idx) in &top_rated.map {
             let mut entry = state.corpus().get(*idx)?.borrow_mut();
-            if entry.fuzzed() {
+            if entry.fuzz_count() > 0 {
                 continue;
             }
 

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -157,6 +157,16 @@ where
 
         Ok(idx)
     }
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        _state: &mut Self::State,
+        _next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        // We do nothing here, the inner scheduler will take care of it
+        Ok(())
+    }
 }
 
 impl<'a, CS> CoverageAccountingScheduler<'a, CS>
@@ -256,7 +266,7 @@ where
 
         for (_key, idx) in &top_rated.map {
             let mut entry = state.corpus().get(*idx)?.borrow_mut();
-            if entry.fuzz_count() > 0 {
+            if entry.scheduled_count() > 0 {
                 continue;
             }
 

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -277,7 +277,7 @@ where
     }
 
     /// Creates a new [`CoverageAccountingScheduler`] that wraps a `base` [`Scheduler`]
-    /// and has a default probability to skip non-faved [`Testcase`]s of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
+    /// and has a default probability to skip non-faved Testcases of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
     pub fn new(state: &mut CS::State, base: CS, accounting_map: &'a [u32]) -> Self {
         match state.metadata().get::<TopAccountingMetadata>() {
             Some(meta) => {
@@ -297,7 +297,7 @@ where
     }
 
     /// Creates a new [`CoverageAccountingScheduler`] that wraps a `base` [`Scheduler`]
-    /// and has a non-default probability to skip non-faved [`Testcase`]s using (`skip_non_favored_prob`).
+    /// and has a non-default probability to skip non-faved Testcases using (`skip_non_favored_prob`).
     pub fn with_skip_prob(
         state: &mut CS::State,
         base: CS,

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -130,6 +130,18 @@ where
         self.inner.on_add(state, idx)
     }
 
+    fn on_evaluation<OT>(
+        &mut self,
+        state: &mut Self::State,
+        input: &<Self::State as UsesInput>::Input,
+        observers: &OT,
+    ) -> Result<(), Error>
+    where
+        OT: ObserversTuple<Self::State>,
+    {
+        self.inner.on_evaluation(state, input, observers)
+    }
+
     fn next(&mut self, state: &mut Self::State) -> Result<CorpusId, Error> {
         if state
             .metadata()

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -170,6 +170,9 @@ where
         {
             idx = self.inner.base_mut().next(state)?;
         }
+
+        // Don't add corpus.curret(). The inner scheduler will take care of it
+
         Ok(idx)
     }
 }

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -11,6 +11,7 @@ use crate::{
     corpus::{Corpus, CorpusId},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
+    observers::ObserversTuple,
     schedulers::{
         minimizer::{IsFavoredMetadata, MinimizerScheduler, DEFAULT_SKIP_NON_FAVORED_PROB},
         LenTimeMulTestcaseScore, Scheduler,

--- a/libafl/src/schedulers/ecofuzz.rs
+++ b/libafl/src/schedulers/ecofuzz.rs
@@ -312,7 +312,7 @@ where
         Ok(())
     }
 
-    fn on_execution<OT>(
+    fn on_evaluation<OT>(
         &mut self,
         state: &mut S,
         _input: &S::Input,

--- a/libafl/src/schedulers/ecofuzz.rs
+++ b/libafl/src/schedulers/ecofuzz.rs
@@ -399,7 +399,7 @@ where
         }
 
         let id = Self::schedule(state)?;
-        *state.corpus_mut().current_mut() = Some(id);
+        self.set_current_scheduled(state, Some(id))?;
 
         let mutation_num = state
             .corpus()
@@ -423,6 +423,16 @@ where
         meta.last_executions = executions;
 
         Ok(id)
+    }
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        state: &mut Self::State,
+        next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        *state.corpus_mut().current_mut() = next_idx;
+        Ok(())
     }
 }
 

--- a/libafl/src/schedulers/ecofuzz.rs
+++ b/libafl/src/schedulers/ecofuzz.rs
@@ -312,7 +312,7 @@ where
         Ok(())
     }
 
-    fn on_evaluation<OT>(
+    fn on_execution<OT>(
         &mut self,
         state: &mut S,
         _input: &S::Input,

--- a/libafl/src/schedulers/ecofuzz.rs
+++ b/libafl/src/schedulers/ecofuzz.rs
@@ -301,10 +301,14 @@ where
 
         // Attach a `SchedulerTestcaseMetaData` to the queue entry.
         depth += 1;
-        state.corpus().get(idx)?.borrow_mut().add_metadata(
-            SchedulerTestcaseMetaData::with_n_fuzz_entry(depth, self.last_hash),
-        );
-
+        {
+            let mut testcase = state.corpus().get(idx)?.borrow_mut();
+            testcase.add_metadata(SchedulerTestcaseMetaData::with_n_fuzz_entry(
+                depth,
+                self.last_hash,
+            ));
+            testcase.set_parent_id_optional(current_idx);
+        }
         // Add the testcase metadata for this scheduler
         state
             .corpus()
@@ -321,25 +325,6 @@ where
         let last_find_iteration = executions - meta.last_executions + 1;
         meta.last_find_iteration = last_find_iteration;
 
-        Ok(())
-    }
-
-    fn on_replace(
-        &mut self,
-        state: &mut S,
-        idx: CorpusId,
-        _testcase: &Testcase<S::Input>,
-    ) -> Result<(), Error> {
-        self.on_add(state, idx)
-    }
-
-    #[allow(clippy::unused_self)]
-    fn on_remove(
-        &mut self,
-        _state: &mut S,
-        _idx: CorpusId,
-        _testcase: &Option<Testcase<S::Input>>,
-    ) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libafl/src/schedulers/ecofuzz.rs
+++ b/libafl/src/schedulers/ecofuzz.rs
@@ -1,10 +1,8 @@
 //! The corpus scheduler from `EcoFuzz` (`https://www.usenix.org/conference/usenixsecurity20/presentation/yue`)
 
 use alloc::string::{String, ToString};
-use core::{
-    borrow::{Borrow, BorrowMut},
-    marker::PhantomData,
-};
+use core::marker::PhantomData;
+
 
 use serde::{Deserialize, Serialize};
 

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -12,12 +12,10 @@ use crate::{
     corpus::{Corpus, CorpusId, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
-    schedulers::{LenTimeMulTestcaseScore, Scheduler, TestcaseScore},
+    schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasMetadata, HasRand, UsesState},
     Error,
 };
-
-use super::RemovableScheduler;
 
 /// Default probability to skip the non-favored values
 pub const DEFAULT_SKIP_NON_FAVORED_PROB: u64 = 95;
@@ -78,7 +76,7 @@ where
 
 impl<CS, F, M> RemovableScheduler for MinimizerScheduler<CS, F, M>
 where
-    CS: Scheduler,
+    CS: RemovableScheduler,
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
@@ -188,6 +186,16 @@ where
             idx = self.base.next(state)?;
         }
         Ok(idx)
+    }
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        _state: &mut Self::State,
+        _next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        // We do nothing here, the inner scheduler will take care of it
+        Ok(())
     }
 }
 

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -172,7 +172,7 @@ where
     }
 
     /// An input has been evaluated
-    fn on_evaluation<OT>(
+    fn on_execution<OT>(
         &mut self,
         state: &mut Self::State,
         input: &<Self::State as UsesInput>::Input,
@@ -181,7 +181,7 @@ where
     where
         OT: ObserversTuple<Self::State>,
     {
-        self.base.on_evaluation(state, input, observers)
+        self.base.on_execution(state, input, observers)
     }
 
     /// Gets the next entry

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -172,7 +172,7 @@ where
     }
 
     /// An input has been evaluated
-    fn on_execution<OT>(
+    fn on_evaluation<OT>(
         &mut self,
         state: &mut Self::State,
         input: &<Self::State as UsesInput>::Input,
@@ -181,7 +181,7 @@ where
     where
         OT: ObserversTuple<Self::State>,
     {
-        self.base.on_execution(state, input, observers)
+        self.base.on_evaluation(state, input, observers)
     }
 
     /// Gets the next entry

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -88,6 +88,13 @@ pub trait Scheduler: UsesState {
     /// Gets the next entry
     fn next(&mut self, state: &mut Self::State) -> Result<CorpusId, Error>;
     // Increment corpus.current() here if it has no inner
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        state: &mut Self::State,
+        next_idx: Option<CorpusId>,
+    ) -> Result<(), Error>;
 }
 
 /// Feed the fuzzer simply with a random testcase on request
@@ -125,9 +132,19 @@ where
             Err(Error::empty("No entries in corpus".to_owned()))
         } else {
             let id = random_corpus_id!(state.corpus(), state.rand_mut());
-            *state.corpus_mut().current_mut() = Some(id);
+            self.set_current_scheduled(state, Some(id))?;
             Ok(id)
         }
+    }
+
+    /// Set current fuzzed corpus id and `scheduled_count`. You should call this from `next`
+    fn set_current_scheduled(
+        &mut self,
+        state: &mut Self::State,
+        next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        *state.corpus_mut().current_mut() = next_idx;
+        Ok(())
     }
 }
 

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -73,7 +73,7 @@ pub trait Scheduler: UsesState {
     // Add parent_id here if it has no inner
 
     /// An input has been evaluated
-    fn on_execution<OT>(
+    fn on_evaluation<OT>(
         &mut self,
         _state: &mut Self::State,
         _input: &<Self::State as UsesInput>::Input,

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -47,6 +47,7 @@ use crate::{
 pub trait Scheduler: UsesState {
     /// Added an entry to the corpus at the given index
     fn on_add(&mut self, _state: &mut Self::State, _idx: CorpusId) -> Result<(), Error> {
+        // Add parent_id here if it has no inner
         Ok(())
     }
 
@@ -85,6 +86,7 @@ pub trait Scheduler: UsesState {
 
     /// Gets the next entry
     fn next(&mut self, state: &mut Self::State) -> Result<CorpusId, Error>;
+    // Increment corpus.current() here if it has no inner
 }
 
 /// Feed the fuzzer simply with a random testcase on request

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -73,7 +73,7 @@ pub trait Scheduler: UsesState {
     // Add parent_id here if it has no inner
 
     /// An input has been evaluated
-    fn on_evaluation<OT>(
+    fn on_execution<OT>(
         &mut self,
         _state: &mut Self::State,
         _input: &<Self::State as UsesInput>::Input,

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -302,7 +302,7 @@ where
         Ok(())
     }
 
-    fn on_evaluation<OT>(
+    fn on_execution<OT>(
         &mut self,
         state: &mut Self::State,
         _input: &<Self::State as UsesInput>::Input,

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -302,7 +302,7 @@ where
         Ok(())
     }
 
-    fn on_execution<OT>(
+    fn on_evaluation<OT>(
         &mut self,
         state: &mut Self::State,
         _input: &<Self::State as UsesInput>::Input,

--- a/libafl/src/schedulers/probabilistic_sampling.rs
+++ b/libafl/src/schedulers/probabilistic_sampling.rs
@@ -131,9 +131,19 @@ where
                     break;
                 }
             }
-            *state.corpus_mut().current_mut() = Some(ret);
+            self.set_current_scheduled(state, Some(ret))?;
             Ok(ret)
         }
+    }
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        state: &mut Self::State,
+        next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        *state.corpus_mut().current_mut() = next_idx;
+        Ok(())
     }
 }
 

--- a/libafl/src/schedulers/probabilistic_sampling.rs
+++ b/libafl/src/schedulers/probabilistic_sampling.rs
@@ -100,6 +100,13 @@ where
     S: HasCorpus + HasMetadata + HasRand,
 {
     fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
+        let current_idx = *state.corpus().current();
+        state
+            .corpus()
+            .get(idx)?
+            .borrow_mut()
+            .set_parent_id_optional(current_idx);
+
         if state.metadata().get::<ProbabilityMetadata>().is_none() {
             state.add_metadata(ProbabilityMetadata::new());
         }

--- a/libafl/src/schedulers/queue.rs
+++ b/libafl/src/schedulers/queue.rs
@@ -28,6 +28,18 @@ impl<S> Scheduler for QueueScheduler<S>
 where
     S: HasCorpus,
 {
+    fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
+        // Set parent id
+        let current_idx = *state.corpus().current();
+        state
+            .corpus()
+            .get(idx)?
+            .borrow_mut()
+            .set_parent_id_optional(current_idx);
+
+        Ok(())
+    }
+
     /// Gets the next entry in the queue
     fn next(&mut self, state: &mut Self::State) -> Result<CorpusId, Error> {
         if state.corpus().count() == 0 {

--- a/libafl/src/schedulers/queue.rs
+++ b/libafl/src/schedulers/queue.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use crate::{
     corpus::{Corpus, CorpusId},
     inputs::UsesInput,
-    schedulers::Scheduler,
+    schedulers::{Scheduler, RemovableScheduler},
     state::{HasCorpus, UsesState},
     Error,
 };
@@ -22,6 +22,13 @@ where
     S: UsesInput,
 {
     type State = S;
+}
+
+impl<S> RemovableScheduler for QueueScheduler<S> 
+where
+    S: HasCorpus,
+{
+
 }
 
 impl<S> Scheduler for QueueScheduler<S>

--- a/libafl/src/schedulers/queue.rs
+++ b/libafl/src/schedulers/queue.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use crate::{
     corpus::{Corpus, CorpusId},
     inputs::UsesInput,
-    schedulers::{Scheduler, RemovableScheduler},
+    schedulers::{RemovableScheduler, Scheduler},
     state::{HasCorpus, UsesState},
     Error,
 };
@@ -24,12 +24,7 @@ where
     type State = S;
 }
 
-impl<S> RemovableScheduler for QueueScheduler<S> 
-where
-    S: HasCorpus,
-{
-
-}
+impl<S> RemovableScheduler for QueueScheduler<S> where S: HasCorpus {}
 
 impl<S> Scheduler for QueueScheduler<S>
 where

--- a/libafl/src/schedulers/queue.rs
+++ b/libafl/src/schedulers/queue.rs
@@ -51,9 +51,19 @@ where
                 .map(|id| state.corpus().next(id))
                 .flatten()
                 .unwrap_or_else(|| state.corpus().first().unwrap());
-            *state.corpus_mut().current_mut() = Some(id);
+            self.set_current_scheduled(state, Some(id))?;
             Ok(id)
         }
+    }
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        state: &mut Self::State,
+        next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        *state.corpus_mut().current_mut() = next_idx;
+        Ok(())
     }
 }
 

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -205,7 +205,7 @@ where
                     }
                 }
                 PowerSchedule::FAST => {
-                    if entry.fuzz_count() != 0 {
+                    if entry.scheduled_count() != 0 {
                         let lg = libm::log2(f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()]));
 
                         match lg {
@@ -244,11 +244,11 @@ where
                     }
                 }
                 PowerSchedule::LIN => {
-                    factor = (entry.fuzz_count() as f64)
+                    factor = (entry.scheduled_count() as f64)
                         / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
                 }
                 PowerSchedule::QUAD => {
-                    factor = ((entry.fuzz_count() * entry.fuzz_count()) as f64)
+                    factor = ((entry.scheduled_count() * entry.scheduled_count()) as f64)
                         / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
                 }
             }
@@ -310,7 +310,7 @@ where
         // This means that this testcase has never gone through the calibration stage before1,
         // In this case we'll just return the default weight
         // This methoud is called in corpus's on_add() method. Fuzz_level is zero at that time.
-        if entry.fuzz_count() == 0 || psmeta.cycles() == 0 {
+        if entry.scheduled_count() == 0 || psmeta.cycles() == 0 {
             return Ok(weight);
         }
 
@@ -362,7 +362,7 @@ where
         }
 
         // was it fuzzed before?
-        if entry.fuzz_count() == 0 {
+        if entry.scheduled_count() == 0 {
             weight *= 2.0;
         }
 

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -205,7 +205,7 @@ where
                     }
                 }
                 PowerSchedule::FAST => {
-                    if entry.fuzz_level() != 0 {
+                    if entry.fuzz_count() != 0 {
                         let lg = libm::log2(f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()]));
 
                         match lg {
@@ -244,11 +244,11 @@ where
                     }
                 }
                 PowerSchedule::LIN => {
-                    factor = (entry.fuzz_level() as f64)
+                    factor = (entry.fuzz_count() as f64)
                         / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
                 }
                 PowerSchedule::QUAD => {
-                    factor = ((entry.fuzz_level() * entry.fuzz_level()) as f64)
+                    factor = ((entry.fuzz_count() * entry.fuzz_count()) as f64)
                         / f64::from(psmeta.n_fuzz()[tcmeta.n_fuzz_entry()] + 1);
                 }
             }
@@ -310,7 +310,7 @@ where
         // This means that this testcase has never gone through the calibration stage before1,
         // In this case we'll just return the default weight
         // This methoud is called in corpus's on_add() method. Fuzz_level is zero at that time.
-        if entry.fuzz_level() == 0 || psmeta.cycles() == 0 {
+        if entry.fuzz_count() == 0 || psmeta.cycles() == 0 {
             return Ok(weight);
         }
 
@@ -362,7 +362,7 @@ where
         }
 
         // was it fuzzed before?
-        if entry.fuzz_level() == 0 {
+        if entry.fuzz_count() == 0 {
             weight *= 2.0;
         }
 

--- a/libafl/src/schedulers/tuneable.rs
+++ b/libafl/src/schedulers/tuneable.rs
@@ -16,6 +16,8 @@ use crate::{
     Error,
 };
 
+use super::RemovableScheduler;
+
 #[derive(Default, Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize)]
 struct TuneableSchedulerMetadata {
     next: Option<CorpusId>,
@@ -86,6 +88,13 @@ where
     S: UsesInput,
 {
     type State = S;
+}
+
+impl<S> RemovableScheduler for TuneableScheduler<S>
+where
+    S: HasCorpus + HasMetadata,
+{
+
 }
 
 impl<S> Scheduler for TuneableScheduler<S>

--- a/libafl/src/schedulers/tuneable.rs
+++ b/libafl/src/schedulers/tuneable.rs
@@ -92,6 +92,18 @@ impl<S> Scheduler for TuneableScheduler<S>
 where
     S: HasCorpus + HasMetadata,
 {
+    fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
+        // Set parent id
+        let current_idx = *state.corpus().current();
+        state
+            .corpus()
+            .get(idx)?
+            .borrow_mut()
+            .set_parent_id_optional(current_idx);
+
+        Ok(())
+    }
+
     /// Gets the next entry in the queue
     fn next(&mut self, state: &mut Self::State) -> Result<CorpusId, Error> {
         if state.corpus().count() == 0 {

--- a/libafl/src/schedulers/tuneable.rs
+++ b/libafl/src/schedulers/tuneable.rs
@@ -117,7 +117,17 @@ where
         } else {
             state.corpus().first().unwrap()
         };
-        *state.corpus_mut().current_mut() = Some(id);
+        self.set_current_scheduled(state, Some(id))?;
         Ok(id)
+    }
+
+    /// Set current fuzzed corpus id and `scheduled_count`
+    fn set_current_scheduled(
+        &mut self,
+        state: &mut Self::State,
+        next_idx: Option<CorpusId>,
+    ) -> Result<(), Error> {
+        *state.corpus_mut().current_mut() = next_idx;
+        Ok(())
     }
 }

--- a/libafl/src/schedulers/tuneable.rs
+++ b/libafl/src/schedulers/tuneable.rs
@@ -7,6 +7,7 @@ use core::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
+use super::RemovableScheduler;
 use crate::{
     corpus::{Corpus, CorpusId},
     impl_serdeany,
@@ -15,8 +16,6 @@ use crate::{
     state::{HasCorpus, HasMetadata, UsesState},
     Error,
 };
-
-use super::RemovableScheduler;
 
 #[derive(Default, Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize)]
 struct TuneableSchedulerMetadata {
@@ -90,12 +89,7 @@ where
     type State = S;
 }
 
-impl<S> RemovableScheduler for TuneableScheduler<S>
-where
-    S: HasCorpus + HasMetadata,
-{
-
-}
+impl<S> RemovableScheduler for TuneableScheduler<S> where S: HasCorpus + HasMetadata {}
 
 impl<S> Scheduler for TuneableScheduler<S>
 where

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -360,7 +360,7 @@ where
         Ok(())
     }
 
-    fn on_evaluation<OT>(
+    fn on_execution<OT>(
         &mut self,
         state: &mut Self::State,
         _input: &<Self::State as UsesInput>::Input,

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -16,7 +16,7 @@ use crate::{
     schedulers::{
         powersched::{PowerSchedule, SchedulerMetadata},
         testcase_score::{CorpusWeightTestcaseScore, TestcaseScore},
-        Scheduler,
+        RemovableScheduler, Scheduler,
     },
     state::{HasCorpus, HasMetadata, HasRand, UsesState},
     Error,
@@ -227,6 +227,92 @@ where
     S: UsesInput,
 {
     type State = S;
+}
+
+impl<F, O, S> RemovableScheduler for WeightedScheduler<F, O, S>
+where
+    F: TestcaseScore<S>,
+    O: MapObserver,
+    S: HasCorpus + HasMetadata + HasRand,
+{
+    fn on_remove(
+        &mut self,
+        state: &mut Self::State,
+        _idx: CorpusId,
+        prev: &Option<crate::corpus::Testcase<<Self::State as UsesInput>::Input>>,
+    ) -> Result<(), Error> {
+        let prev = prev.as_ref().ok_or_else(|| {
+            Error::illegal_argument(
+                "Power schedulers must be aware of the removed corpus entry for reweighting.",
+            )
+        })?;
+
+        let prev_meta = prev
+            .metadata()
+            .get::<SchedulerTestcaseMetaData>()
+            .ok_or_else(|| {
+                Error::key_not_found("SchedulerTestcaseMetaData not found".to_string())
+            })?;
+
+        // Use these to adjust `SchedulerMetadata`
+        let (prev_total_time, prev_cycles) = prev_meta.cycle_and_time();
+        let prev_bitmap_size = prev_meta.bitmap_size();
+        let prev_bitmap_size_log = libm::log2(prev_bitmap_size as f64);
+
+        let psmeta = state
+            .metadata_mut()
+            .get_mut::<SchedulerMetadata>()
+            .ok_or_else(|| Error::key_not_found("SchedulerMetadata not found".to_string()))?;
+
+        psmeta.set_exec_time(psmeta.exec_time() - prev_total_time);
+        psmeta.set_cycles(psmeta.cycles() - (prev_cycles as u64));
+        psmeta.set_bitmap_size(psmeta.bitmap_size() - prev_bitmap_size);
+        psmeta.set_bitmap_size_log(psmeta.bitmap_size_log() - prev_bitmap_size_log);
+        psmeta.set_bitmap_entries(psmeta.bitmap_entries() - 1);
+
+        Ok(())
+    }
+
+    fn on_replace(
+        &mut self,
+        state: &mut Self::State,
+        idx: CorpusId,
+        prev: &crate::corpus::Testcase<<Self::State as UsesInput>::Input>,
+    ) -> Result<(), Error> {
+        let prev_meta = prev
+            .metadata()
+            .get::<SchedulerTestcaseMetaData>()
+            .ok_or_else(|| {
+                Error::key_not_found("SchedulerTestcaseMetaData not found".to_string())
+            })?;
+
+        // Next depth is + 1
+        let prev_depth = prev_meta.depth() + 1;
+
+        // Use these to adjust `SchedulerMetadata`
+        let (prev_total_time, prev_cycles) = prev_meta.cycle_and_time();
+        let prev_bitmap_size = prev_meta.bitmap_size();
+        let prev_bitmap_size_log = libm::log2(prev_bitmap_size as f64);
+
+        let psmeta = state
+            .metadata_mut()
+            .get_mut::<SchedulerMetadata>()
+            .ok_or_else(|| Error::key_not_found("SchedulerMetadata not found".to_string()))?;
+
+        // We won't add new one because it'll get added when it gets executed in calirbation next time.
+        psmeta.set_exec_time(psmeta.exec_time() - prev_total_time);
+        psmeta.set_cycles(psmeta.cycles() - (prev_cycles as u64));
+        psmeta.set_bitmap_size(psmeta.bitmap_size() - prev_bitmap_size);
+        psmeta.set_bitmap_size_log(psmeta.bitmap_size_log() - prev_bitmap_size_log);
+        psmeta.set_bitmap_entries(psmeta.bitmap_entries() - 1);
+
+        state
+            .corpus()
+            .get(idx)?
+            .borrow_mut()
+            .add_metadata(SchedulerTestcaseMetaData::new(prev_depth));
+        Ok(())
+    }
 }
 
 impl<F, O, S> Scheduler for WeightedScheduler<F, O, S>

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -360,7 +360,7 @@ where
         Ok(())
     }
 
-    fn on_execution<OT>(
+    fn on_evaluation<OT>(
         &mut self,
         state: &mut Self::State,
         _input: &<Self::State as UsesInput>::Input,

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -235,6 +235,7 @@ where
     O: MapObserver,
     S: HasCorpus + HasMetadata + HasRand,
 {
+    #[allow(clippy::cast_precision_loss)]
     fn on_remove(
         &mut self,
         state: &mut Self::State,
@@ -273,6 +274,7 @@ where
         Ok(())
     }
 
+    #[allow(clippy::cast_precision_loss)]
     fn on_replace(
         &mut self,
         state: &mut Self::State,

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -257,13 +257,11 @@ where
         depth += 1;
         {
             let mut testcase = state.corpus().get(idx)?.borrow_mut();
-            let scheduled_count = testcase.scheduled_count();
             testcase.add_metadata(SchedulerTestcaseMetaData::with_n_fuzz_entry(
                 depth,
                 self.last_hash,
             ));
             testcase.set_parent_id_optional(current_idx);
-            testcase.set_scheduled_count(scheduled_count + 1);
         }
 
         // TODO increase perf_score when finding new things like in AFL

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -106,6 +106,8 @@ where
         // Run this stage only once for each corpus entry and only if we haven't already inspected it
         {
             let corpus = state.corpus().get(corpus_idx)?.borrow();
+            // println!("calibration; corpus.scheduled_count() : {}", corpus.scheduled_count());
+
             if corpus.scheduled_count() > 0 {
                 return Ok(());
             }

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -106,7 +106,7 @@ where
         // Run this stage only once for each corpus entry and only if we haven't already inspected it
         {
             let corpus = state.corpus().get(corpus_idx)?.borrow();
-            if corpus.fuzz_level() > 0 {
+            if corpus.fuzz_count() > 0 {
                 return Ok(());
             }
         }
@@ -269,10 +269,10 @@ where
             psmeta.set_bitmap_entries(psmeta.bitmap_entries() + 1);
 
             let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
-            let fuzz_level = testcase.fuzz_level();
+            let fuzz_count = testcase.fuzz_count();
 
             testcase.set_exec_time(total_time / (iter as u32));
-            testcase.set_fuzz_level(fuzz_level + 1);
+            testcase.set_fuzz_count(fuzz_count + 1);
             // log::trace!("time: {:#?}", testcase.exec_time());
 
             let data = testcase

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -106,7 +106,7 @@ where
         // Run this stage only once for each corpus entry and only if we haven't already inspected it
         {
             let corpus = state.corpus().get(corpus_idx)?.borrow();
-            if corpus.fuzz_count() > 0 {
+            if corpus.scheduled_count() > 0 {
                 return Ok(());
             }
         }
@@ -269,10 +269,10 @@ where
             psmeta.set_bitmap_entries(psmeta.bitmap_entries() + 1);
 
             let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
-            let fuzz_count = testcase.fuzz_count();
+            let scheduled_count = testcase.scheduled_count();
 
             testcase.set_exec_time(total_time / (iter as u32));
-            testcase.set_fuzz_count(fuzz_count + 1);
+            testcase.set_scheduled_count(scheduled_count + 1);
             // log::trace!("time: {:#?}", testcase.exec_time());
 
             let data = testcase

--- a/libafl/src/stages/push/mutational.rs
+++ b/libafl/src/stages/push/mutational.rs
@@ -21,9 +21,7 @@ use crate::{
     observers::ObserversTuple,
     schedulers::Scheduler,
     start_timer,
-    state::{
-        HasClientPerfMonitor, HasCorpus, HasExecutions, HasFuzzedCorpusId, HasMetadata, HasRand,
-    },
+    state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasMetadata, HasRand},
     Error, EvaluatorObservers, ExecutionProcessor, HasScheduler,
 };
 
@@ -90,14 +88,8 @@ where
     EM: EventFirer<State = CS::State> + EventRestarter + HasEventManagerId + ProgressReporter,
     M: Mutator<CS::Input, CS::State>,
     OT: ObserversTuple<CS::State>,
-    CS::State: HasFuzzedCorpusId
-        + HasClientPerfMonitor
-        + HasCorpus
-        + HasRand
-        + HasExecutions
-        + HasMetadata
-        + Clone
-        + Debug,
+    CS::State:
+        HasClientPerfMonitor + HasCorpus + HasRand + HasExecutions + HasMetadata + Clone + Debug,
     Z: ExecutionProcessor<OT, State = CS::State>
         + EvaluatorObservers<OT>
         + HasScheduler<Scheduler = CS>,
@@ -144,8 +136,6 @@ where
             return None;
         }
 
-        let idx = self.current_corpus_idx.unwrap();
-        state.set_fuzzed_corpus_id(idx);
         start_timer!(state);
         let mut input = state
             .corpus()
@@ -188,7 +178,6 @@ where
             .post_exec(state, self.stage_idx, self.current_corpus_idx)?;
         mark_feature_time!(state, PerfFeature::MutatePostExec);
         self.testcases_done += 1;
-        state.clear_fuzzed_corpus_id();
 
         Ok(())
     }
@@ -212,14 +201,8 @@ where
     EM: EventFirer + EventRestarter + HasEventManagerId + ProgressReporter<State = CS::State>,
     M: Mutator<CS::Input, CS::State>,
     OT: ObserversTuple<CS::State>,
-    CS::State: HasClientPerfMonitor
-        + HasCorpus
-        + HasRand
-        + HasExecutions
-        + HasMetadata
-        + Clone
-        + Debug
-        + HasFuzzedCorpusId,
+    CS::State:
+        HasClientPerfMonitor + HasCorpus + HasRand + HasExecutions + HasMetadata + Clone + Debug,
     Z: ExecutionProcessor<OT, State = CS::State>
         + EvaluatorObservers<OT>
         + HasScheduler<Scheduler = CS>,

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -21,7 +21,7 @@ use crate::{
     mark_feature_time,
     mutators::Mutator,
     observers::{MapObserver, ObserversTuple},
-    schedulers::Scheduler,
+    schedulers::{RemovableScheduler, Scheduler},
     stages::Stage,
     start_timer,
     state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasMaxSize, HasSolutions, UsesState},
@@ -36,7 +36,7 @@ pub trait TMinMutationalStage<CS, E, EM, F1, F2, M, OT, Z>:
 where
     Self::State: HasCorpus + HasSolutions + HasExecutions + HasMaxSize + HasClientPerfMonitor,
     <Self::State as UsesInput>::Input: HasLen + Hash,
-    CS: Scheduler<State = Self::State>,
+    CS: Scheduler<State = Self::State> + RemovableScheduler,
     E: Executor<EM, Z> + HasObservers<Observers = OT, State = Self::State>,
     EM: EventFirer<State = Self::State>,
     F1: Feedback<Self::State>,
@@ -204,7 +204,7 @@ where
 impl<CS, E, EM, F1, F2, FF, M, OT, Z> Stage<E, EM, Z>
     for StdTMinMutationalStage<CS, E, EM, F1, F2, FF, M, OT, Z>
 where
-    CS: Scheduler,
+    CS: Scheduler + RemovableScheduler,
     CS::State: HasCorpus + HasSolutions + HasExecutions + HasMaxSize + HasClientPerfMonitor,
     <CS::State as UsesInput>::Input: HasLen + Hash,
     E: Executor<EM, Z> + HasObservers<Observers = OT, State = CS::State>,
@@ -252,7 +252,7 @@ where
 impl<CS, E, EM, F1, F2, FF, M, OT, Z> TMinMutationalStage<CS, E, EM, F1, F2, M, OT, Z>
     for StdTMinMutationalStage<CS, E, EM, F1, F2, FF, M, OT, Z>
 where
-    CS: Scheduler,
+    CS: Scheduler + RemovableScheduler,
     E: HasObservers<Observers = OT, State = CS::State> + Executor<EM, Z>,
     EM: EventFirer<State = CS::State>,
     F1: Feedback<CS::State>,

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -60,21 +60,6 @@ pub trait HasCorpus: UsesInput {
     fn corpus_mut(&mut self) -> &mut Self::Corpus;
 }
 
-/// Trait for a state that has information about which [`CorpusId`]
-/// is currently being fuzzed.
-/// When a new interesting input was found, this value becomes the `parent_id`.
-pub trait HasFuzzedCorpusId {
-    /// The currently fuzzed [`CorpusId`], if known.
-    /// If a new interesting testcase was found, this should usually become the `parent_id`.
-    fn fuzzed_corpus_id(&self) -> Option<CorpusId>;
-
-    /// Sets the currently fuzzed [`CorpusId`].
-    fn set_fuzzed_corpus_id(&mut self, corpus_id: CorpusId);
-
-    /// Resets the currently fuzzed [`CorpusId`].
-    fn clear_fuzzed_corpus_id(&mut self);
-}
-
 /// Interact with the maximum size
 pub trait HasMaxSize {
     /// The maximum size hint for items and mutations returned
@@ -207,8 +192,6 @@ pub struct StdState<I, C, R, SC> {
     named_metadata: NamedSerdeAnyMap,
     /// MaxSize testcase size for mutators that appreciate it
     max_size: usize,
-    /// The [`CorpusId`] of the testcase we're currently fuzzing.
-    fuzzed_corpus_id: Option<CorpusId>,
     /// Performance statistics for this fuzzer
     #[cfg(feature = "introspection")]
     introspection_monitor: ClientPerfMonitor,
@@ -271,20 +254,6 @@ where
     #[inline]
     fn corpus_mut(&mut self) -> &mut Self::Corpus {
         &mut self.corpus
-    }
-}
-
-impl<I, C, R, SC> HasFuzzedCorpusId for StdState<I, C, R, SC> {
-    fn fuzzed_corpus_id(&self) -> Option<CorpusId> {
-        self.fuzzed_corpus_id
-    }
-
-    fn set_fuzzed_corpus_id(&mut self, fuzzed_corpus_id: CorpusId) {
-        self.fuzzed_corpus_id = Some(fuzzed_corpus_id);
-    }
-
-    fn clear_fuzzed_corpus_id(&mut self) {
-        self.fuzzed_corpus_id = None;
     }
 }
 
@@ -725,7 +694,6 @@ where
             corpus,
             solutions,
             max_size: DEFAULT_MAX_SIZE,
-            fuzzed_corpus_id: None,
             #[cfg(feature = "introspection")]
             introspection_monitor: ClientPerfMonitor::new(),
             #[cfg(feature = "std")]

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -8,7 +8,7 @@ use frida_gum::{
 #[cfg(windows)]
 use libafl::{
     executors::inprocess::{HasInProcessHandlers, InProcessHandlers},
-    state::{HasClientPerfMonitor, HasSolutions},
+    state::{HasClientPerfMonitor, HasCorpus, HasSolutions},
 };
 use libafl::{
     executors::{Executor, ExitKind, HasObservers, InProcessExecutor},
@@ -200,7 +200,7 @@ impl<'a, 'b, 'c, H, OT, RT, S> HasInProcessHandlers
     for FridaInProcessExecutor<'a, 'b, 'c, H, OT, RT, S>
 where
     H: FnMut(&S::Input) -> ExitKind,
-    S: UsesInput + HasClientPerfMonitor + HasSolutions,
+    S: UsesInput + HasClientPerfMonitor + HasSolutions + HasCorpus,
     S::Input: HasTargetBytes,
     OT: ObserversTuple<S>,
     RT: FridaRuntimeTuple,

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -8,7 +8,7 @@ use frida_gum::{
 #[cfg(windows)]
 use libafl::{
     executors::inprocess::{HasInProcessHandlers, InProcessHandlers},
-    state::{HasClientPerfMonitor, HasFuzzedCorpusId, HasSolutions},
+    state::{HasClientPerfMonitor, HasSolutions},
 };
 use libafl::{
     executors::{Executor, ExitKind, HasObservers, InProcessExecutor},
@@ -200,7 +200,7 @@ impl<'a, 'b, 'c, H, OT, RT, S> HasInProcessHandlers
     for FridaInProcessExecutor<'a, 'b, 'c, H, OT, RT, S>
 where
     H: FnMut(&S::Input) -> ExitKind,
-    S: UsesInput + HasClientPerfMonitor + HasSolutions + HasFuzzedCorpusId,
+    S: UsesInput + HasClientPerfMonitor + HasSolutions,
     S::Input: HasTargetBytes,
     OT: ObserversTuple<S>,
     RT: FridaRuntimeTuple,

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -13,10 +13,7 @@ use libafl::{
     fuzzer::HasObjective,
     inputs::UsesInput,
     observers::{ObserversTuple, UsesObservers},
-    state::{
-        HasClientPerfMonitor, HasCorpus, HasExecutions, HasFuzzedCorpusId, HasSolutions, State,
-        UsesState,
-    },
+    state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasSolutions, State, UsesState},
     Error,
 };
 
@@ -67,12 +64,7 @@ where
     where
         EM: EventFirer<State = S> + EventRestarter<State = S>,
         OF: Feedback<S>,
-        S: State
-            + HasExecutions
-            + HasCorpus
-            + HasSolutions
-            + HasClientPerfMonitor
-            + HasFuzzedCorpusId,
+        S: State + HasExecutions + HasCorpus + HasSolutions + HasClientPerfMonitor,
         Z: HasObjective<Objective = OF, State = S>,
     {
         Ok(Self {

--- a/libafl_targets/src/windows_asan.rs
+++ b/libafl_targets/src/windows_asan.rs
@@ -4,7 +4,7 @@ use libafl::{
     events::{EventFirer, EventRestarter},
     executors::{inprocess::windows_asan_handler::asan_death_handler, Executor, HasObservers},
     feedbacks::Feedback,
-    state::{HasClientPerfMonitor, HasSolutions, HasCorpus},
+    state::{HasClientPerfMonitor, HasCorpus, HasSolutions},
     HasObjective,
 };
 

--- a/libafl_targets/src/windows_asan.rs
+++ b/libafl_targets/src/windows_asan.rs
@@ -4,7 +4,7 @@ use libafl::{
     events::{EventFirer, EventRestarter},
     executors::{inprocess::windows_asan_handler::asan_death_handler, Executor, HasObservers},
     feedbacks::Feedback,
-    state::{HasClientPerfMonitor, HasFuzzedCorpusId, HasSolutions},
+    state::{HasClientPerfMonitor, HasSolutions},
     HasObjective,
 };
 
@@ -32,7 +32,7 @@ where
     E: Executor<EM, Z> + HasObservers,
     EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
     OF: Feedback<E::State>,
-    E::State: HasSolutions + HasClientPerfMonitor + HasFuzzedCorpusId,
+    E::State: HasSolutions + HasClientPerfMonitor,
     Z: HasObjective<Objective = OF, State = E::State>,
 {
     __sanitizer_set_death_callback(asan_death_handler::<E, EM, OF, Z>);

--- a/libafl_targets/src/windows_asan.rs
+++ b/libafl_targets/src/windows_asan.rs
@@ -4,7 +4,7 @@ use libafl::{
     events::{EventFirer, EventRestarter},
     executors::{inprocess::windows_asan_handler::asan_death_handler, Executor, HasObservers},
     feedbacks::Feedback,
-    state::{HasClientPerfMonitor, HasSolutions},
+    state::{HasClientPerfMonitor, HasSolutions, HasCorpus},
     HasObjective,
 };
 

--- a/libafl_targets/src/windows_asan.rs
+++ b/libafl_targets/src/windows_asan.rs
@@ -32,7 +32,7 @@ where
     E: Executor<EM, Z> + HasObservers,
     EM: EventFirer<State = E::State> + EventRestarter<State = E::State>,
     OF: Feedback<E::State>,
-    E::State: HasSolutions + HasClientPerfMonitor,
+    E::State: HasSolutions + HasClientPerfMonitor + HasCorpus,
     Z: HasObjective<Objective = OF, State = E::State>,
 {
     __sanitizer_set_death_callback(asan_death_handler::<E, EM, OF, Z>);


### PR DESCRIPTION
- Rename fuzz_level to scheduled_count
- I forgot to increment fuzz_level (scheduled_count) before, so fix this
- Add set_current_scheduled method. scheduler->next() calls this. it sets corpus.current() and update scheduled_count.
- Separate on_remove/on_replace from Scheduler. AFL never expects any corpus entry. so not every scheduler can have this.
- Remove HasFuzzedCorpusId.
- Remove fuzzed member from Testcase. fuzz_level > 0 is the equivalent thing