### PR TITLE
Disable `af-xdp` from QEMU default config

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -197,6 +197,7 @@ pub fn build(
                 })
                 .arg("--enable-fdt=internal")
                 .arg("--audio-drv-list=")
+                .arg("--disable-af-xdp")
                 .arg("--disable-alsa")
                 .arg("--disable-attr")
                 .arg("--disable-auth-pam")


### PR DESCRIPTION
A linking error can happen if this is enabled by default; for now we can disable it.