### PR TITLE
Make inner value of llmp Flags pub

### DIFF
--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -202,7 +202,7 @@ pub struct BrokerId(pub u32);
 /// The flags, indicating, for example, enabled compression.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Flags(u32);
+pub struct Flags(pub u32);
 
 impl Debug for Flags {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
In my opinion the inner value of `Flags` should be publicly accessible.

I am implementing my own llmp runloop in another crate and I need to create my own set of Flags for message handling. The inner value of Tags are already `pub` as well.