### PR TITLE
QEMU: add injections mode default

### DIFF
--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["fork", "build_libqasan", "serdeany_autoreg"]
+default = ["fork", "build_libqasan", "serdeany_autoreg", "injections"]
 clippy = [] # special feature for clippy, don't use in normal projects§
 document-features = ["dep:document-features"]
 


### PR DESCRIPTION
This makes injections fuzzing easier to use, and it doesn't add much overhead to the build process/downloads (especially when compared to qemu, lol)
