### PR TITLE
switch sancov_8bit.rs to use OwnedMutSlice

### DIFF
--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -1,15 +1,20 @@
 //! [`LLVM` `8-bi-counters`](https://clang.llvm.org/docs/SanitizerCoverage.html#tracing-pcs-with-guards) runtime for `LibAFL`.
 use alloc::vec::Vec;
-use core::slice::from_raw_parts_mut;
+use libafl::bolts::ownedref::OwnedMutSlice;
 
 /// A [`Vec`] of `8-bit-counters` maps for multiple modules.
 /// They are initialized by calling [`__sanitizer_cov_8bit_counters_init`](
-pub static mut COUNTERS_MAPS: Vec<&'static mut [u8]> = Vec::new();
+pub static mut COUNTERS_MAPS: Vec<OwnedMutSlice<'static, u8>> = Vec::new();
 
 /// Initialize the sancov `8-bit-counters` - usually called by `llvm`.
 #[no_mangle]
 #[allow(clippy::cast_sign_loss)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn __sanitizer_cov_8bit_counters_init(start: *mut u8, stop: *mut u8) {
-    unsafe { COUNTERS_MAPS.push(from_raw_parts_mut(start, stop.offset_from(start) as usize)) }
+    unsafe {
+        COUNTERS_MAPS.push(OwnedMutSlice::from_raw_parts_mut(
+            start,
+            stop.offset_from(start) as usize,
+        ));
+    }
 }


### PR DESCRIPTION
Not sure, but shouldn't `sancov_8bit` use the `OwnedMutSlice` type such that it can be used with the `MultiMapObserver`?