### PR TITLE
Add feature to build variants/configurations automatically, with libtool/cc/cxx shims

### DIFF
--- a/fuzzers/baby_fuzzer_swap_differential/src/bin/libafl_cc.rs
+++ b/fuzzers/baby_fuzzer_swap_differential/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/forkserver_libafl_cc/src/bin/libafl_cc.rs
+++ b/fuzzers/forkserver_libafl_cc/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses};
+use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/fuzzbench/src/bin/libafl_cc.rs
+++ b/fuzzers/fuzzbench/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses};
+use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses, ToolWrapper};
 
 pub fn main() {
     let mut args: Vec<String> = env::args().collect();

--- a/fuzzers/fuzzbench_text/src/bin/libafl_cc.rs
+++ b/fuzzers/fuzzbench_text/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses};
+use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libmozjpeg/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libmozjpeg/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_accounting/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses};
+use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses, ToolWrapper};
 
 const GRANULARITY: &str = "FUNC";
 

--- a/fuzzers/libfuzzer_libpng_centralized/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_centralized/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_cmin/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_cmin/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_ctx/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_ctx/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses};
+use libafl_cc::{ClangWrapper, CompilerWrapper, LLVMPasses, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_launcher/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_launcher/Makefile.toml
@@ -4,6 +4,7 @@ FUZZER_NAME='fuzzer_libpng_launcher'
 CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set = ["CARGO_TARGET_DIR"] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/release/libafl_cc'
 LIBAFL_CXX = '${CARGO_TARGET_DIR}/release/libafl_cxx'
+LIBAFL_LIBTOOL = '${CARGO_TARGET_DIR}/release/libafl_libtool'
 FUZZER = '${CARGO_TARGET_DIR}/release/${FUZZER_NAME}'
 PROJECT_DIR = { script = ["pwd"] }
 
@@ -57,7 +58,7 @@ script_runner="@shell"
 script='''
 cd libpng-1.6.37 && ./configure --enable-shared=no --with-pic=yes --enable-hardware-optimizations=yes
 cd "${PROJECT_DIR}"
-make -C libpng-1.6.37 CC="${CARGO_TARGET_DIR}/release/libafl_cc" CXX="${CARGO_TARGET_DIR}/release/libafl_cxx"
+make -C libpng-1.6.37 CC="${CARGO_TARGET_DIR}/release/libafl_cc" CXX="${CARGO_TARGET_DIR}/release/libafl_cxx" LIBTOOL=${CARGO_TARGET_DIR}/release/libafl_libtool
 '''
 dependencies = [ "libpng", "cxx", "cc" ]
 
@@ -82,7 +83,7 @@ windows_alias = "unsupported"
 [tasks.run_unix]
 script_runner = "@shell"
 script='''
-./${FUZZER_NAME} --cores 0 --input ./corpus
+./${FUZZER_NAME}.coverage --broker-port 21337 --cores 0 --input ./corpus
 '''
 dependencies = [ "fuzzer" ]
 
@@ -96,7 +97,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 11s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
+timeout 11s ./${FUZZER_NAME}.coverage --broker-port 21337 --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
 if [ -z "$(grep "corpus: 30" fuzz_stdout.log)" ]; then
     echo "Fuzzer does not generate any testcases or any crashes"
     exit 1

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_ar.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_ar.rs
@@ -1,0 +1,31 @@
+use std::env;
+
+use libafl_cc::{ArWrapper, Configuration, ToolWrapper};
+
+pub fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 {
+        let mut cc = ArWrapper::new();
+        if let Some(code) = cc
+            // silence the compiler wrapper output, needed for some configure scripts.
+            .silence(true)
+            .parse_args(&args)
+            .expect("Failed to parse the command line")
+            .add_configuration(Configuration::GenerateCoverageMap)
+            .add_configuration(Configuration::Compound(vec![
+                Configuration::GenerateCoverageMap,
+                Configuration::CmpLog,
+            ]))
+            .add_configuration(Configuration::UndefinedBehaviorSanitizer)
+            .add_configuration(Configuration::AddressSanitizer)
+            // .add_arg("-fsanitize-coverage=trace-pc-guard,trace-cmp")
+            // .add_arg("-fsanitize=address")
+            .run()
+            .expect("Failed to run the wrapped libtool")
+        {
+            std::process::exit(code);
+        }
+    } else {
+        panic!("LibAFL libtool: No Arguments given");
+    }
+}

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
@@ -25,7 +25,10 @@ pub fn main() {
             .expect("Failed to parse the command line")
             .link_staticlib(&dir, "libfuzzer_libpng")
             .add_configuration(Configuration::GenerateCoverageMap)
-            .add_configuration(Configuration::LogComparisons)
+            .add_configuration(Configuration::Compound(vec![
+                Configuration::GenerateCoverageMap,
+                Configuration::LogComparisons,
+            ]))
             .add_configuration(Configuration::SanitizeUndefinedBehavior)
             .add_configuration(Configuration::SanitizeAddresses)
             // .add_arg("-fsanitize-coverage=trace-pc-guard,trace-cmp")

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, Configuration, ToolWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, Configuration, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, Configuration, ToolWrapper};
+use libafl_cc::{ClangWrapper, Configuration, ToolWrapper, CompilerWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_cc.rs
@@ -27,10 +27,10 @@ pub fn main() {
             .add_configuration(Configuration::GenerateCoverageMap)
             .add_configuration(Configuration::Compound(vec![
                 Configuration::GenerateCoverageMap,
-                Configuration::LogComparisons,
+                Configuration::CmpLog,
             ]))
-            .add_configuration(Configuration::SanitizeUndefinedBehavior)
-            .add_configuration(Configuration::SanitizeAddresses)
+            .add_configuration(Configuration::UndefinedBehaviorSanitizer)
+            .add_configuration(Configuration::AddressSanitizer)
             // .add_arg("-fsanitize-coverage=trace-pc-guard,trace-cmp")
             // .add_arg("-fsanitize=address")
             .run()

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_libtool.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_libtool.rs
@@ -1,29 +1,16 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, Configuration, ToolWrapper};
+use libafl_cc::{Configuration, LibtoolWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() > 1 {
-        let mut dir = env::current_exe().unwrap();
-        let wrapper_name = dir.file_name().unwrap().to_str().unwrap();
-
-        let is_cpp = match wrapper_name[wrapper_name.len()-2..].to_lowercase().as_str() {
-            "cc" => false,
-            "++" | "pp" | "xx" => true,
-            _ => panic!("Could not figure out if c or c++ wrapper was called. Expected {dir:?} to end with c or cxx"),
-        };
-
-        dir.pop();
-
-        let mut cc = ClangWrapper::new();
+        let mut cc = LibtoolWrapper::new();
         if let Some(code) = cc
-            .cpp(is_cpp)
             // silence the compiler wrapper output, needed for some configure scripts.
             .silence(true)
             .parse_args(&args)
             .expect("Failed to parse the command line")
-            .link_staticlib(&dir, "libfuzzer_libpng")
             .add_configuration(Configuration::GenerateCoverageMap)
             .add_configuration(Configuration::LogComparisons)
             .add_configuration(Configuration::SanitizeUndefinedBehavior)
@@ -31,11 +18,11 @@ pub fn main() {
             // .add_arg("-fsanitize-coverage=trace-pc-guard,trace-cmp")
             // .add_arg("-fsanitize=address")
             .run()
-            .expect("Failed to run the wrapped compiler")
+            .expect("Failed to run the wrapped libtool")
         {
             std::process::exit(code);
         }
     } else {
-        panic!("LibAFL CC: No Arguments given");
+        panic!("LibAFL libtool: No Arguments given");
     }
 }

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_libtool.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_libtool.rs
@@ -12,7 +12,10 @@ pub fn main() {
             .parse_args(&args)
             .expect("Failed to parse the command line")
             .add_configuration(Configuration::GenerateCoverageMap)
-            .add_configuration(Configuration::LogComparisons)
+            .add_configuration(Configuration::Compound(vec![
+                Configuration::GenerateCoverageMap,
+                Configuration::LogComparisons,
+            ]))
             .add_configuration(Configuration::SanitizeUndefinedBehavior)
             .add_configuration(Configuration::SanitizeAddresses)
             // .add_arg("-fsanitize-coverage=trace-pc-guard,trace-cmp")

--- a/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_libtool.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/bin/libafl_libtool.rs
@@ -14,10 +14,10 @@ pub fn main() {
             .add_configuration(Configuration::GenerateCoverageMap)
             .add_configuration(Configuration::Compound(vec![
                 Configuration::GenerateCoverageMap,
-                Configuration::LogComparisons,
+                Configuration::CmpLog,
             ]))
-            .add_configuration(Configuration::SanitizeUndefinedBehavior)
-            .add_configuration(Configuration::SanitizeAddresses)
+            .add_configuration(Configuration::UndefinedBehaviorSanitizer)
+            .add_configuration(Configuration::AddressSanitizer)
             // .add_arg("-fsanitize-coverage=trace-pc-guard,trace-cmp")
             // .add_arg("-fsanitize=address")
             .run()

--- a/fuzzers/libfuzzer_libpng_norestart/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_norestart/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_libpng_tcp_manager/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_libpng_tcp_manager/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_reachability/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_reachability/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/libfuzzer_windows_asan/src/bin/libafl_cc.rs
+++ b/fuzzers/libfuzzer_windows_asan/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/nautilus_sync/src/bin/libafl_cc.rs
+++ b/fuzzers/nautilus_sync/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::{env, process::Command, str};
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 fn find_libpython() -> Result<String, String> {
     match Command::new("python3")

--- a/fuzzers/nyx_libxml2_parallel/src/bin/libafl_cc.rs
+++ b/fuzzers/nyx_libxml2_parallel/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/nyx_libxml2_standalone/src/bin/libafl_cc.rs
+++ b/fuzzers/nyx_libxml2_standalone/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/tutorial/src/bin/libafl_cc.rs
+++ b/fuzzers/tutorial/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper};
+use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -93,7 +93,7 @@ impl ToolWrapper for ArWrapper {
                         self.configurations.extend(
                             args[i + 1]
                                 .as_ref()
-                                .split(",")
+                                .split(',')
                                 .map(|x| crate::Configuration::from_str(x).unwrap()),
                         );
                         i += 2;
@@ -185,9 +185,7 @@ impl ToolWrapper for ArWrapper {
             })
             .collect::<Vec<_>>();
 
-        let ar_path = if let Ok(ar_dir) = std::env::var("LLVM_AR_PATH") {
-            ar_dir
-        } else {
+        let Ok(ar_path) = std::env::var("LLVM_AR_PATH") else {
             panic!("Couldn't find llvm-ar. Specify the `LLVM_AR_PATH` environment variable");
         };
 

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -1,14 +1,7 @@
 //! Ar Wrapper from `LibAFL`
 // pass to e.g. cmake with -DCMAKE_AR=/path/to/fuzzer/target/release/libafl_ar
 
-use std::{
-    convert::Into,
-    env,
-    path::{Path, PathBuf},
-    str::FromStr,
-    string::String,
-    vec::Vec,
-};
+use std::{convert::Into, env, path::PathBuf, str::FromStr, string::String, vec::Vec};
 
 use crate::{Error, ToolWrapper, LIB_EXT, LIB_PREFIX};
 
@@ -141,27 +134,6 @@ impl ToolWrapper for ArWrapper {
         self
     }
 
-    fn add_cc_arg<S>(&mut self, arg: S) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        self
-    }
-
-    fn add_link_arg<S>(&mut self, arg: S) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        self
-    }
-
-    fn link_staticlib<S>(&mut self, dir: &Path, name: S) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        self
-    }
-
     fn add_configuration(&mut self, configuration: crate::Configuration) -> &'_ mut Self {
         self.configurations.push(configuration);
         self
@@ -197,7 +169,7 @@ impl ToolWrapper for ArWrapper {
                         let extension_lowercase = extension.to_lowercase();
                         match &extension_lowercase[..] {
                             "o" | "lo" | "a" | "la" | "so" => {
-                                configuration.replace_extension(arg_as_path)
+                                configuration.replace_extension(&arg_as_path)
                             }
                             _ => arg_as_path,
                         }

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -163,7 +163,7 @@ impl ToolWrapper for ArWrapper {
             .iter()
             .map(|r| {
                 let arg_as_path = std::path::PathBuf::from(r);
-                if !r.ends_with(".") {
+                if !r.ends_with('.') {
                     if let Some(extension) = arg_as_path.extension() {
                         let extension = extension.to_str().unwrap();
                         let extension_lowercase = extension.to_lowercase();
@@ -186,7 +186,7 @@ impl ToolWrapper for ArWrapper {
             .collect::<Vec<_>>();
 
         let ar_path = if let Ok(ar_dir) = std::env::var("LLVM_AR_PATH") {
-            format!("{ar_dir}")
+            ar_dir.to_string()
         } else {
             panic!("Couldn't find llvm-ar. Specify the `LLVM_AR_PATH` environment variable");
         };

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -140,7 +140,7 @@ impl ToolWrapper for ArWrapper {
     }
 
     fn configurations(&self) -> Result<Vec<crate::Configuration>, Error> {
-        let mut configs = self.configurations.clone();
+        let configs = self.configurations.clone();
         Ok(configs)
     }
 
@@ -206,7 +206,7 @@ impl ToolWrapper for ArWrapper {
         self.linking
     }
 
-    fn filter(&self, args: &mut Vec<String>) {}
+    fn filter(&self, _args: &mut Vec<String>) {}
 
     fn silence(&mut self, value: bool) -> &'_ mut Self {
         self.is_silent = value;

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -1,0 +1,285 @@
+//! Ar Wrapper from `LibAFL`
+// pass to e.g. cmake with -DCMAKE_AR=/path/to/fuzzer/target/release/libafl_ar
+
+use std::{
+    convert::Into,
+    env,
+    path::{Path, PathBuf},
+    str::FromStr,
+    string::String,
+    vec::Vec,
+};
+
+use crate::{Error, ToolWrapper, LIB_EXT, LIB_PREFIX};
+
+/// Wrap Clang
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug)]
+pub struct ArWrapper {
+    is_silent: bool,
+
+    name: String,
+    linking: bool,
+    need_libafl_arg: bool,
+    has_libafl_arg: bool,
+
+    configurations: Vec<crate::Configuration>,
+    parse_args_called: bool,
+    base_args: Vec<String>,
+}
+
+#[allow(clippy::match_same_arms)] // for the linking = false wip for "shared"
+impl ToolWrapper for ArWrapper {
+    #[allow(clippy::too_many_lines)]
+    fn parse_args<S>(&mut self, args: &[S]) -> Result<&'_ mut Self, Error>
+    where
+        S: AsRef<str>,
+    {
+        let mut new_args: Vec<String> = vec![];
+        if args.is_empty() {
+            return Err(Error::InvalidArguments(
+                "The number of arguments cannot be 0".to_string(),
+            ));
+        }
+
+        if self.parse_args_called {
+            return Err(Error::Unknown(
+                "ToolWrapper::parse_args cannot be called twice on the same instance".to_string(),
+            ));
+        }
+        self.parse_args_called = true;
+
+        if args.len() == 1 {
+            return Err(Error::InvalidArguments(
+                "LibAFL Tool wrapper - no commands specified. Use me as compiler.".to_string(),
+            ));
+        }
+
+        self.name = args[0].as_ref().to_string();
+
+        let mut linking = true;
+        // Detect stray -v calls from ./configure scripts.
+        if args.len() > 1 && args[1].as_ref() == "-v" {
+            if args.len() == 2 {
+                self.base_args.push(args[1].as_ref().into());
+                return Ok(self);
+            }
+            linking = false;
+        }
+
+        let mut suppress_linking = 0;
+        let mut i = 1;
+        while i < args.len() {
+            match args[i].as_ref() {
+                "--libafl-no-link" => {
+                    suppress_linking += 1;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "--libafl" => {
+                    suppress_linking += 1337;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "-fsanitize=fuzzer-no-link" => {
+                    suppress_linking += 1;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "-fsanitize=fuzzer" => {
+                    suppress_linking += 1337;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "--libafl-configurations" => {
+                    if i + 1 < args.len() {
+                        self.configurations.extend(
+                            args[i + 1]
+                                .as_ref()
+                                .split(",")
+                                .map(|x| crate::Configuration::from_str(x).unwrap()),
+                        );
+                        i += 2;
+                        continue;
+                    }
+                }
+                _ => (),
+            };
+            new_args.push(args[i].as_ref().to_string());
+            i += 1;
+        }
+        if linking
+            && (suppress_linking > 0 || (self.has_libafl_arg && suppress_linking == 0))
+            && suppress_linking < 1337
+        {
+            linking = false;
+            new_args.push(
+                PathBuf::from(env!("OUT_DIR"))
+                    .join(format!("{LIB_PREFIX}no-link-rt.{LIB_EXT}"))
+                    .into_os_string()
+                    .into_string()
+                    .unwrap(),
+            );
+        }
+
+        self.linking = linking;
+
+        // Libraries needed by libafl on Windows
+        self.base_args.extend(new_args);
+        Ok(self)
+    }
+
+    fn add_arg<S>(&mut self, arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self.base_args.push(arg.as_ref().to_string());
+        self
+    }
+
+    fn add_cc_arg<S>(&mut self, arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self
+    }
+
+    fn add_link_arg<S>(&mut self, arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self
+    }
+
+    fn link_staticlib<S>(&mut self, dir: &Path, name: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self
+    }
+
+    fn add_configuration(&mut self, configuration: crate::Configuration) -> &'_ mut Self {
+        self.configurations.push(configuration);
+        self
+    }
+
+    fn configurations(&self) -> Result<Vec<crate::Configuration>, Error> {
+        let mut configs = self.configurations.clone();
+        Ok(configs)
+    }
+
+    fn ignore_configurations(&self) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    fn command(&mut self) -> Result<Vec<String>, Error> {
+        self.command_for_configuration(crate::Configuration::Default)
+    }
+
+    fn command_for_configuration(
+        &mut self,
+        configuration: crate::Configuration,
+    ) -> Result<Vec<String>, Error> {
+        let mut args = vec![];
+
+        let base_args = self
+            .base_args
+            .iter()
+            .map(|r| {
+                let arg_as_path = std::path::PathBuf::from(r);
+                if !r.ends_with(".") {
+                    if let Some(extension) = arg_as_path.extension() {
+                        let extension = extension.to_str().unwrap();
+                        let extension_lowercase = extension.to_lowercase();
+                        match &extension_lowercase[..] {
+                            "o" | "lo" | "a" | "la" | "so" => {
+                                configuration.replace_extension(arg_as_path)
+                            }
+                            _ => arg_as_path,
+                        }
+                    } else {
+                        arg_as_path
+                    }
+                    .into_os_string()
+                    .into_string()
+                    .unwrap()
+                } else {
+                    r.to_string()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let ar_path = if let Ok(ar_dir) = std::env::var("LLVM_AR_PATH") {
+            format!("{ar_dir}")
+        } else {
+            panic!("Couldn't find llvm-ar. Specify the `LLVM_AR_PATH` environment variable");
+        };
+
+        args.push(ar_path);
+
+        args.extend_from_slice(base_args.as_slice());
+
+        if self.need_libafl_arg && !self.has_libafl_arg {
+            return Ok(args);
+        }
+
+        Ok(args)
+    }
+
+    fn is_linking(&self) -> bool {
+        self.linking
+    }
+
+    fn filter(&self, args: &mut Vec<String>) {}
+
+    fn silence(&mut self, value: bool) -> &'_ mut Self {
+        self.is_silent = value;
+        self
+    }
+
+    fn is_silent(&self) -> bool {
+        self.is_silent
+    }
+}
+
+impl Default for ArWrapper {
+    /// Create a new Clang Wrapper
+    #[must_use]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArWrapper {
+    /// Create a new Clang Wrapper
+    #[must_use]
+    pub fn new() -> Self {
+        #[cfg(unix)]
+        Self {
+            name: String::new(),
+            linking: false,
+            need_libafl_arg: false,
+            has_libafl_arg: false,
+            configurations: vec![crate::Configuration::Default],
+            parse_args_called: false,
+            base_args: vec![],
+            is_silent: false,
+        }
+    }
+
+    /// Set if linking
+    pub fn linking(&mut self, value: bool) -> &'_ mut Self {
+        self.linking = value;
+        self
+    }
+
+    /// Set if it needs the --libafl arg to add the custom arguments to clang
+    pub fn need_libafl_arg(&mut self, value: bool) -> &'_ mut Self {
+        self.need_libafl_arg = value;
+        self
+    }
+}

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -163,7 +163,9 @@ impl ToolWrapper for ArWrapper {
             .iter()
             .map(|r| {
                 let arg_as_path = std::path::PathBuf::from(r);
-                if !r.ends_with('.') {
+                if r.ends_with('.') {
+                    r.to_string()
+                } else {
                     if let Some(extension) = arg_as_path.extension() {
                         let extension = extension.to_str().unwrap();
                         let extension_lowercase = extension.to_lowercase();
@@ -179,14 +181,12 @@ impl ToolWrapper for ArWrapper {
                     .into_os_string()
                     .into_string()
                     .unwrap()
-                } else {
-                    r.to_string()
                 }
             })
             .collect::<Vec<_>>();
 
         let ar_path = if let Ok(ar_dir) = std::env::var("LLVM_AR_PATH") {
-            ar_dir.to_string()
+            ar_dir
         } else {
             panic!("Couldn't find llvm-ar. Specify the `LLVM_AR_PATH` environment variable");
         };

--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -230,7 +230,6 @@ impl ArWrapper {
     /// Create a new Clang Wrapper
     #[must_use]
     pub fn new() -> Self {
-        #[cfg(unix)]
         Self {
             name: String::new(),
             linking: false,

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -332,7 +332,7 @@ impl ToolWrapper for ClangWrapper {
                         let extension = extension.to_str().unwrap();
                         let extension_lowercase = extension.to_lowercase();
                         match &extension_lowercase[..] {
-                            "a" | "la" => configuration.replace_extension(arg_as_path),
+                            "a" | "la" => configuration.replace_extension(&arg_as_path),
                             _ => arg_as_path,
                         }
                     } else {
@@ -346,7 +346,7 @@ impl ToolWrapper for ClangWrapper {
             .collect::<Vec<_>>();
 
         if let Some(output) = self.output.clone() {
-            let output = configuration.replace_extension(output);
+            let output = configuration.replace_extension(&output);
             let new_filename = output.into_os_string().into_string().unwrap();
             args.push("-o".to_string());
             args.push(new_filename);
@@ -366,7 +366,7 @@ impl ToolWrapper for ClangWrapper {
                                 let extension_lowercase = extension.to_lowercase();
                                 match &extension_lowercase[..] {
                                     "c" | "cc" | "cxx" | "cpp" => {
-                                        configuration.replace_extension(arg_as_path)
+                                        configuration.replace_extension(&arg_as_path)
                                     }
                                     _ => arg_as_path,
                                 }

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -204,7 +204,7 @@ impl ToolWrapper for ClangWrapper {
                         self.configurations.extend(
                             args[i + 1]
                                 .as_ref()
-                                .split(",")
+                                .split(',')
                                 .map(|x| crate::Configuration::from_str(x).unwrap()),
                         );
                         i += 2;
@@ -325,7 +325,9 @@ impl ToolWrapper for ClangWrapper {
             .iter()
             .map(|r| {
                 let arg_as_path = std::path::PathBuf::from(r);
-                if !r.ends_with(".") {
+                if r.ends_with('.') {
+                    r.to_string()
+                } else {
                     if let Some(extension) = arg_as_path.extension() {
                         let extension = extension.to_str().unwrap();
                         let extension_lowercase = extension.to_lowercase();
@@ -339,8 +341,6 @@ impl ToolWrapper for ClangWrapper {
                     .into_os_string()
                     .into_string()
                     .unwrap()
-                } else {
-                    r.to_string()
                 }
             })
             .collect::<Vec<_>>();
@@ -358,7 +358,9 @@ impl ToolWrapper for ClangWrapper {
                     .iter()
                     .map(|r| {
                         let arg_as_path = std::path::PathBuf::from(r);
-                        if !r.ends_with(".") {
+                        if r.ends_with('.') {
+                            r.to_string()
+                        } else {
                             if let Some(extension) = arg_as_path.extension() {
                                 let extension = extension.to_str().unwrap();
                                 let extension_lowercase = extension.to_lowercase();
@@ -374,31 +376,14 @@ impl ToolWrapper for ClangWrapper {
                             .into_os_string()
                             .into_string()
                             .unwrap()
-                        } else {
-                            r.to_string()
                         }
                     })
                     .collect::<Vec<_>>(),
-            )
+            );
         }
 
-        // args.extend(self.base_args.iter().map(|x| {
-        //     let arg_as_path = std::path::Path::new(x);
-        //
-        //     let new_arg =
-        //         arg_as_path.with_extension(arg_as_path.extension().map_or("".to_string(), |ext| {
-        //             let ext = ext.to_str().unwrap();
-        //             println!("{:?}: {}", arg_as_path, ext);
-        //             match ext {
-        //                 "a" | "A" | "la" | "LA" | "o" | "O" | "lo" | "LO" => {
-        //                     format!("{}{}", configuration.to_extension(), ext)
-        //                 }
-        //                 _ => ext.to_string(),
-        //             }
-        //         }));
-        //     new_arg.into_os_string().into_string().unwrap()
-        // }));
         args.extend_from_slice(&configuration.to_flags()?);
+
         if self.need_libafl_arg && !self.has_libafl_arg {
             return Ok(args);
         }

--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -307,6 +307,7 @@ impl ToolWrapper for ClangWrapper {
         self.command_for_configuration(crate::Configuration::Default)
     }
 
+    #[allow(clippy::too_many_lines)]
     fn command_for_configuration(
         &mut self,
         configuration: crate::Configuration,

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -138,12 +138,12 @@ impl Configuration {
             if let crate::Configuration::Default = self {
                 format!("{filename}.{extension}")
             } else {
-                format!("{}.{}.{}", filename, self, extension)
+                format!("{filename}.{self}.{extension}")
             }
         } else if let crate::Configuration::Default = self {
             output.to_string()
         } else {
-            format!("{}.{}", output, self)
+            format!("{output}.{self}")
         };
         parent.push(new_filename);
         parent

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -128,7 +128,7 @@ impl Configuration {
 
     /// Insert a `Configuration` specific 'tag' in the extension of the given file
     #[must_use]
-    pub fn replace_extension(&self, path: &std::path::PathBuf) -> std::path::PathBuf {
+    pub fn replace_extension(&self, path: &Path) -> std::path::PathBuf {
         let mut parent = if let Some(parent) = path.parent() {
             parent.to_path_buf()
         } else {
@@ -137,7 +137,7 @@ impl Configuration {
         let output = path.file_name().unwrap();
         let output = output.to_str().unwrap();
 
-        let new_filename = if let Some((filename, extension)) = output.split_once(".") {
+        let new_filename = if let Some((filename, extension)) = output.split_once('.') {
             if let crate::Configuration::Default = self {
                 format!("{filename}.{extension}")
             } else {

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -123,25 +123,6 @@ impl Configuration {
             }
         })
     }
-    /// Get a string representation of this `Configuration`
-    fn to_string(&self) -> String {
-        match self {
-            Configuration::Default => "".to_string(),
-            Configuration::SanitizeAddresses => "asan".to_string(),
-            Configuration::SanitizeUndefinedBehavior => "ubsan".to_string(),
-            Configuration::GenerateCoverageMap => "coverage".to_string(),
-            Configuration::GenerateCoverageProfile => "llvm-cov".to_string(),
-            Configuration::LogComparisons => "cmplog".to_string(),
-            Configuration::Compound(configurations) => {
-                let mut result: Vec<String> = vec![];
-                for configuration in configurations {
-                    result.push(configuration.to_string());
-                }
-                result.join("_")
-            }
-        }
-    }
-
     /// Insert a `Configuration` specific 'tag' in the extension of the given file
     #[must_use]
     pub fn replace_extension(&self, path: &Path) -> std::path::PathBuf {
@@ -180,6 +161,26 @@ impl std::str::FromStr for Configuration {
             "cmplog" => Configuration::LogComparisons,
             _ => Configuration::Default,
         })
+    }
+}
+
+impl std::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Configuration::Default => write!(f, ""),
+            Configuration::SanitizeAddresses => write!(f, "asan"),
+            Configuration::SanitizeUndefinedBehavior => write!(f, "ubsan"),
+            Configuration::GenerateCoverageMap => write!(f, "coverage"),
+            Configuration::GenerateCoverageProfile => write!(f, "llvm-cov"),
+            Configuration::LogComparisons => write!(f, "cmplog"),
+            Configuration::Compound(configurations) => {
+                let mut result: Vec<String> = vec![];
+                for configuration in configurations {
+                    result.push(format!("{configuration}"));
+                }
+                write!(f, result.join("_"))
+            }
+        }
     }
 }
 

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -143,12 +143,10 @@ impl Configuration {
             } else {
                 format!("{}.{}.{}", filename, self.to_str(), extension)
             }
+        } else if let crate::Configuration::Default = self {
+            output.to_string()
         } else {
-            if let crate::Configuration::Default = self {
-                output.to_string()
-            } else {
-                format!("{}.{}", output, self.to_str())
-            }
+            format!("{}.{}", output, self.to_str())
         };
         parent.push(new_filename);
         parent
@@ -214,6 +212,7 @@ pub trait ToolWrapper {
     fn command(&mut self) -> Result<Vec<String>, Error>;
 
     /// Command to run the compiler for a given `Configuration`
+    #[allow(clippy::too_many_lines)]
     fn command_for_configuration(
         &mut self,
         configuration: Configuration,

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -181,29 +181,19 @@ pub const LIB_PREFIX: &str = "";
 #[cfg(not(windows))]
 pub const LIB_PREFIX: &str = "lib";
 
-/// Wrap a compiler hijacking its arguments
+/// Wrap a tool hijacking its arguments
 pub trait ToolWrapper {
     /// Set the wrapper arguments parsing a command line set of arguments
     fn parse_args<S>(&mut self, args: &[S]) -> Result<&'_ mut Self, Error>
     where
         S: AsRef<str>;
 
-    /// Add a compiler argument
+    /// Add an argument
     fn add_arg<S>(&mut self, arg: S) -> &'_ mut Self
     where
         S: AsRef<str>;
 
-    /// Add a compiler argument only when compiling
-    fn add_cc_arg<S>(&mut self, arg: S) -> &'_ mut Self
-    where
-        S: AsRef<str>;
-
-    /// Add a compiler argument only when linking
-    fn add_link_arg<S>(&mut self, arg: S) -> &'_ mut Self
-    where
-        S: AsRef<str>;
-
-    /// Add compiler arguments
+    /// Add arguments
     fn add_args<S>(&mut self, args: &[S]) -> &'_ mut Self
     where
         S: AsRef<str>,
@@ -213,33 +203,6 @@ pub trait ToolWrapper {
         }
         self
     }
-
-    /// Add compiler arguments only when compiling
-    fn add_cc_args<S>(&mut self, args: &[S]) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        for arg in args {
-            self.add_cc_arg(arg);
-        }
-        self
-    }
-
-    /// Add compiler arguments only when linking
-    fn add_link_args<S>(&mut self, args: &[S]) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        for arg in args {
-            self.add_link_arg(arg);
-        }
-        self
-    }
-
-    /// Link static C lib
-    fn link_staticlib<S>(&mut self, dir: &Path, name: S) -> &'_ mut Self
-    where
-        S: AsRef<str>;
 
     /// Add a `Configuration`
     fn add_configuration(&mut self, configuration: Configuration) -> &'_ mut Self;
@@ -272,7 +235,7 @@ pub trait ToolWrapper {
     /// Returns `true` if `silence` was called with `true`
     fn is_silent(&self) -> bool;
 
-    /// Run the compiler
+    /// Run the tool
     fn run(&mut self) -> Result<Option<i32>, Error> {
         let mut last_status = Ok(None);
         let configurations = if self.ignore_configurations()? {
@@ -307,4 +270,44 @@ pub trait ToolWrapper {
         }
         last_status
     }
+}
+
+/// Wrap a compiler hijacking its arguments
+pub trait CompilerWrapper: ToolWrapper {
+    /// Add a compiler argument only when compiling
+    fn add_cc_arg<S>(&mut self, arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>;
+
+    /// Add a compiler argument only when linking
+    fn add_link_arg<S>(&mut self, arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>;
+
+    /// Add compiler arguments only when compiling
+    fn add_cc_args<S>(&mut self, args: &[S]) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        for arg in args {
+            self.add_cc_arg(arg);
+        }
+        self
+    }
+
+    /// Add compiler arguments only when linking
+    fn add_link_args<S>(&mut self, args: &[S]) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        for arg in args {
+            self.add_link_arg(arg);
+        }
+        self
+    }
+
+    /// Link static C lib
+    fn link_staticlib<S>(&mut self, dir: &Path, name: S) -> &'_ mut Self
+    where
+        S: AsRef<str>;
 }

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -138,12 +138,12 @@ impl Configuration {
             if let crate::Configuration::Default = self {
                 format!("{filename}.{extension}")
             } else {
-                format!("{}.{}.{}", filename, self.to_string(), extension)
+                format!("{}.{}.{}", filename, self, extension)
             }
         } else if let crate::Configuration::Default = self {
             output.to_string()
         } else {
-            format!("{}.{}", output, self.to_string())
+            format!("{}.{}", output, self)
         };
         parent.push(new_filename);
         parent

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -84,15 +84,15 @@ pub enum Configuration {
     /// Default uninstrumented configurations
     Default,
     /// Sanitizing addresses
-    SanitizeAddresses,
+    AddressSanitizer,
     /// Sanitizing undefined behavior
-    SanitizeUndefinedBehavior,
+    UndefinedBehaviorSanitizer,
     /// Generating a coverage map
     GenerateCoverageMap,
     /// Generating coverage profile data for `llvm-cov`
     GenerateCoverageProfile,
     /// Instrumenting for cmplog/redqueen
-    LogComparisons,
+    CmpLog,
     /// A compound `Configuration`, made up of a list of other `Configuration`s
     Compound(Vec<Self>),
 }
@@ -102,12 +102,12 @@ impl Configuration {
     pub fn to_flags(&self) -> Result<Vec<String>, Error> {
         Ok(match self {
             Configuration::Default => vec![],
-            Configuration::SanitizeAddresses => vec!["-fsanitize=address".to_string()],
-            Configuration::SanitizeUndefinedBehavior => vec!["-fsanitize=undefined".to_string()],
+            Configuration::AddressSanitizer => vec!["-fsanitize=address".to_string()],
+            Configuration::UndefinedBehaviorSanitizer => vec!["-fsanitize=undefined".to_string()],
             Configuration::GenerateCoverageMap => {
                 vec!["-fsanitize-coverage=trace-pc-guard".to_string()]
             }
-            Configuration::LogComparisons => vec!["-fsanitize-coverage=trace-cmp".to_string()],
+            Configuration::CmpLog => vec!["-fsanitize-coverage=trace-cmp".to_string()],
             Configuration::GenerateCoverageProfile => {
                 vec![
                     "-fprofile-instr-generate".to_string(),
@@ -154,11 +154,11 @@ impl std::str::FromStr for Configuration {
     type Err = ();
     fn from_str(input: &str) -> Result<Configuration, Self::Err> {
         Ok(match input {
-            "asan" => Configuration::SanitizeAddresses,
-            "ubsan" => Configuration::SanitizeUndefinedBehavior,
+            "asan" => Configuration::AddressSanitizer,
+            "ubsan" => Configuration::UndefinedBehaviorSanitizer,
             "coverage" => Configuration::GenerateCoverageMap,
             "llvm-cov" => Configuration::GenerateCoverageProfile,
-            "cmplog" => Configuration::LogComparisons,
+            "cmplog" => Configuration::CmpLog,
             _ => Configuration::Default,
         })
     }
@@ -168,11 +168,11 @@ impl std::fmt::Display for Configuration {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Configuration::Default => write!(f, ""),
-            Configuration::SanitizeAddresses => write!(f, "asan"),
-            Configuration::SanitizeUndefinedBehavior => write!(f, "ubsan"),
+            Configuration::AddressSanitizer => write!(f, "asan"),
+            Configuration::UndefinedBehaviorSanitizer => write!(f, "ubsan"),
             Configuration::GenerateCoverageMap => write!(f, "coverage"),
             Configuration::GenerateCoverageProfile => write!(f, "llvm-cov"),
-            Configuration::LogComparisons => write!(f, "cmplog"),
+            Configuration::CmpLog => write!(f, "cmplog"),
             Configuration::Compound(configurations) => {
                 let mut result: Vec<String> = vec![];
                 for configuration in configurations {

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -178,7 +178,7 @@ impl std::fmt::Display for Configuration {
                 for configuration in configurations {
                     result.push(format!("{configuration}"));
                 }
-                write!(f, result.join("_"))
+                write!(f, "{}", result.join("_"))
             }
         }
     }

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -60,6 +60,8 @@
 
 use std::{convert::Into, path::Path, process::Command, string::String, vec::Vec};
 
+pub mod ar;
+pub use ar::ArWrapper;
 pub mod cfg;
 pub use cfg::{CfgEdge, ControlFlowGraph, EntryBasicBlockInfo, HasWeight};
 pub mod clang;

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -127,7 +127,8 @@ impl Configuration {
     }
 
     /// Insert a `Configuration` specific 'tag' in the extension of the given file
-    pub fn replace_extension(&self, path: std::path::PathBuf) -> std::path::PathBuf {
+    #[must_use]
+    pub fn replace_extension(&self, path: &std::path::PathBuf) -> std::path::PathBuf {
         let mut parent = if let Some(parent) = path.parent() {
             parent.to_path_buf()
         } else {
@@ -137,14 +138,16 @@ impl Configuration {
         let output = output.to_str().unwrap();
 
         let new_filename = if let Some((filename, extension)) = output.split_once(".") {
-            match self {
-                crate::Configuration::Default => format!("{}.{}", filename, extension),
-                _ => format!("{}.{}.{}", filename, self.to_str(), extension),
+            if let crate::Configuration::Default = self {
+                format!("{filename}.{extension}")
+            } else {
+                format!("{}.{}.{}", filename, self.to_str(), extension)
             }
         } else {
-            match self {
-                crate::Configuration::Default => output.to_string(),
-                _ => format!("{}.{}", output, self.to_str()),
+            if let crate::Configuration::Default = self {
+                output.to_string()
+            } else {
+                format!("{}.{}", output, self.to_str())
             }
         };
         parent.push(new_filename);
@@ -220,7 +223,7 @@ pub trait ToolWrapper {
     fn configurations(&self) -> Result<Vec<Configuration>, Error>;
 
     /// Whether to ignore the configured `Configurations`. Useful for e.g. nested calls to
-    /// libafl_cc from libafl_libtool.
+    /// `libafl_cc` from `libafl_libtool`.
     fn ignore_configurations(&self) -> Result<bool, Error>;
 
     /// Get if in linking mode

--- a/libafl_cc/src/libtool.rs
+++ b/libafl_cc/src/libtool.rs
@@ -93,7 +93,7 @@ impl ToolWrapper for LibtoolWrapper {
                         self.configurations.extend(
                             args[i + 1]
                                 .as_ref()
-                                .split(",")
+                                .split(',')
                                 .map(|x| crate::Configuration::from_str(x).unwrap()),
                         );
                         i += 2;
@@ -170,13 +170,15 @@ impl ToolWrapper for LibtoolWrapper {
             .iter()
             .map(|r| {
                 let arg_as_path = std::path::PathBuf::from(r);
-                if !r.ends_with(".") {
+                if r.ends_with('.') {
+                    r.to_string()
+                } else {
                     if let Some(extension) = arg_as_path.extension() {
                         let extension = extension.to_str().unwrap();
                         let extension_lowercase = extension.to_lowercase();
                         match &extension_lowercase[..] {
                             "o" | "lo" | "a" | "la" | "so" => {
-                                configuration.replace_extension(arg_as_path)
+                                configuration.replace_extension(&arg_as_path)
                             }
                             _ => arg_as_path,
                         }
@@ -186,25 +188,24 @@ impl ToolWrapper for LibtoolWrapper {
                     .into_os_string()
                     .into_string()
                     .unwrap()
-                } else {
-                    r.to_string()
                 }
             })
             .collect::<Vec<_>>();
 
         let libtool_path = if let Ok(libtool_dir) = std::env::var("LIBTOOL_DIR") {
-            format!("{}/libtool", libtool_dir)
+            format!("{libtool_dir}/libtool")
         } else {
             "./libtool".to_string()
         };
 
-        if !std::path::Path::new(&libtool_path).exists() {
-            panic!("Couldn't find libtool. Specify the `LIBTOOL_DIR` environment variable");
-        }
+        assert!(
+            std::path::Path::new(&libtool_path).exists(),
+            "Couldn't find libtool. Specify the `LIBTOOL_DIR` environment variable"
+        );
         args.push(libtool_path);
 
         if let Some(output) = self.output.clone() {
-            let output = configuration.replace_extension(output);
+            let output = configuration.replace_extension(&output);
             let new_filename = output.into_os_string().into_string().unwrap();
             let dash_c_position = base_args.iter().position(|x| x == "-c");
             if let Some(dash_c_position) = dash_c_position {

--- a/libafl_cc/src/libtool.rs
+++ b/libafl_cc/src/libtool.rs
@@ -1,4 +1,5 @@
 //! Libtool Wrapper from `LibAFL`
+// call make passing LIBTOOL=/path/to/target/release/libafl_libtool
 
 use std::{convert::Into, env, path::PathBuf, str::FromStr, string::String, vec::Vec};
 

--- a/libafl_cc/src/libtool.rs
+++ b/libafl_cc/src/libtool.rs
@@ -1,13 +1,6 @@
 //! Libtool Wrapper from `LibAFL`
 
-use std::{
-    convert::Into,
-    env,
-    path::{Path, PathBuf},
-    str::FromStr,
-    string::String,
-    vec::Vec,
-};
+use std::{convert::Into, env, path::PathBuf, str::FromStr, string::String, vec::Vec};
 
 use crate::{Error, ToolWrapper, LIB_EXT, LIB_PREFIX};
 
@@ -148,27 +141,6 @@ impl ToolWrapper for LibtoolWrapper {
         self
     }
 
-    fn add_cc_arg<S>(&mut self, _arg: S) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        self
-    }
-
-    fn add_link_arg<S>(&mut self, _arg: S) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        self
-    }
-
-    fn link_staticlib<S>(&mut self, _dir: &Path, _name: S) -> &'_ mut Self
-    where
-        S: AsRef<str>,
-    {
-        self
-    }
-
     fn add_configuration(&mut self, configuration: crate::Configuration) -> &'_ mut Self {
         self.configurations.push(configuration);
         self
@@ -290,7 +262,6 @@ impl LibtoolWrapper {
     /// Create a new Clang Wrapper
     #[must_use]
     pub fn new() -> Self {
-        #[cfg(unix)]
         Self {
             name: String::new(),
             linking: false,
@@ -314,22 +285,5 @@ impl LibtoolWrapper {
     pub fn need_libafl_arg(&mut self, value: bool) -> &'_ mut Self {
         self.need_libafl_arg = value;
         self
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{LibtoolWrapper, ToolWrapper};
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_clang_version() {
-        if let Err(res) = LibtoolWrapper::new()
-            .parse_args(&["libtool", "-v"])
-            .unwrap()
-            .run()
-        {
-            println!("Ignored error {res:?} - clang is probably not installed.");
-        }
     }
 }

--- a/libafl_cc/src/libtool.rs
+++ b/libafl_cc/src/libtool.rs
@@ -1,0 +1,335 @@
+//! Libtool Wrapper from `LibAFL`
+
+use std::{
+    convert::Into,
+    env,
+    path::{Path, PathBuf},
+    str::FromStr,
+    string::String,
+    vec::Vec,
+};
+
+use crate::{Error, ToolWrapper, LIB_EXT, LIB_PREFIX};
+
+/// Wrap Clang
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug)]
+pub struct LibtoolWrapper {
+    is_silent: bool,
+
+    name: String,
+    linking: bool,
+    need_libafl_arg: bool,
+    has_libafl_arg: bool,
+
+    output: Option<PathBuf>,
+    configurations: Vec<crate::Configuration>,
+    parse_args_called: bool,
+    base_args: Vec<String>,
+}
+
+#[allow(clippy::match_same_arms)] // for the linking = false wip for "shared"
+impl ToolWrapper for LibtoolWrapper {
+    #[allow(clippy::too_many_lines)]
+    fn parse_args<S>(&mut self, args: &[S]) -> Result<&'_ mut Self, Error>
+    where
+        S: AsRef<str>,
+    {
+        let mut new_args: Vec<String> = vec![];
+        if args.is_empty() {
+            return Err(Error::InvalidArguments(
+                "The number of arguments cannot be 0".to_string(),
+            ));
+        }
+
+        if self.parse_args_called {
+            return Err(Error::Unknown(
+                "ToolWrapper::parse_args cannot be called twice on the same instance".to_string(),
+            ));
+        }
+        self.parse_args_called = true;
+
+        if args.len() == 1 {
+            return Err(Error::InvalidArguments(
+                "LibAFL Tool wrapper - no commands specified. Use me as compiler.".to_string(),
+            ));
+        }
+
+        self.name = args[0].as_ref().to_string();
+
+        let mut linking = true;
+        // Detect stray -v calls from ./configure scripts.
+        if args.len() > 1 && args[1].as_ref() == "-v" {
+            if args.len() == 2 {
+                self.base_args.push(args[1].as_ref().into());
+                return Ok(self);
+            }
+            linking = false;
+        }
+
+        let mut suppress_linking = 0;
+        let mut i = 1;
+        while i < args.len() {
+            match args[i].as_ref() {
+                "--libafl-no-link" => {
+                    suppress_linking += 1;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "--libafl" => {
+                    suppress_linking += 1337;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "-fsanitize=fuzzer-no-link" => {
+                    suppress_linking += 1;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "-fsanitize=fuzzer" => {
+                    suppress_linking += 1337;
+                    self.has_libafl_arg = true;
+                    i += 1;
+                    continue;
+                }
+                "--libafl-configurations" => {
+                    if i + 1 < args.len() {
+                        self.configurations.extend(
+                            args[i + 1]
+                                .as_ref()
+                                .split(",")
+                                .map(|x| crate::Configuration::from_str(x).unwrap()),
+                        );
+                        i += 2;
+                        continue;
+                    }
+                }
+                "-o" => {
+                    if i + 1 < args.len() {
+                        self.output = Some(PathBuf::from(args[i + 1].as_ref()));
+                        i += 2;
+                        continue;
+                    }
+                }
+                _ => (),
+            };
+            new_args.push(args[i].as_ref().to_string());
+            i += 1;
+        }
+        if linking
+            && (suppress_linking > 0 || (self.has_libafl_arg && suppress_linking == 0))
+            && suppress_linking < 1337
+        {
+            linking = false;
+            new_args.push(
+                PathBuf::from(env!("OUT_DIR"))
+                    .join(format!("{LIB_PREFIX}no-link-rt.{LIB_EXT}"))
+                    .into_os_string()
+                    .into_string()
+                    .unwrap(),
+            );
+        }
+
+        self.linking = linking;
+
+        // Libraries needed by libafl on Windows
+        self.base_args.extend(new_args);
+        Ok(self)
+    }
+
+    fn add_arg<S>(&mut self, arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self.base_args.push(arg.as_ref().to_string());
+        self
+    }
+
+    fn add_cc_arg<S>(&mut self, _arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self
+    }
+
+    fn add_link_arg<S>(&mut self, _arg: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self
+    }
+
+    fn link_staticlib<S>(&mut self, _dir: &Path, _name: S) -> &'_ mut Self
+    where
+        S: AsRef<str>,
+    {
+        self
+    }
+
+    fn add_configuration(&mut self, configuration: crate::Configuration) -> &'_ mut Self {
+        self.configurations.push(configuration);
+        self
+    }
+
+    fn configurations(&self) -> Result<Vec<crate::Configuration>, Error> {
+        let configs = self.configurations.clone();
+        Ok(configs)
+    }
+
+    fn ignore_configurations(&self) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    fn command(&mut self) -> Result<Vec<String>, Error> {
+        self.command_for_configuration(crate::Configuration::Default)
+    }
+
+    fn command_for_configuration(
+        &mut self,
+        configuration: crate::Configuration,
+    ) -> Result<Vec<String>, Error> {
+        let mut args = vec![];
+
+        let base_args = self
+            .base_args
+            .iter()
+            .map(|r| {
+                let arg_as_path = std::path::PathBuf::from(r);
+                if !r.ends_with(".") {
+                    if let Some(extension) = arg_as_path.extension() {
+                        let extension = extension.to_str().unwrap();
+                        let extension_lowercase = extension.to_lowercase();
+                        match &extension_lowercase[..] {
+                            "o" | "lo" | "a" | "la" | "so" => {
+                                configuration.replace_extension(arg_as_path)
+                            }
+                            _ => arg_as_path,
+                        }
+                    } else {
+                        arg_as_path
+                    }
+                    .into_os_string()
+                    .into_string()
+                    .unwrap()
+                } else {
+                    r.to_string()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let libtool_path = if let Ok(libtool_dir) = std::env::var("LIBTOOL_DIR") {
+            format!("{}/libtool", libtool_dir)
+        } else {
+            "./libtool".to_string()
+        };
+
+        if !std::path::Path::new(&libtool_path).exists() {
+            panic!("Couldn't find libtool. Specify the `LIBTOOL_DIR` environment variable");
+        }
+        args.push(libtool_path);
+
+        if let Some(output) = self.output.clone() {
+            let output = configuration.replace_extension(output);
+            let new_filename = output.into_os_string().into_string().unwrap();
+            let dash_c_position = base_args.iter().position(|x| x == "-c");
+            if let Some(dash_c_position) = dash_c_position {
+                args.extend_from_slice(&base_args[..dash_c_position]);
+                args.extend_from_slice(&configuration.to_flags()?);
+                args.push("--libafl-ignore-configurations".to_string());
+                args.push("-c".to_string());
+                args.push("-o".to_string());
+                args.push(new_filename);
+                args.extend_from_slice(&base_args[(dash_c_position + 1)..]);
+            } else {
+                args.extend_from_slice(base_args.as_slice());
+                args.extend_from_slice(&configuration.to_flags()?);
+                args.push("--libafl-ignore-configurations".to_string());
+                args.push("-o".to_string());
+                args.push(new_filename);
+            }
+        } else {
+            args.extend_from_slice(base_args.as_slice());
+            args.extend_from_slice(&configuration.to_flags()?);
+        }
+
+        if self.need_libafl_arg && !self.has_libafl_arg {
+            return Ok(args);
+        }
+
+        Ok(args)
+    }
+
+    fn is_linking(&self) -> bool {
+        self.linking
+    }
+
+    fn filter(&self, _args: &mut Vec<String>) {}
+
+    fn silence(&mut self, value: bool) -> &'_ mut Self {
+        self.is_silent = value;
+        self
+    }
+
+    fn is_silent(&self) -> bool {
+        self.is_silent
+    }
+}
+
+impl Default for LibtoolWrapper {
+    /// Create a new Clang Wrapper
+    #[must_use]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LibtoolWrapper {
+    /// Create a new Clang Wrapper
+    #[must_use]
+    pub fn new() -> Self {
+        #[cfg(unix)]
+        Self {
+            name: String::new(),
+            linking: false,
+            need_libafl_arg: false,
+            has_libafl_arg: false,
+            output: None,
+            configurations: vec![crate::Configuration::Default],
+            parse_args_called: false,
+            base_args: vec![],
+            is_silent: false,
+        }
+    }
+
+    /// Set if linking
+    pub fn linking(&mut self, value: bool) -> &'_ mut Self {
+        self.linking = value;
+        self
+    }
+
+    /// Set if it needs the --libafl arg to add the custom arguments to clang
+    pub fn need_libafl_arg(&mut self, value: bool) -> &'_ mut Self {
+        self.need_libafl_arg = value;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{LibtoolWrapper, ToolWrapper};
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_clang_version() {
+        if let Err(res) = LibtoolWrapper::new()
+            .parse_args(&["libtool", "-v"])
+            .unwrap()
+            .run()
+        {
+            println!("Ignored error {res:?} - clang is probably not installed.");
+        }
+    }
+}


### PR DESCRIPTION
This PR implements a new feature for `libafl_cc` which enables automatic compilation/linking of various configurations of a project/fuzzer, including capabilities like `coverage`, `asan`, `cmplog`, `ubsan`, and `llvm-cov`.

The user specifies the Configurations desired either on the command line or in their `src/bin/libafl_cc.rs` file. An example of the latter is included here in the `libfuzzer_libpng_launcher` fuzzer.

At the moment, it is not possible to build variants which include multiple configurations (i.e. a binary with both `asan` and `coverage`), but we could easily extend to allow this.