### PR TITLE
Fix rare precision issue with comparisons on cumulative distributions

### DIFF
--- a/libafl_bolts/src/math.rs
+++ b/libafl_bolts/src/math.rs
@@ -29,7 +29,7 @@ pub fn calculate_cumulative_distribution_in_place(probabilities: &mut [f32]) -> 
     }
 
     // Clamp the end of the vector to account for floating point errors.
-    *last = 1.0_f32;
+    *last = f32::INFINITY;
 
     Ok(())
 }


### PR DESCRIPTION
There's a rare bug which can occur where there is precision loss on f32s s.t. we can panic on comparisons with near-one values: https://docs.rs/libafl/latest/src/libafl/mutators/tuneable.rs.html#180

This addresses it by simply clamping the last value to positive infinity, guaranteeing that it will be compared as greater-than.