### PR TITLE
ForkserverExecutor: stop forked children on exit

### DIFF
--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -211,6 +211,6 @@ pub fn main() {
     let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
     fuzzer
-        .fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)
+        .fuzz_loop_for(&mut stages, &mut executor, &mut state, &mut mgr, 100)
         .expect("Error in the fuzzing loop");
 }

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -211,6 +211,6 @@ pub fn main() {
     let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
     fuzzer
-        .fuzz_loop_for(&mut stages, &mut executor, &mut state, &mut mgr, 100)
+        .fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)
         .expect("Error in the fuzzing loop");
 }


### PR DESCRIPTION
The forkserver did not kill the child on exit.
This adds a `Drop` implementation.