### PR TITLE
Implement type counting in tuples

### DIFF
--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -559,6 +559,8 @@ where
     }
 }
 
+/// Count the number of instances of a certain type in a tuple list. Does not account for
+/// differences in lifetime specifiers.
 pub trait CountType<T> {
     const COUNT: usize;
 }


### PR DESCRIPTION
This implements type counting for tuple lists, allowing us to verify e.g. one and only one `ExecutorHook` of a certain type is registered (see: #1789) in constant time.