### PR TITLE
use yaxpeax-x86 version from crates.io instead of direct git dep

### DIFF
--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -32,7 +32,7 @@ cc = { version = "1.0", features = ["parallel"] }
 yaxpeax-arm = "0.2.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-yaxpeax-x86 = { git = "https://github.com/iximeow/yaxpeax-x86/", rev = "85668b2" } # replace this with origin later
+yaxpeax-x86 = "1.2.2"
 
 [dependencies]
 libafl = { path = "../libafl", default-features = false, version = "0.11.1", features = [


### PR DESCRIPTION
i noticed @tokatoka pointed the new `yaxpeax-x86` dependency directly at the commit fixing the `r12`/`r13` constructor confusion, that and a few [other fixes](https://github.com/iximeow/yaxpeax-x86/blob/no-gods-no-/CHANGELOG#L1-L34) are all published to crates.io as of 1.2.2. figured i'd come by and offer that version bump :)