### PR TITLE
Rename option name

### DIFF
--- a/libafl_cc/src/afl-coverage-pass.cc
+++ b/libafl_cc/src/afl-coverage-pass.cc
@@ -81,7 +81,7 @@ typedef uint32_t prev_loc_t;
 
 using namespace llvm;
 
-static cl::opt<bool> Debug("debug", cl::desc("Debug prints"), cl::init(false),
+static cl::opt<bool> Debug("debug-afl-coverage", cl::desc("Debug prints"), cl::init(false),
                            cl::NotHidden);
 static cl::opt<uint32_t> InstRatio(
     "inst_ratio", cl::desc("Instrumentation ratio in percentage"),

--- a/libafl_cc/src/afl-coverage-pass.cc
+++ b/libafl_cc/src/afl-coverage-pass.cc
@@ -81,8 +81,8 @@ typedef uint32_t prev_loc_t;
 
 using namespace llvm;
 
-static cl::opt<bool> Debug("debug-afl-coverage", cl::desc("Debug prints"), cl::init(false),
-                           cl::NotHidden);
+static cl::opt<bool>     Debug("debug-afl-coverage", cl::desc("Debug prints"),
+                               cl::init(false), cl::NotHidden);
 static cl::opt<uint32_t> InstRatio(
     "inst_ratio", cl::desc("Instrumentation ratio in percentage"),
     cl::init(100), cl::NotHidden);

--- a/libafl_cc/src/coverage-accounting-pass.cc
+++ b/libafl_cc/src/coverage-accounting-pass.cc
@@ -148,8 +148,9 @@ enum AccountingGranularity {
   UKNOWN_GRAN
 };
 
-static cl::opt<bool> Debug("debug-coverage-accounting", cl::desc("Debug prints"), cl::init(false),
-                           cl::NotHidden);
+static cl::opt<bool>        Debug("debug-coverage-accounting",
+                                  cl::desc("Debug prints"), cl::init(false),
+                                  cl::NotHidden);
 static cl::opt<std::string> GranularityStr(
     "granularity", cl::desc("Granularity of accounting (BB, FUNC)"),
     cl::init(std::string("BB")), cl::NotHidden);

--- a/libafl_cc/src/coverage-accounting-pass.cc
+++ b/libafl_cc/src/coverage-accounting-pass.cc
@@ -148,7 +148,7 @@ enum AccountingGranularity {
   UKNOWN_GRAN
 };
 
-static cl::opt<bool> Debug("debug", cl::desc("Debug prints"), cl::init(false),
+static cl::opt<bool> Debug("debug-coverage-accounting", cl::desc("Debug prints"), cl::init(false),
                            cl::NotHidden);
 static cl::opt<std::string> GranularityStr(
     "granularity", cl::desc("Granularity of accounting (BB, FUNC)"),


### PR DESCRIPTION
because you can't have identical option name in multiple passes

```
: CommandLine Error: Option 'debug' registered more than once!
fatal error: error in backend: inconsistency in registered CommandLine options
```