### PR TITLE
load unicode_categories.rs from the correct location in mutator?

### DIFF
--- a/libafl/src/mutators/string.rs
+++ b/libafl/src/mutators/string.rs
@@ -273,7 +273,7 @@ pub mod unicode_categories {
     #![allow(missing_docs)]
     #![allow(clippy::redundant_static_lifetimes)]
 
-    include!(concat!(env!("OUT_DIR"), "/unicode_categories.rs"));
+    include!(concat!(env!("OUT_DIR"), "/ucd-dir", "/unicode_categories.rs"));
 }
 
 /// Mutator which randomly replaces a randomly selected range of bytes with bytes that preserve the

--- a/libafl/src/mutators/string.rs
+++ b/libafl/src/mutators/string.rs
@@ -273,7 +273,11 @@ pub mod unicode_categories {
     #![allow(missing_docs)]
     #![allow(clippy::redundant_static_lifetimes)]
 
-    include!(concat!(env!("OUT_DIR"), "/ucd-dir", "/unicode_categories.rs"));
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/ucd-dir",
+        "/unicode_categories.rs"
+    ));
 }
 
 /// Mutator which randomly replaces a randomly selected range of bytes with bytes that preserve the


### PR DESCRIPTION
i saw CI in https://github.com/AFLplusplus/LibAFL/pull/1733 and PRs fails on a few targets for.. what looks to be a mismatch in paths? i'm not sure if this will actually fix CI, but i'm curious...