### PR TITLE
Improve find_llvm for MacOS

### DIFF
--- a/libafl_cc/build.rs
+++ b/libafl_cc/build.rs
@@ -39,14 +39,23 @@ fn find_llvm_config_brew() -> Result<PathBuf, String> {
             if brew_cellar_location.is_empty() {
                 return Err("Empty return from brew --cellar".to_string());
             }
-            let cellar_glob = format!("{brew_cellar_location}/llvm/*/bin/llvm-config");
-            let glob_results = glob(&cellar_glob).unwrap_or_else(|err| {
-                panic!("Could not read glob path {} ({err})", &cellar_glob);
+            let location_suffix = "*/bin/llvm-config";
+            let cellar_glob = vec![
+                // location for explicitly versioned brew formulae
+                format!("{brew_cellar_location}/llvm@*/{location_suffix}"),
+                // location for current release brew formulae
+                format!("{brew_cellar_location}/llvm/{location_suffix}"),
+            ];
+            let glob_results = cellar_glob.iter().flat_map(|location| {
+                glob(location).unwrap_or_else(|err| {
+                    panic!("Could not read glob path {location} ({err})");
+                })
             });
             match glob_results.last() {
                 Some(path) => Ok(path.unwrap()),
                 None => Err(format!(
-                    "No llvm-config found in brew cellar with pattern {cellar_glob}"
+                    "No llvm-config found in brew cellar with patterns {}",
+                    cellar_glob.join(" ")
                 )),
             }
         }


### PR DESCRIPTION
### TL;DR
When looking for LLVM in Brew Cellar include also explicitly versioned Homebrew formulae for LLVM.

### Motivation
When installing llvm through Homebrew it is possible to choose explicitly a major version by using the formulae `llvm@[version]` instead of installing the current stable by simply using the formulae `llvm` ([Formulae Versions - Homebrew Documentation](https://docs.brew.sh/Versions#acceptable-versioned-formulae)).  
This is useful since the [LibAFL README.md](https://github.com/AFLplusplus/LibAFL/blob/main/README.md) states:
> The LLVM tools are needed (newer than LLVM 11.0.0 but older than LLVM 15.0.0)

### The problem
The `find_llvm_config_brew()` function is looking for the directory `{brew_cellar_location}/llvm/` and therefore it targets only the current stable version of LLVM (version 15 atm).

### The solution
In `find_llvm_config_brew()`  look also for `{brew_cellar_location}/llvm@*/`

### Possible improvement
No check about the llvm version is enforced, could it be possible to use `LLVM_VERSION_MIN` and `LLVM_VERSION_MAX` also for MacOS?

Thanks :)