### PR TITLE
Rework Frida instrumentation to decouple it from FuzzerOptions and add FridaInstrumentationHelperBuilder

### DIFF
--- a/fuzzers/frida_executable_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_executable_libpng/src/fuzzer.rs
@@ -104,7 +104,7 @@ unsafe fn fuzz(
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
-                let asan = AsanRuntime::new(options.clone());
+                let asan = AsanRuntime::new(&options);
 
                 #[cfg(unix)]
                 let mut frida_helper =

--- a/fuzzers/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida_gdiplus/src/fuzzer.rs
@@ -99,7 +99,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
-                let asan = AsanRuntime::new(options.clone());
+                let asan = AsanRuntime::new(&options);
 
                 #[cfg(unix)]
                 let mut frida_helper =

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -94,7 +94,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
-                let asan = AsanRuntime::new(options.clone());
+                let asan = AsanRuntime::new(&options);
 
                 #[cfg(unix)]
                 let mut frida_helper =

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -170,7 +170,7 @@ impl FridaRuntime for AsanRuntime {
         module_map: &Rc<ModuleMap>,
     ) {
         unsafe {
-            ASAN_ERRORS = Some(AsanErrors::new(self.options.clone()));
+            ASAN_ERRORS = Some(AsanErrors::new(self.options.continue_on_error));
         }
 
         self.generate_instrumentation_blobs();

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -299,7 +299,7 @@ impl AsanRuntime {
         Self {
             check_for_leaks_enabled: options.detect_leaks,
             current_report_impl: 0,
-            allocator: Allocator::new(options.clone()),
+            allocator: Allocator::new(&options),
             regs: [0; ASAN_SAVE_REGISTER_COUNT],
             blob_report: None,
             blob_check_mem_byte: None,

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -57,7 +57,7 @@ use crate::utils::instruction_width;
 use crate::{
     alloc::Allocator,
     asan::errors::{AsanError, AsanErrors, AsanReadWriteError, ASAN_ERRORS},
-    helper::FridaRuntime,
+    helper::{FridaRuntime, SkipRange},
     utils::writer_register,
 };
 
@@ -139,9 +139,10 @@ pub struct AsanRuntime {
     blob_check_mem_48bytes: Option<Box<[u8]>>,
     blob_check_mem_64bytes: Option<Box<[u8]>>,
     stalked_addresses: HashMap<usize, usize>,
-    options: FuzzerOptions,
     module_map: Option<Rc<ModuleMap>>,
     suppressed_addresses: Vec<usize>,
+    skip_ranges: Vec<SkipRange>,
+    continue_on_error: bool,
     shadow_check_func: Option<extern "C" fn(*const c_void, usize) -> bool>,
 
     #[cfg(target_arch = "aarch64")]
@@ -152,8 +153,9 @@ impl Debug for AsanRuntime {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("AsanRuntime")
             .field("stalked_addresses", &self.stalked_addresses)
-            .field("options", &self.options)
+            .field("continue_on_error", &self.continue_on_error)
             .field("module_map", &"<ModuleMap>")
+            .field("skip_ranges", &self.skip_ranges)
             .field("suppressed_addresses", &self.suppressed_addresses)
             .finish_non_exhaustive()
     }
@@ -170,7 +172,7 @@ impl FridaRuntime for AsanRuntime {
         module_map: &Rc<ModuleMap>,
     ) {
         unsafe {
-            ASAN_ERRORS = Some(AsanErrors::new(self.options.continue_on_error));
+            ASAN_ERRORS = Some(AsanErrors::new(self.continue_on_error));
         }
 
         self.generate_instrumentation_blobs();
@@ -179,13 +181,15 @@ impl FridaRuntime for AsanRuntime {
         self.unpoison_all_existing_memory();
 
         self.module_map = Some(module_map.clone());
-        if !self.options.dont_instrument.is_empty() {
-            for (module_name, offset) in self.options.dont_instrument.clone() {
-                let module_details = ModuleDetails::with_name(module_name).unwrap();
-                let lib_start = module_details.range().base_address().0 as usize;
-                self.suppressed_addresses.push(lib_start + offset);
-            }
-        }
+        self.suppressed_addresses
+            .extend(self.skip_ranges.iter().map(|skip| match skip {
+                SkipRange::Absolute(range) => range.start,
+                SkipRange::ModuleRelative { name, range } => {
+                    let module_details = ModuleDetails::with_name(name.clone()).unwrap();
+                    let lib_start = module_details.range().base_address().0 as usize;
+                    lib_start + range.start
+                }
+            }));
 
         self.hook_functions(gum);
         /*
@@ -295,33 +299,22 @@ impl FridaRuntime for AsanRuntime {
 impl AsanRuntime {
     /// Create a new `AsanRuntime`
     #[must_use]
-    pub fn new(options: FuzzerOptions) -> AsanRuntime {
+    pub fn new(options: &FuzzerOptions) -> AsanRuntime {
+        let skip_ranges = options
+            .dont_instrument
+            .iter()
+            .map(|(name, offset)| SkipRange::ModuleRelative {
+                name: name.clone(),
+                range: *offset..*offset + 4,
+            })
+            .collect();
+        let continue_on_error = options.continue_on_error;
         Self {
             check_for_leaks_enabled: options.detect_leaks,
-            current_report_impl: 0,
-            allocator: Allocator::new(&options),
-            regs: [0; ASAN_SAVE_REGISTER_COUNT],
-            blob_report: None,
-            blob_check_mem_byte: None,
-            blob_check_mem_halfword: None,
-            blob_check_mem_dword: None,
-            blob_check_mem_qword: None,
-            blob_check_mem_16bytes: None,
-            blob_check_mem_3bytes: None,
-            blob_check_mem_6bytes: None,
-            blob_check_mem_12bytes: None,
-            blob_check_mem_24bytes: None,
-            blob_check_mem_32bytes: None,
-            blob_check_mem_48bytes: None,
-            blob_check_mem_64bytes: None,
-            stalked_addresses: HashMap::new(),
-            options,
-            module_map: None,
-            suppressed_addresses: Vec::new(),
-            shadow_check_func: None,
-
-            #[cfg(target_arch = "aarch64")]
-            eh_frame: [0; ASAN_EH_FRAME_DWORD_COUNT],
+            allocator: Allocator::new(options),
+            skip_ranges,
+            continue_on_error,
+            ..Self::default()
         }
     }
 
@@ -2714,5 +2707,37 @@ impl AsanRuntime {
             16 + i64::from(redzone_size),
             IndexMode::PostAdjust,
         ));
+    }
+}
+
+impl Default for AsanRuntime {
+    fn default() -> Self {
+        Self {
+            check_for_leaks_enabled: false,
+            current_report_impl: 0,
+            allocator: Allocator::default(),
+            regs: [0; ASAN_SAVE_REGISTER_COUNT],
+            blob_report: None,
+            blob_check_mem_byte: None,
+            blob_check_mem_halfword: None,
+            blob_check_mem_dword: None,
+            blob_check_mem_qword: None,
+            blob_check_mem_16bytes: None,
+            blob_check_mem_3bytes: None,
+            blob_check_mem_6bytes: None,
+            blob_check_mem_12bytes: None,
+            blob_check_mem_24bytes: None,
+            blob_check_mem_32bytes: None,
+            blob_check_mem_48bytes: None,
+            blob_check_mem_64bytes: None,
+            stalked_addresses: HashMap::new(),
+            module_map: None,
+            suppressed_addresses: Vec::new(),
+            skip_ranges: Vec::new(),
+            continue_on_error: false,
+            shadow_check_func: None,
+            #[cfg(target_arch = "aarch64")]
+            eh_frame: [0; ASAN_EH_FRAME_DWORD_COUNT],
+        }
     }
 }

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -17,7 +17,7 @@ use libafl::{
     state::{HasClientPerfMonitor, HasMetadata},
     Error,
 };
-use libafl_bolts::{cli::FuzzerOptions, ownedref::OwnedPtr, Named, SerdeAny};
+use libafl_bolts::{ownedref::OwnedPtr, Named, SerdeAny};
 use serde::{Deserialize, Serialize};
 use termcolor::{Color, ColorSpec, WriteColor};
 
@@ -95,17 +95,17 @@ impl AsanError {
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeAny)]
 pub struct AsanErrors {
-    options: FuzzerOptions,
+    continue_on_error: bool,
     errors: Vec<AsanError>,
 }
 
 impl AsanErrors {
     /// Creates a new `AsanErrors` struct
     #[must_use]
-    pub fn new(options: FuzzerOptions) -> Self {
+    pub fn new(continue_on_error: bool) -> Self {
         Self {
-            options,
             errors: Vec::new(),
+            continue_on_error,
         }
     }
 
@@ -529,7 +529,7 @@ impl AsanErrors {
         };
 
         #[allow(clippy::manual_assert)]
-        if !self.options.continue_on_error {
+        if !self.continue_on_error {
             panic!("ASAN: Crashing target!");
         }
     }

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -19,6 +19,9 @@ extern "C" {
     pub fn __libafl_targets_cmplog_instructions(k: u64, shape: u8, arg1: u64, arg2: u64);
 }
 
+use frida_gum::ModuleMap;
+use std::rc::Rc;
+
 #[cfg(target_arch = "aarch64")]
 use frida_gum::{
     instruction_writer::{Aarch64Register, IndexMode, InstructionWriter},
@@ -90,7 +93,7 @@ impl FridaRuntime for CmpLogRuntime {
         &mut self,
         _gum: &frida_gum::Gum,
         _ranges: &RangeMap<usize, (u16, String)>,
-        _modules_to_instrument: &[&str],
+        _module_map: &Rc<ModuleMap>,
     ) {
         self.generate_instrumentation_blobs();
     }

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, marker::PhantomPinned, pin::Pin, rc::Rc};
 #[cfg(target_arch = "aarch64")]
 use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
-use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput};
+use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
 use libafl_bolts::math::xxh3_rrmxmx_mixer;
 use rangemap::RangeMap;
 
@@ -38,7 +38,7 @@ impl FridaRuntime for CoverageRuntime {
         &mut self,
         _gum: &frida_gum::Gum,
         _ranges: &RangeMap<usize, (u16, String)>,
-        _modules_to_instrument: &[&str],
+        _module_map: &Rc<ModuleMap>,
     ) {
     }
 

--- a/libafl_frida/src/drcov_rt.rs
+++ b/libafl_frida/src/drcov_rt.rs
@@ -2,9 +2,11 @@
 use std::{
     collections::HashMap,
     hash::{BuildHasher, Hasher},
+    rc::Rc,
 };
 
 use ahash::RandomState;
+use frida_gum::ModuleMap;
 use libafl::{
     inputs::{HasTargetBytes, Input},
     Error,
@@ -31,7 +33,7 @@ impl FridaRuntime for DrCovRuntime {
         &mut self,
         _gum: &frida_gum::Gum,
         ranges: &RangeMap<usize, (u16, String)>,
-        _modules_to_instrument: &[&str],
+        _module_map: &Rc<ModuleMap>,
     ) {
         self.ranges = ranges.clone();
         std::fs::create_dir_all("./coverage")

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -202,7 +202,7 @@ where
             }
         }
 
-        if !helper.options().disable_excludes {
+        if !helper.disable_excludes {
             for range in ranges.gaps(&(0..usize::MAX)) {
                 log::info!("excluding range: {:x}-{:x}", range.start, range.end);
                 stalker.exclude(&MemoryRange::new(

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -46,7 +46,7 @@ pub trait FridaRuntime: 'static + Debug {
         &mut self,
         gum: &Gum,
         ranges: &RangeMap<usize, (u16, String)>,
-        modules_to_instrument: &[&str],
+        module_map: &Rc<ModuleMap>,
     );
 
     /// Method called before execution
@@ -63,7 +63,7 @@ pub trait FridaRuntimeTuple: MatchFirstType + Debug {
         &mut self,
         gum: &Gum,
         ranges: &RangeMap<usize, (u16, String)>,
-        modules_to_instrument: &[&str],
+        module_map: &Rc<ModuleMap>,
     );
 
     /// Method called before execution
@@ -78,7 +78,7 @@ impl FridaRuntimeTuple for () {
         &mut self,
         _gum: &Gum,
         _ranges: &RangeMap<usize, (u16, String)>,
-        _modules_to_instrument: &[&str],
+        _module_map: &Rc<ModuleMap>,
     ) {
     }
     fn pre_exec_all<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {
@@ -98,10 +98,10 @@ where
         &mut self,
         gum: &Gum,
         ranges: &RangeMap<usize, (u16, String)>,
-        modules_to_instrument: &[&str],
+        module_map: &Rc<ModuleMap>,
     ) {
-        self.0.init(gum, ranges, modules_to_instrument);
-        self.1.init_all(gum, ranges, modules_to_instrument);
+        self.0.init(gum, ranges, module_map);
+        self.1.init_all(gum, ranges, module_map);
     }
 
     fn pre_exec_all<I: Input + HasTargetBytes>(&mut self, input: &I) -> Result<(), Error> {
@@ -205,7 +205,7 @@ where
                 "instrumented libraries must not include the fuzzer"
             );
 
-            runtimes.init_all(gum, &ranges, &modules_to_instrument);
+            runtimes.init_all(gum, &ranges, &Rc::new(module_map));
         }
 
         // Wrap ranges and runtimes in reference-counted refcells in order to move
@@ -427,11 +427,11 @@ where
         &mut self,
         gum: &'a Gum,
         ranges: &RangeMap<usize, (u16, String)>,
-        modules_to_instrument: &'a [&str],
+        module_map: &Rc<ModuleMap>,
     ) {
         (*self.runtimes)
             .borrow_mut()
-            .init_all(gum, ranges, modules_to_instrument);
+            .init_all(gum, ranges, module_map);
     }
 
     /// Method called before execution

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -164,31 +164,8 @@ where
     #[allow(clippy::too_many_lines)]
     #[must_use]
     pub fn new(gum: &'a Gum, options: &'a FuzzerOptions, mut runtimes: RT) -> Self {
-        // workaround frida's frida-gum-allocate-near bug:
         #[cfg(unix)]
-        unsafe {
-            for _ in 0..512 {
-                mmap(
-                    None,
-                    std::num::NonZeroUsize::new_unchecked(128 * 1024),
-                    ProtFlags::PROT_NONE,
-                    ANONYMOUS_FLAG | MapFlags::MAP_PRIVATE | MapFlags::MAP_NORESERVE,
-                    -1,
-                    0,
-                )
-                .expect("Failed to map dummy regions for frida workaround");
-                mmap(
-                    None,
-                    std::num::NonZeroUsize::new_unchecked(4 * 1024 * 1024),
-                    ProtFlags::PROT_NONE,
-                    ANONYMOUS_FLAG | MapFlags::MAP_PRIVATE | MapFlags::MAP_NORESERVE,
-                    -1,
-                    0,
-                )
-                .expect("Failed to map dummy regions for frida workaround");
-            }
-        }
-
+        Self::workaround_gum_allocate_near();
         let mut modules_to_instrument = vec![options
             .harness
             .as_ref()
@@ -395,6 +372,33 @@ where
         (*self.runtimes).borrow_mut().match_first_type_mut::<R>()
     }
     */
+
+    // workaround frida's frida-gum-allocate-near bug:
+    #[cfg(unix)]
+    fn workaround_gum_allocate_near() {
+        unsafe {
+            for _ in 0..512 {
+                mmap(
+                    None,
+                    std::num::NonZeroUsize::new_unchecked(128 * 1024),
+                    ProtFlags::PROT_NONE,
+                    ANONYMOUS_FLAG | MapFlags::MAP_PRIVATE | MapFlags::MAP_NORESERVE,
+                    -1,
+                    0,
+                )
+                .expect("Failed to map dummy regions for frida workaround");
+                mmap(
+                    None,
+                    std::num::NonZeroUsize::new_unchecked(4 * 1024 * 1024),
+                    ProtFlags::PROT_NONE,
+                    ANONYMOUS_FLAG | MapFlags::MAP_PRIVATE | MapFlags::MAP_NORESERVE,
+                    -1,
+                    0,
+                )
+                .expect("Failed to map dummy regions for frida workaround");
+            }
+        }
+    }
 
     /// Returns ref to the Transformer
     pub fn transformer(&self) -> &Transformer<'a> {

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -1,6 +1,8 @@
 use core::fmt::{self, Debug, Formatter};
 use std::{
     cell::{Ref, RefCell, RefMut},
+    fs,
+    path::{Path, PathBuf},
     rc::Rc,
 };
 
@@ -115,6 +117,227 @@ where
     }
 }
 
+/// Represents a range to be skipped for instrumentation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipRange {
+    /// An absolute range
+    Absolute(std::ops::Range<usize>),
+
+    /// A range relative to the module with the given name
+    ModuleRelative {
+        /// The module name
+        name: String,
+
+        /// The address range
+        range: std::ops::Range<usize>,
+    },
+}
+
+/// Builder for [`FridaInstrumentationHelper`](FridaInstrumentationHelper)
+pub struct FridaInstrumentationHelperBuilder {
+    stalker_enabled: bool,
+    disable_excludes: bool,
+    #[allow(clippy::type_complexity)]
+    instrument_module_predicate: Option<Box<dyn FnMut(&ModuleDetails) -> bool>>,
+    skip_module_predicate: Box<dyn FnMut(&ModuleDetails) -> bool>,
+    skip_ranges: Vec<SkipRange>,
+}
+
+impl FridaInstrumentationHelperBuilder {
+    /// Create a new `FridaInstrumentationHelperBuilder`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable or disable the Stalker
+    ///
+    /// Required for coverage collection, ASAN, and `CmpLog`.
+    /// Enabled by default.
+    #[must_use]
+    pub fn enable_stalker(self, enabled: bool) -> Self {
+        Self {
+            stalker_enabled: enabled,
+            ..self
+        }
+    }
+
+    /// Disable excludes
+    ///
+    /// Don't use `stalker.exclude()`.
+    /// See <https://github.com/AFLplusplus/LibAFL/issues/830>
+    #[must_use]
+    pub fn disable_excludes(self, disabled: bool) -> Self {
+        Self {
+            disable_excludes: disabled,
+            ..self
+        }
+    }
+
+    /// Modules for which the given predicate returns `true` will be instrumented.
+    ///
+    /// Can be specified multiple times; a module will be instrumented if _any_ of the given predicates match.
+    /// [`skip_modules_if`](Self::skip_modules-if) will override these.
+    ///
+    /// # Example
+    /// Instrument all modules in `/usr/lib` as well as `libfoo.so`:
+    /// ```
+    ///# use libafl_frida::helper::FridaInstrumentationHelperBuilder;
+    /// let builder = FridaInstrumentationHelperBuilder::new()
+    ///     .instrument_module_if(|module| module.name() == "libfoo.so")
+    ///     .instrument_module_if(|module| module.path().starts_with("/usr/lib"));
+    /// ```
+    #[must_use]
+    pub fn instrument_module_if<F: FnMut(&ModuleDetails) -> bool + 'static>(
+        mut self,
+        mut predicate: F,
+    ) -> Self {
+        let new = move |module: &_| match &mut self.instrument_module_predicate {
+            Some(existing) => existing(module) || predicate(module),
+            None => predicate(module),
+        };
+        Self {
+            instrument_module_predicate: Some(Box::new(new)),
+            ..self
+        }
+    }
+
+    /// Modules for which the given predicate returns `true` will not be instrumented.
+    ///
+    /// Can be specified multiple times; a module will be skipped  if _any_ of the given predicates match.
+    /// Overrides modules included using [`instrument_module_if`](Self::instrument_module_if).
+    ///
+    /// # Example
+    /// Instrument all modules in `/usr/lib`, but exclude `libfoo.so`.
+    ///
+    /// ```
+    ///# use libafl_frida::helper::FridaInstrumentationHelperBuilder;
+    /// let builder = FridaInstrumentationHelperBuilder::new()
+    ///     .instrument_module_if(|module| module.path().starts_with("/usr/lib"))
+    ///     .skip_module_if(|module| module.name() == "libfoo.so");
+    /// ```
+    #[must_use]
+    pub fn skip_module_if<F: FnMut(&ModuleDetails) -> bool + 'static>(
+        mut self,
+        mut predicate: F,
+    ) -> Self {
+        let new = move |module: &_| (self.skip_module_predicate)(module) || predicate(module);
+        Self {
+            skip_module_predicate: Box::new(new),
+            ..self
+        }
+    }
+
+    /// Skip a specific range
+    #[must_use]
+    pub fn skip_range(mut self, range: SkipRange) -> Self {
+        self.skip_ranges.push(range);
+        self
+    }
+
+    /// Skip a set of ranges
+    #[must_use]
+    pub fn skip_ranges<I: IntoIterator<Item = SkipRange>>(mut self, ranges: I) -> Self {
+        self.skip_ranges.extend(ranges);
+        self
+    }
+
+    /// Build a `FridaInstrumentationHelper`
+    pub fn build<RT: FridaRuntimeTuple>(
+        self,
+        gum: &Gum,
+        mut runtimes: RT,
+    ) -> FridaInstrumentationHelper<'_, RT> {
+        let Self {
+            stalker_enabled,
+            disable_excludes,
+            mut instrument_module_predicate,
+            mut skip_module_predicate,
+            skip_ranges,
+        } = self;
+
+        let mut module_filter = Box::new(move |module| {
+            if let Some(instrument_module_predicate) = &mut instrument_module_predicate {
+                let skip = skip_module_predicate(&module);
+                let should_instrument = instrument_module_predicate(&module);
+                should_instrument && !skip
+            } else {
+                !skip_module_predicate(&module)
+            }
+        });
+        let module_map = Rc::new(ModuleMap::new_with_filter(gum, &mut module_filter));
+
+        let mut ranges = RangeMap::new();
+        if stalker_enabled {
+            for (i, module) in module_map.values().iter().enumerate() {
+                let range = module.range();
+                let start = range.base_address().0 as usize;
+                ranges.insert(start..(start + range.size()), (i as u16, module.path()));
+            }
+            for skip in skip_ranges {
+                match skip {
+                    SkipRange::Absolute(range) => ranges.remove(range),
+                    SkipRange::ModuleRelative { name, range } => {
+                        let module_details = ModuleDetails::with_name(name).unwrap();
+                        let lib_start = module_details.range().base_address().0 as usize;
+                        ranges.remove((lib_start + range.start)..(lib_start + range.end));
+                    }
+                }
+            }
+            runtimes.init_all(gum, &ranges, &module_map);
+        }
+
+        // Wrap ranges and runtimes in reference-counted refcells in order to move
+        // these references both into the struct that we return and the transformer callback
+        // that we pass to frida-gum.
+        let ranges = Rc::new(RefCell::new(ranges));
+        let runtimes = Rc::new(RefCell::new(runtimes));
+
+        let transformer = FridaInstrumentationHelper::build_transformer(gum, &ranges, &runtimes);
+
+        #[cfg(unix)]
+        FridaInstrumentationHelper::<'_, RT>::workaround_gum_allocate_near();
+
+        FridaInstrumentationHelper {
+            transformer,
+            ranges,
+            runtimes,
+            stalker_enabled,
+            disable_excludes,
+        }
+    }
+}
+
+impl Debug for FridaInstrumentationHelperBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut dbg_me = f.debug_struct("FridaInstrumentationHelper");
+        dbg_me
+            .field("stalker_enabled", &self.stalker_enabled)
+            .field("instrument_module_predicate", &"<closure>")
+            .field("skip_module_predicate", &"<closure>")
+            .field("skip_ranges", &self.skip_ranges)
+            .field("disable_excludes", &self.disable_excludes);
+        dbg_me.finish()
+    }
+}
+
+impl Default for FridaInstrumentationHelperBuilder {
+    fn default() -> Self {
+        Self {
+            stalker_enabled: true,
+            disable_excludes: true,
+            instrument_module_predicate: None,
+            skip_module_predicate: Box::new(|module| {
+                // Skip the instrumentation module to avoid recursion.
+                let range = module.range();
+                let start = range.base_address().0 as usize;
+                let range = start..(start + range.size());
+                range.contains(&(Self::new as usize))
+            }),
+            skip_ranges: Vec::new(),
+        }
+    }
+}
+
 /// An helper that feeds `FridaInProcessExecutor` with edge-coverage instrumentation
 pub struct FridaInstrumentationHelper<'a, RT: 'a> {
     transformer: Transformer<'a>,
@@ -158,71 +381,61 @@ fn pc(context: &CpuContext) -> usize {
     context.rip() as usize
 }
 
+fn pathlist_contains_module<I, P>(list: I, module: &ModuleDetails) -> bool
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    let module_name = module.name();
+    let module_path = PathBuf::from(module.path());
+    let canonicalized_module_path = fs::canonicalize(&module_path).ok();
+    list.into_iter().any(|path| {
+        let path = path.as_ref();
+
+        path == Path::new(&module_name)
+            || path == module_path
+            || fs::canonicalize(path).ok() == canonicalized_module_path
+    })
+}
+
+impl<'a> FridaInstrumentationHelper<'a, ()> {
+    /// Create a builder to initialize a `FridaInstrumentationHelper`.
+    ///
+    /// See the documentation of [`FridaInstrumentationHelperBuilder`](FridaInstrumentationHelperBuilder)
+    /// for more details.
+    pub fn builder() -> FridaInstrumentationHelperBuilder {
+        FridaInstrumentationHelperBuilder::default()
+    }
+}
+
 /// The implementation of the [`FridaInstrumentationHelper`]
 impl<'a, RT> FridaInstrumentationHelper<'a, RT>
 where
     RT: FridaRuntimeTuple + 'a,
 {
-    /// Constructor function to create a new [`FridaInstrumentationHelper`], given a `module_name`.
+    /// Constructor function to create a new [`FridaInstrumentationHelper`], given CLI Options.
     #[must_use]
-    pub fn new(gum: &'a Gum, options: &'a FuzzerOptions, mut runtimes: RT) -> Self {
-        #[cfg(unix)]
-        Self::workaround_gum_allocate_near();
-        let mut modules_to_instrument = vec![options
-            .harness
-            .as_ref()
-            .unwrap()
-            .to_string_lossy()
-            .to_string()];
-        modules_to_instrument.append(&mut options.libs_to_instrument.clone());
-        let modules_to_instrument: Vec<&str> =
-            modules_to_instrument.iter().map(AsRef::as_ref).collect();
-
-        let module_map = ModuleMap::new_from_names(gum, &modules_to_instrument);
-        let mut ranges = RangeMap::new();
-
-        let stalker_enabled = options.cmplog || options.asan || !options.disable_coverage;
-
-        if stalker_enabled {
-            for (i, module) in module_map.values().iter().enumerate() {
-                let range = module.range();
-                let start = range.base_address().0 as usize;
-                // log::trace!("start: {:x}", start);
-                ranges.insert(start..(start + range.size()), (i as u16, module.path()));
-            }
-            if !options.dont_instrument.is_empty() {
-                for (module_name, offset) in options.dont_instrument.clone() {
-                    let module_details = ModuleDetails::with_name(module_name).unwrap();
-                    let lib_start = module_details.range().base_address().0 as usize;
-                    // log::info!("removing address: {:#x}", lib_start + offset);
-                    ranges.remove((lib_start + offset)..(lib_start + offset + 4));
+    pub fn new<'b>(gum: &'a Gum, options: &'b FuzzerOptions, runtimes: RT) -> Self {
+        let harness = options.harness.clone();
+        let libs_to_instrument = options
+            .libs_to_instrument
+            .iter()
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+        return FridaInstrumentationHelper::builder()
+            .enable_stalker(options.cmplog || options.asan || !options.disable_coverage)
+            .disable_excludes(options.disable_excludes)
+            .instrument_module_if(move |module| pathlist_contains_module(&harness, module))
+            .instrument_module_if(move |module| {
+                pathlist_contains_module(&libs_to_instrument, module)
+            })
+            .skip_ranges(options.dont_instrument.iter().map(|(name, offset)| {
+                SkipRange::ModuleRelative {
+                    name: name.clone(),
+                    range: *offset..*offset + 4,
                 }
-            }
-
-            // make sure we aren't in the instrumented list, as it would cause recursions
-            assert!(
-                !ranges.contains_key(&(Self::new as usize)),
-                "instrumented libraries must not include the fuzzer"
-            );
-
-            runtimes.init_all(gum, &ranges, &Rc::new(module_map));
-        }
-
-        // Wrap ranges and runtimes in reference-counted refcells in order to move
-        // these references both into the struct that we return and the transformer callback
-        // that we pass to frida-gum.
-        let ranges = Rc::new(RefCell::new(ranges));
-        let runtimes = Rc::new(RefCell::new(runtimes));
-
-        let transformer = Self::build_transformer(gum, &ranges, &runtimes);
-
-        Self {
-            transformer,
-            ranges,
-            runtimes,
-            stalker_enabled,
-            disable_excludes: options.disable_excludes,
-        }
+            }))
+            .build(gum, runtimes);
     }
 
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
Currently the Frida helper is very dependent on using the FuzzerOptions from `libafl_bolts`. However, there is no reason it has to be, and Frida mode should totally be usable without needing clap or the like.