### PR TITLE
libafl: Mark `buffer_{self_,}copy` as unsafe, don't export them

### DIFF
--- a/libafl/src/mutators/encoded_mutations.rs
+++ b/libafl/src/mutators/encoded_mutations.rs
@@ -241,10 +241,12 @@ where
 
         input.codes_mut().resize(size + len, 0);
         self.tmp_buf.resize(len, 0);
-        buffer_copy(&mut self.tmp_buf, input.codes(), from, 0, len);
+        unsafe {
+            buffer_copy(&mut self.tmp_buf, input.codes(), from, 0, len);
 
-        buffer_self_copy(input.codes_mut(), off, off + len, size - off);
-        buffer_copy(input.codes_mut(), &self.tmp_buf, 0, off, len);
+            buffer_self_copy(input.codes_mut(), off, off + len, size - off);
+            buffer_copy(input.codes_mut(), &self.tmp_buf, 0, off, len);
+        };
 
         Ok(MutationResult::Mutated)
     }
@@ -284,7 +286,9 @@ impl<S: HasRand> Mutator<EncodedInput, S> for EncodedCopyMutator {
         let to = state.rand_mut().below(size as u64) as usize;
         let len = 1 + state.rand_mut().below((size - max(from, to)) as u64) as usize;
 
-        buffer_self_copy(input.codes_mut(), from, to, len);
+        unsafe {
+            buffer_self_copy(input.codes_mut(), from, to, len);
+        }
 
         Ok(MutationResult::Mutated)
     }
@@ -356,8 +360,10 @@ where
         }
 
         input.codes_mut().resize(size + len, 0);
-        buffer_self_copy(input.codes_mut(), to, to + len, size - to);
-        buffer_copy(input.codes_mut(), other.codes(), from, to, len);
+        unsafe {
+            buffer_self_copy(input.codes_mut(), to, to + len, size - to);
+            buffer_copy(input.codes_mut(), other.codes(), from, to, len);
+        }
 
         Ok(MutationResult::Mutated)
     }
@@ -422,7 +428,9 @@ where
         let mut other_testcase = state.corpus().get(idx)?.borrow_mut();
         let other = other_testcase.load_input()?;
 
-        buffer_copy(input.codes_mut(), other.codes(), from, to, len);
+        unsafe {
+            buffer_copy(input.codes_mut(), other.codes(), from, to, len);
+        }
 
         Ok(MutationResult::Mutated)
     }

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -15,7 +15,7 @@ use crate::{
 
 /// Mem move in the own vec
 #[inline]
-pub fn buffer_self_copy<T>(data: &mut [T], from: usize, to: usize, len: usize) {
+pub(crate) unsafe fn buffer_self_copy<T>(data: &mut [T], from: usize, to: usize, len: usize) {
     debug_assert!(!data.is_empty());
     debug_assert!(from + len <= data.len());
     debug_assert!(to + len <= data.len());
@@ -29,7 +29,7 @@ pub fn buffer_self_copy<T>(data: &mut [T], from: usize, to: usize, len: usize) {
 
 /// Mem move between vecs
 #[inline]
-pub fn buffer_copy<T>(dst: &mut [T], src: &[T], from: usize, to: usize, len: usize) {
+pub(crate) unsafe fn buffer_copy<T>(dst: &mut [T], src: &[T], from: usize, to: usize, len: usize) {
     debug_assert!(!dst.is_empty());
     debug_assert!(!src.is_empty());
     debug_assert!(from + len <= src.len());
@@ -538,12 +538,14 @@ where
         let range = rand_range(state, size, min(16, max_size - size));
 
         input.bytes_mut().resize(size + range.len(), 0);
-        buffer_self_copy(
-            input.bytes_mut(),
-            range.start,
-            range.start + range.len(),
-            size - range.start,
-        );
+        unsafe {
+            buffer_self_copy(
+                input.bytes_mut(),
+                range.start,
+                range.start + range.len(),
+                size - range.start,
+            );
+        }
 
         Ok(MutationResult::Mutated)
     }
@@ -598,7 +600,9 @@ where
         let val = input.bytes()[state.rand_mut().below(size as u64) as usize];
 
         input.bytes_mut().resize(size + amount, 0);
-        buffer_self_copy(input.bytes_mut(), offset, offset + amount, size - offset);
+        unsafe {
+            buffer_self_copy(input.bytes_mut(), offset, offset + amount, size - offset);
+        }
         buffer_set(input.bytes_mut(), offset, amount, val);
 
         Ok(MutationResult::Mutated)
@@ -654,7 +658,9 @@ where
         let val = state.rand_mut().next() as u8;
 
         input.bytes_mut().resize(size + amount, 0);
-        buffer_self_copy(input.bytes_mut(), offset, offset + amount, size - offset);
+        unsafe {
+            buffer_self_copy(input.bytes_mut(), offset, offset + amount, size - offset);
+        }
         buffer_set(input.bytes_mut(), offset, amount, val);
 
         Ok(MutationResult::Mutated)
@@ -784,7 +790,9 @@ where
         let target = state.rand_mut().below(size as u64) as usize;
         let range = rand_range(state, size, size - target);
 
-        buffer_self_copy(input.bytes_mut(), range.start, target, range.len());
+        unsafe {
+            buffer_self_copy(input.bytes_mut(), range.start, target, range.len());
+        }
 
         Ok(MutationResult::Mutated)
     }
@@ -833,21 +841,23 @@ where
 
         input.bytes_mut().resize(size + range.len(), 0);
         self.tmp_buf.resize(range.len(), 0);
-        buffer_copy(
-            &mut self.tmp_buf,
-            input.bytes(),
-            range.start,
-            0,
-            range.len(),
-        );
+        unsafe {
+            buffer_copy(
+                &mut self.tmp_buf,
+                input.bytes(),
+                range.start,
+                0,
+                range.len(),
+            );
 
-        buffer_self_copy(
-            input.bytes_mut(),
-            target,
-            target + range.len(),
-            size - target,
-        );
-        buffer_copy(input.bytes_mut(), &self.tmp_buf, 0, target, range.len());
+            buffer_self_copy(
+                input.bytes_mut(),
+                target,
+                target + range.len(),
+                size - target,
+            );
+            buffer_copy(input.bytes_mut(), &self.tmp_buf, 0, target, range.len());
+        }
         Ok(MutationResult::Mutated)
     }
 }
@@ -895,79 +905,81 @@ where
 
             let second = rand_range(state, first.start, first.start);
             self.tmp_buf.resize(first.len(), 0);
-            // If range first is larger
-            if first.len() >= second.len() {
-                let diff_in_size = first.len() - second.len();
+            unsafe {
+                // If range first is larger
+                if first.len() >= second.len() {
+                    let diff_in_size = first.len() - second.len();
 
-                // copy first range to tmp
-                buffer_copy(
-                    &mut self.tmp_buf,
-                    input.bytes(),
-                    first.start,
-                    0,
-                    first.len(),
-                );
+                    // copy first range to tmp
+                    buffer_copy(
+                        &mut self.tmp_buf,
+                        input.bytes(),
+                        first.start,
+                        0,
+                        first.len(),
+                    );
 
-                // adjust second.end..first.start, move them by diff_in_size to the right
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    second.end,
-                    second.end + diff_in_size,
-                    first.start - second.end,
-                );
+                    // adjust second.end..first.start, move them by diff_in_size to the right
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        second.end,
+                        second.end + diff_in_size,
+                        first.start - second.end,
+                    );
 
-                // copy second to where first was
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    second.start,
-                    first.start + diff_in_size,
-                    second.len(),
-                );
+                    // copy second to where first was
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        second.start,
+                        first.start + diff_in_size,
+                        second.len(),
+                    );
 
-                // copy first back
-                buffer_copy(
-                    input.bytes_mut(),
-                    &self.tmp_buf,
-                    0,
-                    second.start,
-                    first.len(),
-                );
-            } else {
-                let diff_in_size = second.len() - first.len();
+                    // copy first back
+                    buffer_copy(
+                        input.bytes_mut(),
+                        &self.tmp_buf,
+                        0,
+                        second.start,
+                        first.len(),
+                    );
+                } else {
+                    let diff_in_size = second.len() - first.len();
 
-                // copy first range to tmp
-                buffer_copy(
-                    &mut self.tmp_buf,
-                    input.bytes(),
-                    first.start,
-                    0,
-                    first.len(),
-                );
+                    // copy first range to tmp
+                    buffer_copy(
+                        &mut self.tmp_buf,
+                        input.bytes(),
+                        first.start,
+                        0,
+                        first.len(),
+                    );
 
-                // adjust second.end..first.start, move them by diff_in_size to the left
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    second.end,
-                    second.end - diff_in_size,
-                    first.start - second.end,
-                );
+                    // adjust second.end..first.start, move them by diff_in_size to the left
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        second.end,
+                        second.end - diff_in_size,
+                        first.start - second.end,
+                    );
 
-                // copy second to where first was
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    second.start,
-                    first.start - diff_in_size,
-                    second.len(),
-                );
+                    // copy second to where first was
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        second.start,
+                        first.start - diff_in_size,
+                        second.len(),
+                    );
 
-                // copy first back
-                buffer_copy(
-                    input.bytes_mut(),
-                    &self.tmp_buf,
-                    0,
-                    second.start,
-                    first.len(),
-                );
+                    // copy first back
+                    buffer_copy(
+                        input.bytes_mut(),
+                        &self.tmp_buf,
+                        0,
+                        second.start,
+                        first.len(),
+                    );
+                }
             }
             Ok(MutationResult::Mutated)
         } else if first.end != size {
@@ -977,76 +989,78 @@ where
             second.end += first.end;
 
             self.tmp_buf.resize(second.len(), 0);
-            if second.len() >= first.len() {
-                let diff_in_size = second.len() - first.len();
-                // copy second range to tmp
-                buffer_copy(
-                    &mut self.tmp_buf,
-                    input.bytes(),
-                    second.start,
-                    0,
-                    second.len(),
-                );
+            unsafe {
+                if second.len() >= first.len() {
+                    let diff_in_size = second.len() - first.len();
+                    // copy second range to tmp
+                    buffer_copy(
+                        &mut self.tmp_buf,
+                        input.bytes(),
+                        second.start,
+                        0,
+                        second.len(),
+                    );
 
-                // adjust first.end..second.start, move them by diff_in_size to the right
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    first.end,
-                    first.end + diff_in_size,
-                    second.start - first.end,
-                );
+                    // adjust first.end..second.start, move them by diff_in_size to the right
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        first.end,
+                        first.end + diff_in_size,
+                        second.start - first.end,
+                    );
 
-                // copy first to where second was
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    first.start,
-                    second.start + diff_in_size,
-                    first.len(),
-                );
+                    // copy first to where second was
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        first.start,
+                        second.start + diff_in_size,
+                        first.len(),
+                    );
 
-                // copy second back
-                buffer_copy(
-                    input.bytes_mut(),
-                    &self.tmp_buf,
-                    0,
-                    first.start,
-                    second.len(),
-                );
-            } else {
-                let diff_in_size = first.len() - second.len();
-                // copy second range to tmp
-                buffer_copy(
-                    &mut self.tmp_buf,
-                    input.bytes(),
-                    second.start,
-                    0,
-                    second.len(),
-                );
+                    // copy second back
+                    buffer_copy(
+                        input.bytes_mut(),
+                        &self.tmp_buf,
+                        0,
+                        first.start,
+                        second.len(),
+                    );
+                } else {
+                    let diff_in_size = first.len() - second.len();
+                    // copy second range to tmp
+                    buffer_copy(
+                        &mut self.tmp_buf,
+                        input.bytes(),
+                        second.start,
+                        0,
+                        second.len(),
+                    );
 
-                // adjust first.end..second.start, move them by diff_in_size to the left
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    first.end,
-                    first.end - diff_in_size,
-                    second.start - first.end,
-                );
+                    // adjust first.end..second.start, move them by diff_in_size to the left
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        first.end,
+                        first.end - diff_in_size,
+                        second.start - first.end,
+                    );
 
-                // copy first to where second was
-                buffer_self_copy(
-                    input.bytes_mut(),
-                    first.start,
-                    second.start - diff_in_size,
-                    first.len(),
-                );
+                    // copy first to where second was
+                    buffer_self_copy(
+                        input.bytes_mut(),
+                        first.start,
+                        second.start - diff_in_size,
+                        first.len(),
+                    );
 
-                // copy second back
-                buffer_copy(
-                    input.bytes_mut(),
-                    &self.tmp_buf,
-                    0,
-                    first.start,
-                    second.len(),
-                );
+                    // copy second back
+                    buffer_copy(
+                        input.bytes_mut(),
+                        &self.tmp_buf,
+                        0,
+                        first.start,
+                        second.len(),
+                    );
+                }
             }
 
             Ok(MutationResult::Mutated)
@@ -1118,19 +1132,21 @@ where
         let other = other_testcase.load_input()?;
 
         input.bytes_mut().resize(size + range.len(), 0);
-        buffer_self_copy(
-            input.bytes_mut(),
-            target,
-            target + range.len(),
-            size - target,
-        );
-        buffer_copy(
-            input.bytes_mut(),
-            other.bytes(),
-            range.start,
-            target,
-            range.len(),
-        );
+        unsafe {
+            buffer_self_copy(
+                input.bytes_mut(),
+                target,
+                target + range.len(),
+                size - target,
+            );
+            buffer_copy(
+                input.bytes_mut(),
+                other.bytes(),
+                range.start,
+                target,
+                range.len(),
+            );
+        }
         Ok(MutationResult::Mutated)
     }
 }
@@ -1194,13 +1210,15 @@ where
         let mut other_testcase = state.corpus().get(idx)?.borrow_mut();
         let other = other_testcase.load_input()?;
 
-        buffer_copy(
-            input.bytes_mut(),
-            other.bytes(),
-            range.start,
-            target,
-            range.len(),
-        );
+        unsafe {
+            buffer_copy(
+                input.bytes_mut(),
+                other.bytes(),
+                range.start,
+                target,
+                range.len(),
+            );
+        }
         Ok(MutationResult::Mutated)
     }
 }

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -329,8 +329,10 @@ where
         }
 
         input.bytes_mut().resize(size + len, 0);
-        buffer_self_copy(input.bytes_mut(), off, off + len, size - off);
-        buffer_copy(input.bytes_mut(), token, 0, off, len);
+        unsafe {
+            buffer_self_copy(input.bytes_mut(), off, off + len, size - off);
+            buffer_copy(input.bytes_mut(), token, 0, off, len);
+        }
 
         Ok(MutationResult::Mutated)
     }
@@ -392,7 +394,9 @@ where
             len = size - off;
         }
 
-        buffer_copy(input.bytes_mut(), token, 0, off, len);
+        unsafe {
+            buffer_copy(input.bytes_mut(), token, 0, off, len);
+        }
 
         Ok(MutationResult::Mutated)
     }
@@ -560,7 +564,9 @@ where
                     let mut size = core::cmp::min(v.0.len(), len - i);
                     while size != 0 {
                         if v.0[0..size] == input.bytes()[i..i + size] {
-                            buffer_copy(input.bytes_mut(), &v.1, 0, i, size);
+                            unsafe {
+                                buffer_copy(input.bytes_mut(), &v.1, 0, i, size);
+                            }
                             result = MutationResult::Mutated;
                             break 'outer;
                         }
@@ -569,7 +575,9 @@ where
                     size = core::cmp::min(v.1.len(), len - i);
                     while size != 0 {
                         if v.1[0..size] == input.bytes()[i..i + size] {
-                            buffer_copy(input.bytes_mut(), &v.0, 0, i, size);
+                            unsafe {
+                                buffer_copy(input.bytes_mut(), &v.0, 0, i, size);
+                            }
                             result = MutationResult::Mutated;
                             break 'outer;
                         }
@@ -1037,7 +1045,9 @@ impl AFLppRedQueen {
         }
 
         if copy_len > 0 {
-            buffer_copy(buf, repl, 0, buf_idx, copy_len);
+            unsafe {
+                buffer_copy(buf, repl, 0, buf_idx, copy_len);
+            }
             true
         } else {
             false

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -202,13 +202,15 @@ where
                 let range_start = r.start;
                 let range_end = r.end;
                 let copy_len = r.len();
-                buffer_copy(
-                    input.bytes_mut(),
-                    changed.bytes(),
-                    range_start,
-                    range_start,
-                    copy_len,
-                );
+                unsafe {
+                    buffer_copy(
+                        input.bytes_mut(),
+                        changed.bytes(),
+                        range_start,
+                        range_start,
+                        copy_len,
+                    );
+                }
 
                 let consumed_input = input.clone();
                 let changed_hash = Self::get_raw_map_hash_run(
@@ -229,13 +231,15 @@ where
                     // Seems like this range is too big that we can't keep the original hash anymore
 
                     // Revert the changes
-                    buffer_copy(
-                        input.bytes_mut(),
-                        backup.bytes(),
-                        range_start,
-                        range_start,
-                        copy_len,
-                    );
+                    unsafe {
+                        buffer_copy(
+                            input.bytes_mut(),
+                            backup.bytes(),
+                            range_start,
+                            range_start,
+                            copy_len,
+                        );
+                    }
 
                     // Add smaller range
                     if copy_len > 1 {


### PR DESCRIPTION
Fixes #1206 