### PR TITLE
Fix SimplePrintingMonitor

### DIFF
--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -319,10 +319,19 @@ impl Default for NopMonitor {
 
 #[cfg(feature = "std")]
 /// Tracking monitor during fuzzing that just prints to `stdout`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SimplePrintingMonitor {
     start_time: Duration,
     client_stats: Vec<ClientStats>,
+}
+
+impl Default for SimplePrintingMonitor {
+    fn default() -> Self {
+        Self {
+            start_time: current_time(),
+            client_stats: Vec::new(),
+        }
+    }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
The default `start_time` in a `SimplePrintingMonitor` is initialized to 0, leading to incorrect report times:
```
[Stats #0] run time: 466516h-12m-51s, clients: 1, corpus: 0, objectives: 0, executions: 0, exec/sec: 0.000
[Testcase #0] run time: 466516h-12m-51s, clients: 1, corpus: 1, objectives: 0, executions: 1, exec/sec: 0.000
```