### PR TITLE
fix libafl_qemu recompilation trigger

### DIFF
--- a/libafl_qemu/build_linux.rs
+++ b/libafl_qemu/build_linux.rs
@@ -95,6 +95,5 @@ pub fn build() {
             .status()
             .expect("make failed")
             .success());
-        println!("cargo:rerun-if-changed={}/libqasan.so", target_dir.display());
     }
 }


### PR DESCRIPTION
fix #1831

This line will trigger libafl_qemu recompilation every time, it's not required to watch the `libqasan.so` file, only to watch the source files.