### PR TITLE
Remove macos-clippy

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -500,24 +500,6 @@ jobs:
     - name: Run Tests
       run: cargo test
 
-  macos-clippy:
-    runs-on: macOS-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-    - name: Add nightly rustfmt and clippy
-      run: rustup toolchain install nightly --component clippy --allow-downgrade && rustup default nightly
-    - name: Install deps
-      run: brew install z3 gtk+3
-    - name: Install cxxbridge
-      run: cargo install cxxbridge-cmd
-    - uses: actions/checkout@v3
-    - uses: Swatinem/rust-cache@v2
-    - name: Run clippy
-      run: ./scripts/clippy.sh
-
   other_targets:
     runs-on: macOS-latest
     steps:


### PR DESCRIPTION
Because it simply doesn't work for the last couple of weeks

https://github.com/AFLplusplus/LibAFL/actions/runs/7515657601/job/20459829193

