### PR TITLE
libafl{,_sugar}: Bump typed-builder to 0.15 for syn 2 support

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -70,7 +70,7 @@ postcard = { version = "1.0", features = ["alloc"] } # no_std compatible serde s
 bincode = {version = "1.3", optional = true }
 c2rust-bitfields = { version = "0.17", features = ["no_std"] }
 num_enum = { version = "0.5.7", default-features = false }
-typed-builder = "0.14" # Implement the builder pattern at compiletime
+typed-builder = "0.15" # Implement the builder pattern at compiletime
 ahash = { version = "0.8", default-features=false } # The hash function already used in hashbrown
 intervaltree = { version = "0.2.7", default-features = false, features = ["serde"] }
 backtrace = {version = "0.3", optional = true} # Used to get the stacktrace in StacktraceObserver

--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -31,7 +31,7 @@ libafl = { path = "../libafl", version = "0.10.1" }
 libafl_targets = { path = "../libafl_targets", version = "0.10.1" }
 libafl_qemu = { path = "../libafl_qemu", version = "0.10.1" }
 
-typed-builder = "0.12" # Implement the builder pattern at compiletime
+typed-builder = "0.15" # Implement the builder pattern at compiletime
 pyo3 = { version = "0.18.3", optional = true }
 log = "0.4.17"
 


### PR DESCRIPTION
Trying to update all the transitive deps of my project to syn 2 so I don't have to build syn twice...