### PR TITLE
DRAFT: Adding precise BB-based coverage with DrCov export to Frida

### DIFF
--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -348,8 +348,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
                 let coverage = CoverageRuntime::new()
                     .save_dr_cov(options.save_bb_coverage)
-                    .max_cnt(options.drcov_max_execution_cnt)
-                    .build();
+                    .max_cnt(options.drcov_max_execution_cnt);
 
                 let mut frida_helper =
                     FridaInstrumentationHelper::new(&gum, options, tuple_list!(coverage));

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -346,7 +346,11 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
             (|state: Option<_>, mut mgr: LlmpRestartingEventManager<_, _>, _core_id| {
                 let gum = Gum::obtain();
 
-                let coverage = CoverageRuntime::new();
+                let coverage = CoverageRuntime::new()
+                    .block_mode(options.bb_coverage)
+                    .save_dr_cov(options.save_bb_coverage)
+                    .max_cnt(options.drcov_max_execution_cnt)
+                    .build();
 
                 let mut frida_helper =
                     FridaInstrumentationHelper::new(&gum, options, tuple_list!(coverage));

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -347,7 +347,6 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let gum = Gum::obtain();
 
                 let coverage = CoverageRuntime::new()
-                    .block_mode(options.bb_coverage)
                     .save_dr_cov(options.save_bb_coverage)
                     .max_cnt(options.drcov_max_execution_cnt)
                     .build();

--- a/libafl_bolts/src/cli.rs
+++ b/libafl_bolts/src/cli.rs
@@ -231,6 +231,21 @@ pub struct FuzzerOptions {
     #[arg(long, help_heading = "Frida Options")]
     pub disable_coverage: bool,
 
+    /// Collect basic block coverage instead of edge coverage
+    #[cfg(feature = "frida_cli")]
+    #[arg(long, help_heading = "Frida Options")]
+    pub bb_coverage: bool,
+
+    /// Write basic block coverage to disk in DrCov format
+    #[cfg(feature = "frida_cli")]
+    #[arg(long, help_heading = "Frida Options")]
+    pub save_bb_coverage: bool,
+
+    /// Accumulate `DrCov` coverage for `N` executions before writing to disk
+    #[cfg(feature = "frida_cli")]
+    #[arg(long, help_heading = "Frida Options", default_value = "0")]
+    pub drcov_max_execution_cnt: usize,
+
     /// Enable `DrCov` (aarch64 only)
     #[cfg(feature = "frida_cli")]
     #[arg(long, help_heading = "Frida Options")]

--- a/libafl_bolts/src/cli.rs
+++ b/libafl_bolts/src/cli.rs
@@ -231,11 +231,6 @@ pub struct FuzzerOptions {
     #[arg(long, help_heading = "Frida Options")]
     pub disable_coverage: bool,
 
-    /// Collect basic block coverage instead of edge coverage
-    #[cfg(feature = "frida_cli")]
-    #[arg(long, help_heading = "Frida Options")]
-    pub bb_coverage: bool,
-
     /// Write basic block coverage to disk in DrCov format
     #[cfg(feature = "frida_cli")]
     #[arg(long, help_heading = "Frida Options")]

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -107,16 +107,17 @@ impl FridaRuntime for CoverageRuntime {
                 coverage_hasher.write_usize(bb.end);
             }
             let coverage_hash = coverage_hasher.finish();
-            let input_name = input.generate_name(0);// The input index is not known at this point, but is not used in the filename
+            let input_name = input.generate_name(0); // The input index is not known at this point, but is not used in the filename
             let filename = if self.drcov.max_cnt > 0 {
                 self.drcov.coverage_directory.join(format!(
                     "{}_{coverage_hash:016x}_{}-{}.drcov",
-                    &input_name, 
+                    &input_name,
                     self.drcov.stored_cnt,
                     self.drcov.stored_cnt + self.drcov.cnt
                 ))
             } else {
-                self.drcov.coverage_directory
+                self.drcov
+                    .coverage_directory
                     .join(format!("{}_{coverage_hash:016x}.drcov", &input_name))
             };
 
@@ -150,7 +151,7 @@ impl CoverageRuntime {
                 previous_pc: 0,
                 _pinned: PhantomPinned,
             })),
-            save_dr_cov: false,            
+            save_dr_cov: false,
             drcov: DrCov {
                 ranges: RangeMap::new(),
                 coverage_directory: PathBuf::from("./coverage"),

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -87,6 +87,11 @@ impl FridaRuntime for CoverageRuntime {
             let mut drcov_basic_blocks: Vec<DrCovBasicBlock> = vec![];
 
             for (key, value) in &self.basic_blocks {
+                // Is map[key] greater than 0?
+                if self.inner.borrow().map[*key as usize] == 0 {
+                    continue;
+                }
+
                 log::trace!(
                     "Covered BB key: {:x}, value: {:016x} - {:016x}",
                     key,

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -1,12 +1,22 @@
 //! Functionality regarding binary-only coverage collection.
 use core::ptr::addr_of_mut;
-use std::{cell::RefCell, marker::PhantomPinned, pin::Pin, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    hash::{BuildHasher, Hasher},
+    marker::PhantomPinned,
+    path::PathBuf,
+    pin::Pin,
+    rc::Rc,
+};
 
+use ahash::RandomState;
 #[cfg(target_arch = "aarch64")]
 use dynasmrt::DynasmLabelApi;
 use dynasmrt::{dynasm, DynasmApi};
 use frida_gum::{instruction_writer::InstructionWriter, stalker::StalkerOutput, ModuleMap};
-use libafl_bolts::hash_std;
+use libafl_bolts::{hash_std, AsSlice};
+use libafl_targets::drcov::{DrCovBasicBlock, DrCovWriter};
 use rangemap::RangeMap;
 
 use crate::helper::FridaRuntime;
@@ -23,7 +33,18 @@ struct CoverageRuntimeInner {
 
 /// Frida binary-only coverage
 #[derive(Debug)]
-pub struct CoverageRuntime(Pin<Rc<RefCell<CoverageRuntimeInner>>>);
+pub struct CoverageRuntime {
+    inner: Pin<Rc<RefCell<CoverageRuntimeInner>>>,
+    block_mode: bool,
+    /// The memory ranges of this target
+    ranges: RangeMap<usize, (u16, String)>,
+    save_dr_cov: bool,
+    coverage_directory: PathBuf,
+    basic_blocks: HashMap<u64, DrCovBasicBlock>,
+    cnt: usize,
+    max_cnt: usize,
+    stored_cnt: usize,
+}
 
 impl Default for CoverageRuntime {
     fn default() -> Self {
@@ -37,9 +58,12 @@ impl FridaRuntime for CoverageRuntime {
     fn init(
         &mut self,
         _gum: &frida_gum::Gum,
-        _ranges: &RangeMap<usize, (u16, String)>,
+        ranges: &RangeMap<usize, (u16, String)>,
         _module_map: &Rc<ModuleMap>,
     ) {
+        self.ranges = ranges.clone();
+        std::fs::create_dir_all(&self.coverage_directory)
+            .expect("failed to create directory for coverage files");
     }
 
     fn pre_exec<I: libafl::inputs::Input + libafl::inputs::HasTargetBytes>(
@@ -51,8 +75,57 @@ impl FridaRuntime for CoverageRuntime {
 
     fn post_exec<I: libafl::inputs::Input + libafl::inputs::HasTargetBytes>(
         &mut self,
-        _input: &I,
+        input: &I,
     ) -> Result<(), libafl::Error> {
+        if self.block_mode && self.save_dr_cov {
+            self.cnt += 1;
+            if self.max_cnt > 0 && self.cnt < self.max_cnt {
+                return Ok(());
+            }
+
+            // Create basic blocks
+            let mut drcov_basic_blocks: Vec<DrCovBasicBlock> = vec![];
+
+            for (key, value) in &self.basic_blocks {
+                log::trace!(
+                    "Covered BB key: {:x}, value: {:016x} - {:016x}",
+                    key,
+                    value.start,
+                    value.end
+                );
+                drcov_basic_blocks.push(*value);
+            }
+
+            let mut input_hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
+            input_hasher.write(input.target_bytes().as_slice());
+            let input_hash = input_hasher.finish();
+
+            let mut coverage_hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
+            for bb in &drcov_basic_blocks {
+                coverage_hasher.write_usize(bb.start);
+                coverage_hasher.write_usize(bb.end);
+            }
+            let coverage_hash = coverage_hasher.finish();
+
+            let filename = if self.max_cnt > 0 {
+                self.coverage_directory.join(format!(
+                    "{input_hash:016x}_{coverage_hash:016x}_{}-{}.drcov",
+                    self.stored_cnt,
+                    self.stored_cnt + self.cnt
+                ))
+            } else {
+                self.coverage_directory
+                    .join(format!("{input_hash:016x}_{coverage_hash:016x}.drcov"))
+            };
+
+            DrCovWriter::new(&self.ranges).write(filename, &drcov_basic_blocks)?;
+            if self.max_cnt > 0 {
+                self.stored_cnt += self.cnt;
+                self.cnt = 0;
+            }
+
+            return Ok(());
+        }
         Ok(())
     }
 }
@@ -61,16 +134,75 @@ impl CoverageRuntime {
     /// Create a new coverage runtime
     #[must_use]
     pub fn new() -> Self {
-        Self(Rc::pin(RefCell::new(CoverageRuntimeInner {
-            map: [0_u8; MAP_SIZE],
-            previous_pc: 0,
-            _pinned: PhantomPinned,
-        })))
+        Self {
+            inner: Rc::pin(RefCell::new(CoverageRuntimeInner {
+                map: [0_u8; MAP_SIZE],
+                previous_pc: 0,
+                _pinned: PhantomPinned,
+            })),
+            block_mode: false,
+            ranges: RangeMap::new(),
+            save_dr_cov: false,
+            coverage_directory: PathBuf::from("./coverage"),
+            basic_blocks: HashMap::new(),
+            cnt: 0,
+            max_cnt: 0,
+            stored_cnt: 0,
+        }
+    }
+
+    /// Set the block mode
+    #[must_use]
+    pub fn block_mode(mut self, block_mode: bool) -> Self {
+        log::info!("Setting block mode to {}", block_mode);
+        self.block_mode = block_mode;
+        self
+    }
+
+    /// Set whether to save `DrCov` files
+    #[must_use]
+    pub fn save_dr_cov(mut self, save_dr_cov: bool) -> Self {
+        self.save_dr_cov = save_dr_cov;
+        self
+    }
+
+    /// Set the coverage directory
+    #[must_use]
+    pub fn coverage_directory(mut self, coverage_directory: &str) -> Self {
+        self.coverage_directory = PathBuf::from(coverage_directory);
+        self
+    }
+
+    /// Set the maximum number of executions to accumulate before writing the coverage to disk
+    #[must_use]
+    pub fn max_cnt(mut self, max_cnt: usize) -> Self {
+        self.max_cnt = max_cnt;
+        self
+    }
+
+    /// Builder pattern
+    #[must_use]
+    pub fn build(self) -> CoverageRuntime {
+        CoverageRuntime {
+            inner: Rc::pin(RefCell::new(CoverageRuntimeInner {
+                map: [0_u8; MAP_SIZE],
+                previous_pc: 0,
+                _pinned: PhantomPinned,
+            })),
+            block_mode: self.block_mode,
+            ranges: self.ranges,
+            save_dr_cov: self.save_dr_cov,
+            coverage_directory: self.coverage_directory,
+            basic_blocks: self.basic_blocks,
+            cnt: self.cnt,
+            max_cnt: self.max_cnt,
+            stored_cnt: self.stored_cnt,
+        }
     }
 
     /// Retrieve the coverage map pointer
     pub fn map_mut_ptr(&mut self) -> *mut u8 {
-        self.0.borrow_mut().map.as_mut_ptr()
+        self.inner.borrow_mut().map.as_mut_ptr()
     }
 
     /// A minimal `maybe_log` implementation. We insert this into the transformed instruction stream
@@ -79,108 +211,189 @@ impl CoverageRuntime {
     #[cfg(target_arch = "aarch64")]
     #[allow(clippy::cast_possible_wrap)]
     pub fn generate_inline_code(&mut self, h64: u64) -> Box<[u8]> {
-        let mut borrow = self.0.borrow_mut();
+        let mut borrow = self.inner.borrow_mut();
         let prev_loc_ptr = addr_of_mut!(borrow.previous_pc);
         let map_addr_ptr = addr_of_mut!(borrow.map);
         let mut ops = dynasmrt::VecAssembler::<dynasmrt::aarch64::Aarch64Relocation>::new(0);
-        dynasm!(ops
-            ;   .arch aarch64
-            // Store the context
-            ;   b >start
+        if block_mode {
+            dynasm!(ops
+                ;   .arch aarch64
+                // Store the context
+                ;   b >start
 
-            ;   stp x16, x17, [sp, -0x90]!
-            ; start:
+                ;   stp x16, x17, [sp, -0x90]!
+                ; start:
 
-            // Load the previous_pc
-            ;   ldr x17, >previous_loc
-            ;   ldr x17, [x17]
+                // Load the block id
+                ;   ldr x16, >loc
 
-            // Caltulate the edge id
-            ;   ldr x16, >loc
-            ;   eor x16, x17, x16
+                // Load the map byte address
+                ;   ldr x17, >map_addr
+                ;   add x16, x17, x16
 
-            // Load the map byte address
-            ;   ldr x17, >map_addr
-            ;   add x16, x17, x16
+                // Update the map byte
+                ;   ldrb w17, [x16]
+                ;   add w17, w17, #1
+                ;   add x17, x17, x17, lsr #8
+                ;   strb w17, [x16]
 
-            // Update the map byte
-            ;   ldrb w17, [x16]
-            ;   add w17, w17, #1
-            ;   add x17, x17, x17, lsr #8
-            ;   strb w17, [x16]
+                // Restore the context
+                ;   ldp x16, x17, [sp], #0x90
 
-            // Update the previous_pc value
-            ;   ldr x16, >loc_shr
-            ;   ldr x17, >previous_loc
-            ;   str x16, [x17]
+                // Skip the data
+                ;   b >end
 
-            // Restore the context
-            ;   ldp x16, x17, [sp], #0x90
+                ;map_addr:
+                ;.qword map_addr_ptr as i64
+                ;previous_loc:
+                ;.qword prev_loc_ptr as i64
+                ;loc:
+                ;.qword h64 as i64
+                ;loc_shr:
+                ;.qword (h64 >> 1) as i64
+                ;end:
+            );
+        } else {
+            dynasm!(ops
+                ;   .arch aarch64
+                // Store the context
+                ;   b >start
 
-            // Skip the data
-            ;   b >end
+                ;   stp x16, x17, [sp, -0x90]!
+                ; start:
 
-            ;map_addr:
-            ;.qword map_addr_ptr as i64
-            ;previous_loc:
-            ;.qword prev_loc_ptr as i64
-            ;loc:
-            ;.qword h64 as i64
-            ;loc_shr:
-            ;.qword (h64 >> 1) as i64
-            ;end:
-        );
+                // Load the previous_pc
+                ;   ldr x17, >previous_loc
+                ;   ldr x17, [x17]
+
+                // Caltulate the edge id
+                ;   ldr x16, >loc
+                ;   eor x16, x17, x16
+
+                // Load the map byte address
+                ;   ldr x17, >map_addr
+                ;   add x16, x17, x16
+
+                // Update the map byte
+                ;   ldrb w17, [x16]
+                ;   add w17, w17, #1
+                ;   add x17, x17, x17, lsr #8
+                ;   strb w17, [x16]
+
+                // Update the previous_pc value
+                ;   ldr x16, >loc_shr
+                ;   ldr x17, >previous_loc
+                ;   str x16, [x17]
+
+                // Restore the context
+                ;   ldp x16, x17, [sp], #0x90
+
+                // Skip the data
+                ;   b >end
+
+                ;map_addr:
+                ;.qword map_addr_ptr as i64
+                ;previous_loc:
+                ;.qword prev_loc_ptr as i64
+                ;loc:
+                ;.qword h64 as i64
+                ;loc_shr:
+                ;.qword (h64 >> 1) as i64
+                ;end:
+            );
+        }
         let ops_vec = ops.finalize().unwrap();
         ops_vec[..ops_vec.len()].to_vec().into_boxed_slice()
     }
 
     /// Write inline instrumentation for coverage
     #[cfg(target_arch = "x86_64")]
-    pub fn generate_inline_code(&mut self, h64: u64) -> Box<[u8]> {
-        let mut borrow = self.0.borrow_mut();
+    pub fn generate_inline_code(&mut self, h64: u64, block_mode: bool) -> Box<[u8]> {
+        let mut borrow = self.inner.borrow_mut();
         let prev_loc_ptr = addr_of_mut!(borrow.previous_pc);
         let map_addr_ptr = addr_of_mut!(borrow.map);
         let mut ops = dynasmrt::VecAssembler::<dynasmrt::x64::X64Relocation>::new(0);
-        dynasm!(ops
-            ;   .arch x64
-            // Store the context
-            ; mov    QWORD [rsp-0x88], rax
-            ; lahf
-            ; mov    QWORD [rsp-0x90], rax
-            ; mov    QWORD [rsp-0x98], rbx
+        if block_mode {
+            dynasm!(ops
+                ;   .arch x64
+                // Store the context
+                ; mov    QWORD [rsp-0x88], rax
+                ; lahf
+                ; mov    QWORD [rsp-0x90], rax
+                ; mov    QWORD [rsp-0x98], rbx
 
-            // Load the previous_pc
-            ; mov rax, QWORD prev_loc_ptr as _
-            ; mov rax, QWORD [rax]
+                // Load the block id
+                ; mov eax, WORD h64 as i32
 
-            // Calculate the edge id
-            ; mov ebx, WORD h64 as i32
-            ; xor rax, rbx
+                // Load the map byte address
+                ; mov rbx, QWORD map_addr_ptr as _
+                ; add rax, rbx
 
-            // Load the map byte address
-            ; mov rbx, QWORD map_addr_ptr as _
-            ; add rax, rbx
+                // Update the map byte
+                ; mov bl, BYTE [rax]
+                ; add bl,0x1
+                ; adc bl,0x0
+                ; mov BYTE [rax],bl
 
-            // Update the map byte
-            ; mov bl, BYTE [rax]
-            ; add bl,0x1
-            ; adc bl,0x0
-            ; mov BYTE [rax],bl
+                // Restore the context
+                ; mov    rbx, QWORD [rsp-0x98]
+                ; mov    rax, QWORD [rsp-0x90]
+                ; sahf
+                ; mov    rax, QWORD [rsp-0x88]
+            );
+        } else {
+            dynasm!(ops
+                ;   .arch x64
+                // Store the context
+                ; mov    QWORD [rsp-0x88], rax
+                ; lahf
+                ; mov    QWORD [rsp-0x90], rax
+                ; mov    QWORD [rsp-0x98], rbx
 
-            // Update the previous_pc value
-            ; mov rax, QWORD prev_loc_ptr as _
-            ; mov ebx, WORD (h64 >> 1) as i32
-            ; mov QWORD [rax], rbx
+                // Load the previous_pc
+                ; mov rax, QWORD prev_loc_ptr as _
+                ; mov rax, QWORD [rax]
 
-            // Restore the context
-            ; mov    rbx, QWORD [rsp-0x98]
-            ; mov    rax, QWORD [rsp-0x90]
-            ; sahf
-            ; mov    rax, QWORD [rsp-0x88]
-        );
+                // Calculate the edge id
+                ; mov ebx, WORD h64 as i32
+                ; xor rax, rbx
+
+                // Load the map byte address
+                ; mov rbx, QWORD map_addr_ptr as _
+                ; add rax, rbx
+
+                // Update the map byte
+                ; mov bl, BYTE [rax]
+                ; add bl,0x1
+                ; adc bl,0x0
+                ; mov BYTE [rax],bl
+
+                // Update the previous_pc value
+                ; mov rax, QWORD prev_loc_ptr as _
+                ; mov ebx, WORD (h64 >> 1) as i32
+                ; mov QWORD [rax], rbx
+
+                // Restore the context
+                ; mov    rbx, QWORD [rsp-0x98]
+                ; mov    rax, QWORD [rsp-0x90]
+                ; sahf
+                ; mov    rax, QWORD [rsp-0x88]
+            );
+        }
         let ops_vec = ops.finalize().unwrap();
 
         ops_vec[..ops_vec.len()].to_vec().into_boxed_slice()
+    }
+
+    /// Keeps track of the basic block in the map
+    #[inline]
+    pub fn set_bb_size(&mut self, address: u64, size: usize) {
+        if self.save_dr_cov {
+            let h64 = hash_std(&address.to_le_bytes());
+            let map_idx: u64 = h64 & (MAP_SIZE as u64 - 1);
+            let basic_block = DrCovBasicBlock::with_size(address as usize, size);
+            self.basic_blocks.insert(map_idx, basic_block);
+        }
     }
 
     /// Emits coverage mapping into the current basic block.
@@ -209,7 +422,7 @@ impl CoverageRuntime {
             writer.reset(pc - 4);
         }
 
-        let code = self.generate_inline_code(h64 & (MAP_SIZE as u64 - 1));
+        let code = self.generate_inline_code(h64 & (MAP_SIZE as u64 - 1), self.block_mode);
         writer.put_bytes(&code);
     }
 }

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -210,7 +210,7 @@ impl CoverageRuntime {
     /// block.
     #[cfg(target_arch = "aarch64")]
     #[allow(clippy::cast_possible_wrap)]
-    pub fn generate_inline_code(&mut self, h64: u64) -> Box<[u8]> {
+    pub fn generate_inline_code(&mut self, h64: u64, block_mode: bool) -> Box<[u8]> {
         let mut borrow = self.inner.borrow_mut();
         let prev_loc_ptr = addr_of_mut!(borrow.previous_pc);
         let map_addr_ptr = addr_of_mut!(borrow.map);

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -484,9 +484,7 @@ where
                         rt.emit_coverage_mapping(address, output);
                     }
 
-                    if let Some(_rt) = runtimes.match_first_type_mut::<DrCovRuntime>() {
-                        basic_block_start = address;
-                    }
+                    basic_block_start = address;
                 }
 
                 #[cfg(unix)]
@@ -549,19 +547,23 @@ where
                     );
                 }
 
-                if let Some(_rt) = runtimes.match_first_type_mut::<DrCovRuntime>() {
-                    basic_block_size += instr_size;
-                }
+                basic_block_size += instr_size;
             }
             instruction.keep();
         }
         if basic_block_size != 0 {
+            log::trace!("{basic_block_start:#016X}:{basic_block_size:X}");
             if let Some(rt) = runtimes.borrow_mut().match_first_type_mut::<DrCovRuntime>() {
-                log::trace!("{basic_block_start:#016X}:{basic_block_size:X}");
                 rt.drcov_basic_blocks.push(DrCovBasicBlock::new(
                     basic_block_start as usize,
                     basic_block_start as usize + basic_block_size,
                 ));
+            }
+            if let Some(rt) = runtimes
+                .borrow_mut()
+                .match_first_type_mut::<CoverageRuntime>()
+            {
+                rt.set_bb_size(basic_block_start, basic_block_size);
             }
         }
     }

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -552,7 +552,7 @@ where
             instruction.keep();
         }
         if basic_block_size != 0 {
-            log::trace!("{basic_block_start:#016X}:{basic_block_size:X}");
+            // log::trace!("{basic_block_start:#016X}:{basic_block_size:X}");
             if let Some(rt) = runtimes.borrow_mut().match_first_type_mut::<DrCovRuntime>() {
                 rt.drcov_basic_blocks.push(DrCovBasicBlock::new(
                     basic_block_start as usize,

--- a/libafl_qemu/libqasan/hooks.c
+++ b/libafl_qemu/libqasan/hooks.c
@@ -480,7 +480,7 @@ char *strndup(const char *s, size_t n) {
   QASAN_LOAD(s, l + 1);
   void *r = __libqasan_malloc(l + 1);
   __libqasan_memcpy(r, s, l);
-  ((char*)r)[l] = 0;
+  ((char *)r)[l] = 0;
   QASAN_DEBUG("\t\t = %p\n", r);
 
   return r;

--- a/utils/drcov/drcov.py
+++ b/utils/drcov/drcov.py
@@ -1,0 +1,533 @@
+#!/usr/bin/python
+import os
+import re
+import sys
+import mmap
+import struct
+import collections
+from ctypes import *
+
+#
+# I know people like to use this parser in their own projects, so this
+# if/def makes it compatible with being imported or used outside Lighthouse
+#
+
+try:
+    from lighthouse.exceptions import CoverageMissingError
+    from lighthouse.reader.coverage_file import CoverageFile
+    g_lighthouse = True
+except ImportError as e:
+    CoverageFile = object
+    g_lighthouse = False
+
+#------------------------------------------------------------------------------
+# DynamoRIO Drcov Log Parser
+#------------------------------------------------------------------------------
+
+class DrcovData(CoverageFile):
+    """
+    A drcov log parser.
+    """
+
+    def __init__(self, filepath=None):
+        self.filepath = filepath
+
+        # drcov header attributes
+        self.version = 0
+        self.flavor = None
+
+        # drcov module table
+        self.module_table_count = 0
+        self.module_table_version = 0
+        self.modules = {}
+
+        # drcov basic block data
+        self.bbs = []
+        self.bb_table_count = 0
+        self.bb_table_is_binary = True
+
+        # parse
+        if g_lighthouse:
+            super(DrcovData, self).__init__(filepath)
+        else:
+            self._parse()
+
+    #--------------------------------------------------------------------------
+    # Public
+    #--------------------------------------------------------------------------
+
+    def get_offsets(self, module_name):
+        """
+        Return coverage data as basic block offsets for the named module.
+        """
+        modules = self.modules.get(module_name, [])
+        if not modules:
+            return []
+
+        #
+        # I don't know if this should ever actually trigger, but if it does,
+        # it is a strange testcase to collect coverage against. It means that
+        # maybe the target library/module was loaded, unloaded, and reloaded?
+        #
+        # if someone ever actally triggers this, we can look into it :S
+        #
+
+        if self.version > 2:
+            assert all(module.containing_id == modules[0].id for module in modules)
+
+        # extract the unique module ids that we need to collect blocks for
+        mod_ids = [module.id for module in modules]
+
+        # loop through the coverage data and filter out data for the target ids
+        coverage_blocks = [bb.start for bb in self.bbs if bb.mod_id in mod_ids]
+
+        # return the filtered coverage blocks
+        return coverage_blocks
+
+    def get_offset_blocks(self, module_name):
+        """
+        Return coverage data as basic blocks (offset, size) for the named module.
+        """
+        modules = self.modules.get(module_name, [])
+        if not modules:
+            return []
+
+        # NOTE: see comment in get_offsets() for more info...
+        if self.version > 2:
+            assert all(module.containing_id == modules[0].id for module in modules)
+
+        # extract the unique module ids that we need to collect blocks for
+        mod_ids = [module.id for module in modules]
+
+        # loop through the coverage data and filter out data for the target ids
+        if self.version < 3:
+            coverage_blocks = [(bb.start, bb.size) for bb in self.bbs if bb.mod_id in mod_ids]
+
+        #
+        # drcov version 3 does not include the 'preferred' / sub-module base
+        # in the bb offset, so we must add that base offset before returning
+        # the block offsets to correctly normalize things
+        #
+        # it's unclear if the preferred_base for given sub-module segments
+        # will always be correct, so we opt to simply use the first segment
+        # in a given module as the base to compute the known runtime offset
+        #
+
+        else:
+            mod_bases = dict([(module.id, module.start - modules[0].start) for module in modules])
+            coverage_blocks = [(mod_bases[bb.mod_id] + bb.start, bb.size) for bb in self.bbs if bb.mod_id in mod_ids]
+
+        # return the filtered coverage blocks
+        return coverage_blocks
+
+    #--------------------------------------------------------------------------
+    # Parsing Routines - Top Level
+    #--------------------------------------------------------------------------
+
+    def _parse(self):
+        """
+        Parse drcov coverage from the given log file.
+        """
+        with open(self.filepath, "rb") as f:
+            self._parse_drcov_header(f)
+            self._parse_module_table(f)
+            self._parse_bb_table(f)
+
+    #--------------------------------------------------------------------------
+    # Parsing Routines - Internals
+    #--------------------------------------------------------------------------
+
+    def _parse_drcov_header(self, f):
+        """
+        Parse drcov log header from filestream.
+        """
+
+        # parse drcov version from log
+        #   eg: DRCOV VERSION: 2
+        version_line = f.readline().decode('utf-8').strip()
+        self.version = int(version_line.split(":")[1])
+
+        # parse drcov flavor from log
+        #   eg: DRCOV FLAVOR: drcov
+        flavor_line = f.readline().decode('utf-8').strip()
+        self.flavor = flavor_line.split(":")[1]
+
+        assert self.version == 2 or self.version == 3, "Only drcov versions 2 and 3 log files supported"
+
+    def _parse_module_table(self, f):
+        """
+        Parse drcov log module table from filestream.
+        """
+        self._parse_module_table_header(f)
+        self._parse_module_table_columns(f)
+        self._parse_module_table_modules(f)
+
+    def _parse_module_table_header(self, f):
+        """
+        Parse drcov log module table header from filestream.
+
+        -------------------------------------------------------------------
+
+        Format used in DynamoRIO v6.1.1 through 6.2.0
+           eg: 'Module Table: 11'
+
+        Format used in DynamoRIO v7.0.0-RC1 (and hopefully above)
+           eg: 'Module Table: version X, count 11'
+
+        """
+
+        # parse module table 'header'
+        #   eg: Module Table: version 2, count 11
+        header_line = f.readline().decode('utf-8').strip()
+        field_name, field_data = header_line.split(": ")
+        #assert field_name == "Module Table"
+
+        #
+        # NOTE/COMPAT:
+        #
+        #   DynamoRIO doesn't document their drcov log format, and it has
+        #   changed its format at least once during its lifetime.
+        #
+        #   we just have to try parsing the table header one way to determine
+        #   if its the old (say, a 'v1') table, or the new 'v2' table.
+        #
+
+        try:
+
+            # seperate 'version X' and 'count Y' from each other ('v2')
+            version_data, count_data = field_data.split(", ")
+
+        # failure to unpack indicates this is an 'older, v1' drcov log
+        except ValueError:
+            self.module_table_count   = int(field_data)
+            self.module_table_version = 1
+            return
+
+        # parse module table version out of 'version X'
+        data_name, version = version_data.split(" ")
+        #assert data_name == "version"
+        self.module_table_version = int(version)
+        if not self.module_table_version in [2, 3, 4, 5]:
+            raise ValueError("Unsupported (new?) drcov log format...")
+
+        # parse module count in table from 'count Y'
+        data_name, count = count_data.split(" ")
+        #assert data_name == "count"
+        self.module_table_count = int(count)
+
+    def _parse_module_table_columns(self, f):
+        """
+        Parse drcov log module table columns from filestream.
+
+        -------------------------------------------------------------------
+
+        DynamoRIO v6.1.1, table version 1:
+           eg: (Not present)
+
+        DynamoRIO v7.0.0-RC1, table version 2:
+           Windows:
+             'Columns: id, base, end, entry, checksum, timestamp, path'
+           Mac/Linux:
+             'Columns: id, base, end, entry, path'
+
+        DynamoRIO v7.0.17594B, table version 3:
+           Windows:
+             'Columns: id, containing_id, start, end, entry, checksum, timestamp, path'
+           Mac/Linux:
+             'Columns: id, containing_id, start, end, entry, path'
+
+        DynamoRIO v7.0.17640, table version 4:
+           Windows:
+             'Columns: id, containing_id, start, end, entry, offset, checksum, timestamp, path'
+           Mac/Linux:
+             'Columns: id, containing_id, start, end, entry, offset, path'
+
+        DynamoRIO v10.0.19734, table version 5:
+           Windows:
+             'Columns: id, containing_id, start, end, entry, offset, preferred_base, checksum, timestamp, path'
+           Mac/Linux:
+             'Columns: id, containing_id, start, end, entry, offset, preferred_base, path'
+
+        """
+
+        # NOTE/COMPAT: there is no 'Columns' line for the v1 table...
+        if self.module_table_version == 1:
+            return
+
+        # parse module table 'columns'
+        #   eg: Columns: id, base, end, entry, checksum, timestamp, path
+        column_line = f.readline().decode('utf-8').strip()
+        field_name, field_data = column_line.split(": ")
+        #assert field_name == "Columns"
+
+        # seperate column names
+        #   Windows:   id, base, end, entry, checksum, timestamp, path
+        #   Mac/Linux: id, base, end, entry, path
+        columns = field_data.split(", ")
+
+    def _parse_module_table_modules(self, f):
+        """
+        Parse drcov log modules in the module table from filestream.
+        """
+        modules = collections.defaultdict(list)
+
+        # loop through each *expected* line in the module table and parse it
+        for i in range(self.module_table_count):
+            module = DrcovModule(f.readline().decode('utf-8').strip(), self.module_table_version)
+            modules[module.filename].append(module)
+
+        self.modules = modules
+
+    def _parse_bb_table(self, f):
+        """
+        Parse dcov log basic block table from filestream.
+        """
+        self._parse_bb_table_header(f)
+        self._parse_bb_table_entries(f)
+
+    def _parse_bb_table_header(self, f):
+        """
+        Parse drcov log basic block table header from filestream.
+        """
+
+        # parse basic block table 'header'
+        #   eg: BB Table: 2792 bbs
+        header_line = f.readline().decode('utf-8').strip()
+        field_name, field_data = header_line.split(": ")
+        #assert field_name == "BB Table"
+
+        # parse basic block count out of 'X bbs'
+        count_data, data_name = field_data.split(" ")
+        #assert data_name == "bbs"
+        self.bb_table_count = int(count_data)
+
+        # peek at the next few bytes to determine if this is a binary bb table.
+        # An ascii bb table will have the line: 'module id, start, size:'
+        token = b"module id"
+        saved_position = f.tell()
+
+        # is this an ascii table?
+        if f.read(len(token)) == token:
+            self.bb_table_is_binary = False
+
+        # nope! binary table
+        else:
+            self.bb_table_is_binary = True
+
+        # seek back to the start of the table
+        f.seek(saved_position)
+
+    def _parse_bb_table_entries(self, f):
+        """
+        Parse drcov log basic block table entries from filestream.
+        """
+
+        # allocate the ctypes structure array of basic blocks
+        self.bbs = (DrcovBasicBlock * self.bb_table_count)()
+
+        # read binary basic block entries directly into the newly allocated array
+        if self.bb_table_is_binary:
+            f.readinto(self.bbs)
+
+        # parse the plaintext basic block entries one by one
+        else:
+            self._parse_bb_table_text_entries(f)
+
+    def _parse_bb_table_text_entries(self, f):
+        """
+        Parse drcov log basic block table text entries from filestream.
+        """
+        table_header = f.readline().decode('utf-8').strip()
+
+        if table_header != "module id, start, size:":
+            raise ValueError("Invalid BB header: %r" % table_header)
+
+        pattern = re.compile(r"^module\[\s*(?P<mod>[0-9]+)\]\:\s*(?P<start>0x[0-9a-fA-F]+)\,\s*(?P<size>[0-9]+)$")
+        for i, bb in enumerate(self.bbs):
+            text_entry = f.readline().decode('utf-8').strip()
+            if not text_entry:
+                continue
+
+            match = pattern.match(text_entry)
+            if not match:
+                raise ValueError("Invalid BB entry: %r" % text_entry)
+
+            bb.start = int(match.group("start"), 16)
+            bb.size = int(match.group("size"), 10)
+            bb.mod_id = int(match.group("mod"), 10)
+
+#------------------------------------------------------------------------------
+# drcov module parser
+#------------------------------------------------------------------------------
+
+class DrcovModule(object):
+    """
+    Parser & wrapper for module details as found in a drcov coverage log.
+
+    A 'module' in this context is a .EXE, .DLL, ELF, MachO, etc.
+    """
+    def __init__(self, module_data, version):
+        self.id    = 0
+        self.base  = 0
+        self.end   = 0
+        self.size  = 0
+        self.entry = 0
+        self.checksum  = 0
+        self.timestamp = 0
+        self.path      = ""
+        self.filename  = ""
+        self.containing_id = 0
+
+        # parse the module
+        self._parse_module(module_data, version)
+
+    @property
+    def start(self):
+        """
+        Compatability alias for the module base.
+
+        DrCov table version 2 --> 3 changed this paramter name base --> start.
+        """
+        return self.base
+
+    def _parse_module(self, module_line, version):
+        """
+        Parse a module table entry.
+        """
+        data = module_line.split(", ")
+
+        # NOTE/COMPAT
+        if version == 1:
+            self._parse_module_v1(data)
+        elif version == 2:
+            self._parse_module_v2(data)
+        elif version == 3:
+            self._parse_module_v3(data)
+        elif version == 4:
+            self._parse_module_v4(data)
+        elif version == 5:
+            self._parse_module_v5(data)
+        else:
+            raise ValueError("Unknown module format (v%u)" % version)
+
+    def _parse_module_v1(self, data):
+        """
+        Parse a module table v1 entry.
+        """
+        self.id       = int(data[0])
+        self.size     = int(data[1])
+        self.path     = str(data[2])
+        self.filename = os.path.basename(self.path.replace('\\', os.sep))
+
+    def _parse_module_v2(self, data):
+        """
+        Parse a module table v2 entry.
+        """
+        self.id        = int(data[0])
+        self.base      = int(data[1], 16)
+        self.end       = int(data[2], 16)
+        self.entry     = int(data[3], 16)
+        if len(data) == 7: # Windows Only
+            self.checksum  = int(data[4], 16)
+            self.timestamp = int(data[5], 16)
+        self.path      = str(data[-1])
+        self.size      = self.end-self.base
+        self.filename  = os.path.basename(self.path.replace('\\', os.sep))
+
+    def _parse_module_v3(self, data):
+        """
+        Parse a module table v3 entry.
+        """
+        self.id            = int(data[0])
+        self.containing_id = int(data[1])
+        self.base          = int(data[2], 16)
+        self.end           = int(data[3], 16)
+        self.entry         = int(data[4], 16)
+        if len(data) > 7: # Windows Only
+            self.checksum  = int(data[5], 16)
+            self.timestamp = int(data[6], 16)
+        self.path          = str(data[-1])
+        self.size          = self.end-self.base
+        self.filename      = os.path.basename(self.path.replace('\\', os.sep))
+
+    def _parse_module_v4(self, data):
+        """
+        Parse a module table v4 entry.
+        """
+        self.id            = int(data[0])
+        self.containing_id = int(data[1])
+        self.base          = int(data[2], 16)
+        self.end           = int(data[3], 16)
+        self.entry         = int(data[4], 16)
+        self.offset        = int(data[5], 16)
+        if len(data) > 8: # Windows Only
+            self.checksum  = int(data[6], 16)
+            self.timestamp = int(data[7], 16)
+        self.path          = str(data[-1])
+        self.size          = self.end-self.base
+        self.filename      = os.path.basename(self.path.replace('\\', os.sep))
+
+    def _parse_module_v5(self, data):
+        """
+        Parse a module table v5 entry.
+        """
+        self.id             = int(data[0])
+        self.containing_id  = int(data[1])
+        self.base           = int(data[2], 16)
+        self.end            = int(data[3], 16)
+        self.entry          = int(data[4], 16)
+        self.offset         = int(data[5], 16)
+        self.preferred_base = int(data[6], 16)
+        if len(data) > 8: # Windows Only
+            self.checksum   = int(data[7], 16)
+            self.timestamp  = int(data[8], 16)
+        self.path           = str(data[-1])
+        self.size           = self.end-self.base
+        self.filename       = os.path.basename(self.path.replace('\\', os.sep))
+
+
+#------------------------------------------------------------------------------
+# drcov basic block parser
+#------------------------------------------------------------------------------
+
+class DrcovBasicBlock(Structure):
+    """
+    Parser & wrapper for basic block details as found in a drcov coverage log.
+
+    NOTE:
+
+      Based off the C structure as used by drcov -
+
+        /* Data structure for the coverage info itself */
+        typedef struct _bb_entry_t {
+            uint   start;      /* offset of bb start from the image base */
+            ushort size;
+            ushort mod_id;
+        } bb_entry_t;
+
+    """
+    _pack_   = 1
+    _fields_ = [
+        ('start',  c_uint32),
+        ('size',   c_uint16),
+        ('mod_id', c_uint16)
+    ]
+
+#------------------------------------------------------------------------------
+# Command Line Testing
+#------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    argc = len(sys.argv)
+    argv = sys.argv
+
+    # base usage
+    if argc < 2:
+        print("usage: {} <coverage filename>".format(os.path.basename(sys.argv[0])))
+        sys.exit()
+
+    # attempt file parse
+    x = DrcovData(argv[1])
+    for bb in x.bbs:
+        print("0x{:08x}".format(bb.start))
+

--- a/utils/drcov/merge_drcov.py
+++ b/utils/drcov/merge_drcov.py
@@ -1,0 +1,290 @@
+import argparse
+import os
+import glob
+import time
+import drcov
+import platform
+import json
+import tqdm
+
+verbose = False
+# DrCov file writer based on 
+# https://github.com/gaasedelen/lighthouse/blob/f4642e8b4b4347b11ccb25a79ec4f490c9ad901d/coverage/frida/frida-drcov.py
+
+class HashableDrcovBasicBlock(drcov.DrcovBasicBlock):
+    def __init__(self, block):
+        self.mod_id = block.mod_id
+        self.start = block.start
+        self.size = block.size
+
+    def __hash__(self):
+        return hash((self.start, self.size, self.mod_id))
+
+    def __eq__(self, other):
+        if isinstance(other, HashableDrcovBasicBlock):
+            return self.start == other.start and self.size == other.size and self.mod_id == other.mod_id
+        return False
+    
+# A class that creates a DrCov file
+class DrcovFile:
+    def __init__(self, file_name):
+        self.file_name = file_name
+        # Each module is a dictionary with the following keys
+        # m = {
+        # 'id': idx,
+        # 'path': path,
+        # 'base': base,
+        # 'end': end,
+        # 'size': size}
+        self.mods = dict() # A dictionary of modules id -> {path, base, end, size}
+        self.bbs = set() # A set HashableDrcovBasicBlock
+
+    def _write_header(self):
+        header = ''
+        header += 'DRCOV VERSION: 2\n'
+        header += 'DRCOV FLAVOR: drcov-64\n'
+        header += 'Module Table: version 2, count %d\n' % len(self.mods)
+
+        #     DynamoRIO v7.0.0-RC1, table version 2:
+        #    Windows:
+        #      'Columns: id, base, end, entry, checksum, timestamp, path'
+        #    Mac/Linux:
+        #      'Columns: id, base, end, entry, path'
+        if platform.system() == 'Windows':
+            have_checksum = True
+        else:
+            have_checksum = False
+        
+        if have_checksum:
+            header += 'Columns: id, base, end, entry, checksum, timestamp, path\n'
+        else:
+            header += 'Columns: id, base, end, entry, path\n'
+
+        entries = []
+
+        # Sort the modules by ID in ascending order
+        sorted_modules = sorted(self.mods.items(), key=lambda x: x[0])
+
+        for m_id, m in sorted_modules:
+            # drcov: id, base, end, entry, checksum, timestamp, path
+            # drcov expects the size to be page aligned
+            # align the m['end'] to the next page
+            m['end'] = (m['end'] + 0xfff) & ~0xfff
+            if have_checksum:
+                entry = '%3d, %#016x, %#016x, %#016x, %#08x, %#08x, %s' % (
+                    m_id, m['base'], m['end'], 0, 0, 0, m['path'])
+            else:
+                entry = '%3d, %#016x, %#016x, %#016x, %s' % (
+                    m_id, m['base'], m['end'], 0, m['path'])
+
+            entries.append(entry)
+
+        header_modules = '\n'.join(entries)
+
+        self.file.write(("%s%s\n" % (header, header_modules)).encode("utf-8"))
+
+
+    def _write_bbs(self):
+        bb_header = b'BB Table: %d bbs\n' % len(self.bbs)
+        self.file.write(bb_header)
+
+        for bb in self.bbs:
+            # self.file.write(struct.pack("<IHH", bb["start"], bb["size"], bb["module_id"]))
+            self.file.write(bb)
+
+    def check_module_compatible(self, id, path, base, end):
+        if id in self.mods:
+            m = self.mods[id]
+            if m['path'] != path or m['base'] != base or m['end'] != end:
+                return False
+        return True
+            
+        self.mods[id] = {'path': path, 'base': base, 'end': end, 'size': end - base}
+    def add_module(self, id, path, base, end):
+        # Is there a module with this ID 
+        if id in self.mods:
+            m = self.mods[id]
+            # Check if the module has the same attributes
+            if m['path'] != path or m['base'] != base or m['end'] != end:
+                raise ValueError("Module with ID %d already exists with different attributes" % id)
+            else:
+                return
+        self.mods[id] = {'path': path, 'base': base, 'end': end, 'size': end - base}
+    
+    
+    # Add a basic block to the file
+    # Returns True if the basic block already exists
+    def add_bb(self, drcov_bb) -> bool:
+        hbb = HashableDrcovBasicBlock(drcov_bb)
+        if hbb.mod_id not in self.mods:
+            raise ValueError("Module ID %d not found" % hbb.mod_id)
+        if hbb in self.bbs:
+            if verbose:
+                print("Duplicate basic block found:", hbb)
+            return True
+        self.bbs.add(hbb)
+        return False
+    
+    def write(self):
+        if self.mods is None or len(self.mods) == 0:
+            raise ValueError("No modules to write")
+        
+        self.file = open(self.file_name, "wb")
+        self._write_header()
+        self._write_bbs()
+        self.file.close()
+
+def generate_merged_file_name(base_file, aggregate, base_dir=None):
+    if base_dir is None:
+        # Get the base file directory
+        base_dir = os.path.dirname(base_file)
+    if aggregate is None:
+        merged_name = "merged.drcov"
+    else:
+        # Get the creation time of the base file
+        creation_time = os.path.getctime(base_file)
+        # Convert the creation time to a string based on the aggregate
+        if aggregate == "s":
+            creation_time_str = time.strftime("%Y%m%d%H%M%S", time.gmtime(creation_time))
+        elif aggregate == "m":
+            creation_time_str = time.strftime("%Y%m%d%H%M", time.gmtime(creation_time))
+        elif aggregate == "h":
+            creation_time_str = time.strftime("%Y%m%d%H", time.gmtime(creation_time))
+        elif aggregate == "d":
+            creation_time_str = time.strftime("%Y%m%d", time.gmtime(creation_time))
+        else:
+            raise ValueError("Invalid aggregate value")
+        merged_name = "merged_" + creation_time_str + ".drcov"
+    return os.path.join(base_dir, merged_name)
+
+def create_merged_drcov_writer(base_file_name, aggregate, base_dir=None):
+    # Generate the output file name. 
+    output_file = generate_merged_file_name(base_file_name, aggregate, base_dir)
+    if verbose:
+        print("Output file:", output_file)
+    return DrcovFile(output_file)
+
+def merge_drcov(directory, aggregate, keep=False, output_directory=None, counters=False):
+    # Start measuring the time
+    start_time = time.time()
+
+    # List all files in the directory with .drcov extension, sorted by time, in ascending order
+    files = sorted(glob.glob(os.path.join(directory, "*.drcov")), key=os.path.getmtime)
+
+    if files is None or len(files) == 0:
+        print("No files to process")
+        return
+    
+    writer = create_merged_drcov_writer(files[0], aggregate, output_directory)
+    bb_counters = {}
+    modules = {}
+
+    def write_results():
+        # use the outer scope variables
+        nonlocal writer
+        nonlocal bb_counters
+        nonlocal modules
+        nonlocal counters
+        writer.write()
+        if counters:
+            with open(writer.file_name + ".json", "w") as f:
+                md = {"modules": modules, "bb_counters": bb_counters}
+                json.dump(md, f)
+        writer = create_merged_drcov_writer(file, aggregate, output_directory)
+        bb_counters = {}
+        modules = {}
+
+    print(f"Found {len(files)} files")
+    for file in tqdm.tqdm(files):
+        # Skip the files that start with merged
+        if os.path.basename(file).startswith("merged"):
+            continue
+        # Process each input file
+        if verbose:
+            print("Processing file:", file)
+
+        # should we start a new file?
+        if generate_merged_file_name(file, aggregate, output_directory) != writer.file_name:
+            if verbose:
+                print("Starting new file")
+            write_results()
+
+        try:
+            DrcovData = drcov.DrcovData(file)
+        except Exception as e:
+            print("Error processing file:", file)
+            print(e)
+            continue
+        if verbose:
+            print("# of modules:", len(DrcovData.modules))
+        if verbose:
+            print("# of basic blocks:", len(DrcovData.bbs))
+        # First check we have compatible modules
+        for _, mods in DrcovData.modules.items():
+            compatible = True
+            for m in mods:
+                if not writer.check_module_compatible(m.id, m.path, m.base, m.end):
+                    if verbose:
+                        print("Incompatible module found, starting new file")
+                    write_results()
+                    compatible = False
+                    break
+            if not compatible:
+                break
+
+        for _, mods in DrcovData.modules.items():
+            for m in mods:
+                writer.add_module(m.id, m.path, m.base, m.end)
+                modules[m.id] = {"path": m.path, "base": hex(m.base), "end": hex(m.end)}
+        for bb in DrcovData.bbs:
+            if verbose:
+                print(f"{hex(bb.start), hex(bb.size)}")
+            bb_exists = writer.add_bb(bb)  
+            if counters:
+                if not bb_exists:
+                    if bb.mod_id not in bb_counters:
+                        bb_counters[bb.mod_id] = {}
+                    if bb.start not in bb_counters[bb.mod_id]:
+                        bb_counters[bb.mod_id][hex(bb.start)] = 1
+                else:
+                    bb_counters[bb.mod_id][hex(bb.start)] += 1                 
+
+        if not keep:
+            os.remove(file)
+
+    write_results()
+    end_time = time.time()
+    print("Elapsed time:", end_time - start_time)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Utility to merge files in DrCov format")
+    parser.add_argument("-d", "--directory", type=str, help="Directory to process", default=".")
+    parser.add_argument("-od", "--output-directory", type=str, help="Output directory")
+    parser.add_argument("-a", "--aggregate", choices=["s", "m", "h", "d"], help="Aggregate per second|minute|hour|day")
+    parser.add_argument("-k", "--keep", action="store_true", help="Keep the original files")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    # Generate block counters for a merged file
+    parser.add_argument("-c", "--counters", action="store_true", help="Generate block counters for a merged file")
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    # Add a parser for the 'convert' command
+    convert_parser = subparsers.add_parser('convert')
+    convert_parser.add_argument("-i", "--input", required=True, help="Input drcov file")
+    convert_parser.add_argument("-o", "--output", required=True, help="Output drcov file")
+
+    args = parser.parse_args()
+
+    verbose = args.verbose
+    if args.command == "convert":
+        drcov_data = drcov.DrcovData(args.input)
+        writer = DrcovFile(args.output)
+        for _, mods in drcov_data.modules.items():
+            for m in mods:
+                writer.add_module(m.id, m.path, m.base, m.end)
+        for bb in drcov_data.bbs:
+            writer.add_bb(bb)                   
+
+        writer.write()
+    else:
+        merge_drcov(args.directory, args.aggregate, args.keep, args.output_directory, args.counters)


### PR DESCRIPTION
Currently, DrCovRuntime in Frida tracks new basic blocks translated and executed during target execution. While exporting the BBs in DrCov format is possible, each run will collect only new blocks relative to all previously executed ones. So, it is impossible to know what parts of the target were executed for each input/for the specific part of the fuzzing campaign.

This PR allows for collecting the precise (up to the hash collision) BBs executed during each run and saving them in DrCov format.

The collection is integrated into the CoverageRuntime. When the `save_dr_cov` is set (via the `save_bb_coverage` cmd parameter), the instrumentation changes slightly - it increments the BB counter in an additional map. No other changes are made to the instrumentation. The runtime builds a map of the coverage map indices to the BB attributes (start, size). At the post_exec stage, the map's content is dumped in DrCov format. As this [format](https://github.com/DynamoRIO/dynamorio/blob/fe065da323d2adb39b81412cc0cfde5afba03182/ext/drcovlib/drcovlib.h#L151) does not support counters, each BB is written to the output file only once. (*UPD*, it appears that the DrCov format [supports](https://github.com/DynamoRIO/dynamorio/blob/master/ext/drcovlib/drcovlib.c#L370) the same BB present multiple times to allow traces and such, so if there is a need, we can do it as well. However, we will not preserve the ordering of BBs as this will cause a tremendous slowdown or memory consumption growth.)

Writing to the disk after each run can slow the fuzzing down significantly. A new CLI parameter, `drcov_max_execution_cnt,` tells the runtime to accumulate the results for X executions before writing them to disk. 

A helper Python script is added in utils - it can merge multiple drcov files into one and produce a JSON file with counters of BB appearances in drcov files.   

The usage is demonstrated in fuzzers/frida_libpng and has been tested on Linux.

Standard map observers and feedbacks are still supported; no changes are required from the fuzzer's perspective except for initializing the CoverageRuntime with the specified parameters.

In my tests, the performance degradation due to the change in instrumentation for this mode was about 1% and did not seem statistically significant.

Comments and ideas are welcome.
