### PR TITLE
Add check for if mutations were skipped to MutationalStages

### DIFF
--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -11,7 +11,7 @@ use crate::{
     fuzzer::Evaluator,
     inputs::Input,
     mark_feature_time,
-    mutators::Mutator,
+    mutators::{MutationResult, Mutator},
     stages::Stage,
     start_timer,
     state::{HasClientPerfMonitor, HasCorpus, HasRand, UsesState},
@@ -127,8 +127,12 @@ where
             let mut input = input.clone();
 
             start_timer!(state);
-            self.mutator_mut().mutate(state, &mut input, i as i32)?;
+            let mutated = self.mutator_mut().mutate(state, &mut input, i as i32)?;
             mark_feature_time!(state, PerfFeature::Mutate);
+
+            if mutated == MutationResult::Skipped {
+                continue;
+            }
 
             // Time is measured directly the `evaluate_input` function
             let (untransformed, post) = input.try_transform_into(state)?;

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -19,7 +19,7 @@ use crate::{
     feedbacks::{Feedback, FeedbackFactory, HasObserverName},
     inputs::UsesInput,
     mark_feature_time,
-    mutators::Mutator,
+    mutators::{MutationResult, Mutator},
     observers::{MapObserver, ObserversTuple},
     schedulers::{RemovableScheduler, Scheduler},
     stages::Stage,
@@ -97,8 +97,12 @@ where
             state.set_max_size(before_len);
 
             start_timer!(state);
-            self.mutator_mut().mutate(state, &mut input, i as i32)?;
+            let mutated = self.mutator_mut().mutate(state, &mut input, i as i32)?;
             mark_feature_time!(state, PerfFeature::Mutate);
+
+            if mutated == MutationResult::Skipped {
+                continue;
+            }
 
             let corpus_idx = if input.len() < before_len {
                 // run the input

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -10,7 +10,7 @@ use crate::{
     bolts::{current_time, rands::Rand},
     corpus::{Corpus, CorpusId},
     impl_serdeany, mark_feature_time,
-    mutators::Mutator,
+    mutators::{MutationResult, Mutator},
     stages::{
         mutational::{MutatedTransform, MutatedTransformPost, DEFAULT_MUTATIONAL_MAX_ITERATIONS},
         MutationalStage, Stage,
@@ -142,8 +142,12 @@ where
             let mut input = input.clone();
 
             start_timer!(state);
-            self.mutator_mut().mutate(state, &mut input, i as i32)?;
+            let mutated = self.mutator_mut().mutate(state, &mut input, i as i32)?;
             mark_feature_time!(state, PerfFeature::Mutate);
+
+            if mutated == MutationResult::Skipped {
+                continue;
+            }
 
             // Time is measured directly the `evaluate_input` function
             let (untransformed, post) = input.try_transform_into(state)?;


### PR DESCRIPTION
Mutations may not actually be performed on the input, in which case the mutator will return MutationResult::Skipped. We should not execute mutants which have no difference from the parent. This especially affects slow-executing targets.