### PR TITLE
Clippy error + warning fixes

### DIFF
--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -61,7 +61,6 @@ Welcome to `LibAFL`
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -62,7 +62,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_cc/src/lib.rs
+++ b/libafl_cc/src/lib.rs
@@ -48,7 +48,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_concolic/symcc_runtime/src/lib.rs
+++ b/libafl_concolic/symcc_runtime/src/lib.rs
@@ -127,7 +127,7 @@ macro_rules! unwrap_option {
     };
 }
 
-/// Creates an exported extern C function for the given runtime function declaration, forwarding to the runtime as obtained by $rt_cb (which should be `fn (fn (&mut impl Runtime))`).
+/// Creates an exported extern C function for the given runtime function declaration, forwarding to the runtime as obtained by `$rt_cb` (which should be `fn (fn (&mut impl Runtime))`).
 #[doc(hidden)]
 #[macro_export]
 macro_rules! export_rust_runtime_fn {

--- a/libafl_derive/src/lib.rs
+++ b/libafl_derive/src/lib.rs
@@ -49,7 +49,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -55,7 +55,6 @@ Additional documentation is available in [the `LibAFL` book](https://aflplus.plu
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs
@@ -58,7 +58,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_sugar/src/lib.rs
+++ b/libafl_sugar/src/lib.rs
@@ -48,7 +48,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_targets/src/lib.rs
+++ b/libafl_targets/src/lib.rs
@@ -50,7 +50,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/libafl_tinyinst/src/lib.rs
+++ b/libafl_tinyinst/src/lib.rs
@@ -52,7 +52,6 @@ The tinyinst module for `LibAFL`.
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -4,7 +4,7 @@ cd "$SCRIPT_DIR/.." || exit 1
 
 set -e
 
-RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --release --tests --examples --benches -- -Z macro-backtrace \
+RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --tests --examples --benches -- -Z macro-backtrace \
    -D clippy::all \
    -D clippy::pedantic \
    -W clippy::similar_names \
@@ -21,7 +21,7 @@ RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --release --tests
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   cd libafl_libfuzzer/libafl_libfuzzer_runtime
-  RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --release --tests --examples --benches -- -Z macro-backtrace \
+  RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --tests --examples --benches -- -Z macro-backtrace \
      -D clippy::all \
      -D clippy::pedantic \
      -W clippy::similar_names \


### PR DESCRIPTION
- Addresses some recent clippy error and warning updates which affected #1503.
- Change clippy to use debug instead of release builds to speed up CI a touch.