### PR TITLE
Metadata + infinite loop fix for TuneableMutationalStage

### DIFF
--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -199,10 +199,10 @@ where
                 if current_time() - start_time >= fuzz_time {
                     break;
                 }
-            }
 
-            i += 1;
-            self.perform_mutation(fuzzer, executor, state, manager, &input, i)?;
+                i += 1;
+                self.perform_mutation(fuzzer, executor, state, manager, &input, i)?;
+            }
         } else {
             let iters = iters.map_or_else(|| self.iterations(state, corpus_idx), Ok)?;
             for i in 1..=iters {


### PR DESCRIPTION
TuneableMutationalStage did not correctly access metadata (it should use named metadata, but was not) and could enter an infinite loop if the global metadata was set, but not the named metadata. This fixes both issues.