### PR TITLE
Less unsafe `type_eq` in stable

### DIFF
--- a/libafl/src/bolts/llmp.rs
+++ b/libafl/src/bolts/llmp.rs
@@ -499,8 +499,7 @@ fn recv_tcp_msg(stream: &mut TcpStream) -> Result<Vec<u8>, Error> {
     let mut size_bytes = [0_u8; 4];
     stream.read_exact(&mut size_bytes)?;
     let size = u32::from_be_bytes(size_bytes);
-    let mut bytes = vec![];
-    bytes.resize(size as usize, 0_u8);
+    let mut bytes = vec![0; size.try_into().unwrap()];
 
     #[cfg(feature = "llmp_debug")]
     log::trace!("LLMP TCP: Receiving payload of size {size}");

--- a/libafl/src/bolts/os/unix_shmem_server.rs
+++ b/libafl/src/bolts/os/unix_shmem_server.rs
@@ -607,8 +607,7 @@ where
         let mut size_bytes = [0_u8; 4];
         client.stream.read_exact(&mut size_bytes)?;
         let size = u32::from_be_bytes(size_bytes);
-        let mut bytes = vec![];
-        bytes.resize(size as usize, 0_u8);
+        let mut bytes = vec![0; size.try_into().unwrap()];
         client
             .stream
             .read_exact(&mut bytes)

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -1,5 +1,7 @@
 //! Compiletime lists/tuples used throughout the `LibAFL` universe
 
+#[rustversion::not(nightly)]
+use core::any::type_name;
 use core::{
     any::TypeId,
     ptr::{addr_of, addr_of_mut},
@@ -33,11 +35,12 @@ pub const fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
 }
 
 /// Returns if the type `T` is equal to `U`
+/// As this uses `type_name` internally, there is a slight chance for collisions.
+/// Use `nightly` if you need a perfect match at all times.
 #[rustversion::not(nightly)]
 #[must_use]
-pub const fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
-    // BEWARE! This is not unsafe, it is SUPER UNSAFE
-    true
+pub fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
+    type_name::<T>() == type_name::<U>()
 }
 
 /// Gets the length of the element

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -530,10 +530,17 @@ mod test {
 
     #[test]
     fn test_type_eq() {
+        // test eq
         assert!(type_eq::<u64, u64>());
-        assert!(!type_eq::<u64, usize>());
+        assert!(type_eq::<BytesInput, BytesInput>());
         assert!(type_eq::<NopState<BytesInput>, NopState<BytesInput>>());
+
+        // test neq
+        assert!(!type_eq::<u64, usize>());
+        assert!(!type_eq::<NopInput, BytesInput>());
+        assert!(!type_eq::<BytesInput, NopInput>());
         assert!(!type_eq::<NopState<BytesInput>, NopState<NopInput>>());
-        assert!(!type_eq::<NopState<BytesInput>, i64>());
+        assert!(!type_eq::<NopState<BytesInput>, BytesInput>());
+        assert!(!type_eq::<NopState<BytesInput>, u64>());
     }
 }

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -553,8 +553,14 @@ mod test {
             StdMapObserver<u8, false>,
         >());
 
-        assert!(type_eq::<StdMapObserver<u8, true>, crate::observers::StdMapObserver<u8, true>>());
-        assert!(!type_eq::<StdMapObserver<u8, true>, crate::observers::StdMapObserver<i8, true>>());
+        assert!(type_eq::<
+            StdMapObserver<u8, true>,
+            crate::observers::StdMapObserver<u8, true>,
+        >());
+        assert!(!type_eq::<
+            StdMapObserver<u8, true>,
+            crate::observers::StdMapObserver<i8, true>,
+        >());
 
         type MapObserverAlias<'a, T> = StdMapObserver<'a, T, true>;
         assert!(type_eq::<StdMapObserver<u8, true>, MapObserverAlias<u8>>());

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -523,61 +523,40 @@ impl<Head, Tail> PlusOne for (Head, Tail) where
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        bolts::{ownedref::OwnedMutSlice, tuples::type_eq},
-        inputs::{BytesInput, NopInput},
-        observers::StdMapObserver,
-        state::NopState,
-    };
+    use crate::bolts::{ownedref::OwnedMutSlice, tuples::type_eq};
 
     #[test]
     #[allow(unused_qualifications)] // for type name tests
     fn test_type_eq() {
         // test eq
         assert!(type_eq::<u64, u64>());
-        assert!(type_eq::<BytesInput, BytesInput>());
-        assert!(type_eq::<NopState<BytesInput>, NopState<BytesInput>>());
 
         // test neq
         assert!(!type_eq::<u64, usize>());
-        assert!(!type_eq::<NopInput, BytesInput>());
-        assert!(!type_eq::<BytesInput, NopInput>());
-        assert!(!type_eq::<NopState<BytesInput>, NopState<NopInput>>());
-        assert!(!type_eq::<NopState<BytesInput>, BytesInput>());
-        assert!(!type_eq::<NopState<BytesInput>, u64>());
 
         // test weirder lifetime things
-        assert!(type_eq::<StdMapObserver<u8, true>, StdMapObserver<u8, true>>());
-        assert!(!type_eq::<
-            StdMapObserver<u8, true>,
-            StdMapObserver<u8, false>,
-        >());
+        assert!(type_eq::<OwnedMutSlice<u8>, OwnedMutSlice<u8>>());
+        assert!(!type_eq::<OwnedMutSlice<u8>, OwnedMutSlice<u32>>());
 
         assert!(type_eq::<
-            StdMapObserver<u8, true>,
-            crate::observers::StdMapObserver<u8, true>,
+            OwnedMutSlice<u8>,
+            crate::bolts::ownedref::OwnedMutSlice<u8>,
         >());
         assert!(!type_eq::<
-            StdMapObserver<u8, true>,
-            crate::observers::StdMapObserver<i8, true>,
+            OwnedMutSlice<u8>,
+            crate::bolts::ownedref::OwnedMutSlice<u32>,
         >());
 
-        type MapObserverAlias<'a, T> = StdMapObserver<'a, T, true>;
-        assert!(type_eq::<StdMapObserver<u8, true>, MapObserverAlias<u8>>());
+        type OwnedMutSliceAlias<'a> = OwnedMutSlice<'a, u8>;
+        assert!(type_eq::<OwnedMutSlice<u8>, OwnedMutSliceAlias>());
 
-        fn lifetimes<'a, 'b>() {
-            assert!(type_eq::<
-                StdMapObserver<'a, u8, true>,
-                StdMapObserver<'b, u8, true>,
-            >());
-            assert!(type_eq::<
-                StdMapObserver<'static, u8, true>,
-                StdMapObserver<'a, u8, true>,
-            >());
+        fn test_lifetimes<'a, 'b>() {
+            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, u8>>());
+            assert!(type_eq::<OwnedMutSlice<'static, u8>, OwnedMutSlice<'a, u8>>());
             assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, u8>>());
             assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'static, u8>>());
             assert!(!type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, i8>>());
         }
-        lifetimes();
+        test_lifetimes();
     }
 }

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -528,6 +528,18 @@ mod test {
     #[test]
     #[allow(unused_qualifications)] // for type name tests
     fn test_type_eq() {
+        #[allow(extra_unused_lifetimes)]
+        fn test_lifetimes<'a, 'b>() {
+            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, u8>>());
+            assert!(type_eq::<OwnedMutSlice<'static, u8>, OwnedMutSlice<'a, u8>>());
+            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, u8>>());
+            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'static, u8>>());
+            assert!(!type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, i8>>());
+        }
+        type OwnedMutSliceAlias<'a> = OwnedMutSlice<'a, u8>;
+        assert!(type_eq::<OwnedMutSlice<u8>, OwnedMutSliceAlias>());
+
+        test_lifetimes();
         // test eq
         assert!(type_eq::<u64, u64>());
 
@@ -546,17 +558,5 @@ mod test {
             OwnedMutSlice<u8>,
             crate::bolts::ownedref::OwnedMutSlice<u32>,
         >());
-
-        type OwnedMutSliceAlias<'a> = OwnedMutSlice<'a, u8>;
-        assert!(type_eq::<OwnedMutSlice<u8>, OwnedMutSliceAlias>());
-
-        fn test_lifetimes<'a, 'b>() {
-            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, u8>>());
-            assert!(type_eq::<OwnedMutSlice<'static, u8>, OwnedMutSlice<'a, u8>>());
-            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, u8>>());
-            assert!(type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'static, u8>>());
-            assert!(!type_eq::<OwnedMutSlice<'a, u8>, OwnedMutSlice<'b, i8>>());
-        }
-        test_lifetimes();
     }
 }

--- a/libafl/src/bolts/tuples.rs
+++ b/libafl/src/bolts/tuples.rs
@@ -531,6 +531,7 @@ mod test {
     };
 
     #[test]
+    #[allow(unused_qualifications)] // for type name tests
     fn test_type_eq() {
         // test eq
         assert!(type_eq::<u64, u64>());
@@ -545,12 +546,18 @@ mod test {
         assert!(!type_eq::<NopState<BytesInput>, BytesInput>());
         assert!(!type_eq::<NopState<BytesInput>, u64>());
 
+        // test weirder lifetime things
         assert!(type_eq::<StdMapObserver<u8, true>, StdMapObserver<u8, true>>());
         assert!(!type_eq::<
             StdMapObserver<u8, true>,
             StdMapObserver<u8, false>,
         >());
-        assert!(!type_eq::<StdMapObserver<u8, true>, StdMapObserver<i8, true>>());
+
+        assert!(type_eq::<StdMapObserver<u8, true>, crate::observers::StdMapObserver<u8, true>>());
+        assert!(!type_eq::<StdMapObserver<u8, true>, crate::observers::StdMapObserver<i8, true>>());
+
+        type MapObserverAlias<'a, T> = StdMapObserver<'a, T, true>;
+        assert!(type_eq::<StdMapObserver<u8, true>, MapObserverAlias<u8>>());
 
         fn lifetimes<'a, 'b>() {
             assert!(type_eq::<


### PR DESCRIPTION
This is still not perfect, but at least should be quite a bit better