### PR TITLE
Warn on missing testcase after fuzz run

### DIFF
--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -636,6 +636,8 @@ where
                 let scheduled_count = testcase.scheduled_count();
                 // increase scheduled count, this was fuzz_level in afl
                 testcase.set_scheduled_count(scheduled_count + 1);
+            } else {
+                log::warn!("Tetcase for idx {idx} no longer in corpus. Removed?");
             }
         }
 


### PR DESCRIPTION
How about this as follow-up for #1717 ?