### PR TITLE
Ignore 'Broken Pipe' if child process does not read all of stdin

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -139,11 +139,9 @@ impl CommandConfigurator for StdCommandConfigurator {
                     if err.kind() != std::io::ErrorKind::BrokenPipe {
                         return Err(err.into());
                     }
-                } else {
-                    if let Err(err) = stdin.flush() {
-                        if err.kind() != std::io::ErrorKind::BrokenPipe {
-                            return Err(err.into());
-                        }
+                } else if let Err(err) = stdin.flush() {
+                    if err.kind() != std::io::ErrorKind::BrokenPipe {
+                        return Err(err.into());
                     }
                 }
                 drop(stdin);


### PR DESCRIPTION
Avoid the fuzzer from getting killed if the child process closes the other end of the pipe before the fuzzer has finished writing to it.
I'm not sure if this is an idiomatic way to do this or if this signal should be handled at the global level.