### PR TITLE
Fixes offset math in Frida Offset Checks

### DIFF
--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -2416,7 +2416,7 @@ impl AsanRuntime {
                 }
                 X86Register::Rdi => {
                     // In this case rdi is already clobbered, so we want it from the stack (we pushed rdi onto stack before!)
-                    writer.put_mov_reg_reg_offset_ptr(X86Register::Rsi, X86Register::Rsp, -0x28);
+                    writer.put_mov_reg_reg_offset_ptr(X86Register::Rsi, X86Register::Rsp, 0x20);
                 }
                 X86Register::Rsp => {
                     // In this case rsp is also clobbered


### PR DESCRIPTION
I ran into an issue with a stack offset being incorrect for saved registers, in `emit_shadow_check`, in Frida mode, on x64.

In particular, the saved value for RDI is off, when it is used as the index register, and needs to be loaded from the stack.

```
Low mem addr 

|   rax    |   <-- rsp
|   rcx    |
|   rdx    |
|   rsi    |
|   rdi    |  < -- rsp + 0x20

High mem addr
```

This commit makes things work on my target, and seems to match the stack diagram I made while debugging the issue!

Thanks!