### PR TITLE
Miri ignores for M1 regex

### DIFF
--- a/libafl/src/inputs/encoded.rs
+++ b/libafl/src/inputs/encoded.rs
@@ -271,6 +271,7 @@ mod tests {
     };
 
     #[test]
+    #[cfg_attr(all(miri, target_arch = "aarch64", target_vendor = "apple"), ignore)] // Regex miri fails on M1
     fn test_input() {
         let mut t = NaiveTokenizer::default();
         let mut ed = TokenInputEncoderDecoder::new();

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1569,6 +1569,7 @@ mod tests {
 
     /// This test guarantees that the likelihood of a byte being re-inserted is equally likely
     #[test]
+    #[cfg_attr(all(miri, target_arch = "aarch64", target_vendor = "apple"), ignore)] // Regex miri fails on M1
     fn test_insert() -> Result<(), Error> {
         let base = BytesInput::new((0..10).collect());
         let mut counts = [0usize; 10];
@@ -1618,6 +1619,7 @@ mod tests {
 
     /// This test guarantees that the likelihood of a random byte being inserted is equally likely
     #[test]
+    #[cfg_attr(all(miri, target_arch = "aarch64", target_vendor = "apple"), ignore)] // Regex miri fails on M1
     fn test_rand_insert() -> Result<(), Error> {
         let base = BytesInput::new((0..10).collect());
         let mut counts = [0usize; 256];


### PR DESCRIPTION
The regex crate seems incompatible with Miri on M1
I don't think we'll need #1760 apart from this fix.

Tested using `RUST_BACKTRACE=1 MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test`.

Edit: opened a bug report in the underlying crate here https://github.com/BurntSushi/aho-corasick/issues/138