### PR TITLE
Removed unused intrinsics features

### DIFF
--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -6,9 +6,6 @@ Welcome to `LibAFL`
 #![no_std]
 // For `type_eq`
 #![cfg_attr(nightly, feature(specialization))]
-// For `type_id` and owned things
-#![allow(internal_features)]
-#![cfg_attr(nightly, feature(intrinsics))]
 // For `std::simd`
 #![cfg_attr(nightly, feature(portable_simd))]
 #![warn(clippy::cargo)]

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -8,9 +8,6 @@ Welcome to `LibAFL`
 #![no_std]
 // For `type_eq`
 #![cfg_attr(nightly, feature(specialization))]
-// For `type_id` and owned things
-#![allow(internal_features)]
-#![cfg_attr(nightly, feature(intrinsics))]
 // For `std::simd`
 #![cfg_attr(nightly, feature(portable_simd))]
 // For `core::error`


### PR DESCRIPTION
Follow up on #1402: We don't actually use this atm, the `owned` module is disabled.