### PR TITLE
Added Truncate trait

### DIFF
--- a/fuzzers/forkserver_libafl_cc/src/main.rs
+++ b/fuzzers/forkserver_libafl_cc/src/main.rs
@@ -180,7 +180,7 @@ pub fn main() {
             .observers_mut()
             .match_name_mut::<HitcountsMapObserver<StdMapObserver<'_, u8, false>>>("shared_mem")
             .unwrap()
-            .downsize_map(dynamic_map_size);
+            .truncate(dynamic_map_size);
     }
 
     let mut executor = TimeoutForkserverExecutor::with_signal(

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -180,7 +180,7 @@ pub fn main() {
             .observers_mut()
             .match_name_mut::<HitcountsMapObserver<StdMapObserver<'_, u8, false>>>("shared_mem")
             .unwrap()
-            .downsize_map(dynamic_map_size);
+            .truncate(dynamic_map_size);
     }
 
     let mut executor = TimeoutForkserverExecutor::with_signal(

--- a/libafl/src/bolts/mod.rs
+++ b/libafl/src/bolts/mod.rs
@@ -154,6 +154,12 @@ pub trait HasRefCnt {
     fn refcnt_mut(&mut self) -> &mut isize;
 }
 
+/// Trait to truncate slices and maps to a new size
+pub trait Truncate {
+    /// Reduce the size of the slice
+    fn truncate(&mut self, len: usize);
+}
+
 /// Current time
 #[cfg(feature = "std")]
 #[must_use]

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -32,7 +32,7 @@ use crate::{
         os::{dup2, pipes::Pipe},
         shmem::{ShMem, ShMemProvider, UnixShMemProvider},
         tuples::Prepend,
-        AsMutSlice, AsSlice,
+        AsMutSlice, AsSlice, Truncate,
     },
     executors::{Executor, ExitKind, HasObservers},
     inputs::{HasTargetBytes, Input, UsesInput},
@@ -653,7 +653,7 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
         other_observers: OT,
     ) -> Result<ForkserverExecutor<(MO, OT), S, SP>, Error>
     where
-        MO: Observer<S> + MapObserver, // TODO maybe enforce Entry = u8 for the cov map
+        MO: Observer<S> + MapObserver + Truncate, // TODO maybe enforce Entry = u8 for the cov map
         OT: ObserversTuple<S> + Prepend<MO, PreprendResult = OT>,
         S: UsesInput,
         S::Input: Input + HasTargetBytes,
@@ -671,7 +671,7 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
         );
 
         if let Some(dynamic_map_size) = self.map_size {
-            map_observer.downsize_map(dynamic_map_size);
+            map_observer.truncate(dynamic_map_size);
         }
 
         let observers: (MO, OT) = other_observers.prepend(map_observer);


### PR DESCRIPTION
This replaces all `downsize` calls with `truncate`, the name that's used in `Vec`.
It also adds a `Truncate` trait to `bolts `.
