### PR TITLE
bolts fix musl build.

### DIFF
--- a/libafl_bolts/build.rs
+++ b/libafl_bolts/build.rs
@@ -2,9 +2,13 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-cfg=nightly");
+    #[cfg(target_env = "musl")]
+    println!("cargo:rustc-link-lib=ucontext");
 }
 
 #[rustversion::not(nightly)]
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    #[cfg(target_env = "musl")]
+    println!("cargo:rustc-link-lib=ucontext");
 }


### PR DESCRIPTION
despite being present in the headers, getcontext is not implemented in musl libc, most likely due to the fact it s a deprecated interface. The only way around is having the third party libucontext apk package installed.