### PR TITLE
Fix x86_32 build: Don't build functions using uint128_t data type on x86_32

### DIFF
--- a/libafl_cc/src/no-link-rt.c
+++ b/libafl_cc/src/no-link-rt.c
@@ -56,7 +56,7 @@ void __cmplog_ins_hook8(uint64_t arg1, uint64_t arg2) {
   (void)arg2;
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && defined(__SIZEOF_INT128__)
 void __cmplog_ins_hook16_extended(uint128_t arg1, uint128_t arg2,
                                   uint8_t attr) {
   (void)attr;


### PR DESCRIPTION
libafl_cc fails to build on x86_32 due to usage of uint128_t data type at:

https://github.com/AFLplusplus/LibAFL/blob/main/libafl_cc/src/no-link-rt.c#L60 and following.

These functions are guarded by an incorrect #ifdef at:

https://github.com/AFLplusplus/LibAFL/blob/main/libafl_cc/src/no-link-rt.c#L59

This fix changes the #iffdef to match the #ifdef at:

https://github.com/AFLplusplus/LibAFL/blob/main/libafl_cc/src/no-link-rt.c#L3

