### PR TITLE
[WithObservers] Call the wrapped observer's post run function

### DIFF
--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -1693,7 +1693,7 @@ where
 
                     self.observers
                         .pre_exec_child_all(state, input)
-                        .expect("Failed to run post_exec on observers");
+                        .expect("Failed to run pre_exec on observers");
 
                     (self.harness_fn)(input);
 

--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -30,7 +30,9 @@ where
         mgr: &mut EM,
         input: &Self::Input,
     ) -> Result<ExitKind, Error> {
-        self.executor.run_target(fuzzer, state, mgr, input)
+        let result = self.executor.run_target(fuzzer, state, mgr, input);
+        self.executor.post_run_reset();
+        result
     }
 }
 

--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -30,9 +30,9 @@ where
         mgr: &mut EM,
         input: &Self::Input,
     ) -> Result<ExitKind, Error> {
-        let result = self.executor.run_target(fuzzer, state, mgr, input);
+        let ret = self.executor.run_target(fuzzer, state, mgr, input);
         self.executor.post_run_reset();
-        result
+        ret
     }
 }
 


### PR DESCRIPTION
Added a call to the wrapped observer's post run function (similar to the corresponding call in the combined executor).