### PR TITLE
fix(write_file_atomic): sometimes a file should be overwritten

### DIFF
--- a/libafl_bolts/src/fs.rs
+++ b/libafl_bolts/src/fs.rs
@@ -45,7 +45,7 @@ where
 
         let mut tmpfile = OpenOptions::new()
             .write(true)
-            .create_new(true)
+            .create(true)
             .open(&tmpfile_name)?;
 
         tmpfile.write_all(bytes)?;


### PR DESCRIPTION
I regularly got the error that the fuzzer was falling due to the inability to write a file with the same name. Unfortunately, I can only reproduce the problem stably using a complex example, so I don't have an MRE.