### PR TITLE
fix(libafl): update Z3 dependency

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -100,7 +100,7 @@ tokio = { version = "1.28.1", optional = true, features = ["sync", "net", "rt", 
 
 wait-timeout = { version = "0.2", optional = true } # used by CommandExecutor to wait for child process
 
-z3 = { version = "0.11", features = ["static-link-z3"], optional = true } # for concolic mutation
+z3 = { version = "0.12.0", features = ["static-link-z3"], optional = true } # for concolic mutation
 
 pyo3 = { version = "0.18.3", optional = true, features = ["serde", "macros"] }
 concat-idents = { version = "1.1.3", optional = true }


### PR DESCRIPTION
See Z3Prover/z3#5586. libafl with `cmin` feature cannot be built for Android.