### PR TITLE
Don't use assert fail when building on libafl_libfuzzer on windows

### DIFF
--- a/libafl_cc/build.rs
+++ b/libafl_cc/build.rs
@@ -45,7 +45,7 @@ fn find_llvm_config_brew() -> Result<PathBuf, String> {
                 return Err("Empty return from brew --cellar".to_string());
             }
             let location_suffix = "*/bin/llvm-config";
-            let cellar_glob = vec![
+            let cellar_glob = [
                 // location for explicitly versioned brew formulae
                 format!("{brew_cellar_location}/llvm@*/{location_suffix}"),
                 // location for current release brew formulae

--- a/libafl_concolic/symcc_runtime/src/lib.rs
+++ b/libafl_concolic/symcc_runtime/src/lib.rs
@@ -28,6 +28,7 @@
 //! name = "SymRuntime"
 //! ```
 #![allow(clippy::module_name_repetitions, clippy::missing_panics_doc)]
+#![allow(clippy::pub_underscore_fields)]
 pub mod filter;
 pub mod tracing;
 

--- a/libafl_libfuzzer/build.rs
+++ b/libafl_libfuzzer/build.rs
@@ -16,10 +16,13 @@ fn main() {
     if cfg!(any(feature = "cargo-clippy", docsrs)) {
         return; // skip when clippy or docs is running
     }
-    assert!(
-        cfg!(target_os = "linux"),
-        "The libafl_libfuzzer runtime may only be built for linux; failing fast."
-    );
+
+    if cfg!(target_os = "windows") {
+        println!(
+            "cargo:warning=The libafl_libfuzzer runtime may only be built for linux; failing fast."
+        );
+        return;
+    }
 
     println!("cargo:rerun-if-changed=libafl_libfuzzer_runtime/src");
     println!("cargo:rerun-if-changed=libafl_libfuzzer_runtime/Cargo.toml");

--- a/libafl_qemu/src/edges.rs
+++ b/libafl_qemu/src/edges.rs
@@ -463,7 +463,7 @@ where
     }
 }
 
-thread_local!(static PREV_LOC : UnsafeCell<u64> = UnsafeCell::new(0));
+thread_local!(static PREV_LOC : UnsafeCell<u64> = const { UnsafeCell::new(0) });
 
 pub fn gen_unique_edge_ids<QT, S>(
     hooks: &mut QemuHooks<QT, S>,

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -732,7 +732,7 @@ impl CPU {
         #[cfg(emulation_mode = "usermode")]
         {
             thread_local! {
-                static PAGE_SIZE: OnceCell<usize> = OnceCell::new();
+                static PAGE_SIZE: OnceCell<usize> = const { OnceCell::new() };
             }
 
             PAGE_SIZE.with(|s| {

--- a/libafl_targets/src/lib.rs
+++ b/libafl_targets/src/lib.rs
@@ -13,7 +13,8 @@
     clippy::missing_panics_doc,
     clippy::missing_docs_in_private_items,
     clippy::module_name_repetitions,
-    clippy::unreadable_literal
+    clippy::unreadable_literal,
+    clippy::pub_underscore_fields
 )]
 #![cfg_attr(not(test), warn(
     missing_debug_implementations,


### PR DESCRIPTION
Because else Rust linter on Windows doesn't work (cargo check fails) 