### PR TITLE
Fix incorrect imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN rustup default nightly
 
 # Install clang 11, common build tools
 RUN apt update && apt install -y build-essential gdb git wget python3-venv ninja-build lsb-release software-properties-common gnupg
-RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 15
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 16
 
 # Copy a dummy.rs and Cargo.toml first, so that dependencies are cached
 WORKDIR /libafl

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -5,7 +5,7 @@ use alloc::{
     vec::Vec,
 };
 #[rustversion::nightly]
-use core::simd::cmp::SimdOrd;
+use core::simd::SimdOrd;
 use core::{
     fmt::Debug,
     marker::PhantomData,

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -5,7 +5,7 @@ use alloc::{
     vec::Vec,
 };
 #[rustversion::nightly]
-use core::simd::SimdOrd;
+use core::simd::prelude::SimdOrd;
 use core::{
     fmt::Debug,
     marker::PhantomData,


### PR DESCRIPTION
According to https://doc.rust-lang.org/core/simd/trait.SimdOrd.html , the correct import seems `core::simd::SimdOrd`.

0.11.2 breaks several downstream project buildings. Currently, I'm setting `=0.11.1` as workaround.
