### PR TITLE
Enabling DrCov on Windows

### DIFF
--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -17,7 +17,6 @@ use libafl::{
     Error,
 };
 use libafl_bolts::{cli::FuzzerOptions, tuples::MatchFirstType};
-#[cfg(unix)]
 use libafl_targets::drcov::DrCovBasicBlock;
 #[cfg(unix)]
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
@@ -33,7 +32,8 @@ use yaxpeax_x86::amd64::InstDecoder;
 use crate::cmplog_rt::CmpLogRuntime;
 use crate::coverage_rt::CoverageRuntime;
 #[cfg(unix)]
-use crate::{asan::asan_rt::AsanRuntime, drcov_rt::DrCovRuntime};
+use crate::asan::asan_rt::AsanRuntime;
+use crate::drcov_rt::DrCovRuntime;
 
 #[cfg(target_vendor = "apple")]
 const ANONYMOUS_FLAG: MapFlags = MapFlags::MAP_ANON;
@@ -467,7 +467,6 @@ where
         let mut basic_block_size = 0;
         for instruction in basic_block {
             let instr = instruction.instr();
-            #[cfg(unix)]
             let instr_size = instr.bytes().len();
             let address = instr.address();
             // log::trace!("block @ {:x} transformed to {:x}", address, output.writer().pc());
@@ -485,7 +484,6 @@ where
                         rt.emit_coverage_mapping(address, output);
                     }
 
-                    #[cfg(unix)]
                     if let Some(_rt) = runtimes.match_first_type_mut::<DrCovRuntime>() {
                         basic_block_start = address;
                     }
@@ -548,14 +546,12 @@ where
                     );
                 }
 
-                #[cfg(unix)]
                 if let Some(_rt) = runtimes.match_first_type_mut::<DrCovRuntime>() {
                     basic_block_size += instr_size;
                 }
             }
             instruction.keep();
         }
-        #[cfg(unix)]
         if basic_block_size != 0 {
             if let Some(rt) = runtimes.borrow_mut().match_first_type_mut::<DrCovRuntime>() {
                 log::trace!("{basic_block_start:#016X}:{basic_block_size:X}");

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -28,12 +28,11 @@ use yaxpeax_arm::armv8::a64::{ARMv8, InstDecoder};
 #[cfg(target_arch = "x86_64")]
 use yaxpeax_x86::amd64::InstDecoder;
 
-#[cfg(all(feature = "cmplog", target_arch = "aarch64"))]
-use crate::cmplog_rt::CmpLogRuntime;
-use crate::coverage_rt::CoverageRuntime;
 #[cfg(unix)]
 use crate::asan::asan_rt::AsanRuntime;
-use crate::drcov_rt::DrCovRuntime;
+#[cfg(all(feature = "cmplog", target_arch = "aarch64"))]
+use crate::cmplog_rt::CmpLogRuntime;
+use crate::{coverage_rt::CoverageRuntime, drcov_rt::DrCovRuntime};
 
 #[cfg(target_vendor = "apple")]
 const ANONYMOUS_FLAG: MapFlags = MapFlags::MAP_ANON;


### PR DESCRIPTION
DrCov was enabled on unix only, however, it works perfectly fine on Windows - thus removing unix conditioning.