### PR TITLE
fix: use correct trait bound in WithObservers Executor

### DIFF
--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -51,7 +51,7 @@ where
 
 impl<E, OT> HasObservers for WithObservers<E, OT>
 where
-    E: HasObservers + Debug,
+    E: UsesState + Debug,
     OT: ObserversTuple<E::State> + Debug,
 {
     fn observers(&self) -> &OT {


### PR DESCRIPTION
The WithObserver executor is a wrapper to implement the HadObservers trait for other executors but required the wrapped executor to implement HasObserver.