### PR TITLE
Safe access to QEMU's `Emulator` struct

### DIFF
--- a/libafl_qemu/src/cmplog.rs
+++ b/libafl_qemu/src/cmplog.rs
@@ -246,7 +246,7 @@ impl QemuCmpLogRoutinesHelper {
             }
         }
 
-        let emu = Emulator::new_empty();
+        let emu = Emulator::get().unwrap();
 
         let a0: GuestAddr = emu
             .read_function_argument(CallingConvention::Cdecl, 0)

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -508,7 +508,7 @@ pub trait ArchExtras {
 impl CPU {
     #[must_use]
     pub fn emulator(&self) -> Emulator {
-        Emulator::new_empty()
+        unsafe { Emulator::new_empty() }
     }
 
     #[must_use]
@@ -997,8 +997,14 @@ impl Emulator {
         }
     }
 
+    /// Get an empty emulator.
+    ///
+    /// # Safety
+    ///
+    /// Should not be used if `Emulator::new` has never been used before (otherwise QEMU will not be initialized).
+    /// Prefer `Emulator::get` for a safe version of this method.
     #[must_use]
-    pub fn new_empty() -> Emulator {
+    unsafe fn new_empty() -> Emulator {
         Emulator { _private: () }
     }
 

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -212,7 +212,7 @@ where
         mgr: &mut EM,
         input: &Self::Input,
     ) -> Result<ExitKind, Error> {
-        let emu = Emulator::new_empty();
+        let emu = Emulator::get().unwrap();
         if self.first_exec {
             self.hooks.helpers().first_exec_all(self.hooks);
             self.first_exec = false;
@@ -377,7 +377,7 @@ where
         mgr: &mut EM,
         input: &Self::Input,
     ) -> Result<ExitKind, Error> {
-        let emu = Emulator::new_empty();
+        let emu = Emulator::get().unwrap();
         if self.first_exec {
             self.hooks.helpers().first_exec_all(self.hooks);
             self.first_exec = false;

--- a/libafl_qemu/src/snapshot.rs
+++ b/libafl_qemu/src/snapshot.rs
@@ -331,7 +331,7 @@ impl QemuSnapshotHelper {
 
         if self.mmap_limit != 0 && total_size > self.mmap_limit {
             let mut cb = self.stop_execution.take().unwrap();
-            let emu = Emulator::new_empty();
+            let emu = Emulator::get().unwrap();
             (cb)(self, &emu);
             self.stop_execution = Some(cb);
         }


### PR DESCRIPTION
Remove the unsafe access to `Emulator` and always check for initialization instead.

Check issue #1757 for more details.