### PR TITLE
Use truncate, not pop, for state resume

### DIFF
--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -556,13 +556,7 @@ impl<I, C, R, SC> HasCurrentStage for StdState<I, C, R, SC> {
     }
 
     fn clear_stage(&mut self) -> Result<(), Error> {
-        self.stage_idx_stack.pop();
-        // ensure we are in the right frame
-        if self.stage_depth != self.stage_idx_stack.len() {
-            return Err(Error::illegal_state(
-                "we somehow cleared too many or too few states!",
-            ));
-        }
+        self.stage_idx_stack.truncate(self.stage_depth);
         Ok(())
     }
 


### PR DESCRIPTION
OptionalStage is a good example of why truncate is desirable over pop.

Suppose that the state is resumed to the OptionalStage, but OptionalStage is now unfilled. OptionalStage will be entered, then popped at the wrong depth. We must assume that the user intends to do this, otherwise they would've used the runtime-dependent IfStage.

cc @tokatoka; this is a revert of a change you suggested.