### PR TITLE
Pr/xxh3 rrmxmx mixer fix

### DIFF
--- a/libafl_bolts/src/math.rs
+++ b/libafl_bolts/src/math.rs
@@ -62,13 +62,14 @@ pub const fn integer_sqrt(val: u64) -> u64 {
 /// Given a u64 number, return a hashed number using this mixing function
 /// This function is used to hash an address into a more random number (used in `libafl_frida`).
 /// Mixing function: <http://mostlymangling.blogspot.com/2018/07/on-mixing-functions-in-fast-splittable.html>
+/// This implementation is based on `XXH3_rrmxmx` from `xxHash` that is used in `AFLPlusPlus`
 #[inline]
 #[must_use]
 pub const fn xxh3_rrmxmx_mixer(v: u64) -> u64 {
     let tmp = (v >> 32) + ((v & 0xffffffff) << 32);
     let bitflip = 0x1cad21f72c81017c ^ 0xdb979082e96dd4de;
     let mut h64 = tmp ^ bitflip;
-    h64 = h64.rotate_left(49) & h64.rotate_left(24);
+    h64 ^= h64.rotate_left(49) ^ h64.rotate_left(24);
     h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
     h64 ^= (h64 >> 35) + 8;
     h64 = h64.wrapping_mul(0x9FB21C651E98DF25);

--- a/libafl_bolts/src/math.rs
+++ b/libafl_bolts/src/math.rs
@@ -59,24 +59,6 @@ pub const fn integer_sqrt(val: u64) -> u64 {
     ret
 }
 
-/// Given a u64 number, return a hashed number using this mixing function
-/// This function is used to hash an address into a more random number (used in `libafl_frida`).
-/// Mixing function: <http://mostlymangling.blogspot.com/2018/07/on-mixing-functions-in-fast-splittable.html>
-/// This implementation is based on `XXH3_rrmxmx` from `xxHash` that is used in `AFLPlusPlus`
-#[inline]
-#[must_use]
-pub const fn xxh3_rrmxmx_mixer(v: u64) -> u64 {
-    let tmp = (v >> 32) + ((v & 0xffffffff) << 32);
-    let bitflip = 0x1cad21f72c81017c ^ 0xdb979082e96dd4de;
-    let mut h64 = tmp ^ bitflip;
-    h64 ^= h64.rotate_left(49) ^ h64.rotate_left(24);
-    h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
-    h64 ^= (h64 >> 35) + 8;
-    h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
-    h64 ^= h64 >> 28;
-    h64
-}
-
 /// Calculates the cumulative sum for a slice, in-place.
 /// The values are useful for example for cumulative probabilities.
 ///

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -82,7 +82,6 @@ log = "0.4.20"
 mmap-rs = "0.6.0"
 
 yaxpeax-arch = "0.2.7"
-xxhash-rust = { version = "0.8.5", features = ["xxh3"]} # xxh3 hashing for rust
 
 [dev-dependencies]
 serial_test = { version = "2", default-features = false, features = ["logging"] }

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -44,8 +44,7 @@ libafl = { path = "../libafl", default-features = false, version = "0.11.2", fea
 libafl_bolts = { path = "../libafl_bolts", version = "0.11.2", default-features = false, features = [
     "std",
     "derive",
-    "frida_cli",
-    "xxh3"
+    "frida_cli"
 ] }
 libafl_targets = { path = "../libafl_targets", version = "0.11.2", features = [
     "std",
@@ -83,6 +82,7 @@ log = "0.4.20"
 mmap-rs = "0.6.0"
 
 yaxpeax-arch = "0.2.7"
+xxhash-rust = { version = "0.8.5", features = ["xxh3"]} # xxh3 hashing for rust
 
 [dev-dependencies]
 serial_test = { version = "2", default-features = false, features = ["logging"] }

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -44,7 +44,8 @@ libafl = { path = "../libafl", default-features = false, version = "0.11.2", fea
 libafl_bolts = { path = "../libafl_bolts", version = "0.11.2", default-features = false, features = [
     "std",
     "derive",
-    "frida_cli"
+    "frida_cli",
+    "xxh3"
 ] }
 libafl_targets = { path = "../libafl_targets", version = "0.11.2", features = [
     "std",

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -6,8 +6,8 @@ use std::{cell::RefCell, marker::PhantomPinned, pin::Pin, rc::Rc};
 use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
 use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
-use xxhash_rust::xxh3::xxh3_64;
 use rangemap::RangeMap;
+use xxhash_rust::xxh3::xxh3_64;
 
 use crate::helper::FridaRuntime;
 

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -6,8 +6,8 @@ use std::{cell::RefCell, marker::PhantomPinned, pin::Pin, rc::Rc};
 use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
 use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
-use rangemap::RangeMap;
 use libafl_bolts::hash_std;
+use rangemap::RangeMap;
 
 use crate::helper::FridaRuntime;
 

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -6,7 +6,7 @@ use std::{cell::RefCell, marker::PhantomPinned, pin::Pin, rc::Rc};
 use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
 use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
-use libafl_bolts::hash_std;
+use xxhash_rust::xxh3::xxh3_64;
 use rangemap::RangeMap;
 
 use crate::helper::FridaRuntime;
@@ -188,7 +188,7 @@ impl CoverageRuntime {
     /// Emits coverage mapping into the current basic block.
     #[inline]
     pub fn emit_coverage_mapping(&mut self, address: u64, output: &StalkerOutput) {
-        let h64 = hash_std(&address.to_le_bytes());
+        let h64 = xxh3_64(&address.to_le_bytes());
         let writer = output.writer();
 
         // Since the AARCH64 instruction set requires that a register be used if

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -6,7 +6,7 @@ use std::{cell::RefCell, marker::PhantomPinned, pin::Pin, rc::Rc};
 use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
 use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
-use libafl_bolts::math::xxh3_rrmxmx_mixer;
+use libafl_bolts::hash_std;
 use rangemap::RangeMap;
 
 use crate::helper::FridaRuntime;
@@ -169,7 +169,9 @@ impl CoverageRuntime {
 
             // Update the previous_pc value
             ; mov rax, QWORD prev_loc_ptr as _
-            ; mov ebx, WORD (h64 >> 1) as i32
+            // ; mov ebx, WORD (h64 >> 1) as i32
+            ; mov ebx, WORD h64 as i32
+            ; ror ebx, 1
             ; mov QWORD [rax], rbx
 
             // Restore the context
@@ -186,7 +188,7 @@ impl CoverageRuntime {
     /// Emits coverage mapping into the current basic block.
     #[inline]
     pub fn emit_coverage_mapping(&mut self, address: u64, output: &StalkerOutput) {
-        let h64 = xxh3_rrmxmx_mixer(address);
+        let h64 = hash_std(&address.to_le_bytes());
         let writer = output.writer();
 
         // Since the AARCH64 instruction set requires that a register be used if

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -169,9 +169,7 @@ impl CoverageRuntime {
 
             // Update the previous_pc value
             ; mov rax, QWORD prev_loc_ptr as _
-            // ; mov ebx, WORD (h64 >> 1) as i32
-            ; mov ebx, WORD h64 as i32
-            ; ror ebx, 1
+            ; mov ebx, WORD (h64 >> 1) as i32
             ; mov QWORD [rax], rbx
 
             // Restore the context

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -7,7 +7,7 @@ use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
 use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
 use rangemap::RangeMap;
-use xxhash_rust::xxh3::xxh3_64;
+use libafl_bolts::hash_std;
 
 use crate::helper::FridaRuntime;
 
@@ -186,7 +186,7 @@ impl CoverageRuntime {
     /// Emits coverage mapping into the current basic block.
     #[inline]
     pub fn emit_coverage_mapping(&mut self, address: u64, output: &StalkerOutput) {
-        let h64 = xxh3_64(&address.to_le_bytes());
+        let h64 = hash_std(&address.to_le_bytes());
         let writer = output.writer();
 
         // Since the AARCH64 instruction set requires that a register be used if


### PR DESCRIPTION
Using the Rust implementation of xxHash instead of the handwritten implementation (which has a bug in it).
For the record, The bug was here (the commented-out line):

fn xxh3_rrmxmx_mixer(v: u64) -> u64 {
    let tmp = (v >> 32) + ((v & 0xffffffff) << 32);
    let bitflip = 0x1cad21f72c81017c ^ 0xdb979082e96dd4de;
    let mut h64 = tmp ^ bitflip;
    // h64 = h64.rotate_left(49) & h64.rotate_left(24);
    h64 ^= h64.rotate_left(49) ^ h64.rotate_left(24);
    h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
    h64 ^= (h64 >> 35) + 8;
    h64 = h64.wrapping_mul(0x9FB21C651E98DF25);
    h64 ^= h64 >> 28;
    h64
}

Attached are Rust and Python tests that helped me detect that there is a problem with the collisions in the previous implementation

[edge_entropy_test.zip](https://github.com/AFLplusplus/LibAFL/files/14156777/edge_entropy_test.zip)
