### PR TITLE
Make it possible to escape from simple event restarter

### DIFF
--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -506,6 +506,10 @@ where
 
                 compiler_fence(Ordering::SeqCst);
 
+                if staterestorer.wants_to_exit() {
+                    return Err(Error::shutting_down());
+                }
+
                 #[allow(clippy::manual_assert)]
                 if !staterestorer.has_content() {
                     #[cfg(unix)]


### PR DESCRIPTION
Does what it says on the tin. Allows you to do:

```rs
mgr.send_exiting()
```

To end the fuzzing campaign.