### PR TITLE
Update from unmaintained tui-rs to ratatui

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -74,7 +74,7 @@ prometheus_monitor = ["std", "async-std", "prometheus-client", "tide", "futures"
 concolic_mutation = ["z3"]
 
 ## Enable the fancy TuiMonitor for a termanal UI using crossterm
-tui_monitor = ["tui", "crossterm"]
+tui_monitor = ["ratatui", "crossterm"]
 
 
 #! ## LibAFL-Bolts Features
@@ -154,8 +154,8 @@ nix = { version = "0.26", optional = true }
 regex = { version = "1", optional = true }
 uuid = { version = "1.4", optional = true, features = ["serde", "v4"] }
 libm = "0.2.2"
-tui = { version = "0.19", default-features = false, features = ['crossterm'], optional = true } # Commandline rendering, for TUI Monitor
-crossterm = { version = "0.25", optional = true }
+ratatui = { version = "0.23.0", default-features = false, features = ['crossterm'], optional = true } # Commandline rendering, for TUI Monitor
+crossterm = { version = "0.27.0", optional = true }
 
 prometheus-client = { version= "0.19", optional = true} # For the prometheus monitor
 tide = { version = "0.16.0", optional = true }

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -1,4 +1,4 @@
-//! Monitor based on tui-rs
+//! Monitor based on ratatui
 
 use alloc::boxed::Box;
 use std::{
@@ -21,7 +21,7 @@ use crossterm::{
 };
 use hashbrown::HashMap;
 use libafl_bolts::{current_time, format_duration_hms, ClientId};
-use tui::{backend::CrosstermBackend, Terminal};
+use ratatui::{backend::CrosstermBackend, Terminal};
 
 #[cfg(feature = "introspection")]
 use super::{ClientPerfMonitor, PerfFeature};
@@ -230,7 +230,7 @@ impl TuiContext {
     }
 }
 
-/// Tracking monitor during fuzzing and display with tui-rs.
+/// Tracking monitor during fuzzing and display with ratatui
 #[derive(Debug, Clone)]
 pub struct TuiMonitor {
     pub(crate) context: Arc<RwLock<TuiContext>>,

--- a/libafl/src/monitors/tui/ui.rs
+++ b/libafl/src/monitors/tui/ui.rs
@@ -4,12 +4,12 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{
         Axis, Block, Borders, Cell, Chart, Dataset, List, ListItem, Paragraph, Row, Table, Tabs,
     },
@@ -117,7 +117,7 @@ impl TuiUI {
         let mut status_bar: String = self.title.clone();
         status_bar = status_bar + " (" + self.version.as_str() + ")";
 
-        let text = vec![Spans::from(Span::styled(
+        let text = vec![Line::from(Span::styled(
             &status_bar,
             Style::default()
                 .fg(Color::LightMagenta)
@@ -135,15 +135,15 @@ impl TuiUI {
             .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
             .split(top_layout[1]);
         let titles = vec![
-            Spans::from(Span::styled(
+            Line::from(Span::styled(
                 "speed",
                 Style::default().fg(Color::LightGreen),
             )),
-            Spans::from(Span::styled(
+            Line::from(Span::styled(
                 "corpus",
                 Style::default().fg(Color::LightGreen),
             )),
-            Spans::from(Span::styled(
+            Line::from(Span::styled(
                 "objectives",
                 Style::default().fg(Color::LightGreen),
             )),


### PR DESCRIPTION
Change from `Spans` to `Line` is due to a deprecation. Everything else is 1:1, as ratatui is a fork.