### PR TITLE
Default `ignore_*` flags to true when `tui=1`

### DIFF
--- a/libafl_libfuzzer/README.md
+++ b/libafl_libfuzzer/README.md
@@ -130,6 +130,7 @@ to partial support of libfuzzer flags, `libafl_libfuzzer` offers:
 - `-fork` and `-jobs`
     - in `libafl_libfuzzer`, these are synonymous
 - `-ignore_crashes`, `-ignore_ooms`, and `-ignore_timeouts`
+    - note that setting `-tui=1` enables these flags by default, so you'll need to explicitly mention `-ignore_...=0` to disable them
 - `-rss_limit_mb` and `-malloc_limit_mb`
 - `-ignore_remaining_args`
 - `-shrink`

--- a/libafl_libfuzzer/src/lib.rs
+++ b/libafl_libfuzzer/src/lib.rs
@@ -58,6 +58,7 @@
 //! - `-fork` and `-jobs`
 //!   - in `libafl_libfuzzer`, these are synonymous
 //! - `-ignore_crashes`, `-ignore_ooms`, and `-ignore_timeouts`
+//!   - note that setting `-tui=1` enables these flags by default, so you'll need to explicitly mention `-ignore_...=0` to disable them
 //! - `-rss_limit_mb` and `-malloc_limit_mb`
 //! - `-ignore_remaining_args`
 //! - `-shrink`


### PR DESCRIPTION
Closes #1566

When the `tui` flag is set, we default `ignore_crashes`, `ignore_ooms` and `ignore_timeouts` to true.

The `no_ignore_...` struct members of `LibfuzzerOptionsBuilder` are used to distinguish between the user not using a flag and the user explicitly setting a flag to false (0) as both these cases result in the `ignore_...` struct member being false.