### PR TITLE
Give baby fuzzer listings unique package names

### DIFF
--- a/docs/listings/baby_fuzzer/listing-01/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-01/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_listing_01"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 edition = "2018"

--- a/docs/listings/baby_fuzzer/listing-02/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-02/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_listing_02"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 edition = "2018"

--- a/docs/listings/baby_fuzzer/listing-03/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-03/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_listing_03"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 edition = "2018"

--- a/docs/listings/baby_fuzzer/listing-04/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-04/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_listing_04"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 edition = "2018"

--- a/docs/listings/baby_fuzzer/listing-05/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-05/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_listing_05"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 edition = "2018"

--- a/docs/listings/baby_fuzzer/listing-06/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-06/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "baby_fuzzer"
+name = "baby_fuzzer_listing_06"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 edition = "2018"


### PR DESCRIPTION
As discussed in [#1305], it is problematic for the listings to have the same package name, as they cause warnings to be emitted.