### PR TITLE
libafl_ar: add extensions

### DIFF
--- a/libafl_cc/src/ar.rs
+++ b/libafl_cc/src/ar.rs
@@ -170,7 +170,7 @@ impl ToolWrapper for ArWrapper {
                         let extension = extension.to_str().unwrap();
                         let extension_lowercase = extension.to_lowercase();
                         match &extension_lowercase[..] {
-                            "o" | "lo" | "a" | "la" | "so" => {
+                            "o" | "lo" | "a" | "la" | "so" | "ao" | "c.o" => {
                                 configuration.replace_extension(&arg_as_path)
                             }
                             _ => arg_as_path,


### PR DESCRIPTION
Add `.ao` and `.c.o` to extensions supported by `libafl_ar`
