### PR TITLE
Check canonicalized_module_path before used

### DIFF
--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -390,7 +390,8 @@ where
 
         path == Path::new(&module_name)
             || path == module_path
-            || fs::canonicalize(path).ok() == canonicalized_module_path
+            || (canonicalized_module_path.is_some()
+                && fs::canonicalize(path).ok() == canonicalized_module_path)
     })
 }
 


### PR DESCRIPTION
Module such as `linux-vdso.so.1` doesn't have related file on disk.