### PR TITLE
Add environment variable for LLMP CLIENT_TIMEOUT duration

### DIFF
--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -1934,6 +1934,7 @@ where
     clients_to_remove: Vec<usize>,
     /// The ShMemProvider to use
     shmem_provider: SP,
+    #[cfg(feature = "std")]
     /// The duration after which a non-communicative client is considered dead.
     client_timeout: Duration,
 }

--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -110,8 +110,9 @@ use crate::{
 /// [`DEFAULT_CLIENT_TIMEOUT`] for the broker's stale client detection.
 const _LLMP_CLIENT_TIMEOUT_ENV_STR: &str = "LLMP_CLIENT_TIMEOUT";
 
-/// The timeout after which a client will be considered stale, and removed. Defaults to 5 minutes.
-/// If LLMP_CLIENT_TIMEOUT is set, it will be used instead.
+/// The timeout in seconds after which a client will be considered stale, and removed.
+/// Defaults to 5 minutes.  If the `LLMP_CLIENT_TIMEOUT` environment variable is set, it
+/// will be used instead.
 #[cfg(feature = "std")]
 const DEFAULT_CLIENT_TIMEOUT: u64 = 60 * 5;
 

--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -105,9 +105,15 @@ use crate::{
     ClientId, Error,
 };
 
-/// The timeout after which a client will be considered stale, and removed.
 #[cfg(feature = "std")]
-const CLIENT_TIMEOUT: Duration = Duration::from_secs(60 * 5);
+/// An environment variable of this name, set to a number in seconds, overrides
+/// [`DEFAULT_CLIENT_TIMEOUT`] for the broker's stale client detection.
+const _LLMP_CLIENT_TIMEOUT_ENV_STR: &str = "LLMP_CLIENT_TIMEOUT";
+
+/// The timeout after which a client will be considered stale, and removed. Defaults to 5 minutes.
+/// If LLMP_CLIENT_TIMEOUT is set, it will be used instead.
+#[cfg(feature = "std")]
+const DEFAULT_CLIENT_TIMEOUT: u64 = 60 * 5;
 
 /// The max number of pages a [`client`] may have mapped that were not yet read by the [`broker`]
 /// Usually, this value should not exceed `1`, else the broker cannot keep up with the amount of incoming messages.
@@ -1928,6 +1934,8 @@ where
     clients_to_remove: Vec<usize>,
     /// The ShMemProvider to use
     shmem_provider: SP,
+    /// The duration after which a non-communicative client is considered dead.
+    client_timeout: Duration,
 }
 
 /// A signal handler for the [`LlmpBroker`].
@@ -1987,6 +1995,13 @@ where
             listeners: vec![],
             exit_cleanly_after: None,
             num_clients_total: 0,
+            #[cfg(feature = "std")]
+            client_timeout: Duration::from_secs(
+                env::var(_LLMP_CLIENT_TIMEOUT_ENV_STR)
+                    .ok()
+                    .and_then(|env| env.parse().ok())
+                    .unwrap_or(DEFAULT_CLIENT_TIMEOUT),
+            ),
         })
     }
 
@@ -2181,7 +2196,7 @@ where
                     if !has_messages && !self.listeners.iter().any(|&x| x == client_id) {
                         let last_msg_time = self.llmp_clients[i].last_msg_time;
                         if last_msg_time < current_time
-                            && current_time - last_msg_time > CLIENT_TIMEOUT
+                            && current_time - last_msg_time > self.client_timeout
                         {
                             self.clients_to_remove.push(i);
                             #[cfg(feature = "llmp_debug")]


### PR DESCRIPTION
I am using a Launcher in a pretty complex fuzzer where LLMP clients can take a very long time between their first connection and the next message (fuzzer stats update) that they send due to a long startup sequence for the simulator the fuzzer is running with.

This is a pretty rare scenario, but right now my only fix is to change the hardcoded CLIENT_TIMEOUT to 60 minutes instead of 5. Adding an environment variable allows overriding it more easily. If wanted, I can update the whole tree of calls between Launcher and the LlmpBroker to allow passing a client timeout down, but that seems excessive for a very rare case.