### PR TITLE
bolts: disable build for rust < 1.70 proposal.

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
 edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
+rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 features = ["document-features"]


### PR DESCRIPTION
mostly due std::cell namespace introduction in the 1.70 version. as rust versions evolve fast enough, it might be easier than having conditional dependency on he old once_cell crate.