### PR TITLE
bolts: Fix shmem leak when Drop-ing CommonUnixShMem

### DIFF
--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -623,7 +623,7 @@ pub mod unix_shmem {
 
         use libc::{
             c_int, c_long, c_uchar, c_uint, c_ulong, c_ushort, close, ftruncate, mmap, munmap,
-            perror, shm_open, shm_unlink, shmat, shmctl, shmget,
+            perror, shm_open, shm_unlink, shmat, shmctl, shmdt, shmget,
         };
 
         use crate::{
@@ -971,13 +971,15 @@ pub mod unix_shmem {
             }
         }
 
-        /// [`Drop`] implementation for [`UnixShMem`], which cleans up the mapping.
+        /// [`Drop`] implementation for [`UnixShMem`], which detaches the memory and cleans up the mapping.
         #[cfg(unix)]
         impl Drop for CommonUnixShMem {
             fn drop(&mut self) {
                 unsafe {
                     let id_int: i32 = self.id.into();
                     shmctl(id_int, libc::IPC_RMID, ptr::null_mut());
+
+                    shmdt(self.map as *mut _);
                 }
             }
         }


### PR DESCRIPTION
Improved `CommonUnixShMem` implementation:

In the current implementation, the `new` function allocates new shared memory using `shmctl(IPC_PRIVATE, size, IPC_CREAT)` and attaches it to the current process with `shmat(id, NULL, 0)`. However, when it comes time to `drop` this shared memory, it merely releases the shared memory object with `shmctl(id, IPC_RMID, NULL)`. Unfortunately, this approach leaves the mounted shared memory lingering in the current process's memory space. Even worse, the shared memory won't deallocate from the system until the current process ends.

This pull request addresses this issue by implementing a solution to properly deallocate the shared memory, ensuring that it is no longer present in the process's memory space and is also released from the system resources when no longer needed.