### PR TITLE
Rename QemuHelpers to QemuTools and make them include QemuHooks

### DIFF
--- a/bindings/clibafl/a.cpp
+++ b/bindings/clibafl/a.cpp
@@ -1,0 +1,3 @@
+
+
+class Input {};

--- a/bindings/clibafl/a.rs
+++ b/bindings/clibafl/a.rs
@@ -1,0 +1,7 @@
+use libafl::Input;
+
+struct CppInput {
+    ptr: *mut c_void
+}
+
+

--- a/libafl_qemu/src/calls.rs
+++ b/libafl_qemu/src/calls.rs
@@ -278,6 +278,12 @@ where
         S: UsesInput,
         QT: QemuHelperTuple<S>,
     {
+        let mut cnt = 0;let yy = &mut cnt;
+        hooks.crash_closure(Box::new(|h, _| {
+            *yy += 1;
+        }));
+
+    
         if let Some(h) = hooks.helpers_mut().match_first_type_mut::<Self>() {
             if !h.must_instrument(pc) {
                 return None;
@@ -320,10 +326,10 @@ where
                 for detail in insn_detail.groups() {
                     match u32::from(detail.0) {
                         capstone::InsnGroupType::CS_GRP_CALL => {
-                            let call_len = insn.bytes().len();
+                            let call_len = insn.bytes().len();let mut cnt = 0;let mut yy = &mut cnt;
                             // TODO do not use a closure, find a more efficient way to pass call_len
                             let call_cb = Box::new(
-                                move |hooks: &mut QemuHooks<QT, S>, state: Option<&mut S>, pc| {
+                                move |hooks: &mut QemuHooks<QT, S>, state: Option<&mut S>, pc| {*yy+= 1;
                                     // eprintln!("CALL @ 0x{:#x}", pc + call_len);
                                     let mut collectors = if let Some(h) =
                                         hooks.helpers_mut().match_first_type_mut::<Self>()

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -37,7 +37,7 @@ where
     QT: QemuHelperTuple<S>,
 {
     inner: InProcessExecutor<'a, H, OT, S>,
-    hooks: &'a mut QemuHooks<QT, S>,
+    hooks: &'a mut QemuHooks<'a, QT, S>,
     first_exec: bool,
 }
 
@@ -120,7 +120,7 @@ where
     QT: QemuHelperTuple<S>,
 {
     pub fn new<EM, OF, Z>(
-        hooks: &'a mut QemuHooks<QT, S>,
+        hooks: &'a mut QemuHooks<'a, QT, S>,
         harness_fn: &'a mut H,
         observers: OT,
         fuzzer: &mut Z,
@@ -183,11 +183,11 @@ where
         &mut self.inner
     }
 
-    pub fn hooks(&self) -> &QemuHooks<QT, S> {
+    pub fn hooks(&self) -> &QemuHooks<'a, QT, S> {
         self.hooks
     }
 
-    pub fn hooks_mut(&mut self) -> &mut QemuHooks<QT, S> {
+    pub fn hooks_mut(&mut self) -> &mut QemuHooks<'a, QT, S> {
         self.hooks
     }
 
@@ -277,7 +277,7 @@ where
     SP: ShMemProvider,
 {
     first_exec: bool,
-    hooks: &'a mut QemuHooks<QT, S>,
+    hooks: &'a mut QemuHooks<'a, QT, S>,
     inner: InProcessForkExecutor<'a, H, OT, S, SP>,
 }
 
@@ -308,7 +308,7 @@ where
     SP: ShMemProvider,
 {
     pub fn new<EM, OF, Z>(
-        hooks: &'a mut QemuHooks<QT, S>,
+        hooks: &'a mut QemuHooks<'a, QT, S>,
         harness_fn: &'a mut H,
         observers: OT,
         fuzzer: &mut Z,
@@ -346,11 +346,11 @@ where
         &mut self.inner
     }
 
-    pub fn hooks(&self) -> &QemuHooks<QT, S> {
+    pub fn hooks(&self) -> &QemuHooks<'a, QT, S> {
         self.hooks
     }
 
-    pub fn hooks_mut(&mut self) -> &mut QemuHooks<QT, S> {
+    pub fn hooks_mut(&mut self) -> &mut QemuHooks<'a, QT, S> {
         self.hooks
     }
 


### PR DESCRIPTION
ATM QemuHooks includes the helpers list as field, do the opposite to allow mut self references when installing hooks