### PR TITLE
refactor: Remove unnecessary Debug trait bounds

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -215,7 +215,7 @@ where
 
 impl<OT, S> CommandExecutor<OT, S, StdCommandConfigurator>
 where
-    OT: MatchName + Debug + ObserversTuple<S>,
+    OT: MatchName + ObserversTuple<S>,
     S: UsesInput,
 {
     /// Creates a new `CommandExecutor`.
@@ -315,7 +315,7 @@ where
     EM: UsesState<State = S>,
     S: UsesInput + HasExecutions,
     S::Input: HasTargetBytes,
-    T: CommandConfigurator + Debug,
+    T: CommandConfigurator,
     OT: Debug + MatchName + ObserversTuple<S>,
     Z: UsesState<State = S>,
 {
@@ -565,7 +565,7 @@ impl CommandExecutorBuilder {
         observers: OT,
     ) -> Result<CommandExecutor<OT, S, StdCommandConfigurator>, Error>
     where
-        OT: Debug + MatchName + ObserversTuple<S>,
+        OT: MatchName + ObserversTuple<S>,
         S: UsesInput,
     {
         let Some(program) = &self.program else {
@@ -660,7 +660,7 @@ impl CommandExecutorBuilder {
 /// ```
 
 #[cfg(all(feature = "std", any(unix, doc)))]
-pub trait CommandConfigurator: Sized + Debug {
+pub trait CommandConfigurator: Sized {
     /// Spawns a new process with the given configuration.
     fn spawn_child<I>(&mut self, input: &I) -> Result<Child, Error>
     where
@@ -672,7 +672,7 @@ pub trait CommandConfigurator: Sized + Debug {
     /// Create an `Executor` from this `CommandConfigurator`.
     fn into_executor<OT, S>(self, observers: OT) -> CommandExecutor<OT, S, Self>
     where
-        OT: Debug + MatchName,
+        OT: MatchName,
     {
         CommandExecutor {
             observers,

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -522,7 +522,7 @@ impl<E> TimeoutForkserverExecutor<E> {
 
 impl<E, EM, Z> Executor<EM, Z> for TimeoutForkserverExecutor<E>
 where
-    E: Executor<EM, Z> + HasForkserver + HasObservers + Debug,
+    E: Executor<EM, Z> + HasForkserver + HasObservers,
     E::Input: HasTargetBytes,
     E::State: HasExecutions,
     EM: UsesState<State = E::State>,

--- a/libafl/src/executors/inprocess.rs
+++ b/libafl/src/executors/inprocess.rs
@@ -90,7 +90,7 @@ impl<H, HB, OT, S> Debug for GenericInProcessExecutor<H, HB, OT, S>
 where
     H: FnMut(&S::Input) -> ExitKind + ?Sized,
     HB: BorrowMut<H>,
-    OT: ObserversTuple<S>,
+    OT: ObserversTuple<S> + Debug,
     S: UsesInput,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -1599,7 +1599,7 @@ where
 impl<'a, H, OT, S, SP> Debug for InProcessForkExecutor<'a, H, OT, S, SP>
 where
     H: FnMut(&S::Input) -> ExitKind + ?Sized,
-    OT: ObserversTuple<S>,
+    OT: ObserversTuple<S> + Debug,
     S: UsesInput,
     SP: ShMemProvider,
 {
@@ -1615,7 +1615,7 @@ where
 impl<'a, H, OT, S, SP> Debug for TimeoutInProcessForkExecutor<'a, H, OT, S, SP>
 where
     H: FnMut(&S::Input) -> ExitKind + ?Sized,
-    OT: ObserversTuple<S>,
+    OT: ObserversTuple<S> + Debug,
     S: UsesInput,
     SP: ShMemProvider,
 {

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -118,7 +118,7 @@ pub trait HasObservers: UsesObservers {
 }
 
 /// An executor takes the given inputs, and runs the harness/target.
-pub trait Executor<EM, Z>: UsesState + Debug
+pub trait Executor<EM, Z>: UsesState
 where
     EM: UsesState<State = Self::State>,
     Z: UsesState<State = Self::State>,
@@ -166,7 +166,7 @@ where
 impl<EM, S, Z> Executor<EM, Z> for NopExecutor<S>
 where
     EM: UsesState<State = S>,
-    S: UsesInput + Debug + HasExecutions,
+    S: UsesInput + HasExecutions,
     S::Input: HasTargetBytes,
     Z: UsesState<State = S>,
 {

--- a/libafl/src/executors/shadow.rs
+++ b/libafl/src/executors/shadow.rs
@@ -32,8 +32,8 @@ where
 
 impl<E, SOT> ShadowExecutor<E, SOT>
 where
-    E: HasObservers + Debug,
-    SOT: ObserversTuple<E::State> + Debug,
+    E: HasObservers,
+    SOT: ObserversTuple<E::State>,
 {
     /// Create a new `ShadowExecutor`, wrapping the given `executor`.
     pub fn new(executor: E, shadow_observers: SOT) -> Self {

--- a/libafl/src/executors/with_observers.rs
+++ b/libafl/src/executors/with_observers.rs
@@ -18,8 +18,7 @@ pub struct WithObservers<E, OT> {
 
 impl<E, EM, OT, Z> Executor<EM, Z> for WithObservers<E, OT>
 where
-    E: Executor<EM, Z> + Debug,
-    OT: Debug,
+    E: Executor<EM, Z>,
     EM: UsesState<State = E::State>,
     Z: UsesState<State = E::State>,
 {
@@ -53,8 +52,8 @@ where
 
 impl<E, OT> HasObservers for WithObservers<E, OT>
 where
-    E: UsesState + Debug,
-    OT: ObserversTuple<E::State> + Debug,
+    E: UsesState,
+    OT: ObserversTuple<E::State>,
 {
     fn observers(&self) -> &OT {
         &self.observers
@@ -65,7 +64,7 @@ where
     }
 }
 
-impl<E: Debug, OT: Debug> WithObservers<E, OT> {
+impl<E, OT> WithObservers<E, OT> {
     /// Wraps the given [`Executor`] with the given [`ObserversTuple`] to implement [`HasObservers`].
     ///
     /// If the executor already implements [`HasObservers`], then the original implementation will be overshadowed by

--- a/libafl/src/feedbacks/concolic.rs
+++ b/libafl/src/feedbacks/concolic.rs
@@ -49,7 +49,7 @@ impl<S> Named for ConcolicFeedback<S> {
 
 impl<S> Feedback<S> for ConcolicFeedback<S>
 where
-    S: UsesInput + Debug + HasClientPerfMonitor,
+    S: UsesInput + HasClientPerfMonitor,
 {
     #[allow(clippy::wrong_self_convention)]
     fn is_interesting<EM, OT>(

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -50,7 +50,7 @@ pub type MaxMapPow2Feedback<O, S, T> = MapFeedback<NextPow2IsNovel, O, MaxReduce
 pub type MaxMapOneOrFilledFeedback<O, S, T> = MapFeedback<OneOrFilledIsNovel, O, MaxReducer, S, T>;
 
 /// A `Reducer` function is used to aggregate values for the novelty search
-pub trait Reducer<T>: 'static + Debug
+pub trait Reducer<T>: 'static
 where
     T: Default + Copy + 'static,
 {
@@ -137,7 +137,7 @@ where
 }
 
 /// A `IsNovel` function is used to discriminate if a reduced value is considered novel.
-pub trait IsNovel<T>: 'static + Debug
+pub trait IsNovel<T>: 'static
 where
     T: Default + Copy + 'static,
 {
@@ -392,10 +392,10 @@ where
 
 impl<N, O, R, S, T> Feedback<S> for MapFeedback<N, O, R, S, T>
 where
-    N: IsNovel<T> + Debug,
+    N: IsNovel<T>,
     O: MapObserver<Entry = T> + for<'it> AsIter<'it, Item = T>,
-    R: Reducer<T> + Debug,
-    S: UsesInput + HasClientPerfMonitor + HasNamedMetadata + Debug,
+    R: Reducer<T>,
+    S: UsesInput + HasClientPerfMonitor + HasNamedMetadata,
     T: Default + Copy + Serialize + for<'de> Deserialize<'de> + PartialEq + Debug + 'static,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
@@ -496,7 +496,7 @@ impl<O, S> Feedback<S> for MapFeedback<DifferentIsNovel, O, MaxReducer, S, u8>
 where
     O: MapObserver<Entry = u8> + AsSlice<Entry = u8>,
     for<'it> O: AsIter<'it, Item = u8>,
-    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor + Debug,
+    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor,
 {
     #[allow(clippy::wrong_self_convention)]
     #[allow(clippy::needless_range_loop)]
@@ -664,7 +664,7 @@ where
     O: MapObserver<Entry = T>,
     for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
-    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor + Debug,
+    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor,
 {
     /// Create new `MapFeedback`
     #[must_use]
@@ -875,7 +875,7 @@ where
 
 impl<O, S> Feedback<S> for ReachabilityFeedback<O, S>
 where
-    S: UsesInput + Debug + HasClientPerfMonitor,
+    S: UsesInput + HasClientPerfMonitor,
     O: MapObserver<Entry = usize>,
     for<'it> O: AsIter<'it, Item = usize>,
 {

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -47,7 +47,7 @@ use crate::{
 /// Feedbacks evaluate the observers.
 /// Basically, they reduce the information provided by an observer to a value,
 /// indicating the "interestingness" of the last run.
-pub trait Feedback<S>: Named + Debug
+pub trait Feedback<S>: Named
 where
     S: UsesInput + HasClientPerfMonitor,
 {
@@ -186,7 +186,7 @@ where
     A: Feedback<S>,
     B: Feedback<S>,
     FL: FeedbackLogic<A, B, S>,
-    S: UsesInput + HasClientPerfMonitor + Debug,
+    S: UsesInput + HasClientPerfMonitor,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
         self.first.init_state(state)?;
@@ -265,7 +265,7 @@ where
 }
 
 /// Logical combination of two feedbacks
-pub trait FeedbackLogic<A, B, S>: 'static + Debug
+pub trait FeedbackLogic<A, B, S>: 'static
 where
     A: Feedback<S>,
     B: Feedback<S>,
@@ -619,7 +619,7 @@ where
 
 impl<A, S> Debug for NotFeedback<A, S>
 where
-    A: Feedback<S>,
+    A: Feedback<S> + Debug,
     S: UsesInput + HasClientPerfMonitor,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/libafl/src/feedbacks/new_hash_feedback.rs
+++ b/libafl/src/feedbacks/new_hash_feedback.rs
@@ -87,8 +87,8 @@ pub struct NewHashFeedback<O, S> {
 
 impl<O, S> Feedback<S> for NewHashFeedback<O, S>
 where
-    O: ObserverWithHashField + Named + Debug,
-    S: UsesInput + Debug + HasNamedMetadata + HasClientPerfMonitor,
+    O: ObserverWithHashField + Named,
+    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
         state.add_named_metadata(
@@ -157,7 +157,7 @@ const DEFAULT_CAPACITY: usize = 4096;
 
 impl<O, S> NewHashFeedback<O, S>
 where
-    O: ObserverWithHashField + Named + Debug,
+    O: ObserverWithHashField + Named,
 {
     /// Returns a new [`NewHashFeedback`].
     /// Setting an observer name that doesn't exist would eventually trigger a panic.

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -83,7 +83,7 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
-pub trait MapObserver: HasLen + Named + Serialize + serde::de::DeserializeOwned + Debug
+pub trait MapObserver: HasLen + Named + Serialize + serde::de::DeserializeOwned
 // where
 //     for<'it> &'it Self: IntoIterator<Item = &'it Self::Entry>
 {

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -47,7 +47,7 @@ where
 
 /// Observers observe different information about the target.
 /// They can then be used by various sorts of feedback.
-pub trait Observer<S>: Named + Debug
+pub trait Observer<S>: Named
 where
     S: UsesInput,
 {
@@ -124,7 +124,7 @@ pub trait UsesObservers: UsesState {
 }
 
 /// A haskell-style tuple of observers
-pub trait ObserversTuple<S>: MatchName + Debug
+pub trait ObserversTuple<S>: MatchName
 where
     S: UsesInput,
 {

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -331,8 +331,8 @@ impl<M, S> HasObserverName for MapEqualityFeedback<M, S> {
 
 impl<M, S> Feedback<S> for MapEqualityFeedback<M, S>
 where
-    M: MapObserver + Debug,
-    S: UsesInput + HasClientPerfMonitor + Debug,
+    M: MapObserver,
+    S: UsesInput + HasClientPerfMonitor,
 {
     fn is_interesting<EM, OT>(
         &mut self,

--- a/libafl_bolts/src/serdeany.rs
+++ b/libafl_bolts/src/serdeany.rs
@@ -17,10 +17,11 @@ pub trait SerdeAny: Any + erased_serde::Serialize + Debug {
 
 /// Wrap a type for serialization
 #[derive(Debug)]
-pub struct Wrap<'a, T: ?Sized + Debug>(pub &'a T);
+pub struct Wrap<'a, T: ?Sized>(pub &'a T);
+
 impl<'a, T> Serialize for Wrap<'a, T>
 where
-    T: ?Sized + erased_serde::Serialize + 'a + Debug,
+    T: ?Sized + erased_serde::Serialize + 'a,
 {
     /// Serialize the type
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/libafl_frida/src/executor.rs
+++ b/libafl_frida/src/executor.rs
@@ -49,7 +49,7 @@ where
     H: FnMut(&S::Input) -> ExitKind,
     S: UsesInput,
     S::Input: HasTargetBytes,
-    OT: ObserversTuple<S>,
+    OT: ObserversTuple<S> + Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("FridaInProcessExecutor")

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -45,8 +45,8 @@ impl<'a, H, OT, QT, S> Debug for QemuExecutor<'a, H, OT, QT, S>
 where
     H: FnMut(&S::Input) -> ExitKind,
     S: UsesInput,
-    OT: ObserversTuple<S>,
-    QT: QemuHelperTuple<S>,
+    OT: ObserversTuple<S> + Debug,
+    QT: QemuHelperTuple<S> + Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QemuExecutor")
@@ -289,8 +289,8 @@ impl<'a, H, OT, QT, S, SP> Debug for QemuForkExecutor<'a, H, OT, QT, S, SP>
 where
     H: FnMut(&S::Input) -> ExitKind,
     S: UsesInput,
-    OT: ObserversTuple<S>,
-    QT: QemuHelperTuple<S>,
+    OT: ObserversTuple<S> + Debug,
+    QT: QemuHelperTuple<S> + Debug,
     SP: ShMemProvider,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/libafl_qemu/src/helper.rs
+++ b/libafl_qemu/src/helper.rs
@@ -43,7 +43,7 @@ where
 }
 
 pub trait QemuHelperTuple<S>:
-    MatchFirstType + for<'a> SplitBorrowExtractFirstType<'a> + Debug
+    MatchFirstType + for<'a> SplitBorrowExtractFirstType<'a>
 where
     S: UsesInput,
 {

--- a/libafl_qemu/src/helper.rs
+++ b/libafl_qemu/src/helper.rs
@@ -42,8 +42,7 @@ where
     }
 }
 
-pub trait QemuHelperTuple<S>:
-    MatchFirstType + for<'a> SplitBorrowExtractFirstType<'a>
+pub trait QemuHelperTuple<S>: MatchFirstType + for<'a> SplitBorrowExtractFirstType<'a>
 where
     S: UsesInput,
 {

--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -729,7 +729,7 @@ where
 impl<'a, QT, S> Debug for QemuHooks<'a, QT, S>
 where
     S: UsesInput,
-    QT: QemuHelperTuple<S>,
+    QT: QemuHelperTuple<S> + Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QemuHooks")


### PR DESCRIPTION
Having Debug as supertrait is undesirable in my opinion, since this propagates everywhere. I would suggest limiting Debug as trait bound to the actual `Debug` trait implementations. This also doesn't really make sense from a semantic standpoint, since most of these traits don't actually need anything from the Debug trait.
There are probably more occurrences of this, but i didn't look through all the code yet. What is your opinion on this?