### PR TITLE
fix(bolts/unix_signals): unaligned ucontexts

### DIFF
--- a/libafl_bolts/src/os/unix_signals.rs
+++ b/libafl_bolts/src/os/unix_signals.rs
@@ -390,7 +390,11 @@ unsafe fn handle_signal(sig: c_int, info: siginfo_t, void: *mut c_void) {
             None => return,
         }
     };
-    handler.handle(*signal, info, &mut *(void as *mut ucontext_t));
+    handler.handle(
+        *signal,
+        info,
+        &mut ptr::read_unaligned(void as *mut ucontext_t),
+    );
 }
 
 /// Setup signal handlers in a somewhat rusty way.


### PR DESCRIPTION
When entering a signal handler, the ucontext_t is not necessarily 0x10-aligned, so we need to use read_unaligned instead of dereferencing.