### PR TITLE
fix(drcov_rt): coverage files are overwritten if have the same names

### DIFF
--- a/libafl_frida/src/drcov_rt.rs
+++ b/libafl_frida/src/drcov_rt.rs
@@ -53,9 +53,13 @@ impl FridaRuntime for DrCovRuntime {
         let mut hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
         hasher.write(input.target_bytes().as_slice());
 
-        let filename = self
-            .coverage_directory
-            .join(format!("{:016x}.drcov", hasher.finish(),));
+        let hash = hasher.finish();
+        let mut filename = self.coverage_directory.join(format!("{hash:016x}.drcov"));
+        let mut i = 0;
+        while filename.exists() {
+            filename.set_file_name(format!("{hash:016x}_{i}.drcov"));
+            i += 1;
+        }
         DrCovWriter::new(&self.ranges).write(filename, &self.drcov_basic_blocks)?;
         self.drcov_basic_blocks.clear();
 

--- a/libafl_frida/src/drcov_rt.rs
+++ b/libafl_frida/src/drcov_rt.rs
@@ -23,14 +23,14 @@ use crate::helper::FridaRuntime;
 pub struct DrCovRuntime {
     /// The basic blocks of this execution
     pub drcov_basic_blocks: Vec<DrCovBasicBlock>,
-    /// The memory ragnes of this target
+    /// The memory ranges of this target
     ranges: RangeMap<usize, (u16, String)>,
     stalked_addresses: HashMap<usize, usize>,
     coverage_directory: PathBuf,
 }
 
 impl FridaRuntime for DrCovRuntime {
-    /// initializes this runtime wiith the given `ranges`
+    /// initializes this runtime with the given `ranges`
     fn init(
         &mut self,
         _gum: &frida_gum::Gum,
@@ -48,18 +48,27 @@ impl FridaRuntime for DrCovRuntime {
     }
 
     /// Called after execution, writes the trace to a unique `DrCov` file for this trace
-    /// into `./coverage/<trace_hash>.drcov`
+    /// into `./coverage/<input_hash>_<coverage_hash>.drcov`. Empty coverages will be skipped.
     fn post_exec<I: Input + HasTargetBytes>(&mut self, input: &I) -> Result<(), Error> {
-        let mut hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
-        hasher.write(input.target_bytes().as_slice());
-
-        let hash = hasher.finish();
-        let mut filename = self.coverage_directory.join(format!("{hash:016x}.drcov"));
-        let mut i = 0;
-        while filename.exists() {
-            filename.set_file_name(format!("{hash:016x}_{i}.drcov"));
-            i += 1;
+        // We don't need empty coverage files
+        if self.drcov_basic_blocks.is_empty() {
+            return Ok(());
         }
+
+        let mut input_hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
+        input_hasher.write(input.target_bytes().as_slice());
+        let input_hash = input_hasher.finish();
+
+        let mut coverage_hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
+        for bb in &self.drcov_basic_blocks {
+            coverage_hasher.write_usize(bb.start);
+            coverage_hasher.write_usize(bb.end);
+        }
+        let coverage_hash = coverage_hasher.finish();
+
+        let filename = self
+            .coverage_directory
+            .join(format!("{input_hash:016x}_{coverage_hash:016x}.drcov"));
         DrCovWriter::new(&self.ranges).write(filename, &self.drcov_basic_blocks)?;
         self.drcov_basic_blocks.clear();
 


### PR DESCRIPTION
Unlike `Input` object, which generates files with a unique name, in the coverage module, files are written with a non-unique name, which is why overwriting occurs. It would not play a big role, but the coverage is recorded only once --- when instrumenting by Frida (inside [Transformer](https://github.com/AFLplusplus/LibAFL/blob/5b0e3dd3bcbefc4f02e44a6ee0237998cea294ec/libafl_frida/src/helper.rs#L519-L522)), that is, running the same files leads to overwriting the coverage file with an empty DrCov table.

I used a dirty hack, I admit. If there are better ideas, then I am open to suggestions.