### PR TITLE
Fix linkage on arm macs when building libafl_targets

### DIFF
--- a/libafl_targets/build.rs
+++ b/libafl_targets/build.rs
@@ -156,7 +156,7 @@ fn main() {
         .file(src_dir.join("cmplog.c"))
         .compile("cmplog");
 
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(unix)]
     {
         println!("cargo:rerun-if-changed=src/forkserver.c");
 


### PR DESCRIPTION
There was a linkage issue on ARM macOS when linking here because of the difference between unix/linux/freebsd cfgs. This fixes it. cc: @jhertz