### PR TITLE
Fixed panic feature in baby_fuzzer example

### DIFF
--- a/docs/listings/baby_fuzzer/listing-04/src/main.rs
+++ b/docs/listings/baby_fuzzer/listing-04/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
     /* ANCHOR_END: event_manager */
 
     /* ANCHOR: scheduler_fuzzer */
-    // A queue policy to get testcasess from the corpus
+    // A queue policy to get testcases from the corpus
     let scheduler = QueueScheduler::new();
 
     // A fuzzer with feedbacks and a corpus scheduler

--- a/docs/src/baby_fuzzer/baby_fuzzer.md
+++ b/docs/src/baby_fuzzer/baby_fuzzer.md
@@ -57,7 +57,7 @@ To start, we create the closure that we want to fuzz. It takes a buffer as input
 To test the crash manually, you can add a feature in `Cargo.toml` that enables the call that triggers the panic:
 
 ```toml
-{{#include ../../listings/baby_fuzzer/listing-03/Cargo.toml:22:23}}
+{{#include ../../listings/baby_fuzzer/listing-03/Cargo.toml:22:24}}
 ```
 
 And then run the program with that feature activated:


### PR DESCRIPTION
Otherwise we have an empty feature section and cargo does not find the `panic` feature.

Small fix :) 

It's really cool to have this guide as such a simple starting point to a really complex topic!