### PR TITLE
qemu: Return errors from `Emulator::new` instead of asserting

### DIFF
--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -147,7 +147,7 @@ fn fuzz(
 
     let args: Vec<String> = env::args().collect();
     let env: Vec<(String, String)> = env::vars().collect();
-    let emu = Emulator::new(&args, &env);
+    let emu = Emulator::new(&args, &env).unwrap();
 
     let mut elf_buffer = Vec::new();
     let elf = EasyElf::from_file(emu.binary_path(), &mut elf_buffer)?;

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -147,7 +147,7 @@ fn fuzz(
 
     let args: Vec<String> = env::args().collect();
     let env: Vec<(String, String)> = env::vars().collect();
-    let emu = Emulator::new(&args, &env).unwrap();
+    let emu = Emulator::new(&args, &env)?;
 
     let mut elf_buffer = Vec::new();
     let elf = EasyElf::from_file(emu.binary_path(), &mut elf_buffer)?;

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -171,7 +171,7 @@ fn fuzz(
 
     let args: Vec<String> = env::args().collect();
     let env: Vec<(String, String)> = env::vars().collect();
-    let emu = Emulator::new(&args, &env);
+    let emu = Emulator::new(&args, &env).unwrap();
     //let emu = init_with_asan(&mut args, &mut env);
 
     let mut elf_buffer = Vec::new();

--- a/fuzzers/qemu_arm_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_arm_launcher/src/fuzzer.rs
@@ -54,7 +54,7 @@ pub fn fuzz() {
     env::remove_var("LD_LIBRARY_PATH");
     let args: Vec<String> = env::args().collect();
     let env: Vec<(String, String)> = env::vars().collect();
-    let emu = Emulator::new(&args, &env);
+    let emu = Emulator::new(&args, &env).unwrap();
 
     let mut elf_buffer = Vec::new();
     let elf = EasyElf::from_file(emu.binary_path(), &mut elf_buffer).unwrap();

--- a/fuzzers/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu_launcher/src/fuzzer.rs
@@ -54,7 +54,7 @@ pub fn fuzz() {
     env::remove_var("LD_LIBRARY_PATH");
     let args: Vec<String> = env::args().collect();
     let env: Vec<(String, String)> = env::vars().collect();
-    let emu = Emulator::new(&args, &env);
+    let emu = Emulator::new(&args, &env).unwrap();
 
     let mut elf_buffer = Vec::new();
     let elf = EasyElf::from_file(emu.binary_path(), &mut elf_buffer).unwrap();

--- a/fuzzers/qemu_systemmode/src/fuzzer.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer.rs
@@ -80,7 +80,7 @@ pub fn fuzz() {
         // Initialize QEMU
         let args: Vec<String> = env::args().collect();
         let env: Vec<(String, String)> = env::vars().collect();
-        let emu = Emulator::new(&args, &env);
+        let emu = Emulator::new(&args, &env).unwrap();
 
         emu.set_breakpoint(main_addr);
         unsafe {

--- a/libafl/src/bolts/cli.rs
+++ b/libafl/src/bolts/cli.rs
@@ -41,7 +41,7 @@
 //!
 //!     let env: Vec<(String, String)> = env::vars().collect();
 //!
-//!     let emu = Emulator::new(&mut options.qemu_args.to_vec(), &mut env);
+//!     let emu = Emulator::new(&mut options.qemu_args.to_vec(), &mut env).unwrap();
 //!     // do other stuff...
 //! }
 //!

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -47,7 +47,6 @@ strum = "0.24"
 strum_macros = "0.24"
 syscall-numbers = "3.0"
 meminterval = "0.3"
-thiserror = "1"
 thread_local = "1.1.4"
 capstone = "0.11.0"
 #pyo3 = { version = "0.15", features = ["extension-module"], optional = true }

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -47,6 +47,7 @@ strum = "0.24"
 strum_macros = "0.24"
 syscall-numbers = "3.0"
 meminterval = "0.3"
+thiserror = "1"
 thread_local = "1.1.4"
 capstone = "0.11.0"
 #pyo3 = { version = "0.15", features = ["extension-module"], optional = true }

--- a/libafl_qemu/src/asan.rs
+++ b/libafl_qemu/src/asan.rs
@@ -16,7 +16,7 @@ use meminterval::{Interval, IntervalTree};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-    emu::{Emulator, MemAccessInfo, SyscallHookResult},
+    emu::{EmuError, Emulator, MemAccessInfo, SyscallHookResult},
     helper::{QemuHelper, QemuHelperTuple, QemuInstrumentationFilter},
     hooks::QemuHooks,
     GuestAddr,
@@ -454,8 +454,10 @@ impl AsanGiovese {
 
 static mut ASAN_INITED: bool = false;
 
-pub fn init_with_asan(args: &mut Vec<String>, env: &mut [(String, String)]) -> Emulator {
-    assert!(!args.is_empty());
+pub fn init_with_asan(
+    args: &mut Vec<String>,
+    env: &mut [(String, String)],
+) -> Result<Emulator, EmuError> {
     let current = env::current_exe().unwrap();
     let asan_lib = fs::canonicalize(current)
         .unwrap()


### PR DESCRIPTION
Libraries should not `assert!` except in cases of unrecoverable (library) programmer error. These errors are all potentially recoverable, and aren't internal errors in `libafl_qemu` itself.