### PR TITLE
Allow multiple tuneable mutational stages

### DIFF
--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -12,13 +12,12 @@ use crate::{
     corpus::{Corpus, CorpusId},
     mark_feature_time,
     mutators::{MutationResult, Mutator},
-    prelude::HasNamedMetadata,
     stages::{
         mutational::{MutatedTransform, MutatedTransformPost, DEFAULT_MUTATIONAL_MAX_ITERATIONS},
         MutationalStage, Stage,
     },
     start_timer,
-    state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasRand, UsesState},
+    state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasNamedMetadata, HasRand, UsesState},
     Error, Evaluator,
 };
 

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -33,7 +33,10 @@ impl_serdeany!(TuneableMutationalStageMetadata);
 pub const DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME: &str = "TuneableMutationalStage";
 
 /// Set the number of iterations to be used by this mutational stage
-pub fn set_iters<S: HasNamedMetadata>(state: &mut S, iters: u64, name: &str) -> Result<(), Error> {
+pub fn set_iters<S>(state: &mut S, iters: u64, name: &str) -> Result<(), Error>
+where
+    S: HasNamedMetadata,
+{
     let metadata = state
         .named_metadata_map_mut()
         .get_mut::<TuneableMutationalStageMetadata>(name)
@@ -44,7 +47,10 @@ pub fn set_iters<S: HasNamedMetadata>(state: &mut S, iters: u64, name: &str) -> 
 }
 
 /// Get the set iterations
-pub fn get_iters<S: HasNamedMetadata>(state: &S, name: &str) -> Result<Option<u64>, Error> {
+pub fn get_iters<S>(state: &S, name: &str) -> Result<Option<u64>, Error>
+where
+    S: HasNamedMetadata,
+{
     state
         .named_metadata_map()
         .get::<TuneableMutationalStageMetadata>(name)
@@ -53,11 +59,10 @@ pub fn get_iters<S: HasNamedMetadata>(state: &S, name: &str) -> Result<Option<u6
 }
 
 /// Set the time for a single seed to be used by this mutational stage
-pub fn set_seed_fuzz_time<S: HasNamedMetadata>(
-    state: &mut S,
-    fuzz_time: Duration,
-    name: &str,
-) -> Result<(), Error> {
+pub fn set_seed_fuzz_time<S>(state: &mut S, fuzz_time: Duration, name: &str) -> Result<(), Error>
+where
+    S: HasNamedMetadata,
+{
     let metadata = state
         .named_metadata_map_mut()
         .get_mut::<TuneableMutationalStageMetadata>(name)
@@ -68,10 +73,10 @@ pub fn set_seed_fuzz_time<S: HasNamedMetadata>(
 }
 
 /// Get the time for a single seed to be used by this mutational stage
-pub fn get_seed_fuzz_time<S: HasNamedMetadata>(
-    state: &S,
-    name: &str,
-) -> Result<Option<Duration>, Error> {
+pub fn get_seed_fuzz_time<S>(state: &S, name: &str) -> Result<Option<Duration>, Error>
+where
+    S: HasNamedMetadata,
+{
     state
         .named_metadata_map()
         .get::<TuneableMutationalStageMetadata>(name)
@@ -80,7 +85,10 @@ pub fn get_seed_fuzz_time<S: HasNamedMetadata>(
 }
 
 /// Reset this to a normal, randomized, stage
-pub fn reset<S: HasNamedMetadata>(state: &mut S, name: &str) -> Result<(), Error> {
+pub fn reset<S>(state: &mut S, name: &str) -> Result<(), Error>
+where
+    S: HasNamedMetadata,
+{
     state
         .named_metadata_map_mut()
         .get_mut::<TuneableMutationalStageMetadata>(name)
@@ -259,12 +267,18 @@ where
     }
 
     /// Set the number of iterations to be used by this mutational stage
-    pub fn set_iters<S: HasNamedMetadata>(&self, state: &mut S, iters: u64) -> Result<(), Error> {
+    pub fn set_iters<S>(&self, state: &mut S, iters: u64) -> Result<(), Error>
+    where
+        S: HasNamedMetadata,
+    {
         set_iters(state, iters, &self.name)
     }
 
     /// Get the set iterations
-    pub fn iters<S: HasNamedMetadata>(&self, state: &S) -> Result<Option<u64>, Error> {
+    pub fn iters<S>(&self, state: &S) -> Result<Option<u64>, Error>
+    where
+        S: HasNamedMetadata,
+    {
         get_iters(state, &self.name)
     }
 
@@ -273,15 +287,18 @@ where
         &self,
         state: &mut S,
         fuzz_time: Duration,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        S: HasNamedMetadata,
+    {
         set_seed_fuzz_time(state, fuzz_time, &self.name)
     }
 
     /// Set the time to mutate a single input in this mutational stage
-    pub fn seed_fuzz_time<S: HasNamedMetadata>(
-        &self,
-        state: &S,
-    ) -> Result<Option<Duration>, Error> {
+    pub fn seed_fuzz_time<S>(&self, state: &S) -> Result<Option<Duration>, Error>
+    where
+        S: HasNamedMetadata,
+    {
         get_seed_fuzz_time(state, &self.name)
     }
 }

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -251,7 +251,7 @@ where
     /// Creates a new default tuneable mutational stage
     #[must_use]
     pub fn new(state: &mut Z::State, mutator: M) -> Self {
-        Self::transforming(state, mutator, "TuneableMutationalStage")
+        Self::transforming(state, mutator, DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME)
     }
 
     /// Crates a new tuneable mutational stage with the given name

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -283,7 +283,7 @@ where
     }
 
     /// Set the time to mutate a single input in this mutational stage
-    pub fn set_seed_fuzz_time<S: HasNamedMetadata>(
+    pub fn set_seed_fuzz_time<S>(
         &self,
         state: &mut S,
         fuzz_time: Duration,

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -75,7 +75,11 @@ where
 }
 
 /// Set the time for a single seed to be used by this mutational stage
-pub fn set_seed_fuzz_time_with_name<S>(state: &mut S, fuzz_time: Duration, name: &str) -> Result<(), Error>
+pub fn set_seed_fuzz_time_with_name<S>(
+    state: &mut S,
+    fuzz_time: Duration,
+    name: &str,
+) -> Result<(), Error>
 where
     S: HasNamedMetadata,
 {
@@ -323,11 +327,7 @@ where
     }
 
     /// Set the time to mutate a single input in this mutational stage
-    pub fn set_seed_fuzz_time<S>(
-        &self,
-        state: &mut S,
-        fuzz_time: Duration,
-    ) -> Result<(), Error>
+    pub fn set_seed_fuzz_time<S>(&self, state: &mut S, fuzz_time: Duration) -> Result<(), Error>
     where
         S: HasNamedMetadata,
     {

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -32,8 +32,8 @@ impl_serdeany!(TuneableMutationalStageMetadata);
 /// The default name of the tunenable mutational stage.
 pub const DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME: &str = "TuneableMutationalStage";
 
-/// Set the number of iterations to be used by this mutational stage
-pub fn set_iters<S>(state: &mut S, iters: u64, name: &str) -> Result<(), Error>
+/// Set the number of iterations to be used by this mutational stage by name
+pub fn set_iters_with_name<S>(state: &mut S, iters: u64, name: &str) -> Result<(), Error>
 where
     S: HasNamedMetadata,
 {
@@ -46,8 +46,16 @@ where
     })
 }
 
-/// Get the set iterations
-pub fn get_iters<S>(state: &S, name: &str) -> Result<Option<u64>, Error>
+/// Set the number of iterations to be used by this mutational stage with a default name
+pub fn set_iters<S>(state: &mut S, iters: u64) -> Result<(), Error>
+where
+    S: HasNamedMetadata,
+{
+    set_iters_with_name(state, iters, DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME)
+}
+
+/// Get the set iterations by name
+pub fn get_iters_with_name<S>(state: &S, name: &str) -> Result<Option<u64>, Error>
 where
     S: HasNamedMetadata,
 {
@@ -58,8 +66,16 @@ where
         .map(|metadata| metadata.iters)
 }
 
+/// Get the set iterations with a default name
+pub fn get_iters<S>(state: &S) -> Result<Option<u64>, Error>
+where
+    S: HasNamedMetadata,
+{
+    get_iters_with_name(state, DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME)
+}
+
 /// Set the time for a single seed to be used by this mutational stage
-pub fn set_seed_fuzz_time<S>(state: &mut S, fuzz_time: Duration, name: &str) -> Result<(), Error>
+pub fn set_seed_fuzz_time_with_name<S>(state: &mut S, fuzz_time: Duration, name: &str) -> Result<(), Error>
 where
     S: HasNamedMetadata,
 {
@@ -72,8 +88,16 @@ where
     })
 }
 
-/// Get the time for a single seed to be used by this mutational stage
-pub fn get_seed_fuzz_time<S>(state: &S, name: &str) -> Result<Option<Duration>, Error>
+/// Set the time for a single seed to be used by this mutational stage with a default name
+pub fn set_seed_fuzz_time<S>(state: &mut S, fuzz_time: Duration) -> Result<(), Error>
+where
+    S: HasNamedMetadata,
+{
+    set_seed_fuzz_time_with_name(state, fuzz_time, DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME)
+}
+
+/// Get the time for a single seed to be used by this mutational stage by name
+pub fn get_seed_fuzz_time_with_name<S>(state: &S, name: &str) -> Result<Option<Duration>, Error>
 where
     S: HasNamedMetadata,
 {
@@ -84,8 +108,16 @@ where
         .map(|metadata| metadata.fuzz_time)
 }
 
-/// Reset this to a normal, randomized, stage
-pub fn reset<S>(state: &mut S, name: &str) -> Result<(), Error>
+/// Get the time for a single seed to be used by this mutational stage with a default name
+pub fn get_seed_fuzz_time<S>(state: &S) -> Result<Option<Duration>, Error>
+where
+    S: HasNamedMetadata,
+{
+    get_seed_fuzz_time_with_name(state, DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME)
+}
+
+/// Reset this to a normal, randomized, stage by name
+pub fn reset_with_name<S>(state: &mut S, name: &str) -> Result<(), Error>
 where
     S: HasNamedMetadata,
 {
@@ -97,6 +129,14 @@ where
             metadata.iters = None;
             metadata.fuzz_time = None;
         })
+}
+
+/// Reset this to a normal, randomized, stage with a default name
+pub fn reset<S>(state: &mut S) -> Result<(), Error>
+where
+    S: HasNamedMetadata,
+{
+    reset_with_name(state, DEFAULT_TUNEABLE_MUTATIONAL_STAGE_NAME)
 }
 
 /// A [`crate::stages::MutationalStage`] where the mutator iteration can be tuned at runtime
@@ -271,7 +311,7 @@ where
     where
         S: HasNamedMetadata,
     {
-        set_iters(state, iters, &self.name)
+        set_iters_with_name(state, iters, &self.name)
     }
 
     /// Get the set iterations
@@ -279,7 +319,7 @@ where
     where
         S: HasNamedMetadata,
     {
-        get_iters(state, &self.name)
+        get_iters_with_name(state, &self.name)
     }
 
     /// Set the time to mutate a single input in this mutational stage
@@ -291,7 +331,7 @@ where
     where
         S: HasNamedMetadata,
     {
-        set_seed_fuzz_time(state, fuzz_time, &self.name)
+        set_seed_fuzz_time_with_name(state, fuzz_time, &self.name)
     }
 
     /// Set the time to mutate a single input in this mutational stage
@@ -299,7 +339,7 @@ where
     where
         S: HasNamedMetadata,
     {
-        get_seed_fuzz_time(state, &self.name)
+        get_seed_fuzz_time_with_name(state, &self.name)
     }
 }
 

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -1,8 +1,8 @@
 //! A [`crate::stages::MutationalStage`] where the mutator iteration can be tuned at runtime
 
+use alloc::string::{String, ToString};
 use core::{marker::PhantomData, time::Duration};
 
-use alloc::string::{String, ToString};
 use libafl_bolts::{current_time, impl_serdeany, rands::Rand};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
I can't see obvious reasons to make `TuneableMutationalStage` a singleton class and it's super inconvenient that every fuzzer can only have one `TuneableMutationalStage`. Therefore, like the observers and feedbacks, I assign a name for each `TuneableMutationalStage` to allow multiple mutational strages while keeping maximum backward compatibility.