### PR TITLE
Remove capstone from frida [aarch64]

### DIFF
--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -60,7 +60,10 @@ frida-gum = { version = "0.13.2", features = [
     "module-names",
 ] }
 dynasmrt = "2"
-capstone = "0.11.0"
+
+capstone = "0.11.0" 
+yaxpeax-arm = "0.2.4"
+yaxpeax-arch = "0.2.7"
 color-backtrace = { version = "0.6", features = ["resolve-modules"] }
 termcolor = "1.1.3"
 serde = "1.0"

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -61,9 +61,13 @@ frida-gum = { version = "0.13.2", features = [
 ] }
 dynasmrt = "2"
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 capstone = "0.11.0" 
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
 yaxpeax-arm = "0.2.4"
 yaxpeax-arch = "0.2.7"
+
 color-backtrace = { version = "0.6", features = ["resolve-modules"] }
 termcolor = "1.1.3"
 serde = "1.0"

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -39,8 +39,10 @@ use libc::{c_char, wchar_t};
 use libc::{getrlimit, rlimit};
 #[cfg(all(unix, not(target_vendor = "apple")))]
 use libc::{getrlimit64, rlimit64};
-use nix::sys::mman::{mmap, MapFlags, ProtFlags};
+use nix::sys::mman::{mmap, mprotect, MapFlags, ProtFlags};
 use rangemap::RangeMap;
+
+
 
 #[cfg(any(target_arch = "x86_64"))]
 use crate::utils::frida_to_cs;
@@ -193,15 +195,9 @@ impl FridaRuntime for AsanRuntime {
             }));
 
         self.hook_functions(gum);
-        /*
+        
         unsafe {
             let mem = self.allocator.alloc(0xac + 2, 8);
-            mprotect(
-                (self.shadow_check_func.unwrap() as usize & 0xffffffffffff000) as *mut c_void,
-                0x1000,
-                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE | ProtFlags::PROT_EXEC,
-            )
-            .unwrap();
             log::info!("Test0");
             /*
             0x555555916ce9 <libafl_frida::asan_rt::AsanRuntime::init+13033>    je     libafl_frida::asan_rt::AsanRuntime::init+14852 <libafl_frida::asan_rt::AsanRuntime::init+14852>
@@ -266,7 +262,7 @@ impl FridaRuntime for AsanRuntime {
             }
             // assert!((self.shadow_check_func.unwrap())(((mem2 as usize) + 8875) as *const c_void, 4));
         }
-        */
+        
         self.register_thread();
     }
     fn pre_exec<I: libafl::inputs::Input + libafl::inputs::HasTargetBytes>(

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -34,6 +34,7 @@ use libc::{getrlimit, rlimit};
 use libc::{getrlimit64, rlimit64};
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 use rangemap::RangeMap;
+#[cfg(target_arch = "aarch64")]
 use yaxpeax_arch::Arch;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::{ARMv8, InstDecoder, Opcode, Operand, ShiftStyle, SizeCode};
@@ -43,14 +44,14 @@ use yaxpeax_x86::amd64::{InstDecoder, Instruction, Opcode};
 #[cfg(any(target_arch = "x86_64"))]
 use crate::utils::frida_to_cs;
 #[cfg(target_arch = "aarch64")]
-use crate::utils::instruction_width;
+use crate::utils::{instruction_width, writer_register};
 #[cfg(target_arch = "x86_64")]
-use crate::utils::operand_details;
+use crate::utils::{operand_details, AccessType};
 use crate::{
     alloc::Allocator,
     asan::errors::{AsanError, AsanErrors, AsanReadWriteError, ASAN_ERRORS},
     helper::{FridaRuntime, SkipRange},
-    utils::{disas_count, writer_register},
+    utils::disas_count,
 };
 
 extern "C" {

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -33,7 +33,7 @@ use libc::{c_char, wchar_t};
 use libc::{getrlimit, rlimit};
 #[cfg(all(unix, not(target_vendor = "apple")))]
 use libc::{getrlimit64, rlimit64};
-use nix::sys::mman::{mmap, mprotect, MapFlags, ProtFlags};
+use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 use rangemap::RangeMap;
 #[cfg(target_arch = "x86_64")]
 use yaxpeax_x86::amd64::{InstDecoder, Instruction, Opcode};
@@ -54,7 +54,7 @@ use crate::{
     utils::disas_count
 };
 
-use yaxpeax_arch::{ReaderBuilder, Decoder, Arch};
+use yaxpeax_arch::Arch;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::{ARMv8, Opcode, Operand, SizeCode, ShiftStyle, InstDecoder};
 
@@ -2161,17 +2161,8 @@ impl AsanRuntime {
         )
     > {
         // We need to re-decode frida-internal capstone values to upstream capstone
-        //let instr_bytes = unsafe { std::slice::from_raw_parts(address as *const u8, 4) };
-        let mut reader = ReaderBuilder::<u64, u8>::read_from(instr.bytes());
-        let decode_res = decoder.decode(&mut reader);
 
-        if let Err(e) = decode_res {
-            //println!("{}", e);
-            //instruction is not supported by yaxpeax
-            return None;
-        }
-
-        let instr = decode_res.unwrap();
+        let instr = disas_count(&decoder, instr.bytes(), 1)[0];
         // We have to ignore these instructions. Simulating them with their side effects is
         // complex, to say the least.
         match instr.opcode {

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -142,7 +142,7 @@ impl AsanErrors {
     #[allow(clippy::too_many_lines)]
     pub(crate) fn report_error(&mut self, error: AsanError) {
         self.errors.push(error.clone());
-
+        log::error!("Reporting the error");
         let mut out_stream = default_output_stream();
         let output = out_stream.as_mut();
 
@@ -259,7 +259,7 @@ impl AsanErrors {
 
                 while let Ok(insn) = decoder.decode(&mut reader)
                 {
-                    if <U8Reader<'_> as Reader<u64, u8>>::total_offset(&mut reader).to_linear() == start_pc-error.pc { //error.pc < start_pc
+                    if <U8Reader<'_> as Reader<u64, u8>>::total_offset(&mut reader).to_linear() == error.pc-start_pc { //error.pc < start_pc
                         output
                             .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
                             .unwrap();

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -259,7 +259,7 @@ impl AsanErrors {
 
                 while let Ok(insn) = decoder.decode(&mut reader)
                 {
-                    if <U8Reader<'_> as Reader<u64, u8>>::total_offset(&mut reader).to_linear() == error.pc-start_pc { //error.pc < start_pc
+                    if <U8Reader<'_> as Reader<u64, u8>>::total_offset(&mut reader).to_linear()-4 == error.pc-start_pc { //error.pc < start_pc
                         output
                             .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
                             .unwrap();
@@ -508,7 +508,7 @@ impl AsanErrors {
                 //unsafe { std::slice::from_raw_parts(start_pc as *mut u8, 4 * 11) }
                 
                 while let Ok(insn) = decoder.decode(&mut reader) {
-                    if <U8Reader<'_> as Reader<u64, u8>>::total_offset(&mut reader).to_linear() == pc - start_pc {
+                    if <U8Reader<'_> as Reader<u64, u8>>::total_offset(&mut reader).to_linear()-4 == pc - start_pc {
                         output
                             .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
                             .unwrap();

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -19,9 +19,11 @@ use libafl::{
 use libafl_bolts::{ownedref::OwnedPtr, Named, SerdeAny};
 use serde::{Deserialize, Serialize};
 use termcolor::{Color, ColorSpec, WriteColor};
-use yaxpeax_arch::{Arch, LengthedInstruction};
+use yaxpeax_arch::LengthedInstruction;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::ARMv8;
+#[cfg(target_arch = "aarch64")]
+use yaxpeax_arch::Arch;
 #[cfg(target_arch = "x86_64")]
 use yaxpeax_x86::amd64::InstDecoder;
 

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -142,7 +142,7 @@ impl AsanErrors {
     #[allow(clippy::too_many_lines)]
     pub(crate) fn report_error(&mut self, error: AsanError) {
         self.errors.push(error.clone());
-        log::error!("Reporting the error");
+
         let mut out_stream = default_output_stream();
         let output = out_stream.as_mut();
 
@@ -682,3 +682,5 @@ impl<S> Default for AsanErrorsFeedback<S> {
         Self::new()
     }
 }
+
+

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -19,20 +19,17 @@ use libafl::{
 use libafl_bolts::{ownedref::OwnedPtr, Named, SerdeAny};
 use serde::{Deserialize, Serialize};
 use termcolor::{Color, ColorSpec, WriteColor};
-use yaxpeax_arch::{LengthedInstruction, Arch};
-#[cfg(target_arch = "x86_64")]
-use yaxpeax_x86::amd64::InstDecoder;
+use yaxpeax_arch::{Arch, LengthedInstruction};
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::ARMv8;
-
+#[cfg(target_arch = "x86_64")]
+use yaxpeax_x86::amd64::InstDecoder;
 
 #[cfg(target_arch = "x86_64")]
 use crate::asan::asan_rt::ASAN_SAVE_REGISTER_NAMES;
 use crate::{
     alloc::AllocationMetadata, asan::asan_rt::ASAN_SAVE_REGISTER_COUNT, utils::disas_count,
 };
-
-
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AsanReadWriteError {
@@ -248,7 +245,6 @@ impl AsanErrors {
                 #[cfg(target_arch = "x86_64")]
                 let decoder = InstDecoder::minimal();
 
-                
                 let start_pc = error.pc - 4 * 5;
                 #[cfg(target_arch = "x86_64")]
                 let insts = disas_count(
@@ -698,5 +694,3 @@ impl<S> Default for AsanErrorsFeedback<S> {
         Self::new()
     }
 }
-
-

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -19,11 +19,11 @@ use libafl::{
 use libafl_bolts::{ownedref::OwnedPtr, Named, SerdeAny};
 use serde::{Deserialize, Serialize};
 use termcolor::{Color, ColorSpec, WriteColor};
+#[cfg(target_arch = "aarch64")]
+use yaxpeax_arch::Arch;
 use yaxpeax_arch::LengthedInstruction;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::ARMv8;
-#[cfg(target_arch = "aarch64")]
-use yaxpeax_arch::Arch;
 #[cfg(target_arch = "x86_64")]
 use yaxpeax_x86::amd64::InstDecoder;
 

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -19,9 +19,12 @@ use libafl::{
 use libafl_bolts::{ownedref::OwnedPtr, Named, SerdeAny};
 use serde::{Deserialize, Serialize};
 use termcolor::{Color, ColorSpec, WriteColor};
-use yaxpeax_arch::LengthedInstruction;
+use yaxpeax_arch::{LengthedInstruction, Arch};
 #[cfg(target_arch = "x86_64")]
 use yaxpeax_x86::amd64::InstDecoder;
+#[cfg(target_arch = "aarch64")]
+use yaxpeax_arm::armv8::a64::ARMv8;
+
 
 #[cfg(target_arch = "x86_64")]
 use crate::asan::asan_rt::ASAN_SAVE_REGISTER_NAMES;
@@ -29,9 +32,6 @@ use crate::{
     alloc::AllocationMetadata, asan::asan_rt::ASAN_SAVE_REGISTER_COUNT, utils::disas_count,
 };
 
-#[cfg(target_arch = "aarch64")]
-use yaxpeax_arm::armv8::a64::ARMv8;
-use yaxpeax_arch::{ReaderBuilder, Arch, Decoder, Reader, AddressBase, U8Reader};
 
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -6,6 +6,7 @@
 use std::ffi::c_void;
 
 use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
+#[cfg(target_arch = "aarch64")]
 use frida_gum_sys::Insn;
 use libafl::{
     inputs::{HasTargetBytes, Input},

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -27,11 +27,9 @@ use frida_gum::{
     instruction_writer::{Aarch64Register, IndexMode, InstructionWriter},
     stalker::StalkerOutput,
 };
-#[cfg(target_arch = "aarch64")]
-use frida_gum_sys::Insn;
 
 #[cfg(all(feature = "cmplog", target_arch = "aarch64"))]
-use crate::utils::{frida_to_cs, instruction_width, writer_register};
+use crate::utils::writer_register;
 
 #[cfg(all(feature = "cmplog", target_arch = "aarch64"))]
 /// Speciial `CmpLog` Cases for `aarch64`
@@ -44,7 +42,7 @@ pub enum SpecialCmpLogCase {
 }
 
 #[cfg(target_arch = "aarch64")]
-use yaxpeax_arm::armv8::a64::{Instruction, Operand, Opcode, SizeCode, ShiftStyle, ARMv8};
+use yaxpeax_arm::armv8::a64::{Operand, Opcode, ShiftStyle, ARMv8};
 use yaxpeax_arch::{Arch, ReaderBuilder, Decoder};
 
 
@@ -375,11 +373,9 @@ impl CmpLogRuntime {
         let instr_bytes = unsafe { std::slice::from_raw_parts(address as *const u8, 4) };
         let mut reader = ReaderBuilder::<u64, u8>::read_from(instr_bytes);
         let decoder = <ARMv8 as Arch>::Decoder::default();
-        let mut decode_res = decoder.decode(&mut reader);
+        let decode_res = decoder.decode(&mut reader);
 
-        println!("{:?}", instr_bytes);
-        if let Err(e) = decode_res {
-            println!("{}", e);
+        if let Err(_) = decode_res {
             //instruction is not supported by yaxpeax
             return None;
         }

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -22,6 +22,7 @@ use libafl_targets::drcov::DrCovBasicBlock;
 #[cfg(unix)]
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 use rangemap::RangeMap;
+#[cfg(target_arch = "aarch64")]
 use yaxpeax_arch::Arch;
 #[cfg(all(target_arch = "aarch64", unix))]
 use yaxpeax_arm::armv8::a64::{ARMv8, InstDecoder};
@@ -442,6 +443,9 @@ where
     ) -> Transformer<'a> {
         let ranges = Rc::clone(ranges);
         let runtimes = Rc::clone(runtimes);
+
+        #[cfg(target_arch = "x86_64")]
+        let decoder = InstDecoder::minimal();
 
         #[cfg(target_arch = "aarch64")]
         let decoder = <ARMv8 as Arch>::Decoder::default();

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -6,7 +6,7 @@ use std::{
     rc::Rc,
 };
 
-#[cfg(any(target_arch = "aarch64", all(target_arch = "x86_64", unix)))]
+#[cfg(all(target_arch = "x86_64", unix))]
 use capstone::{
     arch::{self, BuildsCapstone},
     Capstone,

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -17,7 +17,7 @@ use frida_gum::{
     stalker::{StalkerIterator, StalkerOutput, Transformer},
     Gum, Module, ModuleDetails, ModuleMap, PageProtection,
 };
-use frida_gum_sys::Insn;
+
 use libafl::{
     inputs::{HasTargetBytes, Input},
     Error,

--- a/libafl_frida/src/utils.rs
+++ b/libafl_frida/src/utils.rs
@@ -259,6 +259,7 @@ pub fn disas_count(decoder: &InstDecoder, data: &[u8], count: usize) -> Vec<Inst
 }
 
 #[cfg(target_arch = "aarch64")]
+/// Disassemble "count" number of instructions
 pub fn disas_count(decoder: &InstDecoder, data: &[u8], count: usize) -> Vec<Instruction> {
     let _counter = count;
     let mut ret = vec![];

--- a/libafl_frida/src/utils.rs
+++ b/libafl_frida/src/utils.rs
@@ -3,7 +3,7 @@ use frida_gum::instruction_writer::Aarch64Register;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::{Instruction, Operand, Opcode, SIMDSizeCode, SizeCode, InstDecoder};
 #[cfg(target_arch = "aarch64")]
-use yaxpeax_arch::{ReaderBuilder, Arch, Decoder, Reader, AddressBase, U8Reader};
+use yaxpeax_arch::{ReaderBuilder, Decoder};
 #[cfg(target_arch = "x86_64")]
 use frida_gum::instruction_writer::X86Register;
 #[cfg(any(target_arch = "x86_64"))]
@@ -269,9 +269,9 @@ pub fn disas_count(decoder: &InstDecoder, data: &[u8], count: usize) -> Vec<Inst
 
 #[cfg(target_arch = "aarch64")]
 pub fn disas_count(decoder: &InstDecoder, data: &[u8], count: usize) -> Vec<Instruction> {
-    let mut counter = count;
+    let _counter = count;
     let mut ret = vec![];
-    let mut start = 0;
+    let _start = 0;
 
    let mut reader =  ReaderBuilder::<u64, u8>::read_from(data);
 

--- a/libafl_frida/src/utils.rs
+++ b/libafl_frida/src/utils.rs
@@ -77,7 +77,7 @@ pub fn instruction_width(instr: &Instruction) -> u32 {
         _ => (),
     }
 
-   
+
     let size = match instr.operands.first().unwrap() {
         Operand::Register(sizecode, _) => { //this is used for standard loads/stores including ldr, ldp, etc.
             get_reg_size(*sizecode)

--- a/libafl_frida/src/utils.rs
+++ b/libafl_frida/src/utils.rs
@@ -77,7 +77,7 @@ pub fn instruction_width(instr: &Instruction) -> u32 {
         _ => (),
     }
 
-
+   
     let size = match instr.operands.first().unwrap() {
         Operand::Register(sizecode, _) => { //this is used for standard loads/stores including ldr, ldp, etc.
             get_reg_size(*sizecode)
@@ -98,7 +98,7 @@ pub fn instruction_width(instr: &Instruction) -> u32 {
             get_simd_size(*sizecode) * *num as u32
         },
         _ => {
-            panic!("Failed to get size");
+            return 0;
         }
     };
     num_registers * size

--- a/libafl_frida/src/utils.rs
+++ b/libafl_frida/src/utils.rs
@@ -1,22 +1,17 @@
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86_64"))]
 use capstone::Capstone;
-#[cfg(target_arch = "aarch64")]
-use capstone::{
-    arch::{self, arm64::Arm64OperandType, ArchOperand::Arm64Operand},
-    Insn,
-};
 #[cfg(target_arch = "aarch64")]
 use frida_gum::instruction_writer::Aarch64Register;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::{Instruction, Operand, Opcode, SIMDSizeCode, SizeCode};
 #[cfg(target_arch = "x86_64")]
 use frida_gum::instruction_writer::X86Register;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86_64"))]
 use frida_gum_sys;
 #[cfg(target_arch = "aarch64")]
 use num_traits::cast::FromPrimitive;
 
-
+/// Determine the size of an SIMD register
 #[cfg(target_arch = "aarch64")]
 #[inline]
 #[must_use]
@@ -40,6 +35,7 @@ pub fn get_simd_size(sizecode: SIMDSizeCode) -> u32 {
     }
 }
 
+/// Determine the size of a normal register
 #[cfg(target_arch = "aarch64")]
 #[inline]
 #[must_use]
@@ -178,7 +174,7 @@ pub fn writer_register(reg: capstone::RegId) -> X86Register {
 
 /// Translates a frida instruction to a capstone instruction.
 /// Returns a [`capstone::Instructions`] with a single [`capstone::Insn`] inside.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86_64"))]
 pub(crate) fn frida_to_cs<'a>(
     capstone: &'a Capstone,
     frida_insn: &frida_gum_sys::Insn,


### PR DESCRIPTION
Not done yet, but this PR removes capstone from libafl-frida for aarch64. 

The changes themselves are mostly done, but it needs to be tested and some tests need to be added. The API also needs to be made consistent with https://github.com/AFLplusplus/LibAFL/pull/1720 to the extent possible. 