### PR TITLE
Removed `new_` from constructors that don't need it (API consistency)

### DIFF
--- a/fuzzers/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby_fuzzer_grimoire/src/main.rs
@@ -85,7 +85,7 @@ pub fn main() {
     let observer = unsafe { StdMapObserver::new("signals", &mut SIGNALS) };
 
     // Feedback to rate the interestingness of an input
-    let mut feedback = MaxMapFeedback::new_tracking(&observer, false, true);
+    let mut feedback = MaxMapFeedback::tracking(&observer, false, true);
 
     // A feedback to choose if an input is a solution or not
     let mut objective = CrashFeedback::new();

--- a/fuzzers/baby_fuzzer_minimizing/src/main.rs
+++ b/fuzzers/baby_fuzzer_minimizing/src/main.rs
@@ -35,7 +35,7 @@ pub fn main() -> Result<(), Error> {
     let observer =
         unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS.as_mut_ptr(), SIGNALS.len()) };
 
-    let factory = MapEqualityFactory::new_from_observer(&observer);
+    let factory = MapEqualityFactory::with_observer(&observer);
 
     // Feedback to rate the interestingness of an input
     let mut feedback = MaxMapFeedback::new(&observer);

--- a/fuzzers/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
+++ b/fuzzers/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
@@ -54,7 +54,7 @@ pub fn main() {
 
     // Feedback to rate the interestingness of an input
     // This one is composed by two Feedbacks in OR
-    let mut feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let mut feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     // A feedback to choose if an input is a solution or not
     // We want to do the same crash deduplication that AFL does

--- a/fuzzers/forkserver_libafl_cc/src/main.rs
+++ b/fuzzers/forkserver_libafl_cc/src/main.rs
@@ -113,7 +113,7 @@ pub fn main() {
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::new_tracking(&edges_observer, true, false),
+        MaxMapFeedback::tracking(&edges_observer, true, false),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -113,7 +113,7 @@ pub fn main() {
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::new_tracking(&edges_observer, true, false),
+        MaxMapFeedback::tracking(&edges_observer, true, false),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );

--- a/fuzzers/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida_gdiplus/src/fuzzer.rs
@@ -121,7 +121,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                    MaxMapFeedback::tracking(&edges_observer, true, false),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -237,7 +237,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                    MaxMapFeedback::tracking(&edges_observer, true, false),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -367,7 +367,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                    MaxMapFeedback::tracking(&edges_observer, true, false),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -118,7 +118,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                    MaxMapFeedback::tracking(&edges_observer, true, false),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -235,7 +235,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                    MaxMapFeedback::tracking(&edges_observer, true, false),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -365,7 +365,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                    MaxMapFeedback::tracking(&edges_observer, true, false),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );

--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -249,7 +249,7 @@ fn fuzz(
 
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -246,7 +246,7 @@ fn fuzz(
     // Create an observation channel using cmplog map
     let cmplog_observer = unsafe { CmpLogObserver::with_map_ptr("cmplog", cmplog_map_ptr, true) };
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/fuzzbench_forkserver/src/main.rs
@@ -251,7 +251,7 @@ fn fuzz(
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -258,7 +258,7 @@ fn fuzz(
     // Create an observation channel using cmplog map
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/fuzzbench_text/src/lib.rs
+++ b/fuzzers/fuzzbench_text/src/lib.rs
@@ -311,7 +311,7 @@ fn fuzz_binary(
 
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -515,7 +515,7 @@ fn fuzz_text(
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
     // New maximization map feedback linked to the edges observer and the feedback state
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, true);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, true);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libafl_atheris/src/lib.rs
+++ b/fuzzers/libafl_atheris/src/lib.rs
@@ -208,7 +208,7 @@ pub fn LLVMFuzzerRunDriver(
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, false),
+            MaxMapFeedback::tracking(&edges_observer, true, false),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -90,7 +90,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
@@ -144,7 +144,7 @@ pub fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, false),
+            MaxMapFeedback::tracking(&edges_observer, true, false),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng_cmin/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_cmin/src/lib.rs
@@ -89,7 +89,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libfuzzer_libpng_ctx/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_ctx/src/lib.rs
@@ -138,7 +138,7 @@ pub fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, false),
+            MaxMapFeedback::tracking(&edges_observer, true, false),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -143,7 +143,7 @@ pub fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, false),
+            MaxMapFeedback::tracking(&edges_observer, true, false),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -79,7 +79,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::new_tracking(&edges_observer, true, false),
+        MaxMapFeedback::tracking(&edges_observer, true, false),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -116,7 +116,7 @@ fn fuzz(
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::new_tracking(&edges_observer, true, false),
+        MaxMapFeedback::tracking(&edges_observer, true, false),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );

--- a/fuzzers/libfuzzer_windows_asan/src/lib.rs
+++ b/fuzzers/libfuzzer_windows_asan/src/lib.rs
@@ -66,7 +66,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/nautilus_sync/src/lib.rs
+++ b/fuzzers/nautilus_sync/src/lib.rs
@@ -122,7 +122,7 @@ pub fn libafl_main() {
     let context = NautilusContext::from_file(15, "grammar.json");
 
     let mut event_converter = opt.bytes_broker_port.map(|port| {
-        LlmpEventConverter::new_on_port(
+        LlmpEventConverter::on_port(
             shmem_provider.clone(),
             port,
             Some(NautilusToBytesInputConverter::new(&context)),

--- a/fuzzers/qemu_arm_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_arm_launcher/src/fuzzer.rs
@@ -123,7 +123,7 @@ pub fn fuzz() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, false),
+            MaxMapFeedback::tracking(&edges_observer, true, false),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_launcher/src/fuzzer.rs
@@ -127,7 +127,7 @@ pub fn fuzz() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, false),
+            MaxMapFeedback::tracking(&edges_observer, true, false),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/qemu_systemmode/src/fuzzer.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer.rs
@@ -155,7 +155,7 @@ pub fn fuzz() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::new_tracking(&edges_observer, true, true),
+            MaxMapFeedback::tracking(&edges_observer, true, true),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/tutorial/src/lib.rs
+++ b/fuzzers/tutorial/src/lib.rs
@@ -86,7 +86,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::new_tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -103,7 +103,7 @@ where
     /// Create llmp on a port
     /// The port must not be bound yet to have a broker.
     #[cfg(feature = "std")]
-    pub fn new_on_port(shmem_provider: SP, monitor: MT, port: u16) -> Result<Self, Error> {
+    pub fn on_port(shmem_provider: SP, monitor: MT, port: u16) -> Result<Self, Error> {
         Ok(Self {
             monitor,
             llmp: llmp::LlmpBroker::create_attach_to_tcp(shmem_provider, port)?,
@@ -371,7 +371,7 @@ where
     /// If the port is not yet bound, it will act as broker
     /// Else, it will act as client.
     #[cfg(feature = "std")]
-    pub fn new_on_port(
+    pub fn on_port(
         shmem_provider: SP,
         port: u16,
         configuration: EventConfig,
@@ -937,7 +937,7 @@ where
                     }
                 }
                 ManagerKind::Broker => {
-                    let event_broker = LlmpEventBroker::<S::Input, MT, SP>::new_on_port(
+                    let event_broker = LlmpEventBroker::<S::Input, MT, SP>::on_port(
                         self.shmem_provider.clone(),
                         self.monitor.take().unwrap(),
                         self.broker_port,
@@ -948,7 +948,7 @@ where
                 }
                 ManagerKind::Client { cpu_core } => {
                     // We are a client
-                    let mgr = LlmpEventManager::<S, SP>::new_on_port(
+                    let mgr = LlmpEventManager::<S, SP>::on_port(
                         self.shmem_provider.clone(),
                         self.broker_port,
                         self.configuration,
@@ -1166,7 +1166,7 @@ where
 
     /// Create a client from port and the input converters
     #[cfg(feature = "std")]
-    pub fn new_on_port(
+    pub fn on_port(
         shmem_provider: SP,
         port: u16,
         converter: Option<IC>,

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -429,7 +429,7 @@ where
     MT: Monitor, //TODO CE: CustomEvent,
 {
     /// Creates a new [`SimpleEventManager`].
-    fn new_launched(monitor: MT, staterestorer: StateRestorer<SP>) -> Self {
+    fn launched(monitor: MT, staterestorer: StateRestorer<SP>) -> Self {
         Self {
             staterestorer,
             simple_event_mgr: SimpleEventManager::new(monitor),
@@ -535,7 +535,7 @@ where
                 // Mgr to send and receive msgs from/to all other fuzzer instances
                 (
                     None,
-                    SimpleRestartingEventManager::new_launched(monitor, staterestorer),
+                    SimpleRestartingEventManager::launched(monitor, staterestorer),
                 )
             }
             // Restoring from a previous run, deserialize state and corpus.
@@ -551,7 +551,7 @@ where
 
                 (
                     Some(state),
-                    SimpleRestartingEventManager::new_launched(monitor, staterestorer),
+                    SimpleRestartingEventManager::launched(monitor, staterestorer),
                 )
             }
         };

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -666,7 +666,7 @@ where
 
     /// Create new `MapFeedback` specifying if it must track indexes of used entries and/or novelties
     #[must_use]
-    pub fn new_tracking(map_observer: &O, track_indexes: bool, track_novelties: bool) -> Self {
+    pub fn tracking(map_observer: &O, track_indexes: bool, track_novelties: bool) -> Self {
         Self {
             indexes: track_indexes,
             novelties: if track_novelties { Some(vec![]) } else { None },

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -2253,7 +2253,7 @@ pub mod pybind {
 
                 #[must_use]
                 pub fn as_map_observer(slf: Py<Self>) -> $struct_name_trait {
-                    $struct_name_trait::std(slf)
+                    $struct_name_trait::new_std(slf)
                 }
 
                 #[must_use]
@@ -2311,7 +2311,7 @@ pub mod pybind {
 
                 #[must_use]
                 pub fn as_map_observer(slf: Py<Self>) -> $struct_name_trait {
-                    $struct_name_trait::owned(slf)
+                    $struct_name_trait::new_owned(slf)
                 }
 
                 #[must_use]

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -558,7 +558,7 @@ where
 
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]
-    pub fn new_owned<S>(name: S, map: Vec<T>) -> Self
+    pub fn owned<S>(name: S, map: Vec<T>) -> Self
     where
         S: Into<String>,
     {
@@ -905,7 +905,7 @@ where
 
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]
-    pub fn new_owned(name: &'static str, map: Vec<T>) -> Self {
+    pub fn owned(name: &'static str, map: Vec<T>) -> Self {
         assert!(map.len() >= N);
         let initial = if map.is_empty() { T::default() } else { map[0] };
         Self {
@@ -1828,7 +1828,7 @@ where
 {
     /// Creates a new [`MultiMapObserver`], maybe in differential mode
     #[must_use]
-    fn new_maybe_differential(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
+    fn maybe_differential(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
         let mut idx = 0;
         let mut builder = vec![];
         for (v, x) in maps.iter().enumerate() {
@@ -1855,7 +1855,7 @@ where
     /// Creates a new [`MultiMapObserver`] in differential mode
     #[must_use]
     pub fn differential(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
-        Self::new_maybe_differential(name, maps)
+        Self::maybe_differential(name, maps)
     }
 }
 
@@ -1866,12 +1866,12 @@ where
     /// Creates a new [`MultiMapObserver`]
     #[must_use]
     pub fn new(name: &'static str, maps: Vec<OwnedMutSlice<'a, T>>) -> Self {
-        Self::new_maybe_differential(name, maps)
+        Self::maybe_differential(name, maps)
     }
 
     /// Creates a new [`MultiMapObserver`] with an owned map
     #[must_use]
-    pub fn new_owned(name: &'static str, maps: Vec<Vec<T>>) -> Self {
+    pub fn owned(name: &'static str, maps: Vec<Vec<T>>) -> Self {
         let mut idx = 0;
         let mut v = 0;
         let mut builder = vec![];
@@ -2253,7 +2253,7 @@ pub mod pybind {
 
                 #[must_use]
                 pub fn as_map_observer(slf: Py<Self>) -> $struct_name_trait {
-                    $struct_name_trait::new_std(slf)
+                    $struct_name_trait::std(slf)
                 }
 
                 #[must_use]
@@ -2311,7 +2311,7 @@ pub mod pybind {
 
                 #[must_use]
                 pub fn as_map_observer(slf: Py<Self>) -> $struct_name_trait {
-                    $struct_name_trait::new_owned(slf)
+                    $struct_name_trait::owned(slf)
                 }
 
                 #[must_use]

--- a/libafl/src/stages/logics.rs
+++ b/libafl/src/stages/logics.rs
@@ -77,6 +77,8 @@ where
     }
 }
 
+/// A conditionally enabled stage.
+/// If the closure returns true, the wrapped stage will be executed, else it will be skipped.
 #[derive(Debug)]
 pub struct IfStage<CB, E, EM, ST, Z>
 where
@@ -134,7 +136,8 @@ where
     ST: StagesTuple<E, EM, E::State, Z>,
     Z: UsesState<State = E::State>,
 {
-    /// Constructor
+    /// Constructor for this conditionally enabled stage.
+    /// If the closure returns true, the wrapped stage will be executed, else it will be skipped.
     pub fn new(closure: CB, if_stages: ST) -> Self {
         Self {
             closure,

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -578,7 +578,7 @@ impl AsanErrorsObserver {
 
     /// Creates a new `AsanErrorsObserver`, owning the `AsanErrors`
     #[must_use]
-    pub fn new_owned(errors: Option<AsanErrors>) -> Self {
+    pub fn owned(errors: Option<AsanErrors>) -> Self {
         Self {
             errors: OwnedPtr::Owned(Box::new(errors)),
         }

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -136,7 +136,7 @@ impl<'a, const MAP_SIZE: usize> ForkserverBytesCoverageSugar<'a, MAP_SIZE> {
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                MaxMapFeedback::tracking(&edges_observer, true, false),
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::with_observer(&time_observer)
             );

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -155,7 +155,7 @@ where
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                MaxMapFeedback::tracking(&edges_observer, true, false),
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::with_observer(&time_observer)
             );

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -166,7 +166,7 @@ where
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::new_tracking(&edges_observer, true, false),
+                MaxMapFeedback::tracking(&edges_observer, true, false),
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::with_observer(&time_observer)
             );

--- a/libafl_targets/src/drcov.rs
+++ b/libafl_targets/src/drcov.rs
@@ -45,7 +45,7 @@ impl DrCovBasicBlock {
 
     /// Create a new [`DrCovBasicBlock`] with a given `start` address and a block size.
     #[must_use]
-    pub fn new_with_size(start: usize, size: usize) -> Self {
+    pub fn with_size(start: usize, size: usize) -> Self {
         Self::new(start, start + size)
     }
 }


### PR DESCRIPTION
This changes a lot of the constructors that start with a redundant `new_`.
I left Python as is.