### PR TITLE
Generic associated types for MapObserver

### DIFF
--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -654,6 +654,7 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
     ) -> Result<ForkserverExecutor<(MO, OT), S, SP>, Error>
     where
         MO: Observer<S> + MapObserver + Truncate, // TODO maybe enforce Entry = u8 for the cov map
+        for<'it> &'it MO: IntoIterator<Item = &'it MO::Entry>,
         OT: ObserversTuple<S> + Prepend<MO, PreprendResult = OT>,
         S: UsesInput,
         S::Input: Input + HasTargetBytes,

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -382,6 +382,7 @@ impl<N, O, R, S, T> Feedback<S> for MapFeedback<N, O, R, S, T>
 where
     N: IsNovel<T> + Debug,
     O: MapObserver<Entry = T> + for<'it> AsIter<'it, Item = T>,
+    for<'it> &'it O: IntoIterator<Item = &'it T>,
     R: Reducer<T> + Debug,
     S: UsesInput + HasClientPerfMonitor + HasNamedMetadata + Debug,
     T: Default + Copy + Serialize + for<'de> Deserialize<'de> + PartialEq + Debug + 'static,
@@ -628,6 +629,7 @@ where
     R: Reducer<T>,
     N: IsNovel<T>,
     O: MapObserver<Entry = T>,
+    for<'it> &'it O: IntoIterator<Item = &'it T>,
     for<'it> O: AsIter<'it, Item = T>,
     S: HasNamedMetadata,
 {
@@ -646,6 +648,7 @@ where
     T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
     R: Reducer<T>,
     O: MapObserver<Entry = T>,
+    for<'it> &'it O: IntoIterator<Item = &'it T>,
     for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     S: UsesInput + HasNamedMetadata + HasClientPerfMonitor + Debug,
@@ -834,6 +837,7 @@ pub struct ReachabilityFeedback<O, S> {
 impl<O, S> ReachabilityFeedback<O, S>
 where
     O: MapObserver<Entry = usize>,
+    for<'it> &'it O: IntoIterator<Item = &'it usize>,
     for<'it> O: AsIter<'it, Item = usize>,
 {
     /// Creates a new [`ReachabilityFeedback`] for a [`MapObserver`].
@@ -861,7 +865,7 @@ impl<O, S> Feedback<S> for ReachabilityFeedback<O, S>
 where
     S: UsesInput + Debug + HasClientPerfMonitor,
     O: MapObserver<Entry = usize>,
-    for<'it> O: AsIter<'it, Item = usize>,
+    for<'it> &'it O: IntoIterator<Item = &'it usize>,
 {
     #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(
@@ -922,7 +926,7 @@ where
 impl<O, S> Named for ReachabilityFeedback<O, S>
 where
     O: MapObserver<Entry = usize>,
-    for<'it> O: AsIter<'it, Item = usize>,
+    for<'it> &'it O: IntoIterator<Item = &'it usize>,
 {
     #[inline]
     fn name(&self) -> &str {

--- a/libafl/src/schedulers/ecofuzz.rs
+++ b/libafl/src/schedulers/ecofuzz.rs
@@ -79,6 +79,7 @@ impl<O, S> EcoScheduler<O, S>
 where
     S: HasCorpus + HasMetadata + HasRand + HasExecutions + HasTestcase,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
 {
     /// Create a new [`EcoScheduler`] without any power schedule
     #[must_use]
@@ -227,6 +228,7 @@ impl<O, S> Scheduler for EcoScheduler<O, S>
 where
     S: HasCorpus + HasMetadata + HasRand + HasExecutions + HasTestcase,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
 {
     /// Add an entry to the corpus and return its index
     fn on_add(&mut self, state: &mut S, idx: CorpusId) -> Result<(), Error> {

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -182,6 +182,7 @@ impl<O, S> RemovableScheduler for PowerQueueScheduler<O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
 {
     #[allow(clippy::cast_precision_loss)]
     fn on_replace(
@@ -251,6 +252,7 @@ impl<O, S> Scheduler for PowerQueueScheduler<O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
 {
     /// Add an entry to the corpus and return its index
     fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
@@ -359,6 +361,7 @@ impl<O, S> PowerQueueScheduler<O, S>
 where
     S: HasMetadata,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
 {
     /// Create a new [`PowerQueueScheduler`]
     #[must_use]

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -100,6 +100,7 @@ impl<F, O, S> WeightedScheduler<F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     S: HasCorpus + HasMetadata + HasRand,
 {
     /// Create a new [`WeightedScheduler`] without any power schedule
@@ -228,6 +229,7 @@ impl<F, O, S> RemovableScheduler for WeightedScheduler<F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     S: HasCorpus + HasMetadata + HasRand + HasTestcase,
 {
     #[allow(clippy::cast_precision_loss)]
@@ -300,6 +302,7 @@ impl<F, O, S> Scheduler for WeightedScheduler<F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     S: HasCorpus + HasMetadata + HasRand + HasTestcase,
 {
     /// Add an entry to the corpus and return its index

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -84,6 +84,7 @@ where
     E: Executor<EM, Z> + HasObservers<Observers = OT>,
     EM: EventFirer<State = E::State>,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     for<'de> <O as MapObserver>::Entry: Serialize + Deserialize<'de> + 'static,
     OT: ObserversTuple<E::State>,
     E::State: HasCorpus + HasMetadata + HasClientPerfMonitor + HasNamedMetadata,
@@ -322,6 +323,7 @@ where
 impl<O, OT, S> CalibrationStage<O, OT, S>
 where
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     OT: ObserversTuple<S>,
     S: HasCorpus + HasMetadata + HasNamedMetadata,
 {

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -75,6 +75,7 @@ where
     E::State: HasCorpus + HasMetadata + HasRand,
     E::Input: HasBytesVec,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     Z: UsesState<State = E::State>,
 {
     #[inline]
@@ -140,6 +141,7 @@ impl<EM, O, E, Z> ColorizationStage<EM, O, E, Z>
 where
     EM: UsesState<State = E::State> + EventFirer,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     E: HasObservers + Executor<EM, Z>,
     E::State: HasCorpus + HasMetadata + HasRand,
     E::Input: HasBytesVec,

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -57,6 +57,7 @@ where
 impl<E, EM, O, Z> Stage<E, EM, Z> for GeneralizationStage<EM, O, E::Observers, Z>
 where
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     E: Executor<EM, Z> + HasObservers,
     E::Observers: ObserversTuple<E::State>,
     E::State: UsesInput<Input = BytesInput>
@@ -304,6 +305,7 @@ impl<EM, O, OT, Z> GeneralizationStage<EM, O, OT, Z>
 where
     EM: UsesState,
     O: MapObserver,
+    for<'it> &'it O: IntoIterator<Item = &'it O::Entry>,
     OT: ObserversTuple<EM::State>,
     EM::State: UsesInput<Input = BytesInput>
         + HasClientPerfMonitor

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -340,6 +340,7 @@ impl<M, S> HasObserverName for MapEqualityFeedback<M, S> {
 impl<M, S> Feedback<S> for MapEqualityFeedback<M, S>
 where
     M: MapObserver + Debug,
+    for<'it> &'it M: IntoIterator<Item = &'it M::Entry>,
     S: UsesInput + HasClientPerfMonitor + Debug,
 {
     fn is_interesting<EM, OT>(
@@ -371,6 +372,7 @@ pub struct MapEqualityFactory<M, S> {
 impl<M, S> MapEqualityFactory<M, S>
 where
     M: MapObserver,
+    for<'it> &'it M: IntoIterator<Item = &'it M::Entry>,
 {
     /// Creates a new map equality feedback for the given observer
     pub fn new_from_observer(obs: &M) -> Self {
@@ -390,6 +392,7 @@ impl<M, S> HasObserverName for MapEqualityFactory<M, S> {
 impl<M, OT, S> FeedbackFactory<MapEqualityFeedback<M, S>, S, OT> for MapEqualityFactory<M, S>
 where
     M: MapObserver,
+    for<'it> &'it M: IntoIterator<Item = &'it M::Entry>,
     OT: ObserversTuple<S>,
     S: UsesInput + HasClientPerfMonitor + Debug,
 {


### PR DESCRIPTION
Generic associated types for MapObserver.
https://github.com/AFLplusplus/LibAFL/blob/702f163c1305cc5bc9c2fef71a533c7297697dd0/libafl/src/observers/map.rs#L85