### PR TITLE
fix riscv(32) tick reading albeit it passes with gcc it does not with…

### DIFF
--- a/libafl/src/bolts/cpu.rs
+++ b/libafl/src/bolts/cpu.rs
@@ -80,7 +80,7 @@ pub fn read_time_counter() -> u64 {
              "rdcycleh {hg}",
              "rdcycle {lw}",
              "rdcycleh {cmp}",
-             "bne {hg} {cmp}, jmp%=",
+             "bne {hg}, {cmp}, jmp%=",
              hg = out(reg) hg,
              lw = out(reg) lw,
              cmp = out(reg) cmp);


### PR DESCRIPTION
… clang.