### PR TITLE
Make Signals compatible with nix, implement TryFrom<&str>

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -107,7 +107,7 @@ serde_json = { version = "1.0", optional = true, default-features = false, featu
 miniz_oxide = { version = "0.7.1", optional = true}
 hostname = { version = "^0.3", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.6", optional = true }
-nix = { version = "0.26", optional = true , features = ["socket", "poll"] }
+nix = { version = "0.26", default-features = false, optional = true, features = ["signal", "socket", "poll"] }
 uuid = { version = "1.4", optional = true, features = ["serde", "v4"] }
 clap = {version = "4.0", features = ["derive", "wrap_help"], optional = true} # CLI parsing, for libafl_bolts::cli / the `cli` feature
 log = "0.4.20"

--- a/libafl_bolts/src/os/unix_signals.rs
+++ b/libafl_bolts/src/os/unix_signals.rs
@@ -323,6 +323,7 @@ impl TryFrom<&str> for Signal {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Signal> for nix::sys::signal::Signal {
     fn from(value: Signal) -> Self {
         // we can be semi-certain that all signals exist in nix.

--- a/libafl_bolts/src/os/unix_signals.rs
+++ b/libafl_bolts/src/os/unix_signals.rs
@@ -299,6 +299,37 @@ pub enum Signal {
     SigTrap = SIGTRAP,
 }
 
+impl TryFrom<&str> for Signal {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(match value {
+            "SIGABRT" => Signal::SigAbort,
+            "SIGBUS" => Signal::SigBus,
+            "SIGFPE" => Signal::SigFloatingPointException,
+            "SIGILL" => Signal::SigIllegalInstruction,
+            "SIGPIPE" => Signal::SigPipe,
+            "SIGSEGV" => Signal::SigSegmentationFault,
+            "SIGUSR2" => Signal::SigUser2,
+            "SIGALRM" => Signal::SigAlarm,
+            "SIGHUP" => Signal::SigHangUp,
+            "SIGKILL" => Signal::SigKill,
+            "SIGQUIT" => Signal::SigQuit,
+            "SIGTERM" => Signal::SigTerm,
+            "SIGINT" => Signal::SigInterrupt,
+            "SIGTRAP" => Signal::SigTrap,
+            _ => return Err(Error::illegal_argument(format!("No signal named {value}"))),
+        })
+    }
+}
+
+impl From<Signal> for nix::sys::signal::Signal {
+    fn from(value: Signal) -> Self {
+        // we can be semi-certain that all signals exist in nix.
+        i32::from(value).try_into().unwrap()
+    }
+}
+
 /// A list of crashing signals
 pub static CRASH_SIGNALS: &[Signal] = &[
     Signal::SigAbort,


### PR DESCRIPTION
We have a bunch of code for signal handling that we really need, since nix exposes roughly the same API (while supporting more signals)