### PR TITLE
Fuzz_loop should not return CorpusId

### DIFF
--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -187,7 +187,7 @@ where
         executor: &mut E,
         state: &mut EM::State,
         manager: &mut EM,
-    ) -> Result<CorpusId, Error> {
+    ) -> Result<(), Error> {
         let monitor_timeout = STATS_TIMEOUT_DEFAULT;
         loop {
             manager.maybe_report_progress(state, monitor_timeout)?;


### PR DESCRIPTION
There is not really any reason(?)