### PR TITLE
fix CI QemuCmpLogHelper error.

### DIFF
--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -215,11 +215,13 @@ where
             if self.use_cmplog.unwrap_or(false) {
                 let mut hooks = QemuHooks::new(
                     emulator,
+                    #[cfg(not(any(feature = "mips", feature = "hexagon")))]
                     tuple_list!(
                         QemuEdgeCoverageHelper::default(),
-                        #[cfg(not(any(cpu_target = "mips", cpu_target = "hexagon")))]
                         QemuCmpLogHelper::default(),
                     ),
+                    #[cfg(any(feature = "mips", feature = "hexagon"))]
+                    tuple_list!(QemuEdgeCoverageHelper::default()),
                 );
 
                 let executor = QemuExecutor::new(


### PR DESCRIPTION
the `clippy.sh` script and the CI unbuntu-check test previously failed with 
```rust
error[E0433]: failed to resolve: use of undeclared type `QemuCmpLogHelper`
   --> libafl_sugar/src/qemu.rs:221:25
```

this was caused by using `feature = "{mips,hexagon}"` for the import and `cpu_arch = "{mips,hexagon}"` later when using `QemuCmpLogHelper`.