### PR TITLE
Fix UB for differential map observer example

### DIFF
--- a/fuzzers/baby_fuzzer_swap_differential/src/main.rs
+++ b/fuzzers/baby_fuzzer_swap_differential/src/main.rs
@@ -46,16 +46,13 @@ use bindings::{inspect_first, inspect_second};
 
 #[cfg(feature = "multimap")]
 mod multimap {
-    pub use libafl::observers::{HitcountsIterableMapObserver, MultiMapObserver};
-
-    pub static mut FIRST_EDGES: &mut [u8] = &mut [];
-    pub static mut SECOND_EDGES: &mut [u8] = &mut [];
-    pub static mut COMBINED_EDGES: [&mut [u8]; 2] = [&mut [], &mut []];
+    pub use libafl::{
+        bolts::ownedref::OwnedMutSlice,
+        observers::{HitcountsIterableMapObserver, MultiMapObserver},
+    };
 }
 #[cfg(feature = "multimap")]
-use multimap::{
-    HitcountsIterableMapObserver, MultiMapObserver, COMBINED_EDGES, FIRST_EDGES, SECOND_EDGES,
-};
+use multimap::{HitcountsIterableMapObserver, MultiMapObserver, OwnedMutSlice};
 
 #[cfg(not(feature = "multimap"))]
 mod slicemap {
@@ -92,18 +89,32 @@ pub fn main() {
     let num_edges: usize = edges_max_num();
 
     #[cfg(feature = "multimap")]
-    let (first_map_observer, second_map_observer, map_swapper, map_observer) = {
+    let (
+        first_map_observer,
+        second_map_observer,
+        map_swapper,
+        map_observer,
+        layout,
+        first_edges,
+        second_edges,
+    ) = {
         // initialize the maps
-        unsafe {
-            let layout = Layout::from_size_align(num_edges, 64).unwrap();
-            FIRST_EDGES = core::slice::from_raw_parts_mut(alloc_zeroed(layout), num_edges);
-            SECOND_EDGES = core::slice::from_raw_parts_mut(alloc_zeroed(layout), num_edges);
-            COMBINED_EDGES = [&mut FIRST_EDGES, &mut SECOND_EDGES];
-        }
+        let layout = Layout::from_size_align(num_edges, 64).unwrap();
+        let first_edges = unsafe { (alloc_zeroed(layout), num_edges) };
+        let second_edges = unsafe { (alloc_zeroed(layout), num_edges) };
+
+        let combined_edges = unsafe {
+            vec![
+                OwnedMutSlice::from_raw_parts_mut(first_edges.0, first_edges.1),
+                OwnedMutSlice::from_raw_parts_mut(second_edges.0, second_edges.1),
+            ]
+        };
 
         // create the base maps used to observe the different executors from two independent maps
-        let mut first_map_observer = unsafe { StdMapObserver::new("first-edges", FIRST_EDGES) };
-        let mut second_map_observer = unsafe { StdMapObserver::new("second-edges", SECOND_EDGES) };
+        let mut first_map_observer =
+            unsafe { StdMapObserver::from_mut_ptr("first-edges", first_edges.0, first_edges.1) };
+        let mut second_map_observer =
+            unsafe { StdMapObserver::from_mut_ptr("second-edges", second_edges.0, second_edges.1) };
 
         // create a map swapper so that we can replace the coverage map pointer (requires feature pointer_maps!)
         let map_swapper =
@@ -112,18 +123,19 @@ pub fn main() {
         // create a combined map observer, e.g. for calibration
         // we use MultiMapObserver::differential to indicate that we want to use the observer in
         // differential mode
-        let map_observer = unsafe {
-            HitcountsIterableMapObserver::new(MultiMapObserver::differential(
-                "combined-edges",
-                &mut COMBINED_EDGES,
-            ))
-        };
+        let map_observer = HitcountsIterableMapObserver::new(MultiMapObserver::differential(
+            "combined-edges",
+            combined_edges,
+        ));
 
         (
             first_map_observer,
             second_map_observer,
             map_swapper,
             map_observer,
+            layout,
+            first_edges,
+            second_edges,
         )
     };
     #[cfg(not(feature = "multimap"))]
@@ -134,15 +146,13 @@ pub fn main() {
             EDGES = core::slice::from_raw_parts_mut(alloc_zeroed(layout), num_edges * 2);
         }
 
+        let edges_ptr = unsafe { EDGES.as_mut_ptr() };
+
         // create the base maps used to observe the different executors by splitting a slice
         let mut first_map_observer =
-            unsafe { StdMapObserver::from_mut_ptr("first-edges", EDGES.as_mut_ptr(), num_edges) };
+            unsafe { StdMapObserver::from_mut_ptr("first-edges", edges_ptr, num_edges) };
         let mut second_map_observer = unsafe {
-            StdMapObserver::from_mut_ptr(
-                "second-edges",
-                EDGES.as_mut_ptr().add(num_edges),
-                num_edges,
-            )
+            StdMapObserver::from_mut_ptr("second-edges", edges_ptr.add(num_edges), num_edges)
         };
 
         // create a map swapper so that we can replace the coverage map pointer (requires feature pointer_maps!)
@@ -155,7 +165,7 @@ pub fn main() {
         let map_observer = unsafe {
             HitcountsMapObserver::new(StdMapObserver::differential_from_mut_ptr(
                 "combined-edges",
-                EDGES.as_mut_ptr(),
+                edges_ptr,
                 num_edges * 2,
             ))
         };
@@ -262,5 +272,11 @@ pub fn main() {
                 &mut mgr,
             )
             .expect("Error in the fuzzing loop");
+    }
+
+    #[cfg(feature = "multimap")]
+    unsafe {
+        std::alloc::dealloc(first_edges.0, layout);
+        std::alloc::dealloc(second_edges.0, layout);
     }
 }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -1812,21 +1812,17 @@ where
 {
     /// Creates a new [`MultiMapObserver`], maybe in differential mode
     #[must_use]
-    fn new_maybe_differential(name: &'static str, maps: &'a mut [&'a mut [T]]) -> Self {
+    fn new_maybe_differential(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
         let mut idx = 0;
         let mut v = 0;
         let mut builder = vec![];
-        let maps: Vec<_> = maps
-            .iter_mut()
-            .map(|x| {
-                let l = x.len();
-                let r = (idx..(idx + l), v);
-                idx += l;
-                builder.push(r);
-                v += 1;
-                OwnedMutSlice::from(x)
-            })
-            .collect();
+        for x in &maps {
+            let l = x.as_slice().len();
+            let r = (idx..(idx + l), v);
+            idx += l;
+            builder.push(r);
+            v += 1;
+        }
         Self {
             maps,
             intervals: builder.into_iter().collect::<IntervalTree<usize, usize>>(),
@@ -1844,7 +1840,7 @@ where
 {
     /// Creates a new [`MultiMapObserver`] in differential mode
     #[must_use]
-    pub fn differential(name: &'static str, maps: &'a mut [&'a mut [T]]) -> Self {
+    pub fn differential(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
         Self::new_maybe_differential(name, maps)
     }
 }
@@ -1855,7 +1851,7 @@ where
 {
     /// Creates a new [`MultiMapObserver`]
     #[must_use]
-    pub fn new(name: &'static str, maps: &'a mut [&'a mut [T]]) -> Self {
+    pub fn new(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
         Self::new_maybe_differential(name, maps)
     }
 

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -1814,14 +1814,12 @@ where
     #[must_use]
     fn new_maybe_differential(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
         let mut idx = 0;
-        let mut v = 0;
         let mut builder = vec![];
-        for x in &maps {
+        for (v, x) in maps.iter().enumerate() {
             let l = x.as_slice().len();
             let r = (idx..(idx + l), v);
             idx += l;
             builder.push(r);
-            v += 1;
         }
         Self {
             maps,


### PR DESCRIPTION
Right now the Differential Observer used some UB, mainly keeping multiple &mut references to things, see also #1133 

This tries to fix things. @addisoncrump please take a look :)