### PR TITLE
UTF-8 input and mutations

### DIFF
--- a/libafl/src/inputs/convert.rs
+++ b/libafl/src/inputs/convert.rs
@@ -1,0 +1,10 @@
+pub trait ConvertInput<I> {
+    type Error;
+    fn convert_from(i: I) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+pub trait ConvertInputLossy<I> {
+    fn lossy_convert_from(i: I) -> Self;
+}

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -12,6 +12,9 @@ pub use gramatron::*;
 pub mod generalized;
 pub use generalized::*;
 
+pub mod utf8;
+pub use utf8::Utf8Input;
+
 #[cfg(feature = "nautilus")]
 pub mod nautilus;
 use alloc::{

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -3,6 +3,9 @@
 pub mod bytes;
 pub use bytes::BytesInput;
 
+pub mod convert;
+pub use convert::{ConvertInput, ConvertInputLossy};
+
 pub mod encoded;
 pub use encoded::*;
 

--- a/libafl/src/inputs/utf8.rs
+++ b/libafl/src/inputs/utf8.rs
@@ -1,0 +1,91 @@
+//! UTF-8 string input
+
+use alloc::{borrow::ToOwned, rc::Rc, string::String};
+use core::{
+    cell::RefCell,
+    convert::From,
+    hash::{BuildHasher, Hasher},
+};
+#[cfg(feature = "std")]
+use std::{fs, path::Path};
+
+use ahash::RandomState;
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "std")]
+use crate::{bolts::fs::write_file_atomic, Error};
+use crate::{bolts::HasLen, inputs::Input};
+
+/// A UTF-8 string
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Utf8Input {
+    /// The raw input string
+    pub(crate) string: String,
+}
+
+impl Input for Utf8Input {
+    #[cfg(feature = "std")]
+    /// Write this input to the file
+    fn to_file<P>(&self, path: P) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+    {
+        write_file_atomic(path, self.string.as_bytes())
+    }
+
+    /// Load the content of this input from a file
+    #[cfg(feature = "std")]
+    fn from_file<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(Utf8Input::new(fs::read_to_string(path)?))
+    }
+
+    /// Generate a name for this input
+    fn generate_name(&self, _idx: usize) -> String {
+        let mut hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
+        hasher.write(self.string.as_bytes());
+        format!("{:016x}", hasher.finish())
+    }
+}
+
+/// Rc Ref-cell from Input
+impl From<Utf8Input> for Rc<RefCell<Utf8Input>> {
+    fn from(input: Utf8Input) -> Self {
+        Rc::new(RefCell::new(input))
+    }
+}
+
+impl HasLen for Utf8Input {
+    #[inline]
+    fn len(&self) -> usize {
+        self.string.len()
+    }
+}
+
+impl From<String> for Utf8Input {
+    fn from(string: String) -> Self {
+        Self::new(string)
+    }
+}
+
+impl From<&str> for Utf8Input {
+    fn from(string: &str) -> Self {
+        Self::new(string.to_owned())
+    }
+}
+
+impl From<Utf8Input> for String {
+    fn from(value: Utf8Input) -> String {
+        value.string
+    }
+}
+
+impl Utf8Input {
+    /// Creates a new string input using the given string
+    #[must_use]
+    pub fn new(string: String) -> Self {
+        Self { string }
+    }
+}

--- a/libafl/src/inputs/utf8.rs
+++ b/libafl/src/inputs/utf8.rs
@@ -14,7 +14,13 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use crate::{bolts::fs::write_file_atomic, Error};
-use crate::{bolts::HasLen, inputs::Input};
+use crate::{
+    bolts::HasLen,
+    inputs::{
+        convert::{ConvertInput, ConvertInputLossy},
+        BytesInput, HasBytesVec, Input,
+    },
+};
 
 /// A UTF-8 string
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -86,6 +92,22 @@ impl Utf8Input {
     /// Creates a new string input using the given string
     #[must_use]
     pub fn new(string: String) -> Self {
+        Self { string }
+    }
+}
+
+impl ConvertInput<BytesInput> for Utf8Input {
+    type Error = std::string::FromUtf8Error;
+
+    fn convert_from(i: BytesInput) -> Result<Self, Self::Error> {
+        let string = String::from_utf8(i.bytes().to_vec())?;
+        Ok(Self { string })
+    }
+}
+
+impl ConvertInputLossy<BytesInput> for Utf8Input {
+    fn lossy_convert_from(i: BytesInput) -> Self {
+        let string = String::from(String::from_utf8_lossy(i.bytes()));
         Self { string }
     }
 }

--- a/libafl/src/mutators/convert.rs
+++ b/libafl/src/mutators/convert.rs
@@ -1,0 +1,45 @@
+use core::marker::PhantomData;
+
+use crate::{
+    inputs::convert::ConvertInput,
+    mutators::{MutationResult, Mutator},
+    Error,
+};
+
+#[derive(Debug)]
+pub struct ConvertMutator<I, J, S, M>
+where
+    I: Default + ConvertInput<J>,
+    J: for<'a> ConvertInput<&'a I>,
+    M: Mutator<J, S>,
+{
+    mutator: M,
+    phantom: PhantomData<(I, J, S)>,
+}
+
+impl<I, J, S, M> Mutator<I, S> for ConvertMutator<I, J, S, M>
+where
+    I: Default + ConvertInput<J>,
+    J: for<'a> ConvertInput<&'a I>,
+    M: Mutator<J, S>,
+{
+    fn mutate(
+        &mut self,
+        state: &mut S,
+        input: &mut I,
+        stage_idx: i32,
+    ) -> Result<MutationResult, Error> {
+        let converted = if let Ok(mut j) = J::convert_from(&input) {
+            self.mutator.mutate(state, &mut j, stage_idx)?;
+            I::convert_from(j).ok()
+        } else {
+            None
+        };
+        if let Some(converted) = converted {
+            *input = converted;
+            Ok(MutationResult::Mutated)
+        } else {
+            Ok(MutationResult::Skipped)
+        }
+    }
+}

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -19,6 +19,8 @@ pub mod grimoire;
 pub use grimoire::*;
 pub mod tuneable;
 pub use tuneable::*;
+pub mod utf8;
+pub use utf8::*;
 
 #[cfg(feature = "nautilus")]
 pub mod nautilus;

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -21,6 +21,8 @@ pub mod tuneable;
 pub use tuneable::*;
 pub mod utf8;
 pub use utf8::*;
+pub mod convert;
+pub use convert::*;
 
 #[cfg(feature = "nautilus")]
 pub mod nautilus;

--- a/libafl/src/mutators/utf8.rs
+++ b/libafl/src/mutators/utf8.rs
@@ -1,0 +1,203 @@
+//! Mutations for UTF-8 inputs ([`Utf8Input`]).
+
+use alloc::string::String;
+
+use crate::{
+    bolts::{rands::Rand, tuples::Named},
+    inputs::utf8::Utf8Input,
+    mutators::{
+        mutations::{buffer_copy, buffer_self_copy, rand_range},
+        MutationResult, Mutator,
+    },
+    state::{HasMaxSize, HasRand},
+    Error,
+};
+
+/// Like https://doc.rust-lang.org/std/string/struct.String.html#method.floor_char_boundary
+fn floor_char_boundary(s: &str, mut idx: usize) -> usize {
+    debug_assert!(idx <= s.len());
+    // note: 0 is always a char boundary
+    while !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
+/// Delete a chunk of characters.
+///
+/// Compare to [`crate::mtuators::mutations::BytesDeleteMutator`].
+#[derive(Default, Debug)]
+pub struct Utf8DeleteMutator;
+
+impl<S> Mutator<Utf8Input, S> for Utf8DeleteMutator
+where
+    S: HasRand,
+{
+    fn mutate(
+        &mut self,
+        state: &mut S,
+        input: &mut Utf8Input,
+        _stage_idx: i32,
+    ) -> Result<MutationResult, Error> {
+        let size = input.string.len();
+        if size <= 2 {
+            return Ok(MutationResult::Skipped);
+        }
+
+        let mut range = rand_range(state, size, size);
+        range.start = floor_char_boundary(&input.string, range.start);
+        range.end = floor_char_boundary(&input.string, range.end);
+        if range.start == range.end {
+            return Ok(MutationResult::Skipped);
+        }
+
+        input.string.drain(range);
+        Ok(MutationResult::Mutated)
+    }
+}
+
+impl Named for Utf8DeleteMutator {
+    fn name(&self) -> &str {
+        "Utf8DeleteMutator"
+    }
+}
+
+/// Pick a random character from the input and insert it.
+///
+/// Compare to [`crate::mtuators::mutations::BytesInsertMutator`].
+#[derive(Default, Debug)]
+pub struct Utf8InsertMutator;
+
+impl<S> Mutator<Utf8Input, S> for Utf8InsertMutator
+where
+    S: HasRand + HasMaxSize,
+{
+    fn mutate(
+        &mut self,
+        state: &mut S,
+        input: &mut Utf8Input,
+        _stage_idx: i32,
+    ) -> Result<MutationResult, Error> {
+        let max_size = state.max_size();
+        let size = input.string.len();
+        if size == 0 || size >= max_size {
+            return Ok(MutationResult::Skipped);
+        }
+
+        let mut amount = 1 + state.rand_mut().below(16) as usize;
+        let mut offset = state.rand_mut().below(size as u64 + 1) as usize;
+        offset = floor_char_boundary(&input.string, offset);
+
+        if size + amount > max_size {
+            if max_size > size {
+                amount = max_size - size;
+            } else {
+                return Ok(MutationResult::Skipped);
+            }
+        }
+
+        let chars = input.string.chars().count();
+        let val = input
+            .string
+            .chars()
+            .nth(state.rand_mut().below(chars as u64) as usize)
+            .unwrap();
+
+        let inserted_bytes = val.len_utf8() * amount;
+        let mut repeated = String::with_capacity(inserted_bytes);
+        for _ in 0..amount {
+            repeated.push(val);
+        }
+
+        unsafe {
+            let vec = input.string.as_mut_vec();
+            vec.resize(size + inserted_bytes, 0);
+            buffer_self_copy(vec, offset, offset + inserted_bytes, size - offset);
+            buffer_copy(vec, repeated.as_bytes(), 0, offset, repeated.len());
+        }
+
+        Ok(MutationResult::Mutated)
+    }
+}
+
+impl Named for Utf8InsertMutator {
+    fn name(&self) -> &str {
+        "Utf8InsertMutator"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        alloc::string::ToString,
+        bolts::{
+            rands::StdRand,
+            tuples::{tuple_list, HasConstLen},
+        },
+        corpus::{Corpus, InMemoryCorpus},
+        feedbacks::ConstFeedback,
+        inputs::utf8::Utf8Input,
+        mutators::MutatorsTuple,
+        state::{HasCorpus, HasMetadata, StdState},
+    };
+
+    fn test_utf8_mutations<S>() -> impl MutatorsTuple<Utf8Input, S>
+    where
+        S: HasRand + HasMetadata + HasMaxSize,
+    {
+        tuple_list!(Utf8DeleteMutator::default(), Utf8InsertMutator::default())
+    }
+
+    fn test_state() -> impl HasCorpus + HasMetadata + HasRand + HasMaxSize {
+        let rand = StdRand::with_seed(1337);
+        let mut corpus = InMemoryCorpus::new();
+
+        let mut feedback = ConstFeedback::new(false);
+        let mut objective = ConstFeedback::new(false);
+
+        corpus
+            .add(Utf8Input::new("hello, world!".to_string()).into())
+            .unwrap();
+
+        StdState::new(
+            rand,
+            corpus,
+            InMemoryCorpus::new(),
+            &mut feedback,
+            &mut objective,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // testing all mutators would be good but is way too slow. :/
+    fn test_utf8_mutators() {
+        let mut inputs = vec![
+            Utf8Input::new("hello".to_string()),
+            Utf8Input::new("LibAFL".to_string()),
+            Utf8Input::new("0xbad1dea".to_string()),
+        ];
+
+        let mut state = test_state();
+
+        let mut mutations = test_utf8_mutations();
+
+        for _ in 0..2 {
+            let mut new_testcases = vec![];
+            for idx in 0..mutations.len() {
+                for input in &inputs {
+                    let mut mutant = input.clone();
+                    match mutations
+                        .get_and_mutate(idx.into(), &mut state, &mut mutant, 0)
+                        .unwrap()
+                    {
+                        MutationResult::Mutated => new_testcases.push(mutant),
+                        MutationResult::Skipped => (),
+                    };
+                }
+            }
+            inputs.append(&mut new_testcases);
+        }
+    }
+}


### PR DESCRIPTION
A lot of programs take UTF-8 strings as input, and byte-level mutations will often result in invalid UTF-8 that gets rejected very early in the program. Mutations that only produce valid UTF-8 strings are correspondingly more likely to find interesting behavior in such targets.

This could use some additional mutations and additional tests, but for now I just wanted to gauge interest in having this in LibAFL.