### PR TITLE
Fix build issues in frida cmplog for aarch64

### DIFF
--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -8,10 +8,8 @@
 use std::collections::HashMap;
 
 use dynasmrt::dynasm;
-
 #[cfg(target_arch = "aarch64")]
-use dynasmrt::{DynasmLabelApi, DynasmApi};
-
+use dynasmrt::{DynasmApi, DynasmLabelApi};
 use libafl::{
     inputs::{HasTargetBytes, Input},
     Error,
@@ -25,6 +23,8 @@ extern "C" {
     pub fn __libafl_targets_cmplog_instructions(k: u64, shape: u8, arg1: u64, arg2: u64);
 }
 
+#[cfg(target_arch = "aarch64")]
+use core::ffi::c_void;
 use std::rc::Rc;
 
 use frida_gum::ModuleMap;
@@ -35,10 +35,6 @@ use frida_gum::{
     instruction_writer::{Aarch64Register, IndexMode, InstructionWriter},
     stalker::StalkerOutput,
 };
-
-#[cfg(target_arch = "aarch64")]
-use core::ffi::c_void;
-
 use frida_gum_sys::Insn;
 #[cfg(all(feature = "cmplog", target_arch = "x86_64"))]
 use iced_x86::{
@@ -564,7 +560,6 @@ impl CmpLogRuntime {
 
         writer.put_bytes(&self.restore_registers.clone().unwrap());
     }
-
 
     /// Emit the instrumentation code which is responsible for operands value extraction and cmplog map population
     #[cfg(all(feature = "cmplog", target_arch = "aarch64"))]


### PR DESCRIPTION
This fixes a few aarch64-related regressions introduced by https://github.com/AFLplusplus/LibAFL/pull/1713