### PR TITLE
Make harness function take mut ref

### DIFF
--- a/libafl/src/executors/combined.rs
+++ b/libafl/src/executors/combined.rs
@@ -52,7 +52,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         let ret = self.primary.run_target(fuzzer, state, mgr, input);
         self.primary.post_run_reset();

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -323,7 +323,7 @@ where
         _fuzzer: &mut Z,
         _state: &mut Self::State,
         _mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         use std::os::unix::prelude::ExitStatusExt;
 
@@ -712,7 +712,7 @@ mod tests {
                 &mut NopFuzzer::new(),
                 &mut NopState::new(),
                 &mut mgr,
-                &BytesInput::new(b"test".to_vec()),
+                &mut BytesInput::new(b"test".to_vec()),
             )
             .unwrap();
     }
@@ -740,7 +740,7 @@ mod tests {
                 &mut NopFuzzer::new(),
                 &mut NopState::new(),
                 &mut mgr,
-                &BytesInput::new(b"test".to_vec()),
+                &mut BytesInput::new(b"test".to_vec()),
             )
             .unwrap();
     }

--- a/libafl/src/executors/differential.rs
+++ b/libafl/src/executors/differential.rs
@@ -68,7 +68,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         self.observers(); // update in advance
         let observers = self.observers.get_mut();
@@ -128,7 +128,7 @@ where
     DOT: DifferentialObserversTuple<A, B, S>,
     S: UsesInput,
 {
-    fn pre_exec_all(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
+    fn pre_exec_all(&mut self, state: &mut S, input: &mut S::Input) -> Result<(), Error> {
         self.differential.pre_exec_all(state, input)
     }
 

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -429,7 +429,7 @@ where
         _fuzzer: &mut Z,
         _state: &mut Self::State,
         _mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         let mut exit_kind = ExitKind::Ok;
 
@@ -1082,7 +1082,7 @@ where
         _fuzzer: &mut Z,
         _state: &mut Self::State,
         _mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         let mut exit_kind = ExitKind::Ok;
 

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -134,7 +134,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         self.handlers
             .pre_run_target(self, fuzzer, state, mgr, input);
@@ -1703,7 +1703,7 @@ where
         _fuzzer: &mut Z,
         state: &mut Self::State,
         _mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         unsafe {
             self.shmem_provider.pre_fork()?;
@@ -1771,7 +1771,7 @@ where
         _fuzzer: &mut Z,
         state: &mut Self::State,
         _mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         unsafe {
             self.shmem_provider.pre_fork()?;
@@ -2197,13 +2197,13 @@ mod tests {
             handlers: InProcessHandlers::nop(),
             phantom: PhantomData,
         };
-        let input = NopInput {};
+        let mut input = NopInput {};
         in_process_executor
             .run_target(
                 &mut NopFuzzer::new(),
                 &mut NopState::new(),
                 &mut NopEventManager::new(),
-                &input,
+                &mut input,
             )
             .unwrap();
     }
@@ -2231,12 +2231,12 @@ mod tests {
             handlers: InChildProcessHandlers::nop(),
             phantom: PhantomData,
         };
-        let input = NopInput {};
+        let mut input = NopInput {};
         let mut fuzzer = NopFuzzer::new();
         let mut state = NopState::new();
         let mut mgr = SimpleEventManager::printing();
         in_process_fork_executor
-            .run_target(&mut fuzzer, &mut state, &mut mgr, &input)
+            .run_target(&mut fuzzer, &mut state, &mut mgr, &mut input)
             .unwrap();
     }
 }

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -56,7 +56,7 @@ use crate::{
     Error,
 };
 
-// The process executor simply calls a target function, as mutable reference to a closure
+/// The process executor simply calls a target function, as mutable reference to a closure
 pub type InProcessExecutor<'a, H, OT, S> = GenericInProcessExecutor<H, &'a mut H, OT, S>;
 
 /// The process executor simply calls a target function, as boxed `FnMut` trait object
@@ -532,7 +532,7 @@ pub(crate) static mut GLOBAL_STATE: InProcessExecutorHandlerData = InProcessExec
     timeout_executor_ptr: null_mut(),
 };
 
-// The process executor simply calls a target function, as mutable reference to a closure
+/// The process executor simply calls a target function, as mutable reference to a closure
 pub type InProcessExecutorMut<'a, H, OT, S> = GenericInProcessExecutorMut<H, &'a mut H, OT, S>;
 
 /// The process executor simply calls a target function, as boxed `FnMut` trait object

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -121,7 +121,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error>;
 
     /// Wraps this Executor with the given [`ObserversTuple`] to implement [`HasObservers`].
@@ -167,7 +167,7 @@ where
         _fuzzer: &mut Z,
         _state: &mut Self::State,
         _mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         if input.target_bytes().as_slice().is_empty() {
             Err(Error::empty("Input Empty"))
@@ -186,8 +186,8 @@ mod test {
 
     #[test]
     fn nop_executor() {
-        let empty_input = BytesInput::new(vec![]);
-        let nonempty_input = BytesInput::new(vec![1u8]);
+        let mut empty_input = BytesInput::new(vec![]);
+        let mut nonempty_input = BytesInput::new(vec![1u8]);
         let mut executor = NopExecutor {
             phantom: PhantomData,
         };
@@ -200,7 +200,7 @@ mod test {
                 &mut fuzzer,
                 &mut state,
                 &mut NopEventManager::new(),
-                &empty_input,
+                &mut empty_input,
             )
             .unwrap_err();
         executor
@@ -208,7 +208,7 @@ mod test {
                 &mut fuzzer,
                 &mut state,
                 &mut NopEventManager::new(),
-                &nonempty_input,
+                &mut nonempty_input,
             )
             .unwrap();
     }

--- a/libafl/src/executors/shadow.rs
+++ b/libafl/src/executors/shadow.rs
@@ -68,7 +68,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         self.executor.run_target(fuzzer, state, mgr, input)
     }

--- a/libafl/src/executors/timeout.rs
+++ b/libafl/src/executors/timeout.rs
@@ -533,7 +533,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         unsafe {
             setitimer(ITIMER_REAL, &mut self.itimerval, null_mut());

--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -28,7 +28,7 @@ where
         fuzzer: &mut Z,
         state: &mut Self::State,
         mgr: &mut EM,
-        input: &Self::Input,
+        input: &mut Self::Input,
     ) -> Result<ExitKind, Error> {
         self.executor.run_target(fuzzer, state, mgr, input)
     }

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -456,14 +456,14 @@ where
         state: &mut Self::State,
         executor: &mut E,
         manager: &mut EM,
-        input: <Self::State as UsesInput>::Input,
+        mut input: <Self::State as UsesInput>::Input,
         send_events: bool,
     ) -> Result<(ExecuteInputResult, Option<CorpusId>), Error>
     where
         E: Executor<EM, Self> + HasObservers<Observers = OT, State = Self::State>,
         EM: EventFirer<State = Self::State>,
     {
-        let exit_kind = self.execute_input(state, executor, manager, &input)?;
+        let exit_kind = self.execute_input(state, executor, manager, &mut input)?;
         let observers = executor.observers();
 
         self.scheduler.on_evaluation(state, &input, observers)?;
@@ -501,9 +501,9 @@ where
         state: &mut CS::State,
         executor: &mut E,
         manager: &mut EM,
-        input: <CS::State as UsesInput>::Input,
+        mut input: <CS::State as UsesInput>::Input,
     ) -> Result<CorpusId, Error> {
-        let exit_kind = self.execute_input(state, executor, manager, &input)?;
+        let exit_kind = self.execute_input(state, executor, manager, &mut input)?;
         let observers = executor.observers();
         // Always consider this to be "interesting"
 
@@ -647,7 +647,7 @@ where
         state: &mut CS::State,
         executor: &mut E,
         event_mgr: &mut EM,
-        input: &<CS::State as UsesInput>::Input,
+        input: &mut <CS::State as UsesInput>::Input,
     ) -> Result<ExitKind, Error>
     where
         E: Executor<EM, Self> + HasObservers<Observers = OT, State = CS::State>,
@@ -686,7 +686,7 @@ where
         state: &mut Self::State,
         executor: &mut E,
         event_mgr: &mut EM,
-        input: &<Self::State as UsesInput>::Input,
+        input: &mut <Self::State as UsesInput>::Input,
     ) -> Result<ExitKind, Error>;
 }
 
@@ -705,7 +705,7 @@ where
         state: &mut CS::State,
         executor: &mut E,
         event_mgr: &mut EM,
-        input: &<CS::State as UsesInput>::Input,
+        input: &mut <CS::State as UsesInput>::Input,
     ) -> Result<ExitKind, Error> {
         start_timer!(state);
         executor.observers_mut().pre_exec_all(state, input)?;

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -141,7 +141,7 @@ where
     S: UsesInput,
 {
     /// This is called right before the next execution.
-    fn pre_exec_all(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error>;
+    fn pre_exec_all(&mut self, state: &mut S, input: &mut S::Input) -> Result<(), Error>;
 
     /// This is called right after the last execution
     fn post_exec_all(
@@ -177,7 +177,7 @@ impl<S> ObserversTuple<S> for ()
 where
     S: UsesInput,
 {
-    fn pre_exec_all(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
+    fn pre_exec_all(&mut self, _state: &mut S, _input: &mut S::Input) -> Result<(), Error> {
         Ok(())
     }
 
@@ -232,7 +232,7 @@ where
     Tail: ObserversTuple<S>,
     S: UsesInput,
 {
-    fn pre_exec_all(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
+    fn pre_exec_all(&mut self, state: &mut S, input: &mut S::Input) -> Result<(), Error> {
         self.0.pre_exec(state, input)?;
         self.1.pre_exec_all(state, input)
     }

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -115,14 +115,14 @@ where
 
         let mut iter = self.stage_max;
 
-        let input = state.corpus().cloned_input_for_id(corpus_idx)?;
+        let mut input = state.corpus().cloned_input_for_id(corpus_idx)?;
 
         // Run once to get the initial calibration map
-        executor.observers_mut().pre_exec_all(state, &input)?;
+        executor.observers_mut().pre_exec_all(state, &mut input)?;
 
         let mut start = current_time();
 
-        let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
+        let exit_kind = executor.run_target(fuzzer, state, mgr, &mut input)?;
         let mut total_time = if exit_kind == ExitKind::Ok {
             current_time() - start
         } else {
@@ -153,12 +153,12 @@ where
         let mut has_errors = false;
 
         while i < iter {
-            let input = state.corpus().cloned_input_for_id(corpus_idx)?;
+            let mut input = state.corpus().cloned_input_for_id(corpus_idx)?;
 
-            executor.observers_mut().pre_exec_all(state, &input)?;
+            executor.observers_mut().pre_exec_all(state, &mut input)?;
             start = current_time();
 
-            let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
+            let exit_kind = executor.run_target(fuzzer, state, mgr, &mut input)?;
             if exit_kind != ExitKind::Ok {
                 if !has_errors {
                     mgr.log(

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -297,12 +297,12 @@ where
         executor: &mut E,
         state: &mut E::State,
         manager: &mut EM,
-        input: E::Input,
+        mut input: E::Input,
         name: &str,
     ) -> Result<usize, Error> {
-        executor.observers_mut().pre_exec_all(state, &input)?;
+        executor.observers_mut().pre_exec_all(state, &mut input)?;
 
-        let exit_kind = executor.run_target(fuzzer, state, manager, &input)?;
+        let exit_kind = executor.run_target(fuzzer, state, manager, &mut input)?;
 
         let observer = executor
             .observers()

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -77,7 +77,7 @@ where
         manager: &mut EM,
         corpus_idx: CorpusId,
     ) -> Result<(), Error> {
-        let (mut payload, original, novelties) = {
+        let (mut payload, mut original, novelties) = {
             start_timer!(state);
             {
                 let corpus = state.corpus();
@@ -103,7 +103,7 @@ where
         };
 
         // Do not generalized unstable inputs
-        if !self.verify_input(fuzzer, executor, state, manager, &novelties, &original)? {
+        if !self.verify_input(fuzzer, executor, state, manager, &novelties, &mut original)? {
             return Ok(());
         }
 
@@ -343,7 +343,7 @@ where
         state: &mut EM::State,
         manager: &mut EM,
         novelties: &[usize],
-        input: &BytesInput,
+        input: &mut BytesInput,
     ) -> Result<bool, Error>
     where
         E: Executor<EM, Z> + HasObservers<Observers = OT, State = EM::State>,
@@ -409,7 +409,7 @@ where
                 .bytes_mut()
                 .extend(payload[end..].iter().flatten());
 
-            if self.verify_input(fuzzer, executor, state, manager, novelties, &candidate)? {
+            if self.verify_input(fuzzer, executor, state, manager, novelties, &mut candidate)? {
                 for item in &mut payload[start..end] {
                     *item = None;
                 }
@@ -462,7 +462,14 @@ where
                         .bytes_mut()
                         .extend(payload[end..].iter().flatten());
 
-                    if self.verify_input(fuzzer, executor, state, manager, novelties, &candidate)? {
+                    if self.verify_input(
+                        fuzzer,
+                        executor,
+                        state,
+                        manager,
+                        novelties,
+                        &mut candidate,
+                    )? {
                         for item in &mut payload[start..end] {
                             *item = None;
                         }

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -276,14 +276,14 @@ where
         push_stage.init(fuzzer, state, event_mgr, executor.observers_mut())?;
 
         loop {
-            let input =
+            let mut input =
                 match push_stage.pre_exec(fuzzer, state, event_mgr, executor.observers_mut()) {
                     Some(Ok(next_input)) => next_input,
                     Some(Err(err)) => return Err(err),
                     None => break,
                 };
 
-            let exit_kind = fuzzer.execute_input(state, executor, event_mgr, &input)?;
+            let exit_kind = fuzzer.execute_input(state, executor, event_mgr, &mut input)?;
 
             push_stage.post_exec(
                 fuzzer,

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -78,7 +78,7 @@ where
         let base_hash = hasher.finish();
         mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
 
-        fuzzer.execute_input(state, executor, manager, &base)?;
+        fuzzer.execute_input(state, executor, manager, &mut base)?;
         let observers = executor.observers();
 
         let mut feedback = self.create_feedback(observers);
@@ -106,7 +106,7 @@ where
 
             let corpus_idx = if input.len() < before_len {
                 // run the input
-                let exit_kind = fuzzer.execute_input(state, executor, manager, &input)?;
+                let exit_kind = fuzzer.execute_input(state, executor, manager, &mut input)?;
                 let observers = executor.observers();
 
                 // let the fuzzer process this execution -- it's possible that we find something
@@ -156,7 +156,7 @@ where
         base.hash(&mut hasher);
         let new_hash = hasher.finish();
         if base_hash != new_hash {
-            let exit_kind = fuzzer.execute_input(state, executor, manager, &base)?;
+            let exit_kind = fuzzer.execute_input(state, executor, manager, &mut base)?;
             let observers = executor.observers();
             *state.executions_mut() += 1;
             // assumption: this input should not be marked interesting because it was not

--- a/libafl/src/stages/tracing.rs
+++ b/libafl/src/stages/tracing.rs
@@ -51,20 +51,20 @@ where
         corpus_idx: CorpusId,
     ) -> Result<(), Error> {
         start_timer!(state);
-        let input = state.corpus().cloned_input_for_id(corpus_idx)?;
+        let mut input = state.corpus().cloned_input_for_id(corpus_idx)?;
 
         mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
 
         start_timer!(state);
         self.tracer_executor
             .observers_mut()
-            .pre_exec_all(state, &input)?;
+            .pre_exec_all(state, &mut input)?;
         mark_feature_time!(state, PerfFeature::PreExecObservers);
 
         start_timer!(state);
         let exit_kind = self
             .tracer_executor
-            .run_target(fuzzer, state, manager, &input)?;
+            .run_target(fuzzer, state, manager, &mut input)?;
         mark_feature_time!(state, PerfFeature::TargetExecution);
 
         *state.executions_mut() += 1;
@@ -138,7 +138,7 @@ where
     ) -> Result<(), Error> {
         // First run with the un-mutated input
 
-        let unmutated_input = state.corpus().cloned_input_for_id(corpus_idx)?;
+        let mut unmutated_input = state.corpus().cloned_input_for_id(corpus_idx)?;
 
         if let Some(name) = &self.cmplog_observer_name {
             if let Some(ob) = self
@@ -156,11 +156,11 @@ where
 
         self.tracer_executor
             .observers_mut()
-            .pre_exec_all(state, &unmutated_input)?;
+            .pre_exec_all(state, &mut unmutated_input)?;
 
         let exit_kind =
             self.tracer_executor
-                .run_target(fuzzer, state, manager, &unmutated_input)?;
+                .run_target(fuzzer, state, manager, &mut unmutated_input)?;
 
         *state.executions_mut() += 1;
 
@@ -169,7 +169,7 @@ where
             .post_exec_all(state, &unmutated_input, &exit_kind)?;
 
         // Second run with the mutated input
-        let mutated_input = match state.metadata_map().get::<TaintMetadata>() {
+        let mut mutated_input = match state.metadata_map().get::<TaintMetadata>() {
             Some(meta) => BytesInput::from(meta.input_vec().as_ref()),
             None => return Err(Error::unknown("No metadata found")),
         };
@@ -190,11 +190,11 @@ where
 
         self.tracer_executor
             .observers_mut()
-            .pre_exec_all(state, &mutated_input)?;
+            .pre_exec_all(state, &mut mutated_input)?;
 
-        let exit_kind = self
-            .tracer_executor
-            .run_target(fuzzer, state, manager, &mutated_input)?;
+        let exit_kind =
+            self.tracer_executor
+                .run_target(fuzzer, state, manager, &mut mutated_input)?;
 
         *state.executions_mut() += 1;
 
@@ -268,19 +268,19 @@ where
         corpus_idx: CorpusId,
     ) -> Result<(), Error> {
         start_timer!(state);
-        let input = state.corpus().cloned_input_for_id(corpus_idx)?;
+        let mut input = state.corpus().cloned_input_for_id(corpus_idx)?;
 
         mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
 
         start_timer!(state);
         executor
             .shadow_observers_mut()
-            .pre_exec_all(state, &input)?;
-        executor.observers_mut().pre_exec_all(state, &input)?;
+            .pre_exec_all(state, &mut input)?;
+        executor.observers_mut().pre_exec_all(state, &mut input)?;
         mark_feature_time!(state, PerfFeature::PreExecObservers);
 
         start_timer!(state);
-        let exit_kind = executor.run_target(fuzzer, state, manager, &input)?;
+        let exit_kind = executor.run_target(fuzzer, state, manager, &mut input)?;
         mark_feature_time!(state, PerfFeature::TargetExecution);
 
         *state.executions_mut() += 1;


### PR DESCRIPTION
Makes `Executor`'s harness function take a mutable input. This allows harnesses to mutate the input (they don't have to, of course). There are a bunch of reasons this might be desirable, but primarily it allows harnesses that know better about the input format to quickly fix up a corpus (for example, if the harness needs more data, it can extend the input to the length it needs). This can be done with a custom mutator (and still should, for example this won't help much with a target that needs grammar-mutated input), but for simple cases this offers an easy out.

This is ostensibly a breaking API change, although only an internal one. Fuzzers with a harness that take a `|buf: &BytesInput|` will still work and all the test cases pass with only a modification to the `run_target` function needed when calling it directly, which I don't think is super common.

Anyway, open for discussion!

Example:
```
#[cfg(test)]
mod tests {
    use libafl::{
        inputs::{HasBytesVec, HasTargetBytes},
        prelude::{
            current_nanos, havoc_mutations,
            inprocess::{InProcessExecutor, InProcessExecutorMut},
            tuple_list, AsMutSlice, BytesInput, CrashFeedback, ExitKind,
            InMemoryCorpus, MaxMapFeedback, Named, Observer, RandPrintablesGenerator,
            SimpleEventManager, SimpleMonitor, StdMapObserver, StdRand, StdScheduledMutator,
            Truncate, UsesInput,
        },
        schedulers::QueueScheduler,
        stages::StdMutationalStage,
        state::StdState,
        Fuzzer, StdFuzzer,
    };
    use serde::{Deserialize, Serialize};
    use std::ptr::write;

    static mut SIGNALS: [u8; 16] = [0; 16];
    static mut SIGNALS_PTR: *mut u8 = unsafe { SIGNALS.as_mut_ptr() };

    #[derive(Debug, Serialize, Deserialize)]
    struct O {
        name: String,
    }

    impl O {
        pub fn new(name: &str) -> Self {
            Self {
                name: name.to_string(),
            }
        }
    }

    impl Named for O {
        fn name(&self) -> &str {
            &self.name
        }
    }

    impl<S> Observer<S> for O
    where
        S: UsesInput,
    {
        fn pre_exec(
            &mut self,
            _state: &mut S,
            input: &<S as libafl::prelude::UsesInput>::Input,
        ) -> Result<(), libafl::Error> {
            println!("pre_exec: {input:?}");
            Ok(())
        }

        fn post_exec(
            &mut self,
            _state: &mut S,
            input: &<S as UsesInput>::Input,
            _exit_kind: &ExitKind,
        ) -> Result<(), libafl::Error> {
            println!("post_exec: {input:?}");
            Ok(())
        }
    }

    /// Assign a signal to the signals map
    fn signals_set(idx: usize) {
        unsafe { write(SIGNALS_PTR.add(idx), 1) };
    }

    #[test]
    fn test_mutable_bytes() {
        let mut harness = |input: &mut BytesInput| {
            let buf = input.bytes_mut();
            println!("{buf:?}");

            if buf.len() > 3 {
                buf.truncate(3);
            }

            signals_set(0);
            if !buf.is_empty() && buf[0] == b'a' {
                signals_set(1);
                if buf.len() > 1 && buf[1] == b'b' {
                    signals_set(2);
                    if buf.len() > 2 && buf[2] == b'c' {
                        return ExitKind::Crash;
                    }
                }
            }
            ExitKind::Ok
        };

        let observer =
            unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS_PTR, SIGNALS.len()) };

        let test_observer = O::new("test");

        let mut feedback = MaxMapFeedback::new(&observer);

        let mut objective = CrashFeedback::new();

        let mut state = StdState::new(
            StdRand::with_seed(current_nanos()),
            InMemoryCorpus::new(),
            InMemoryCorpus::new(),
            &mut feedback,
            &mut objective,
        )
        .unwrap();

        let mon = SimpleMonitor::new(|s| println!("{s}"));

        let mut mgr = SimpleEventManager::new(mon);

        let scheduler = QueueScheduler::new();

        let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

        let mut executor = InProcessExecutorMut::new(
            &mut harness,
            tuple_list!(observer, test_observer),
            &mut fuzzer,
            &mut state,
            &mut mgr,
        )
        .unwrap();

        let mut generator = RandPrintablesGenerator::new(32);

        state
            .generate_initial_inputs(&mut fuzzer, &mut executor, &mut generator, &mut mgr, 8)
            .expect("Failed to generate the initial corpus");
        let mutator = StdScheduledMutator::new(havoc_mutations());
        let mut stages = tuple_list!(StdMutationalStage::new(mutator));

        fuzzer
            .fuzz_loop_for(&mut stages, &mut executor, &mut state, &mut mgr, 10)
            .expect("Error in the fuzzing loop");
    }
}
```

Output:
```
pre_exec: BytesInput { bytes: [225, 225, 108, 255, 255, 225, 97, 65, 76, 225, 225, 253, 253, 75, 75, 75, 75, 75, 75, 75, 75] }
[225, 225, 108, 255, 255, 225, 97, 65, 76, 225, 225, 253, 253, 75, 75, 75, 75, 75, 75, 75, 75]
post_exec: BytesInput { bytes: [225, 225, 108] }
```