### PR TITLE
Allow setting the max iterations

### DIFF
--- a/fuzzers/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby_fuzzer_grimoire/src/main.rs
@@ -151,7 +151,7 @@ pub fn main() {
     let mut stages = tuple_list!(
         generalization,
         StdMutationalStage::new(mutator),
-        StdMutationalStage::transforming(grimoire_mutator)
+        StdMutationalStage::new(grimoire_mutator)
     );
 
     for input in initial_inputs {

--- a/fuzzers/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby_fuzzer_grimoire/src/main.rs
@@ -151,7 +151,7 @@ pub fn main() {
     let mut stages = tuple_list!(
         generalization,
         StdMutationalStage::new(mutator),
-        StdMutationalStage::new(grimoire_mutator)
+        StdMutationalStage::transforming(grimoire_mutator)
     );
 
     for input in initial_inputs {

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -229,11 +229,11 @@ where
     }
 }
 
-impl<E, EM, I, M, Z> StdMutationalStage<E, EM, I, M, Z>
+impl<E, EM, M, Z> StdMutationalStage<E, EM, Z::Input, M, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
-    M: Mutator<I, Z::State>,
+    M: Mutator<Z::Input, Z::State>,
     Z: Evaluator<E, EM>,
     Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
 {

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -158,6 +158,7 @@ pub static DEFAULT_MUTATIONAL_MAX_ITERATIONS: u64 = 128;
 #[derive(Clone, Debug)]
 pub struct StdMutationalStage<E, EM, I, M, Z> {
     mutator: M,
+    max_iterations: u64,
     #[allow(clippy::type_complexity)]
     phantom: PhantomData<(E, EM, I, Z)>,
 }
@@ -185,7 +186,7 @@ where
 
     /// Gets the number of iterations as a random number
     fn iterations(&self, state: &mut Z::State, _corpus_idx: CorpusId) -> Result<u64, Error> {
-        Ok(1 + state.rand_mut().below(DEFAULT_MUTATIONAL_MAX_ITERATIONS))
+        Ok(1 + state.rand_mut().below(self.max_iterations))
     }
 }
 
@@ -238,7 +239,12 @@ where
 {
     /// Creates a new default mutational stage
     pub fn new(mutator: M) -> Self {
-        Self::transforming(mutator)
+        Self::transforming(mutator, DEFAULT_MUTATIONAL_MAX_ITERATIONS)
+    }
+
+    /// Creates a new mutational stage with the given max iterations
+    pub fn with_iterations(mutator: M, max_iterations: u64) -> Self {
+        Self::transforming(mutator, max_iterations)
     }
 }
 
@@ -251,9 +257,10 @@ where
     Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
 {
     /// Creates a new transforming mutational stage
-    pub fn transforming(mutator: M) -> Self {
+    pub fn transforming(mutator: M, max_iterations: u64) -> Self {
         Self {
             mutator,
+            max_iterations,
             phantom: PhantomData,
         }
     }

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -229,11 +229,11 @@ where
     }
 }
 
-impl<E, EM, M, Z> StdMutationalStage<E, EM, Z::Input, M, Z>
+impl<E, EM, I, M, Z> StdMutationalStage<E, EM, I, M, Z>
 where
     E: UsesState<State = Z::State>,
     EM: UsesState<State = Z::State>,
-    M: Mutator<Z::Input, Z::State>,
+    M: Mutator<I, Z::State>,
     Z: Evaluator<E, EM>,
     Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
 {

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -239,12 +239,12 @@ where
 {
     /// Creates a new default mutational stage
     pub fn new(mutator: M) -> Self {
-        Self::transforming(mutator, DEFAULT_MUTATIONAL_MAX_ITERATIONS)
+        Self::transforming_with_max_iterations(mutator, DEFAULT_MUTATIONAL_MAX_ITERATIONS)
     }
 
     /// Creates a new mutational stage with the given max iterations
     pub fn with_max_iterations(mutator: M, max_iterations: u64) -> Self {
-        Self::transforming(mutator, max_iterations)
+        Self::transforming_with_max_iterations(mutator, max_iterations)
     }
 }
 
@@ -256,8 +256,13 @@ where
     Z: Evaluator<E, EM>,
     Z::State: HasClientPerfMonitor + HasCorpus + HasRand,
 {
-    /// Creates a new transforming mutational stage
-    pub fn transforming(mutator: M, max_iterations: u64) -> Self {
+    /// Creates a new transforming mutational stage with the default max iterations
+    pub fn transforming(mutator: M) -> Self {
+        Self::transforming_with_max_iterations(mutator, DEFAULT_MUTATIONAL_MAX_ITERATIONS)
+    }
+
+    /// Creates a new transforming mutational stage with the given max iterations
+    pub fn transforming_with_max_iterations(mutator: M, max_iterations: u64) -> Self {
         Self {
             mutator,
             max_iterations,

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -243,7 +243,7 @@ where
     }
 
     /// Creates a new mutational stage with the given max iterations
-    pub fn with_iterations(mutator: M, max_iterations: u64) -> Self {
+    pub fn with_max_iterations(mutator: M, max_iterations: u64) -> Self {
         Self::transforming(mutator, max_iterations)
     }
 }


### PR DESCRIPTION
Trivial patch to allow users to set the max iterations for a `StdMutationalStage`