### PR TITLE
Change DumpToDiskStage's callback

### DIFF
--- a/libafl/src/stages/dump.rs
+++ b/libafl/src/stages/dump.rs
@@ -41,7 +41,7 @@ where
 
 impl<CB, E, EM, Z> Stage<E, EM, Z> for DumpToDiskStage<CB, EM, Z>
 where
-    CB: FnMut(&<Z::State as UsesInput>::Input) -> Vec<u8>,
+    CB: FnMut(&<Z::State as UsesInput>::Input, &Z::State) -> Vec<u8>,
     EM: UsesState<State = Z::State>,
     E: UsesState<State = Z::State>,
     Z: UsesState,
@@ -69,7 +69,7 @@ where
         while let Some(i) = corpus_idx {
             let mut testcase = state.corpus().get(i)?.borrow_mut();
             state.corpus().load_input_into(&mut testcase)?;
-            let bytes = (self.to_bytes)(testcase.input().as_ref().unwrap());
+            let bytes = (self.to_bytes)(testcase.input().as_ref().unwrap(), state);
 
             let fname = self.corpus_dir.join(format!(
                 "id_{i}_{}",
@@ -87,7 +87,7 @@ where
         while let Some(i) = solutions_idx {
             let mut testcase = state.solutions().get(i)?.borrow_mut();
             state.solutions().load_input_into(&mut testcase)?;
-            let bytes = (self.to_bytes)(testcase.input().as_ref().unwrap());
+            let bytes = (self.to_bytes)(testcase.input().as_ref().unwrap(), state);
 
             let fname = self.solutions_dir.join(format!(
                 "id_{i}_{}",
@@ -113,7 +113,6 @@ where
 
 impl<CB, EM, Z> DumpToDiskStage<CB, EM, Z>
 where
-    CB: FnMut(&<Z::State as UsesInput>::Input) -> Vec<u8>,
     EM: UsesState<State = Z::State>,
     Z: UsesState,
     Z::State: HasCorpus + HasSolutions + HasRand + HasMetadata,


### PR DESCRIPTION
I need to access to the `state` inside the callback of DumpToDiskStage.

Else I can't implement this
https://github.com/AFLplusplus/libafl_fuzzbench/blob/main/grimoire/src/lib.rs#L451
because now there's no GeneralizedInput and BytesInput has no generalized() method