### PR TITLE
bolts fix solarish cpu binding. seems PS_MYID to save one syscall was

### DIFF
--- a/libafl_bolts/src/core_affinity.rs
+++ b/libafl_bolts/src/core_affinity.rs
@@ -916,7 +916,7 @@ mod solaris {
         let result = unsafe {
             libc::processor_bind(
                 libc::P_PID,
-                libc::PS_MYID,
+                libc::getpid(),
                 core_id.0.try_into().unwrap(),
                 std::ptr::null_mut(),
             )


### PR DESCRIPTION
not really working, explicit current id makes the test always pass.