### PR TITLE
Finalize macOS support for libafl_libfuzzer

### DIFF
--- a/libafl_libfuzzer/README.md
+++ b/libafl_libfuzzer/README.md
@@ -51,6 +51,22 @@ As this branch generally offers the highest performance version of `libafl_libfu
 Remember to `cargo update` often if using the experimental changes, and please [submit an issue]
 if you encounter problems while using `libfuzzer-best`!
 
+#### macOS
+
+On macOS, you will need to add weak linking for some functions in a `build.rs` file:
+
+```rust
+fn main() {
+    for func in [
+        "_libafl_main",
+        "_LLVMFuzzerCustomMutator",
+        "_LLVMFuzzerCustomCrossOver",
+    ] {
+        println!("cargo:rustc-link-arg=-Wl,-U,{func}");
+    }
+}
+```
+
 #### Caveats
 
 Like harnesses built with `libfuzzer-sys`, Rust targets which build other libraries (e.g. C/C++ FFI) may not

--- a/libafl_targets/src/common.h
+++ b/libafl_targets/src/common.h
@@ -140,14 +140,11 @@ typedef uint128_t         u128;
 #else
 
   #if defined(__APPLE__)
-    // On Apple, weak_import and weak attrs behave differently to linux.
-
-    #define EXT_FUNC(NAME, RETURN_TYPE, FUNC_SIG, WARN)                        \
-      __attribute__((weak, visibility("default"))) RETURN_TYPE NAME FUNC_SIG { \
-        return (RETURN_TYPE)0;                                                 \
-      }
-
     #define EXT_FUNC_IMPL(NAME, RETURN_TYPE, FUNC_SIG, WARN) \
+      EXT_FUNC(NAME, RETURN_TYPE, FUNC_SIG, WARN)
+
+    // Declare these symbols as weak to allow them to be optionally defined.
+    #define EXT_FUNC(NAME, RETURN_TYPE, FUNC_SIG, WARN) \
       __attribute__((weak, visibility("default"))) RETURN_TYPE NAME FUNC_SIG
 
     // Weakly defined globals

--- a/libafl_targets/src/sancov_cmp.rs
+++ b/libafl_targets/src/sancov_cmp.rs
@@ -34,11 +34,11 @@ extern "C" {
 unsafe extern "C" fn __sanitizer_cov_pcs_init(pcs_beg: *const usize, pcs_end: *const usize) {
     // "The Unsafe Code Guidelines also notably defines that usize and isize are respectively compatible with uintptr_t and intptr_t defined in C."
     assert!(
-        PCS_BEG.is_null(),
+        pcs_beg == PCS_BEG || PCS_BEG.is_null(),
         "__sanitizer_cov_pcs_init can be called only once."
     );
     assert!(
-        PCS_END.is_null(),
+        pcs_end == PCS_END || PCS_END.is_null(),
         "__sanitizer_cov_pcs_init can be called only once."
     );
 


### PR DESCRIPTION
This PR is the last step in making libafl_libfuzzer work on macOS. I have confirmed that it works with the example from the Rust Fuzzing Book.


# Changes
Two important things were changed:

## Weak Functions

Fixes #1712. The current implementation provides default implementations for weak functions on macOS, breaking `CHECK_WEAK_FN`. This meant important functions were not being called upon running the target. The approach I came up with was to remove this default impl and require explicit weak linking args on macOS only.

## `__sanitizer_cov_pcs_init` calls

We assert that this will only be called once, though [LLVM does not guarantee that](https://clang.llvm.org/docs/SanitizerCoverage.html#pc-table). In reality, it appears this is called more than once on macOS, but with the same exact arguments. Since the arguments are the same and we are just assigning things, it is reasonable to allow it to be called more than once.


# Demo

Output from running the [Fuzzing Book tutorial example](https://rust-fuzz.github.io/book/cargo-fuzz/tutorial.html):

<details><summary>Click to expand output logs</summary>

```
[Testcase #0] run time: 0h-0m-1s, clients: 1, corpus: 910, objectives: 0, executions: 16059, exec/sec: 11.65k
[Stats #0] run time: 0h-0m-1s, clients: 1, corpus: 910, objectives: 0, executions: 16059, exec/sec: 11.38k
[Testcase #0] run time: 0h-0m-1s, clients: 1, corpus: 911, objectives: 0, executions: 16560, exec/sec: 11.74k
[Stats #0] run time: 0h-0m-1s, clients: 1, corpus: 911, objectives: 0, executions: 16560, exec/sec: 9.269k
[Testcase #0] run time: 0h-0m-1s, clients: 1, corpus: 912, objectives: 0, executions: 21181, exec/sec: 11.85k
[Stats #0] run time: 0h-0m-2s, clients: 1, corpus: 912, objectives: 0, executions: 21181, exec/sec: 9.986k
[Testcase #0] run time: 0h-0m-2s, clients: 1, corpus: 913, objectives: 0, executions: 25832, exec/sec: 12.18k
[Stats #0] run time: 0h-0m-2s, clients: 1, corpus: 913, objectives: 0, executions: 25832, exec/sec: 9.767k
[Testcase #0] run time: 0h-0m-2s, clients: 1, corpus: 914, objectives: 0, executions: 33184, exec/sec: 12.54k
thread '<unnamed>' panicked at /Users/sameerpuri/rust-url/src/host.rs:104:12:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[2024-02-08T17:14:54Z ERROR libafl::executors::hooks::unix::unix_signal_handler] Crashed with SIGABRT
[2024-02-08T17:14:54Z ERROR libafl::executors::hooks::unix::unix_signal_handler] Child crashed!
[2024-02-08T17:14:54Z ERROR libafl::executors::hooks::unix::unix_signal_handler] input: "f095267f6d0e7421"
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ CRASH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    Received signal SIGABRT at 0x000000018af260dc, fault address: 0x0000000000000000
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ REGISTERS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    x00: 0x0000000000000000 
    x01: 0x0000000000000000 
    x02: 0x0000000000000000 
    x03: 0x0000000000000000 
    
    x04: 0x000000702debd080 
    x05: 0x0000000000000000 
    x06: 0x000000016ecf8000 
    x07: 0x0000000000000001 
    
    x08: 0x39e86975c4b757d7 
    x09: 0x39e869742535cb97 
    x10: 0x000000702debdcc5 
    x11: 0x000000002de9dcc5 
    
    x12: 0x000000002de9dcc5 
    x13: 0x0000000000000000 
    x14: 0x0000000000000000 
    x15: 0x0000000000000000 
    
    x16: 0x0000000000000148 
    x17: 0x00000001ea8af5a0 
    x18: 0x0000000000000000 
    x19: 0x0000000000000006 
    
    x20: 0x00000001e1829c40 
    x21: 0x0000000000000103 
    x22: 0x00000001e1829d20 
    x23: 0x0000007000020000 
    
    x24: 0x000000018af66620 
    x25: 0x0000000100fb7f78 
    x26: 0x0000000000000000 
    x27: 0x000000016f4ee8e0 
    
    x28: 0x0000007000020000 
    fp: 0x000000016f4ee600 lr: 0x000000018af5dcc0 pc: 0x000000018af260dc ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
       0: backtrace::backtrace::libunwind::trace
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/libunwind.rs:93:5
          backtrace::backtrace::trace_unsynchronized
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/mod.rs:66:5
          backtrace::backtrace::trace
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/mod.rs:53:14
          backtrace::capture::Backtrace::create
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/capture.rs:176:9
       1: backtrace::capture::Backtrace::new
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/capture.rs:140:22
       2: libafl_bolts::minibsod::generate_minibsod
                 at /Users/sameerpuri/LibAFL/libafl_bolts/src/minibsod.rs:1005:30
       3: libafl::executors::hooks::unix::unix_signal_handler::inproc_crash_handler
                 at /Users/sameerpuri/LibAFL/libafl/src/executors/hooks/unix.rs:208:21
       4: libafl::executors::hooks::unix::unix_signal_handler::<impl libafl_bolts::os::unix_signals::Handler for libafl::executors::hooks::inprocess::InProcessExecutorHandlerData>::handle
       5: libafl_bolts::os::unix_signals::handle_signal
                 at /Users/sameerpuri/LibAFL/libafl_bolts/src/os/unix_signals.rs:418:5
       6: __platform_memmove
       7: __pthread_atfork_prepare_handlers
       8: <unknown>
       9: std::sys::unix::abort_internal
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/sys/unix/mod.rs:376:14
      10: std::process::abort
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/process.rs:2279:5
      11: libfuzzer_sys::initialize::{{closure}}
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:91:9
      12: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/alloc/src/boxed.rs:2029:9
          std::panicking::rust_panic_with_hook
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/panicking.rs:783:13
      13: std::panicking::begin_panic_handler::{{closure}}
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/panicking.rs:657:13
      14: std::sys_common::backtrace::__rust_end_short_backtrace
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/sys_common/backtrace.rs:171:18
      15: rust_begin_unwind
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/panicking.rs:645:5
      16: core::panicking::panic_fmt
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/core/src/panicking.rs:72:14
      17: core::panicking::panic_bounds_check
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/core/src/panicking.rs:208:5
      18: url::host::Ipv6Address::parse
                 at /Users/sameerpuri/rust-url/src/host.rs:104:12
      19: url::host::Host::parse
                 at /Users/sameerpuri/rust-url/src/host.rs:51:17
      20: url::parser::parse_hostname
                 at /Users/sameerpuri/rust-url/src/parser.rs:415:21
      21: url::parser::parse_host
                 at /Users/sameerpuri/rust-url/src/parser.rs:379:34
      22: url::parser::parse_absolute_url
                 at /Users/sameerpuri/rust-url/src/parser.rs:177:54
      23: url::parser::parse_url
                 at /Users/sameerpuri/rust-url/src/parser.rs:134:22
      24: url::UrlParser::parse
                 at /Users/sameerpuri/rust-url/src/lib.rs:348:9
          url::Url::parse
                 at /Users/sameerpuri/rust-url/src/lib.rs:474:26
          fuzz_target_1::_::__libfuzzer_sys_run
                 at fuzz_targets/fuzz_target_1.rs:8:17
      25: rust_fuzzer_test_input
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:224:17
      26: libfuzzer_sys::test_input_wrap::{{closure}}
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:61:9
          std::panicking::try::do_call
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/panicking.rs:552:40
      27: ___rust_try
      28: std::panicking::try
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/panicking.rs:516:19
          std::panic::catch_unwind
                 at /rustc/d86d65bbc19b928387f68427fcc3a0da498d8a19/library/std/src/panic.rs:142:14
          LLVMFuzzerTestOneInput
                 at /Users/sameerpuri/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libfuzzer-sys-0.4.7/src/lib.rs:59:22
      29: libafl_libfuzzer_test_one_input
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/harness_wrap.cpp:6:12
      30: afl_libfuzzer_runtime::fuzz::fuzz::{{closure}}::{{closure}}
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs:424:39
          <libafl::executors::inprocess::GenericInProcessExecutor<H,HB,HT,OT,S> as libafl::executors::Executor<EM,Z>>::run_target
                 at /Users/sameerpuri/LibAFL/libafl/src/executors/inprocess.rs:134:19
          libafl::fuzzer::StdFuzzer<CS,F,OF,OT>::execute_input
                 at /Users/sameerpuri/LibAFL/libafl/src/fuzzer/mod.rs:683:25
      31: <libafl::fuzzer::StdFuzzer<CS,F,OF,OT> as libafl::fuzzer::EvaluatorObservers<OT>>::evaluate_input_with_observers
                 at /Users/sameerpuri/LibAFL/libafl/src/fuzzer/mod.rs:462:25
          <libafl::fuzzer::StdFuzzer<CS,F,OF,OT> as libafl::fuzzer::Evaluator<E,EM>>::evaluate_input_events
                 at /Users/sameerpuri/LibAFL/libafl/src/fuzzer/mod.rs:491:9
          libafl::fuzzer::Evaluator::evaluate_input
                 at /Users/sameerpuri/LibAFL/libafl/src/fuzzer/mod.rs:120:9
      32: libafl::stages::mutational::MutationalStage::perform_mutational
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mutational.rs:147:35
          <libafl::stages::mutational::StdMutationalStage<E,EM,I,M,Z> as libafl::stages::Stage<E,EM,Z>>::perform
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mutational.rs:230:19
      33: <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all
          <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mod.rs:174:9
          <libafl::stages::logics::IfStage<CB,E,EM,ST,Z> as libafl::stages::Stage<E,EM,Z>>::perform
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/logics.rs:155:13
      34: <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mod.rs:167:17
          <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mod.rs:174:9
          <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mod.rs:174:9
          <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all
                 at /Users/sameerpuri/LibAFL/libafl/src/stages/mod.rs:174:9
          <libafl::fuzzer::StdFuzzer<CS,F,OF,OT> as libafl::fuzzer::Fuzzer<E,EM,ST>>::fuzz_one
                 at /Users/sameerpuri/LibAFL/libafl/src/fuzzer/mod.rs:621:9
          libafl::fuzzer::Fuzzer::fuzz_loop
                 at /Users/sameerpuri/LibAFL/libafl/src/fuzzer/mod.rs:184:13
          afl_libfuzzer_runtime::fuzz::do_fuzz
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/fuzz.rs:97:5
          afl_libfuzzer_runtime::fuzz::fuzz::{{closure}}
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs:505:13
      35: afl_libfuzzer_runtime::start_fuzzing_single
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs:550:5
          afl_libfuzzer_runtime::fuzz::fuzz::{{closure}}
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/fuzz.rs:230:13
          afl_libfuzzer_runtime::fuzz::fuzz
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs:509:9
          LLVMFuzzerRunDriver
                 at /Users/sameerpuri/LibAFL/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs:650:32
      36: main
                 at /Users/sameerpuri/LibAFL/libafl_targets/src/libfuzzer.c:37:10
    
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ MAPS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ / ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    
[Objective #0] run time: 0h-0m-3s, clients: 1, corpus: 914, objectives: 1, executions: 33184, exec/sec: 11.15k

────────────────────────────────────────────────────────────────────────────────

Failing input:

        artifacts/fuzz_target_1/crash-f095267f6d0e7421

Output of `std::fmt::Debug`:

        [87, 83, 58, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 91, 93, 92, 92, 93, 91, 92, 93, 92, 91, 93, 93, 93, 92, 92, 92, 234, 167, 150, 240, 145, 163, 164, 234, 169, 145, 234, 169, 150, 234, 169, 147, 56, 49, 48, 57, 49, 56, 56, 48, 52, 52, 51, 57, 52, 53, 58, 194, 146, 194, 142, 194, 149, 194, 149, 17, 9, 9, 19, 0, 15, 9, 66, 82, 79, 79, 65, 79, 240, 172, 167, 191, 240, 158, 159, 185]

Reproduce with:

        cargo fuzz run fuzz_target_1 artifacts/fuzz_target_1/crash-f095267f6d0e7421

Minimize test case with:

        cargo fuzz tmin fuzz_target_1 artifacts/fuzz_target_1/crash-f095267f6d0e7421

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 134
```
</details>