### PR TITLE
Refactor stages to allow for continuation after crashes

### DIFF
--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -22,7 +22,10 @@ use crate::{
     observers::{MapObserver, ObserversTuple, UsesObserver},
     schedulers::powersched::SchedulerMetadata,
     stages::Stage,
-    state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasNamedMetadata, UsesState},
+    state::{
+        HasClientPerfMonitor, HasCorpus, HasCurrentStageInfo, HasMetadata, HasNamedMetadata,
+        UsesState,
+    },
     Error,
 };
 
@@ -86,9 +89,12 @@ where
     O: MapObserver,
     for<'de> <O as MapObserver>::Entry: Serialize + Deserialize<'de> + 'static,
     OT: ObserversTuple<E::State>,
-    E::State: HasCorpus + HasMetadata + HasClientPerfMonitor + HasNamedMetadata,
+    E::State:
+        HasCorpus + HasMetadata + HasCurrentStageInfo + HasClientPerfMonitor + HasNamedMetadata,
     Z: Evaluator<E, EM, State = E::State>,
 {
+    type Context = Self::Input;
+
     #[inline]
     #[allow(
         clippy::let_and_return,
@@ -310,6 +316,68 @@ where
         }
 
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }
 

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -17,7 +17,7 @@ use crate::{
     mutators::mutations::buffer_copy,
     observers::{MapObserver, ObserversTuple},
     stages::Stage,
-    state::{HasCorpus, HasMetadata, HasRand, UsesState},
+    state::{HasCorpus, HasCurrentStageInfo, HasMetadata, HasRand, UsesState},
     Error,
 };
 
@@ -72,11 +72,13 @@ impl<E, EM, O, Z> Stage<E, EM, Z> for ColorizationStage<EM, O, E, Z>
 where
     EM: UsesState<State = E::State> + EventFirer,
     E: HasObservers + Executor<EM, Z>,
-    E::State: HasCorpus + HasMetadata + HasRand,
+    E::State: HasCorpus + HasMetadata + HasCurrentStageInfo + HasRand,
     E::Input: HasBytesVec,
     O: MapObserver,
     Z: UsesState<State = E::State>,
 {
+    type Context = Self::Input;
+
     #[inline]
     #[allow(clippy::let_and_return)]
     fn perform(
@@ -98,6 +100,68 @@ where
         )?;
 
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }
 
@@ -141,7 +205,7 @@ where
     EM: UsesState<State = E::State> + EventFirer,
     O: MapObserver,
     E: HasObservers + Executor<EM, Z>,
-    E::State: HasCorpus + HasMetadata + HasRand,
+    E::State: HasCorpus + HasMetadata + HasCurrentStageInfo + HasRand,
     E::Input: HasBytesVec,
     Z: UsesState<State = E::State>,
 {

--- a/libafl/src/stages/concolic.rs
+++ b/libafl/src/stages/concolic.rs
@@ -12,7 +12,7 @@ use crate::{
     corpus::{Corpus, CorpusId},
     executors::{Executor, HasObservers},
     observers::concolic::ConcolicObserver,
-    state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasMetadata},
+    state::{HasClientPerfMonitor, HasCorpus, HasCurrentStageInfo, HasExecutions, HasMetadata},
     Error,
 };
 
@@ -35,9 +35,11 @@ where
     E: UsesState<State = TE::State>,
     EM: UsesState<State = TE::State>,
     TE: Executor<EM, Z> + HasObservers,
-    TE::State: HasClientPerfMonitor + HasExecutions + HasCorpus,
+    TE::State: HasClientPerfMonitor + HasExecutions + HasCorpus + HasCurrentStageInfo,
     Z: UsesState<State = TE::State>,
 {
+    type Context = Self::Input;
+
     #[inline]
     fn perform(
         &mut self,
@@ -65,6 +67,68 @@ where
                 .insert(metadata);
         }
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }
 
@@ -352,7 +416,7 @@ where
     EM: UsesState<State = Z::State>,
     Z: Evaluator<E, EM>,
     Z::Input: HasBytesVec,
-    Z::State: HasClientPerfMonitor + HasExecutions + HasCorpus,
+    Z::State: HasClientPerfMonitor + HasExecutions + HasCorpus + HasCurrentStageInfo,
 {
     #[inline]
     fn perform(
@@ -390,6 +454,68 @@ where
             }
         }
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut Self::State,
+        manager: &mut EM,
+        corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut Self::State,
+        manager: &mut EM,
+        input: E::Input,
+        index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut Self::State,
+        manager: &mut EM,
+        input: E::Input,
+        index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut Self::State,
+        manager: &mut EM,
+        input: E::Input,
+        index: usize,
+        exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut E,
+        state: &mut Self::State,
+        manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }
 

--- a/libafl/src/stages/dump.rs
+++ b/libafl/src/stages/dump.rs
@@ -10,7 +10,7 @@ use crate::{
     corpus::{Corpus, CorpusId},
     inputs::UsesInput,
     stages::Stage,
-    state::{HasCorpus, HasMetadata, HasRand, HasSolutions, UsesState},
+    state::{HasCorpus, HasCurrentStageInfo, HasMetadata, HasRand, HasSolutions, UsesState},
     Error,
 };
 
@@ -45,8 +45,10 @@ where
     EM: UsesState<State = Z::State>,
     E: UsesState<State = Z::State>,
     Z: UsesState,
-    Z::State: HasCorpus + HasSolutions + HasRand + HasMetadata,
+    Z::State: HasCorpus + HasCurrentStageInfo + HasSolutions + HasRand + HasMetadata,
 {
+    type Context = Self::Input;
+
     #[inline]
     fn perform(
         &mut self,
@@ -109,13 +111,75 @@ where
 
         Ok(())
     }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        unimplemented!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        unimplemented!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        unimplemented!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        unimplemented!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        unimplemented!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
 }
 
 impl<CB, EM, Z> DumpToDiskStage<CB, EM, Z>
 where
     EM: UsesState<State = Z::State>,
     Z: UsesState,
-    Z::State: HasCorpus + HasSolutions + HasRand + HasMetadata,
+    Z::State: HasCorpus + HasCurrentStageInfo + HasSolutions + HasRand + HasMetadata,
 {
     /// Create a new [`DumpToDiskStage`]
     pub fn new<A, B>(to_bytes: CB, corpus_dir: A, solutions_dir: B) -> Result<Self, Error>

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -18,7 +18,9 @@ use crate::{
     observers::{MapObserver, ObserversTuple},
     stages::Stage,
     start_timer,
-    state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasMetadata, UsesState},
+    state::{
+        HasClientPerfMonitor, HasCorpus, HasCurrentStageInfo, HasExecutions, HasMetadata, UsesState,
+    },
     Error,
 };
 
@@ -61,12 +63,15 @@ where
     E::Observers: ObserversTuple<E::State>,
     E::State: UsesInput<Input = BytesInput>
         + HasClientPerfMonitor
+        + HasCurrentStageInfo
         + HasExecutions
         + HasMetadata
         + HasCorpus,
     EM: UsesState<State = E::State>,
     Z: UsesState<State = E::State>,
 {
+    type Context = Self::Input;
+
     #[inline]
     #[allow(clippy::too_many_lines)]
     fn perform(
@@ -305,6 +310,68 @@ where
 
         Ok(())
     }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }
 
 impl<EM, O, OT, Z> GeneralizationStage<EM, O, OT, Z>
@@ -314,6 +381,7 @@ where
     OT: ObserversTuple<EM::State>,
     EM::State: UsesInput<Input = BytesInput>
         + HasClientPerfMonitor
+        + HasCurrentStageInfo
         + HasExecutions
         + HasMetadata
         + HasCorpus,

--- a/libafl/src/stages/logics.rs
+++ b/libafl/src/stages/logics.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use crate::{
     corpus::CorpusId,
     stages::{Stage, StagesTuple},
-    state::UsesState,
+    state::{HasCurrentStageInfo, UsesState},
     Error,
 };
 
@@ -39,10 +39,13 @@ impl<CB, E, EM, ST, Z> Stage<E, EM, Z> for WhileStage<CB, E, EM, ST, Z>
 where
     CB: FnMut(&mut Z, &mut E, &mut E::State, &mut EM, CorpusId) -> Result<bool, Error>,
     E: UsesState,
+    E::State: HasCurrentStageInfo,
     EM: UsesState<State = E::State>,
     ST: StagesTuple<E, EM, E::State, Z>,
     Z: UsesState<State = E::State>,
 {
+    type Context = Self::Input;
+
     fn perform(
         &mut self,
         fuzzer: &mut Z,
@@ -56,6 +59,68 @@ where
                 .perform_all(fuzzer, executor, state, manager, corpus_idx)?;
         }
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }
 
@@ -108,10 +173,13 @@ impl<CB, E, EM, ST, Z> Stage<E, EM, Z> for IfStage<CB, E, EM, ST, Z>
 where
     CB: FnMut(&mut Z, &mut E, &mut E::State, &mut EM, CorpusId) -> Result<bool, Error>,
     E: UsesState,
+    E::State: HasCurrentStageInfo,
     EM: UsesState<State = E::State>,
     ST: StagesTuple<E, EM, E::State, Z>,
     Z: UsesState<State = E::State>,
 {
+    type Context = Self::Input;
+
     fn perform(
         &mut self,
         fuzzer: &mut Z,
@@ -126,12 +194,75 @@ where
         }
         Ok(())
     }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }
 
 impl<CB, E, EM, ST, Z> IfStage<CB, E, EM, ST, Z>
 where
     CB: FnMut(&mut Z, &mut E, &mut E::State, &mut EM, CorpusId) -> Result<bool, Error>,
     E: UsesState,
+    E::State: HasCurrentStageInfo,
     EM: UsesState<State = E::State>,
     ST: StagesTuple<E, EM, E::State, Z>,
     Z: UsesState<State = E::State>,
@@ -180,11 +311,14 @@ impl<CB, E, EM, ST1, ST2, Z> Stage<E, EM, Z> for IfElseStage<CB, E, EM, ST1, ST2
 where
     CB: FnMut(&mut Z, &mut E, &mut E::State, &mut EM, CorpusId) -> Result<bool, Error>,
     E: UsesState,
+    E::State: HasCurrentStageInfo,
     EM: UsesState<State = E::State>,
     ST1: StagesTuple<E, EM, E::State, Z>,
     ST2: StagesTuple<E, EM, E::State, Z>,
     Z: UsesState<State = E::State>,
 {
+    type Context = Self::Input;
+
     fn perform(
         &mut self,
         fuzzer: &mut Z,
@@ -201,6 +335,68 @@ where
                 .perform_all(fuzzer, executor, state, manager, corpus_idx)?;
         }
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        todo!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        todo!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        todo!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, crate::executors::ExitKind), Error> {
+        todo!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: crate::executors::ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        todo!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }
 

--- a/libafl/src/stages/sync.rs
+++ b/libafl/src/stages/sync.rs
@@ -17,7 +17,10 @@ use crate::{
     fuzzer::{Evaluator, EvaluatorObservers, ExecutionProcessor},
     inputs::{Input, InputConverter, UsesInput},
     stages::Stage,
-    state::{HasClientPerfMonitor, HasCorpus, HasExecutions, HasMetadata, HasRand, UsesState},
+    state::{
+        HasClientPerfMonitor, HasCorpus, HasCurrentStageInfo, HasExecutions, HasMetadata, HasRand,
+        UsesState,
+    },
     Error,
 };
 
@@ -59,8 +62,10 @@ where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
 {
+    type Context = Self::Input;
+
     #[inline]
     fn perform(
         &mut self,
@@ -96,6 +101,68 @@ where
 
         Ok(())
     }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<E::Input, Error> {
+        unimplemented!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        unimplemented!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        unimplemented!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, ExitKind), Error> {
+        unimplemented!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        unimplemented!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
 }
 
 impl<CB, E, EM, Z> SyncFromDiskStage<CB, E, EM, Z>
@@ -104,7 +171,7 @@ where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
 {
     /// Creates a new [`SyncFromDiskStage`]
     #[must_use]
@@ -170,7 +237,7 @@ where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
 {
     /// Creates a new [`SyncFromDiskStage`] invoking `Input::from_file` to load inputs
     #[must_use]
@@ -236,6 +303,7 @@ where
     EM: UsesState<State = S> + EventFirer,
     S: UsesInput
         + HasClientPerfMonitor
+        + HasCurrentStageInfo
         + HasExecutions
         + HasCorpus
         + HasRand
@@ -249,6 +317,8 @@ where
     ICB: InputConverter<From = DI, To = S::Input>,
     DI: Input,
 {
+    type Context = Self::Input;
+
     #[inline]
     fn perform(
         &mut self,
@@ -305,6 +375,68 @@ where
         #[cfg(feature = "introspection")]
         state.introspection_monitor_mut().finish_stage();
         Ok(())
+    }
+
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _corpus_idx: CorpusId,
+    ) -> Result<Self::Input, Error> {
+        unimplemented!()
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        unimplemented!()
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, bool), Error> {
+        unimplemented!()
+    }
+
+    fn run_target(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+    ) -> Result<(E::Input, ExitKind), Error> {
+        unimplemented!()
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+        _input: E::Input,
+        _index: usize,
+        _exit_kind: ExitKind,
+    ) -> Result<(E::Input, Option<usize>), Error> {
+        unimplemented!()
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        _state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
+        unimplemented!()
     }
 }
 

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -9,6 +9,7 @@ use crate::monitors::PerfFeature;
 use crate::{
     bolts::{current_time, rands::Rand},
     corpus::{Corpus, CorpusId},
+    executors::ExitKind,
     impl_serdeany, mark_feature_time,
     mutators::{MutationResult, Mutator},
     stages::{
@@ -16,7 +17,9 @@ use crate::{
         MutationalStage, Stage,
     },
     start_timer,
-    state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasRand, UsesState},
+    state::{
+        HasClientPerfMonitor, HasCorpus, HasCurrentStageInfo, HasMetadata, HasRand, UsesState,
+    },
     Error, Evaluator,
 };
 
@@ -82,85 +85,26 @@ pub fn reset<S: HasMetadata>(state: &mut S) -> Result<(), Error> {
 
 /// A [`crate::stages::MutationalStage`] where the mutator iteration can be tuned at runtime
 #[derive(Clone, Debug)]
-pub struct TuneableMutationalStage<E, EM, I, M, Z> {
+pub struct TuneableMutationalStage<E, EM, I, M, MTP, Z> {
     mutator: M,
+    limit: usize,
+    corpus_idx: Option<CorpusId>,
+    post: Option<MTP>,
+    fuzz_time: Option<Duration>,
+    start_time: Option<Duration>,
     phantom: PhantomData<(E, EM, I, Z)>,
 }
 
-impl<E, EM, I, M, Z> MutationalStage<E, EM, I, M, Z> for TuneableMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, Z> MutationalStage<E, EM, I, M, Z>
+    for TuneableMutationalStage<E, EM, I, M, I::Post, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     M: Mutator<I, Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
     I: MutatedTransform<Z::Input, Z::State> + Clone,
 {
-    /// Runs this (mutational) stage for the given `testcase`
-    /// Exactly the same functionality as [`MutationalStage::perform_mutational`], but with added timeout support.
-    #[allow(clippy::cast_possible_wrap)] // more than i32 stages on 32 bit system - highly unlikely...
-    fn perform_mutational(
-        &mut self,
-        fuzzer: &mut Z,
-        executor: &mut E,
-        state: &mut Z::State,
-        manager: &mut EM,
-        corpus_idx: CorpusId,
-    ) -> Result<(), Error> {
-        let metadata: &TuneableMutationalStageMetadata = state.metadata()?;
-
-        let fuzz_time = metadata.fuzz_time;
-        let iters = metadata.iters;
-
-        let (start_time, iters) = if fuzz_time.is_some() {
-            (Some(current_time()), iters)
-        } else {
-            (None, Some(self.iterations(state, corpus_idx)?))
-        };
-
-        start_timer!(state);
-        let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
-        let Ok(input) = I::try_transform_from(&mut testcase, state, corpus_idx) else { return Ok(()); };
-        drop(testcase);
-        mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
-
-        let mut i = 0_usize;
-        loop {
-            if let Some(start_time) = start_time {
-                if current_time() - start_time >= fuzz_time.unwrap() {
-                    break;
-                }
-            }
-            if let Some(iters) = iters {
-                if i >= iters as usize {
-                    break;
-                }
-            } else {
-                i += 1;
-            }
-
-            let mut input = input.clone();
-
-            start_timer!(state);
-            let mutated = self.mutator_mut().mutate(state, &mut input, i as i32)?;
-            mark_feature_time!(state, PerfFeature::Mutate);
-
-            if mutated == MutationResult::Skipped {
-                continue;
-            }
-
-            // Time is measured directly the `evaluate_input` function
-            let (untransformed, post) = input.try_transform_into(state)?;
-            let (_, corpus_idx) = fuzzer.evaluate_input(state, executor, manager, untransformed)?;
-
-            start_timer!(state);
-            self.mutator_mut().post_exec(state, i as i32, corpus_idx)?;
-            post.post_exec(state, i as i32, corpus_idx)?;
-            mark_feature_time!(state, PerfFeature::MutatePostExec);
-        }
-        Ok(())
-    }
-
     /// The mutator, added to this stage
     #[inline]
     fn mutator(&self) -> &M {
@@ -185,53 +129,154 @@ where
     }
 }
 
-impl<E, EM, I, M, Z> UsesState for TuneableMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, Z> UsesState for TuneableMutationalStage<E, EM, I, M, I::Post, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     M: Mutator<I, Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand,
     I: MutatedTransform<Z::Input, Z::State> + Clone,
 {
     type State = Z::State;
 }
 
-impl<E, EM, I, M, Z> Stage<E, EM, Z> for TuneableMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, Z> Stage<E, EM, Z> for TuneableMutationalStage<E, EM, I, M, I::Post, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     M: Mutator<I, Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
     I: MutatedTransform<Z::Input, Z::State> + Clone,
 {
-    #[inline]
-    #[allow(clippy::let_and_return)]
-    fn perform(
+    type Context = I;
+    fn init(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        state: &mut Self::State,
+        _manager: &mut EM,
+        corpus_idx: CorpusId,
+    ) -> Result<Self::Context, Error> {
+        let metadata: &TuneableMutationalStageMetadata = state.metadata()?;
+
+        self.fuzz_time = metadata.fuzz_time;
+        let iters = metadata.iters;
+
+        let (start_time, iters) = if self.fuzz_time.is_some() {
+            (Some(current_time()), iters)
+        } else {
+            (None, Some(self.iterations(state, corpus_idx)?))
+        };
+        self.start_time = start_time;
+        self.limit = iters.unwrap() as usize;
+
+        start_timer!(state);
+        let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
+        let Ok(input) = Self::Context::try_transform_from(&mut testcase, state, corpus_idx) else { return Err(Error::unsupported("Couldn't transform test case")) };
+        drop(testcase);
+        mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
+
+        Ok(input)
+    }
+
+    fn limit(&self) -> Result<usize, Error> {
+        Ok(self.limit)
+    }
+
+    fn pre_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        state: &mut Self::State,
+        _manager: &mut EM,
+        input: Self::Context,
+        index: usize,
+    ) -> Result<(Self::Context, bool), Error> {
+        let mut input = input.clone();
+
+        start_timer!(state);
+        let mutated = self.mutator_mut().mutate(state, &mut input, index as i32)?;
+        mark_feature_time!(state, PerfFeature::Mutate);
+
+        if mutated == MutationResult::Skipped {
+            Ok((input, false))
+        } else {
+            Ok((input, true))
+        }
+    }
+
+    fn run_target(
         &mut self,
         fuzzer: &mut Z,
         executor: &mut E,
-        state: &mut Z::State,
+        state: &mut Self::State,
         manager: &mut EM,
-        corpus_idx: CorpusId,
-    ) -> Result<(), Error> {
-        let ret = self.perform_mutational(fuzzer, executor, state, manager, corpus_idx);
+        input: Self::Context,
+        _index: usize,
+    ) -> Result<(Self::Context, ExitKind), Error> {
+        // Time is measured directly the `evaluate_input` function
+        let (untransformed, post) = input.clone().try_transform_into(state)?;
+        let (_, corpus_idx) = fuzzer.evaluate_input(state, executor, manager, untransformed)?;
+        self.post = Some(post);
+        self.corpus_idx = corpus_idx;
 
+        Ok((input, ExitKind::Ok))
+    }
+
+    fn post_exec(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        state: &mut Self::State,
+        _manager: &mut EM,
+        input: Self::Context,
+        index: usize,
+        _exit_kind: ExitKind,
+    ) -> Result<(Self::Context, Option<usize>), Error> {
+        start_timer!(state);
+        let corpus_idx = self.corpus_idx;
+        self.mutator_mut()
+            .post_exec(state, index as i32, corpus_idx)?;
+        self.post
+            .as_mut()
+            .unwrap()
+            .clone()
+            .post_exec(state, index as i32, corpus_idx)?;
+        mark_feature_time!(state, PerfFeature::MutatePostExec);
+
+        if let Some(start_time) = self.start_time {
+            if current_time() - start_time >= self.fuzz_time.unwrap() {
+                Ok((input, Some(self.limit()?)))
+            } else {
+                Ok((input, None))
+            }
+        } else {
+            Ok((input, None))
+        }
+    }
+
+    fn deinit(
+        &mut self,
+        _fuzzer: &mut Z,
+        _executor: &mut E,
+        state: &mut Self::State,
+        _manager: &mut EM,
+    ) -> Result<(), Error> {
         #[cfg(feature = "introspection")]
         state.introspection_monitor_mut().finish_stage();
-
-        ret
+        Ok(())
     }
 }
 
-impl<E, EM, M, Z> TuneableMutationalStage<E, EM, Z::Input, M, Z>
+impl<E, EM, M, MTP, Z> TuneableMutationalStage<E, EM, Z::Input, M, MTP, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     M: Mutator<Z::Input, Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
 {
     /// Creates a new default mutational stage
     #[must_use]
@@ -240,7 +285,7 @@ where
     }
 }
 
-impl TuneableMutationalStage<(), (), (), (), ()> {
+impl TuneableMutationalStage<(), (), (), (), (), ()> {
     /// Set the number of iterations to be used by this mutational stage
     pub fn set_iters<S: HasMetadata>(state: &mut S, iters: u64) -> Result<(), Error> {
         set_iters(state, iters)
@@ -265,13 +310,13 @@ impl TuneableMutationalStage<(), (), (), (), ()> {
     }
 }
 
-impl<E, EM, I, M, Z> TuneableMutationalStage<E, EM, I, M, Z>
+impl<E, EM, I, M, MTP, Z> TuneableMutationalStage<E, EM, I, M, MTP, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
     M: Mutator<I, Z::State>,
     Z: Evaluator<E, EM>,
-    Z::State: HasClientPerfMonitor + HasCorpus + HasRand + HasMetadata,
+    Z::State: HasClientPerfMonitor + HasCurrentStageInfo + HasCorpus + HasRand + HasMetadata,
 {
     /// Creates a new tranforming mutational stage
     #[must_use]
@@ -282,6 +327,11 @@ where
         Self {
             mutator,
             phantom: PhantomData,
+            limit: 0,
+            post: None,
+            corpus_idx: None,
+            fuzz_time: None,
+            start_time: None,
         }
     }
 }


### PR DESCRIPTION
This PR refactors the stages to allow for continuation at the point we left off after a crash, which is necessary for e.g. crash exploration.

- [x] Refactor the base code and traits to allow for this
- [ ] Refactor all of the stages to use the new design
- [ ] Implement post_exec calling from crash handlers
- [ ] Test