### PR TITLE
Add more libafl_qemu archs to libafl_sugar

### DIFF
--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -26,7 +26,6 @@ mips = ["libafl_qemu/mips"] # build qemu for mips (el, use with the 'be' feature
 ppc = ["libafl_qemu/ppc"] # build qemu for powerpc
 hexagon = ["libafl_qemu/hexagon"] # build qemu for hexagon
 
-
 [build-dependencies]
 pyo3-build-config = { version = "0.15", optional = true }
 

--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -22,6 +22,10 @@ x86_64 = ["libafl_qemu/x86_64"] # build qemu for x86_64 (default)
 i386 = ["libafl_qemu/i386"] # build qemu for i386
 arm = ["libafl_qemu/arm"] # build qemu for arm
 aarch64 = ["libafl_qemu/aarch64"] # build qemu for aarch64
+mips = ["libafl_qemu/mips"] # build qemu for mips (el, use with the 'be' feature of mips be)
+ppc = ["libafl_qemu/ppc"] # build qemu for powerpc
+hexagon = ["libafl_qemu/hexagon"] # build qemu for hexagon
+
 
 [build-dependencies]
 pyo3-build-config = { version = "0.15", optional = true }


### PR DESCRIPTION
This adds qemu architectures that are supported but not exposed by the sugar crate right now