### PR TITLE
More Clippy

### DIFF
--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -11,6 +11,7 @@ pub mod launcher;
 #[allow(clippy::ignored_unit_patterns)]
 pub mod llmp;
 #[cfg(feature = "tcp_manager")]
+#[allow(clippy::ignored_unit_patterns)]
 pub mod tcp;
 use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(all(unix, feature = "std"))]

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -1050,7 +1050,7 @@ impl Emulator {
         perms: MmapPerms,
     ) -> Result<GuestAddr, String> {
         self.mmap(addr, size, perms, libc::MAP_PRIVATE | libc::MAP_ANONYMOUS)
-            .map_err(|_| format!("Failed to map {addr}"))
+            .map_err(|()| format!("Failed to map {addr}"))
             .map(|addr| addr as GuestAddr)
     }
 
@@ -1067,7 +1067,7 @@ impl Emulator {
             perms,
             libc::MAP_FIXED | libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
         )
-        .map_err(|_| format!("Failed to map {addr}"))
+        .map_err(|()| format!("Failed to map {addr}"))
         .map(|addr| addr as GuestAddr)
     }
 

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -63,6 +63,7 @@ pub mod inmemory;
 pub use inmemory::InMemoryBytesCoverageSugar;
 
 #[cfg(target_os = "linux")]
+#[allow(clippy::ignored_unit_patterns)]
 pub mod qemu;
 #[cfg(target_os = "linux")]
 pub use qemu::QemuBytesCoverageSugar;

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -58,6 +58,7 @@
     )
 )]
 
+#[allow(clippy::ignored_unit_patterns)]
 pub mod inmemory;
 pub use inmemory::InMemoryBytesCoverageSugar;
 
@@ -67,6 +68,7 @@ pub mod qemu;
 pub use qemu::QemuBytesCoverageSugar;
 
 #[cfg(target_family = "unix")]
+#[allow(clippy::ignored_unit_patterns)]
 pub mod forkserver;
 #[cfg(target_family = "unix")]
 pub use forkserver::ForkserverBytesCoverageSugar;


### PR DESCRIPTION
For the Derive macro apparently it's not enough to ignore the clippy lint on the struct, we need the whole module...