### PR TITLE
Add `serdeany_autoreg` to `libafl_qemu`

### DIFF
--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -31,6 +31,9 @@ be = ["libafl_qemu_sys/be"]
 usermode = ["libafl_qemu_sys/usermode"]
 systemmode = ["libafl_qemu_sys/systemmode"]
 
+# SerdeAny features
+serdeany_autoreg = ["libafl_bolts/serdeany_autoreg"] # Automatically register all `#[derive(SerdeAny)]` types at startup.
+
 slirp = [ "systemmode", "libafl_qemu_sys/slirp" ] # build qemu with host libslirp (for user networking)
 
 clippy = [] # special feature for clippy, don't use in normal projects§

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [features]
-default = ["fork", "build_libqasan"]
+default = ["fork", "build_libqasan", "serdeany_autoreg"]
 python = ["pyo3", "pyo3-build-config"]
 fork = ["libafl/fork"]
 build_libqasan = []


### PR DESCRIPTION
Fix `Cannot deserialize an unregistered type` occurring when using libafl_qemu.