### PR TITLE
Fix infinite calibration

### DIFF
--- a/fuzzers/fuzzbench/fuzz.c
+++ b/fuzzers/fuzzbench/fuzz.c
@@ -2,8 +2,7 @@
 #include <stdlib.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-  if (Size >= 8 && *(uint32_t *)Data == 0xaabbccdd) { abort(); }
-  return 0;
+	abort();
 }
 
 /*

--- a/fuzzers/fuzzbench/fuzz.c
+++ b/fuzzers/fuzzbench/fuzz.c
@@ -2,7 +2,8 @@
 #include <stdlib.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-	abort();
+  if (Size >= 8 && *(uint32_t *)Data == 0xaabbccdd) { abort(); }
+  return 0;
 }
 
 /*

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -153,7 +153,7 @@ where
         let mut unstable_entries: Vec<usize> = vec![];
         let map_len: usize = map_first.len();
         // Run CAL_STAGE_START - 1 times, increase by 2 for every time a new
-        // run is found to be unstable, with CAL_STAGE_MAX total runs.
+        // run is found to be unstable or to crash with CAL_STAGE_MAX total runs.
         let mut i = 1;
         let mut has_errors = false;
 
@@ -178,10 +178,11 @@ where
                     )?;
 
                     has_errors = true;
-                    if iter < CAL_STAGE_MAX {
-                        iter += 2;
-                    };
                 }
+
+                if iter < CAL_STAGE_MAX {
+                    iter += 2;
+                };
             };
 
             total_time += current_time() - start;

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -182,7 +182,6 @@ where
                         iter += 2;
                     };
                 }
-
             };
 
             total_time += current_time() - start;

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -182,7 +182,7 @@ where
                         iter += 2;
                     };
                 }
-                continue;
+
             };
 
             total_time += current_time() - start;


### PR DESCRIPTION
This will continue calibration stage infinitely if the corpus already fails or timeouts. (Could happen if user used load_initial_input_forced() )