### PR TITLE
QEMU: safe linking of extern "C" declarations

### DIFF
--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -87,11 +87,13 @@ enum-map = "2.7"
 serde_yaml = { version = "0.8", optional = true } # For parsing the injections yaml file
 toml = { version = "0.4.2", optional = true } # For parsing the injections toml file
 pyo3 = { version = "0.18", optional = true }
+rustversion = "1.0"
 # Document all features of this crate (for `cargo doc`)
 document-features = { version = "0.2", optional = true }
 
 [build-dependencies]
 pyo3-build-config = { version = "0.18", optional = true }
+rustversion = "1.0"
 
 [lib]
 name = "libafl_qemu"

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -87,7 +87,6 @@ enum-map = "2.7"
 serde_yaml = { version = "0.8", optional = true } # For parsing the injections yaml file
 toml = { version = "0.4.2", optional = true } # For parsing the injections toml file
 pyo3 = { version = "0.18", optional = true }
-rustversion = "1.0"
 # Document all features of this crate (for `cargo doc`)
 document-features = { version = "0.2", optional = true }
 

--- a/libafl_qemu/build.rs
+++ b/libafl_qemu/build.rs
@@ -8,6 +8,13 @@ mod host_specific {
     }
 }
 
+#[rustversion::nightly]
+fn main() {
+    println!("cargo:rustc-cfg=nightly");
+    host_specific::build();
+}
+
+#[rustversion::not(nightly)]
 fn main() {
     host_specific::build();
 }

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -47,6 +47,8 @@ macro_rules! extern_c_checked {
 
     ($visibility:vis static $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
         paste! {
+            #[allow(non_camel_case_types)]
+            #[allow(unused)]
             struct [<__ $c_var:upper _STRUCT__>] { member: &'static $c_var_ty }
 
             unsafe impl Sync for [<__ $c_var:upper _STRUCT__>] {}
@@ -64,6 +66,8 @@ macro_rules! extern_c_checked {
 
     ($visibility:vis static mut $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
         paste! {
+            #[allow(non_camel_case_types)]
+            #[allow(unused)]
             struct [<__ $c_var:upper _STRUCT__>] { member: &'static $c_var_ty }
 
             unsafe impl Sync for [<__ $c_var:upper _STRUCT__>] {}

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -34,7 +34,7 @@ macro_rules! extern_c_checked {
 
     ($visibility:vis fn $c_fn:ident($($param_ident:ident : $param_ty:ty),*) $( -> $ret_ty:ty )?; $($tail:tt)*) =>  {
         paste! {
-            #[rustversion::attr(nightly, used(linker))]
+            #[cfg_attr(nightly, used(linker))]
             static [<__ $c_fn:upper __>]: unsafe extern "C" fn($($param_ty),*) $( -> $ret_ty )? = $c_fn;
         }
 
@@ -53,7 +53,7 @@ macro_rules! extern_c_checked {
 
             unsafe impl Sync for [<__ $c_var:upper _STRUCT__>] {}
 
-            #[rustversion::attr(nightly, used(linker))]
+            #[cfg_attr(nightly, used(linker))]
             static [<__ $c_var:upper __>]: [<__ $c_var:upper _STRUCT__>] = unsafe { [<__ $c_var:upper _STRUCT__>] { member: &$c_var } };
         }
 
@@ -72,7 +72,7 @@ macro_rules! extern_c_checked {
 
             unsafe impl Sync for [<__ $c_var:upper _STRUCT__>] {}
 
-            #[rustversion::attr(nightly, used(linker))]
+            #[cfg_attr(nightly, used(linker))]
             static mut [<__ $c_var:upper __>]: [<__ $c_var:upper _STRUCT__>] = unsafe { [<__ $c_var:upper _STRUCT__>] { member: &$c_var } };
         }
 

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -46,10 +46,17 @@ macro_rules! extern_c_checked {
         extern_c_checked!($($tail)*);
     };
 
-    (static $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
+    ($visibility:vis static $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
         extern "C" {
-            #[rustversion::attr(nightly, used(linker))]
-            static $c_var: $c_var_ty;
+            $visibility static $c_var: $c_var_ty;
+        }
+
+        extern_c_checked!($($tail)*);
+    };
+
+    ($visibility:vis static mut $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
+        extern "C" {
+            $visibility static mut $c_var: $c_var_ty;
         }
 
         extern_c_checked!($($tail)*);

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -33,7 +33,6 @@ macro_rules! extern_c_checked {
     () => {};
 
     (fn $c_fn:ident($($param_ident:ident : $param_ty:ty),*) $( -> $ret_ty:ty )?; $($tail:tt)*) =>  {
-
         paste! {
             #[rustversion::attr(nightly, used(linker))]
             static [<__ $c_fn:upper __>]: unsafe extern "C" fn($($param_ty),*) $( -> $ret_ty )? = $c_fn;
@@ -47,6 +46,15 @@ macro_rules! extern_c_checked {
     };
 
     ($visibility:vis static $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
+        paste! {
+            struct [<__ $c_var:upper _STRUCT__>] { member: &'static $c_var_ty }
+
+            unsafe impl Sync for [<__ $c_var:upper _STRUCT__>] {}
+
+            #[rustversion::attr(nightly, used(linker))]
+            static [<__ $c_var:upper __>]: [<__ $c_var:upper _STRUCT__>] = unsafe { [<__ $c_var:upper _STRUCT__>] { member: &$c_var } };
+        }
+
         extern "C" {
             $visibility static $c_var: $c_var_ty;
         }
@@ -55,6 +63,15 @@ macro_rules! extern_c_checked {
     };
 
     ($visibility:vis static mut $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
+        paste! {
+            struct [<__ $c_var:upper _STRUCT__>] { member: &'static $c_var_ty }
+
+            unsafe impl Sync for [<__ $c_var:upper _STRUCT__>] {}
+
+            #[rustversion::attr(nightly, used(linker))]
+            static mut [<__ $c_var:upper __>]: [<__ $c_var:upper _STRUCT__>] = unsafe { [<__ $c_var:upper _STRUCT__>] { member: &$c_var } };
+        }
+
         extern "C" {
             $visibility static mut $c_var: $c_var_ty;
         }

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -17,10 +17,44 @@ use std::{ffi::CString, ptr, slice::from_raw_parts, str::from_utf8_unchecked};
 use libc::c_int;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use num_traits::Num;
+use paste::paste;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use crate::{GuestReg, Regs};
+
+/// Safe linking with of extern "C" functions.
+/// This macro makes sure the declared symbol is defined *at link time*, avoiding declaring non-existant symbols
+/// that could be silently ignored during linking if unused.
+///
+/// This macro relies on a nightly feature, and can only be used in this mode
+/// It is (nearly) a drop-in replacement for extern "C" { } blocks containing function and static declarations, and will have the same effect in practice.
+macro_rules! extern_c_checked {
+    () => {};
+
+    (fn $c_fn:ident($($param_ident:ident : $param_ty:ty),*) $( -> $ret_ty:ty )?; $($tail:tt)*) =>  {
+
+        paste! {
+            #[rustversion::attr(nightly, used(linker))]
+            static [<__ $c_fn:upper __>]: unsafe extern "C" fn($($param_ty),*) $( -> $ret_ty )? = $c_fn;
+        }
+
+        extern "C" {
+            fn $c_fn($($param_ident : $param_ty),*) $( -> $ret_ty )?;
+        }
+
+        extern_c_checked!($($tail)*);
+    };
+
+    (static $c_var:ident : $c_var_ty:ty; $($tail:tt)*) => {
+        extern "C" {
+            #[rustversion::attr(nightly, used(linker))]
+            static $c_var: $c_var_ty;
+        }
+
+        extern_c_checked!($($tail)*);
+    };
+}
 
 pub type GuestAddr = libafl_qemu_sys::target_ulong;
 pub type GuestUsize = libafl_qemu_sys::target_ulong;
@@ -316,7 +350,7 @@ impl MapInfo {
 }
 
 #[cfg(emulation_mode = "usermode")]
-extern "C" {
+extern_c_checked! {
     fn qemu_user_init(argc: i32, argv: *const *const u8, envp: *const *const u8) -> i32;
 
     fn libafl_qemu_run() -> i32;
@@ -339,7 +373,7 @@ extern "C" {
 }
 
 #[cfg(emulation_mode = "systemmode")]
-extern "C" {
+extern_c_checked! {
     fn qemu_init(argc: i32, argv: *const *const u8, envp: *const *const u8);
 
     fn vm_start();
@@ -348,6 +382,8 @@ extern "C" {
 
     fn libafl_save_qemu_snapshot(name: *const u8, sync: bool);
     fn libafl_load_qemu_snapshot(name: *const u8, sync: bool);
+
+    fn libafl_qemu_current_paging_id(cpu: CPUStatePtr) -> GuestPhysAddr;
 }
 
 #[cfg(emulation_mode = "systemmode")]
@@ -358,7 +394,7 @@ extern "C" fn qemu_cleanup_atexit() {
 }
 
 // TODO rely completely on libafl_qemu_sys
-extern "C" {
+extern_c_checked! {
     //static libafl_page_size: GuestUsize;
     fn libafl_page_from_addr(addr: GuestAddr) -> GuestAddr;
 
@@ -387,12 +423,9 @@ extern "C" {
 
     fn libafl_qemu_add_gdb_cmd(
         callback: extern "C" fn(*const (), *const u8, usize) -> i32,
-        data: *const (),
+        data: *const ()
     );
     fn libafl_qemu_gdb_reply(buf: *const u8, len: usize);
-
-    #[cfg(emulation_mode = "systemmode")]
-    fn libafl_qemu_current_paging_id(cpu: CPUStatePtr) -> GuestPhysAddr;
 }
 
 #[cfg(emulation_mode = "usermode")]

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -32,14 +32,14 @@ use crate::{GuestReg, Regs};
 macro_rules! extern_c_checked {
     () => {};
 
-    (fn $c_fn:ident($($param_ident:ident : $param_ty:ty),*) $( -> $ret_ty:ty )?; $($tail:tt)*) =>  {
+    ($visibility:vis fn $c_fn:ident($($param_ident:ident : $param_ty:ty),*) $( -> $ret_ty:ty )?; $($tail:tt)*) =>  {
         paste! {
             #[rustversion::attr(nightly, used(linker))]
             static [<__ $c_fn:upper __>]: unsafe extern "C" fn($($param_ty),*) $( -> $ret_ty )? = $c_fn;
         }
 
         extern "C" {
-            fn $c_fn($($param_ident : $param_ty),*) $( -> $ret_ty )?;
+            $visibility fn $c_fn($($param_ident : $param_ty),*) $( -> $ret_ty )?;
         }
 
         extern_c_checked!($($tail)*);

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(nightly, feature(used_with_arg))]
 //! Welcome to `LibAFL` QEMU
 //!
 #![doc = include_str!("../../README.md")]


### PR DESCRIPTION
Declared functions in `extern "C"` blocks are not necessarily checked at link-time if the symbols are not necessary during compilation (unused symbols).

Some symbols could be declared without any definition and still compile correctly.
Someone had this issue with `libafl_qemu_trigger_breakpoint` being declared in LibAFL without a definition in QEMU.
Calling the wrapper function in a fuzzer resulted in a linker error.

With the new macro `extern_c_checked!`, it is possible to declare C symbols and still get an error if there is no definition.
It relies on a nightly feature, and thus will only trigger in a nightly build.
Stable builds will work as before.

It is mainly useful to catch those kinds of errors early in the CI.