### PR TITLE
Implement CanTrack - tracking enforcement through rust types

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For bugs, feel free to open issues or contact us directly. Thank you for your su
 
 Even though we will gladly assist you in finishing up your PR, try to
 - keep all the crates compiling with *stable* rust (hide the eventual non-stable code under [`cfg`s](https://github.com/AFLplusplus/LibAFL/blob/main/libafl/build.rs#L26))
-- run `cargo fmt` on your code before pushing
+- run `cargo +nightly fmt` on your code before pushing
 - check the output of `cargo clippy --all` or `./clippy.sh`
 - run `cargo build --no-default-features` to check for `no_std` compatibility (and possibly add `#[cfg(feature = "std")]`) to hide parts of your code.
 

--- a/fuzzers/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby_fuzzer_grimoire/src/main.rs
@@ -15,7 +15,7 @@ use libafl::{
         GrimoireRandomDeleteMutator, GrimoireRecursiveReplacementMutator,
         GrimoireStringReplacementMutator, Tokens,
     },
-    observers::{StdMapObserver, TrackingHinted},
+    observers::{CanTrack, StdMapObserver},
     schedulers::QueueScheduler,
     stages::{mutational::StdMutationalStage, GeneralizationStage},
     state::StdState,

--- a/fuzzers/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby_fuzzer_grimoire/src/main.rs
@@ -83,7 +83,9 @@ pub fn main() {
     };
 
     // Create an observation channel using the signals map
-    let observer = unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS_PTR, SIGNALS.len()).track_novelties() };
+    let observer = unsafe {
+        StdMapObserver::from_mut_ptr("signals", SIGNALS_PTR, SIGNALS.len()).track_novelties()
+    };
     // Feedback to rate the interestingness of an input
     let mut feedback = MaxMapFeedback::new(&observer);
 

--- a/fuzzers/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby_fuzzer_grimoire/src/main.rs
@@ -15,7 +15,7 @@ use libafl::{
         GrimoireRandomDeleteMutator, GrimoireRecursiveReplacementMutator,
         GrimoireStringReplacementMutator, Tokens,
     },
-    observers::StdMapObserver,
+    observers::{StdMapObserver, TrackingHinted},
     schedulers::QueueScheduler,
     stages::{mutational::StdMutationalStage, GeneralizationStage},
     state::StdState,
@@ -83,9 +83,9 @@ pub fn main() {
     };
 
     // Create an observation channel using the signals map
-    let observer = unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS_PTR, SIGNALS.len()) };
+    let observer = unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS_PTR, SIGNALS.len()).track_novelties() };
     // Feedback to rate the interestingness of an input
-    let mut feedback = MaxMapFeedback::tracking(&observer, false, true);
+    let mut feedback = MaxMapFeedback::new(&observer);
 
     // A feedback to choose if an input is a solution or not
     let mut objective = CrashFeedback::new();

--- a/fuzzers/baby_fuzzer_swap_differential/Makefile.toml
+++ b/fuzzers/baby_fuzzer_swap_differential/Makefile.toml
@@ -19,6 +19,9 @@ command = "cargo"
 args = ["build" , "--profile", "${PROFILE}", "--bin", "${FUZZER_NAME}"]
 dependencies = [ "cc" ]
 
+[tasks.build]
+alias = "fuzzer"
+
 # Run the fuzzer
 [tasks.run]
 command = "${CARGO_TARGET_DIR}/${PROFILE_DIR}/${FUZZER_NAME}"

--- a/fuzzers/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
+++ b/fuzzers/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
@@ -54,7 +54,7 @@ pub fn main() {
 
     // Feedback to rate the interestingness of an input
     // This one is composed by two Feedbacks in OR
-    let mut feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let mut feedback = MaxMapFeedback::new(&edges_observer);
 
     // A feedback to choose if an input is a solution or not
     // We want to do the same crash deduplication that AFL does

--- a/fuzzers/forkserver_libafl_cc/src/main.rs
+++ b/fuzzers/forkserver_libafl_cc/src/main.rs
@@ -12,7 +12,7 @@ use libafl::{
     inputs::BytesInput,
     monitors::SimpleMonitor,
     mutators::{scheduled::havoc_mutations, tokens_mutations, StdScheduledMutator, Tokens},
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/fuzzers/forkserver_libafl_cc/src/main.rs
+++ b/fuzzers/forkserver_libafl_cc/src/main.rs
@@ -12,7 +12,7 @@ use libafl::{
     inputs::BytesInput,
     monitors::SimpleMonitor,
     mutators::{scheduled::havoc_mutations, tokens_mutations, StdScheduledMutator, Tokens},
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
@@ -101,8 +101,9 @@ pub fn main() {
     let shmem_buf = shmem.as_mut_slice();
 
     // Create an observation channel using the signals map
-    let edges_observer =
-        unsafe { HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)) };
+    let edges_observer = unsafe {
+        HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)).track_indices()
+    };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
@@ -111,7 +112,7 @@ pub fn main() {
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::tracking(&edges_observer, true, false),
+        MaxMapFeedback::new(&edges_observer),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );
@@ -151,7 +152,7 @@ pub fn main() {
     let mut mgr = SimpleEventManager::new(monitor);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -12,7 +12,7 @@ use libafl::{
     inputs::BytesInput,
     monitors::SimpleMonitor,
     mutators::{scheduled::havoc_mutations, tokens_mutations, StdScheduledMutator, Tokens},
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/fuzzers/forkserver_simple/src/main.rs
+++ b/fuzzers/forkserver_simple/src/main.rs
@@ -12,7 +12,7 @@ use libafl::{
     inputs::BytesInput,
     monitors::SimpleMonitor,
     mutators::{scheduled::havoc_mutations, tokens_mutations, StdScheduledMutator, Tokens},
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
@@ -101,8 +101,9 @@ pub fn main() {
     let shmem_buf = shmem.as_mut_slice();
 
     // Create an observation channel using the signals map
-    let edges_observer =
-        unsafe { HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)) };
+    let edges_observer = unsafe {
+        HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)).track_indices()
+    };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
@@ -111,7 +112,7 @@ pub fn main() {
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::tracking(&edges_observer, true, false),
+        MaxMapFeedback::new(&edges_observer),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );
@@ -151,7 +152,7 @@ pub fn main() {
     let mut mgr = SimpleEventManager::new(monitor);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/frida_executable_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_executable_libpng/src/fuzzer.rs
@@ -104,11 +104,7 @@ unsafe fn fuzz(
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
-<<<<<<< HEAD
-                let asan = AsanRuntime::new(options);
-=======
                 let asan = AsanRuntime::new(&options);
->>>>>>> dc36827a (moar porting)
 
                 #[cfg(unix)]
                 let mut frida_helper =
@@ -189,17 +185,9 @@ unsafe fn fuzz(
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
-<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
-=======
-                let observers = tuple_list!(
-                    edges_observer,
-                    time_observer,
-                    AsanErrorsObserver::new(&ASAN_ERRORS)
-                );
->>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer);
 
@@ -312,17 +300,9 @@ unsafe fn fuzz(
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
-<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
-=======
-                let observers = tuple_list!(
-                    edges_observer,
-                    time_observer,
-                    AsanErrorsObserver::new(&ASAN_ERRORS)
-                );
->>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer,);
 
@@ -450,17 +430,9 @@ unsafe fn fuzz(
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
-<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
-=======
-                let observers = tuple_list!(
-                    edges_observer,
-                    time_observer,
-                    AsanErrorsObserver::new(&ASAN_ERRORS)
-                );
->>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer,);
 

--- a/fuzzers/frida_executable_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_executable_libpng/src/fuzzer.rs
@@ -16,7 +16,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/frida_executable_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_executable_libpng/src/fuzzer.rs
@@ -16,7 +16,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -31,11 +31,6 @@ use libafl_bolts::{
     shmem::{ShMemProvider, StdShMemProvider},
     tuples::{tuple_list, Merge},
     AsSlice,
-};
-#[cfg(unix)]
-use libafl_frida::asan::{
-    asan_rt::AsanRuntime,
-    errors::{AsanErrorsFeedback, AsanErrorsObserver},
 };
 #[cfg(unix)]
 use libafl_frida::asan::{
@@ -109,7 +104,11 @@ unsafe fn fuzz(
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let asan = AsanRuntime::new(options);
+=======
+                let asan = AsanRuntime::new(&options);
+>>>>>>> dc36827a (moar porting)
 
                 #[cfg(unix)]
                 let mut frida_helper =
@@ -123,7 +122,8 @@ unsafe fn fuzz(
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -182,15 +182,24 @@ unsafe fn fuzz(
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
+=======
+                let observers = tuple_list!(
+                    edges_observer,
+                    time_observer,
+                    AsanErrorsObserver::new(&ASAN_ERRORS)
+                );
+>>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer);
 
@@ -238,7 +247,8 @@ unsafe fn fuzz(
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -295,15 +305,24 @@ unsafe fn fuzz(
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
+=======
+                let observers = tuple_list!(
+                    edges_observer,
+                    time_observer,
+                    AsanErrorsObserver::new(&ASAN_ERRORS)
+                );
+>>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer,);
 
@@ -366,7 +385,8 @@ unsafe fn fuzz(
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -423,15 +443,24 @@ unsafe fn fuzz(
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
+=======
+                let observers = tuple_list!(
+                    edges_observer,
+                    time_observer,
+                    AsanErrorsObserver::new(&ASAN_ERRORS)
+                );
+>>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer,);
 

--- a/fuzzers/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida_gdiplus/src/fuzzer.rs
@@ -26,7 +26,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -113,7 +113,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -122,7 +123,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::tracking(&edges_observer, true, false),
+                    MaxMapFeedback::new(&edges_observer),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -171,7 +172,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
@@ -227,7 +229,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -236,7 +239,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::tracking(&edges_observer, true, false),
+                    MaxMapFeedback::new(&edges_observer),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -284,7 +287,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
@@ -356,7 +360,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -365,7 +370,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 // This one is composed by two Feedbacks in OR
                 let mut feedback = feedback_or!(
                     // New maximization map feedback linked to the edges observer and the feedback state
-                    MaxMapFeedback::tracking(&edges_observer, true, false),
+                    MaxMapFeedback::new(&edges_observer),
                     // Time feedback, this one does not need a feedback state
                     TimeFeedback::with_observer(&time_observer)
                 );
@@ -413,7 +418,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida_gdiplus/src/fuzzer.rs
@@ -26,7 +26,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -16,7 +16,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -16,7 +16,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -31,11 +31,6 @@ use libafl_bolts::{
     shmem::{ShMemProvider, StdShMemProvider},
     tuples::{tuple_list, Merge},
     AsSlice,
-};
-#[cfg(unix)]
-use libafl_frida::asan::{
-    asan_rt::AsanRuntime,
-    errors::{AsanErrorsFeedback, AsanErrorsObserver},
 };
 #[cfg(unix)]
 use libafl_frida::asan::{
@@ -99,7 +94,11 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let asan = AsanRuntime::new(options);
+=======
+                let asan = AsanRuntime::new(&options);
+>>>>>>> dc36827a (moar porting)
 
                 #[cfg(unix)]
                 let mut frida_helper =
@@ -113,7 +112,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -172,15 +172,24 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
+=======
+                let observers = tuple_list!(
+                    edges_observer,
+                    time_observer,
+                    AsanErrorsObserver::new(&ASAN_ERRORS)
+                );
+>>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer);
 
@@ -229,7 +238,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -286,15 +296,24 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
+<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
+=======
+                let observers = tuple_list!(
+                    edges_observer,
+                    time_observer,
+                    AsanErrorsObserver::new(&ASAN_ERRORS)
+                );
+>>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer,);
 
@@ -357,7 +376,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                     "edges",
                     frida_helper.map_mut_ptr().unwrap(),
                     MAP_SIZE,
-                ));
+                ))
+                .track_indices();
 
                 // Create an observation channel to keep track of the execution time
                 let time_observer = TimeObserver::new("time");
@@ -414,7 +434,8 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mutator = StdScheduledMutator::new(havoc_mutations().merge(tokens_mutations()));
 
                 // A minimization+queue policy to get testcasess from the corpus
-                let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+                let scheduler =
+                    IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
                 // A fuzzer with feedbacks and a corpus scheduler
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida_libpng/src/fuzzer.rs
@@ -94,11 +94,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
                 let coverage = CoverageRuntime::new();
                 #[cfg(unix)]
-<<<<<<< HEAD
                 let asan = AsanRuntime::new(options);
-=======
-                let asan = AsanRuntime::new(&options);
->>>>>>> dc36827a (moar porting)
 
                 #[cfg(unix)]
                 let mut frida_helper =
@@ -179,17 +175,9 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
-<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
-=======
-                let observers = tuple_list!(
-                    edges_observer,
-                    time_observer,
-                    AsanErrorsObserver::new(&ASAN_ERRORS)
-                );
->>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer);
 
@@ -303,17 +291,9 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
                 let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
                 #[cfg(unix)]
-<<<<<<< HEAD
                 let observers = tuple_list!(edges_observer, time_observer, unsafe {
                     AsanErrorsObserver::from_static_asan_errors()
                 });
-=======
-                let observers = tuple_list!(
-                    edges_observer,
-                    time_observer,
-                    AsanErrorsObserver::new(&ASAN_ERRORS)
-                );
->>>>>>> dc36827a (moar porting)
                 #[cfg(windows)]
                 let observers = tuple_list!(edges_observer, time_observer,);
 

--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -28,7 +28,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -242,14 +242,15 @@ fn fuzz(
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+    let edges_observer =
+        HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") }).track_indices();
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -307,11 +308,10 @@ fn fuzz(
     let power = StdPowerMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::FAST),
-    ));
+        StdWeightedScheduler::with_schedule(&mut state, &edges_observer, Some(PowerSchedule::FAST)),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -28,7 +28,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/fuzzbench_ctx/src/lib.rs
@@ -31,7 +31,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -252,14 +252,15 @@ fn fuzz(
             "edges",
             OwnedMutSlice::from_raw_parts_mut(edges_map_mut_ptr(), EDGES_MAP_SIZE),
         )
-    });
+    })
+    .track_indices();
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -317,11 +318,10 @@ fn fuzz(
     let power = StdPowerMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::FAST),
-    ));
+        StdWeightedScheduler::with_schedule(&mut state, &edges_observer, Some(PowerSchedule::FAST)),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/fuzzbench_ctx/src/lib.rs
@@ -31,7 +31,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -26,7 +26,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{ConstMapObserver, HitcountsMapObserver, TimeObserver},
+    observers::{ConstMapObserver, HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, PowerQueueScheduler,
     },
@@ -242,6 +242,7 @@ fn fuzz(
             "edges",
             edges.as_mut_ptr(),
         ))
+        .track_indices()
     };
 
     // Create an observation channel to keep track of the execution time
@@ -299,11 +300,10 @@ fn fuzz(
     let power = StdPowerMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        PowerSchedule::FAST,
-    ));
+        PowerQueueScheduler::new(&mut state, &edges_observer, PowerSchedule::FAST),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -26,7 +26,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{ConstMapObserver, HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, ConstMapObserver, HitcountsMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, PowerQueueScheduler,
     },

--- a/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -250,7 +250,7 @@ fn fuzz(
     // Create an observation channel using cmplog map
     let cmplog_observer = unsafe { CmpLogObserver::with_map_ptr("cmplog", cmplog_map_ptr, true) };
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/fuzzbench_forkserver/src/main.rs
@@ -21,7 +21,9 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, StdCmpValuesObserver, StdMapObserver, TimeObserver},
+    observers::{
+        HitcountsMapObserver, StdCmpValuesObserver, StdMapObserver, TimeObserver, TrackingHinted,
+    },
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -248,13 +250,14 @@ fn fuzz(
     std::env::set_var("AFL_MAP_SIZE", format!("{}", MAP_SIZE));
 
     // Create an observation channel using the hitcounts map of AFL++
-    let edges_observer =
-        unsafe { HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)) };
+    let edges_observer = unsafe {
+        HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)).track_indices()
+    };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -300,11 +303,14 @@ fn fuzz(
     let power = StdPowerMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::EXPLORE),
-    ));
+        StdWeightedScheduler::with_schedule(
+            &mut state,
+            &edges_observer,
+            Some(PowerSchedule::EXPLORE),
+        ),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/fuzzbench_forkserver/src/main.rs
@@ -22,7 +22,7 @@ use libafl::{
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
     observers::{
-        HitcountsMapObserver, StdCmpValuesObserver, StdMapObserver, TimeObserver, TrackingHinted,
+        CanTrack, HitcountsMapObserver, StdCmpValuesObserver, StdMapObserver, TimeObserver,
     },
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,

--- a/fuzzers/fuzzbench_forkserver_cmplog/src/main.rs
+++ b/fuzzers/fuzzbench_forkserver_cmplog/src/main.rs
@@ -21,7 +21,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::AFLppRedQueen, tokens_mutations,
         StdMOptMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -251,13 +251,14 @@ fn fuzz(
     std::env::set_var("AFL_MAP_SIZE", format!("{MAP_SIZE}"));
 
     // Create an observation channel using the hitcounts map of AFL++
-    let edges_observer =
-        unsafe { HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)) };
+    let edges_observer = unsafe {
+        HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)).track_indices()
+    };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -303,11 +304,14 @@ fn fuzz(
     let power = StdPowerMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::EXPLORE),
-    ));
+        StdWeightedScheduler::with_schedule(
+            &mut state,
+            &edges_observer,
+            Some(PowerSchedule::EXPLORE),
+        ),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_forkserver_cmplog/src/main.rs
+++ b/fuzzers/fuzzbench_forkserver_cmplog/src/main.rs
@@ -21,7 +21,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::AFLppRedQueen, tokens_mutations,
         StdMOptMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -53,6 +53,7 @@ use libafl_qemu::{
     elf::EasyElf,
     filter_qemu_args,
     hooks::QemuHooks,
+    Emulator,
     GuestReg,
     //snapshot::QemuSnapshotHelper,
     MmapPerms,
@@ -267,7 +268,7 @@ fn fuzz(
     // Create an observation channel using cmplog map
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench_qemu/src/fuzzer.rs
@@ -25,7 +25,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver, VariableMapObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, PowerQueueScheduler,
     },

--- a/fuzzers/fuzzbench_text/src/lib.rs
+++ b/fuzzers/fuzzbench_text/src/lib.rs
@@ -34,7 +34,7 @@ use libafl::{
         token_mutations::I2SRandReplace,
         tokens_mutations, StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -310,14 +310,15 @@ fn fuzz_binary(
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+    let edges_observer =
+        HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") }).track_indices();
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -374,11 +375,14 @@ fn fuzz_binary(
     let power = StdPowerMutationalStage::new(mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::EXPLORE),
-    ));
+        StdWeightedScheduler::with_schedule(
+            &mut state,
+            &edges_observer,
+            Some(PowerSchedule::EXPLORE),
+        ),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
@@ -516,7 +520,9 @@ fn fuzz_text(
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+    let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") })
+        .track_indices()
+        .track_novelties();
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
@@ -524,7 +530,7 @@ fn fuzz_text(
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
     // New maximization map feedback linked to the edges observer and the feedback state
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, true);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -594,11 +600,14 @@ fn fuzz_text(
     let grimoire = StdMutationalStage::transforming(grimoire_mutator);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::EXPLORE),
-    ));
+        StdWeightedScheduler::with_schedule(
+            &mut state,
+            &edges_observer,
+            Some(PowerSchedule::EXPLORE),
+        ),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/fuzzbench_text/src/lib.rs
+++ b/fuzzers/fuzzbench_text/src/lib.rs
@@ -34,7 +34,7 @@ use libafl::{
         token_mutations::I2SRandReplace,
         tokens_mutations, StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/libafl_atheris/src/lib.rs
+++ b/fuzzers/libafl_atheris/src/lib.rs
@@ -25,7 +25,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{StdMutationalStage, TracingStage},
     state::{HasCorpus, StdState},
@@ -136,7 +136,8 @@ pub extern "C" fn LLVMFuzzerRunDriver(
         let edges_observer = HitcountsMapObserver::new(StdMapObserver::from_mut_slice(
             "edges",
             edges.into_iter().next().unwrap(),
-        ));
+        ))
+        .track_indices();
 
         // Create an observation channel to keep track of the execution time
         let time_observer = TimeObserver::new("time");
@@ -148,7 +149,7 @@ pub extern "C" fn LLVMFuzzerRunDriver(
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, false),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );
@@ -183,7 +184,8 @@ pub extern "C" fn LLVMFuzzerRunDriver(
         }
 
         // A minimization+queue policy to get testcasess from the corpus
-        let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+        let scheduler =
+            IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libafl_atheris/src/lib.rs
+++ b/fuzzers/libafl_atheris/src/lib.rs
@@ -25,7 +25,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{StdMutationalStage, TracingStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -85,6 +85,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
             EDGES_MAP.as_mut_ptr(),
             MAX_EDGES_NUM,
         ))
+        .track_indices()
     };
 
     // Create an observation channel to keep track of the execution time
@@ -147,11 +148,10 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut stages = tuple_list!(calibration, power);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::FAST),
-    ));
+        StdWeightedScheduler::with_schedule(&mut state, &edges_observer, Some(PowerSchedule::FAST)),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -1,9 +1,5 @@
 //! A libfuzzer-like fuzzer with llmp-multithreading support and restarts
 //! The example harness is built for libpng.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 #[cfg(feature = "crash")]
 use std::ptr;
@@ -37,6 +33,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// The main fn, `no_mangle` as it is a C main
 #[cfg(not(test))]
@@ -90,7 +90,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng/src/lib.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
@@ -2,10 +2,6 @@
 //! The example harness is built for libpng.
 //! In this example, you will see the use of the `launcher` feature.
 //! The `launcher` will spawn new processes for each cpu core.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 use std::{env, net::SocketAddr, path::PathBuf};
 
@@ -40,6 +36,10 @@ use libafl_bolts::{
 use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, ACCOUNTING_MEMOP_MAP, EDGES_MAP, MAX_EDGES_NUM,
 };
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// Parse a millis string to a [`Duration`]. Used for arg parsing.
 fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
@@ -55,11 +55,11 @@ fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
 )]
 struct Opt {
     #[arg(
-        short,
-        long,
-        value_parser = Cores::from_cmdline,
-        help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
-        name = "CORES"
+    short,
+    long,
+    value_parser = Cores::from_cmdline,
+    help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
+    name = "CORES"
     )]
     cores: Cores,
 
@@ -94,12 +94,12 @@ struct Opt {
     output: PathBuf,
 
     #[arg(
-        value_parser = timeout_from_millis_str,
-        short,
-        long,
-        help = "Set the execution timeout in milliseconds, default is 10000",
-        name = "TIMEOUT",
-        default_value = "10000"
+    value_parser = timeout_from_millis_str,
+    short,
+    long,
+    help = "Set the execution timeout in milliseconds, default is 10000",
+    name = "TIMEOUT",
+    default_value = "10000"
     )]
     timeout: Duration,
     /*
@@ -149,7 +149,7 @@ pub extern "C" fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, false),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_accounting/src/lib.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{CoverageAccountingScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_libpng_aflpp_ui/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_aflpp_ui/src/lib.rs
@@ -1,9 +1,5 @@
 //! A libfuzzer-like fuzzer with llmp-multithreading support and restarts
 //! The example harness is built for libpng.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 #[cfg(feature = "crash")]
 use std::ptr;
@@ -37,6 +33,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// The main fn, `no_mangle` as it is a C main
 #[cfg(not(test))]
@@ -104,7 +104,7 @@ fn fuzz(
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libfuzzer_libpng_aflpp_ui/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_aflpp_ui/src/lib.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/libfuzzer_libpng_centralized/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_centralized/src/lib.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
@@ -138,7 +138,8 @@ pub extern "C" fn libafl_main() {
 
     let mut run_client = |state: Option<_>, mut mgr, _core_id: CoreId| {
         // Create an observation channel using the coverage map
-        let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+        let edges_observer =
+            HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") }).track_indices();
 
         // Create an observation channel to keep track of the execution time
         let time_observer = TimeObserver::new("time");
@@ -192,7 +193,8 @@ pub extern "C" fn libafl_main() {
         let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
         // A minimization+queue policy to get testcasess from the corpus
-        let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+        let scheduler =
+            IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_libpng_centralized/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_centralized/src/lib.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_libpng_centralized/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_centralized/src/lib.rs
@@ -2,10 +2,6 @@
 //! The example harness is built for libpng.
 //! In this example, you will see the use of the `launcher` feature.
 //! The `launcher` will spawn new processes for each cpu core.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 use std::{env, net::SocketAddr, path::PathBuf};
 
@@ -38,6 +34,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// Parse a millis string to a [`Duration`]. Used for arg parsing.
 fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
@@ -53,11 +53,11 @@ fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
 )]
 struct Opt {
     #[arg(
-        short,
-        long,
-        value_parser = Cores::from_cmdline,
-        help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
-        name = "CORES"
+    short,
+    long,
+    value_parser = Cores::from_cmdline,
+    help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
+    name = "CORES"
     )]
     cores: Cores,
 
@@ -92,12 +92,12 @@ struct Opt {
     output: PathBuf,
 
     #[arg(
-        value_parser = timeout_from_millis_str,
-        short,
-        long,
-        help = "Set the exeucution timeout in milliseconds, default is 10000",
-        name = "TIMEOUT",
-        default_value = "10000"
+    value_parser = timeout_from_millis_str,
+    short,
+    long,
+    help = "Set the exeucution timeout in milliseconds, default is 10000",
+    name = "TIMEOUT",
+    default_value = "10000"
     )]
     timeout: Duration,
     /*
@@ -147,7 +147,7 @@ pub extern "C" fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, false),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng_cmin/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_cmin/src/lib.rs
@@ -1,9 +1,5 @@
 //! A libfuzzer-like fuzzer with llmp-multithreading support and restarts
 //! The example harness is built for libpng.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 #[cfg(feature = "crash")]
 use std::ptr;
@@ -40,6 +36,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// The main fn, `no_mangle` as it is a C main
 #[cfg(not(test))]
@@ -89,7 +89,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libfuzzer_libpng_cmin/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_cmin/src/lib.rs
@@ -21,7 +21,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -2,10 +2,6 @@
 //! The example harness is built for libpng.
 //! In this example, you will see the use of the `launcher` feature.
 //! The `launcher` will spawn new processes for each cpu core.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 use std::{env, net::SocketAddr, path::PathBuf};
 
@@ -38,6 +34,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// Parse a millis string to a [`Duration`]. Used for arg parsing.
 fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
@@ -53,11 +53,11 @@ fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
 )]
 struct Opt {
     #[arg(
-        short,
-        long,
-        value_parser = Cores::from_cmdline,
-        help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
-        name = "CORES"
+    short,
+    long,
+    value_parser = Cores::from_cmdline,
+    help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
+    name = "CORES"
     )]
     cores: Cores,
 
@@ -92,12 +92,12 @@ struct Opt {
     output: PathBuf,
 
     #[arg(
-        value_parser = timeout_from_millis_str,
-        short,
-        long,
-        help = "Set the exeucution timeout in milliseconds, default is 10000",
-        name = "TIMEOUT",
-        default_value = "10000"
+    value_parser = timeout_from_millis_str,
+    short,
+    long,
+    help = "Set the exeucution timeout in milliseconds, default is 10000",
+    name = "TIMEOUT",
+    default_value = "10000"
     )]
     timeout: Duration,
     /*
@@ -148,7 +148,7 @@ pub extern "C" fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, false),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_launcher/src/lib.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_libpng_norestart/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_norestart/src/lib.rs
@@ -6,6 +6,7 @@
 use core::time::Duration;
 use std::{env, net::SocketAddr, path::PathBuf};
 
+use clap::Parser;
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::{
@@ -22,7 +23,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
@@ -163,7 +164,8 @@ pub extern "C" fn libafl_main() {
                           mut restarting_mgr: LlmpRestartingEventManager<_, _, _>,
                           core_id| {
         // Create an observation channel using the coverage map
-        let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+        let edges_observer =
+            HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") }).track_indices();
 
         // Create an observation channel to keep track of the execution time
         let time_observer = TimeObserver::new("time");
@@ -217,7 +219,8 @@ pub extern "C" fn libafl_main() {
         let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 
         // A minimization+queue policy to get testcasess from the corpus
-        let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+        let scheduler =
+            IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_libpng_norestart/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_norestart/src/lib.rs
@@ -2,14 +2,10 @@
 //! The example harness is built for libpng.
 //! In this example, you will see the use of the `launcher` feature.
 //! The `launcher` will spawn new processes for each cpu core.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
 
 use core::time::Duration;
 use std::{env, net::SocketAddr, path::PathBuf};
 
-use clap::Parser;
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::{
@@ -41,6 +37,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// Parse a millis string to a [`Duration`]. Used for arg parsing.
 fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
@@ -56,11 +56,11 @@ fn timeout_from_millis_str(time: &str) -> Result<Duration, Error> {
 )]
 struct Opt {
     #[arg(
-        short,
-        long,
-        value_parser = Cores::from_cmdline,
-        help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
-        name = "CORES"
+    short,
+    long,
+    value_parser = Cores::from_cmdline,
+    help = "Spawn a client in each of the provided cores. Broker runs in the 0th core. 'all' to select all available cores. 'none' to run a client without binding to any core. eg: '1,2-4,6' selects the cores 1,2,3,4,6.",
+    name = "CORES"
     )]
     cores: Cores,
 
@@ -95,12 +95,12 @@ struct Opt {
     output: PathBuf,
 
     #[arg(
-        value_parser = timeout_from_millis_str,
-        short,
-        long,
-        help = "Set the exeucution timeout in milliseconds, default is 10000",
-        name = "TIMEOUT",
-        default_value = "10000"
+    value_parser = timeout_from_millis_str,
+    short,
+    long,
+    help = "Set the exeucution timeout in milliseconds, default is 10000",
+    name = "TIMEOUT",
+    default_value = "10000"
     )]
     timeout: Duration,
 
@@ -172,7 +172,7 @@ pub extern "C" fn libafl_main() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, false),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/libfuzzer_libpng_norestart/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_norestart/src/lib.rs
@@ -23,7 +23,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_libpng_tcp_manager/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_tcp_manager/src/lib.rs
@@ -1,9 +1,5 @@
 //! A libfuzzer-like fuzzer with llmp-multithreading support and restarts
 //! The example harness is built for libpng.
-use mimalloc::MiMalloc;
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-
 use core::time::Duration;
 #[cfg(feature = "crash")]
 use std::ptr;
@@ -37,6 +33,10 @@ use libafl_bolts::{
     AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_NUM};
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 /// The main fn, `no_mangle` as it is a C main
 #[no_mangle]
@@ -88,7 +88,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 

--- a/fuzzers/libfuzzer_libpng_tcp_manager/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_tcp_manager/src/lib.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/libfuzzer_libpng_tcp_manager/src/lib.rs
+++ b/fuzzers/libfuzzer_libpng_tcp_manager/src/lib.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -83,6 +83,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
             EDGES_MAP.as_mut_ptr(),
             MAX_EDGES_NUM,
         ))
+        .track_indices()
     };
 
     // Create an observation channel to keep track of the execution time
@@ -145,11 +146,10 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut stages = tuple_list!(calibration, power);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::FAST),
-    ));
+        StdWeightedScheduler::with_schedule(&mut state, &edges_observer, Some(PowerSchedule::FAST)),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -68,7 +68,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = unsafe { std_edges_map_observer("edges").with_index_tracking() };
+    let edges_observer = unsafe { std_edges_map_observer("edges").track_indices() };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -68,7 +68,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = unsafe { std_edges_map_observer("edges").with_tracking::<true, false>() };
+    let edges_observer = unsafe { std_edges_map_observer("edges").with_index_tracking() };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, StdScheduledMutator},
         token_mutations::I2SRandReplace,
     },
-    observers::{TimeObserver, TrackingHint},
+    observers::{TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, StdScheduledMutator},
         token_mutations::I2SRandReplace,
     },
-    observers::TimeObserver,
+    observers::{TimeObserver, TrackingHint},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -68,7 +68,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = unsafe { std_edges_map_observer("edges") };
+    let edges_observer = unsafe { std_edges_map_observer("edges").with_tracking::<true, false>() };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
@@ -79,7 +79,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // This one is composed by two Feedbacks in OR
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
-        MaxMapFeedback::tracking(&edges_observer, true, false),
+        MaxMapFeedback::new(&edges_observer),
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );
@@ -109,7 +109,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     println!("We're a client, let's fuzz :)");
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image/src/main.rs
@@ -19,7 +19,7 @@ use libafl::{
         scheduled::{havoc_mutations, StdScheduledMutator},
         token_mutations::I2SRandReplace,
     },
-    observers::{TimeObserver, TrackingHinted},
+    observers::{CanTrack, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -28,7 +28,7 @@ use libafl::{
             serialization_format::{DEFAULT_ENV_NAME, DEFAULT_SIZE},
             ConcolicObserver,
         },
-        TimeObserver, TrackingHinted,
+        TimeObserver, CanTrack,
     },
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -1,12 +1,18 @@
 //! A libfuzzer-like fuzzer with llmp-multithreading support and restarts
 //! The example harness is built for `stb_image`.
+use std::{
+    env, fs,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+
 use clap::{self, Parser};
 use libafl::{
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
-    Error,
-    events::{EventConfig, setup_restarting_mgr_std},
+    events::{setup_restarting_mgr_std, EventConfig},
     executors::{
-        command::CommandConfigurator, ExitKind, inprocess::InProcessExecutor, ShadowExecutor,
+        command::CommandConfigurator, inprocess::InProcessExecutor, ExitKind, ShadowExecutor,
     },
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
@@ -19,8 +25,8 @@ use libafl::{
     },
     observers::{
         concolic::{
-            ConcolicObserver,
             serialization_format::{DEFAULT_ENV_NAME, DEFAULT_SIZE},
+            ConcolicObserver,
         },
         TimeObserver,
     },
@@ -30,25 +36,19 @@ use libafl::{
         StdMutationalStage, TracingStage,
     },
     state::{HasCorpus, StdState},
+    Error,
 };
 use libafl_bolts::{
-    AsMutSlice,
-    AsSlice,
     current_nanos,
-    Named,
-    rands::StdRand, shmem::{ShMem, ShMemProvider, StdShMemProvider}, tuples::tuple_list,
+    rands::StdRand,
+    shmem::{ShMem, ShMemProvider, StdShMemProvider},
+    tuples::tuple_list,
+    AsMutSlice, AsSlice, Named,
 };
 use libafl_targets::{
-    CmpLogObserver, libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer,
+    libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer, CmpLogObserver,
 };
 use mimalloc::MiMalloc;
-use std::{
-    env,
-    path::PathBuf,
-    process::{Child, Command, Stdio},
-    time::Duration,
-};
-use std::fs;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -77,7 +77,7 @@ pub fn main() {
         1337,
         opt.concolic,
     )
-        .expect("An error occurred while fuzzing");
+    .expect("An error occurred while fuzzing");
 }
 
 /// The actual fuzzer
@@ -141,7 +141,7 @@ fn fuzz(
             // Same for objective feedbacks
             &mut objective,
         )
-            .unwrap()
+        .unwrap()
     });
 
     println!("We're a client, let's fuzz :)");

--- a/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -28,7 +28,7 @@ use libafl::{
             serialization_format::{DEFAULT_ENV_NAME, DEFAULT_SIZE},
             ConcolicObserver,
         },
-        TimeObserver,
+        TimeObserver, TrackingHinted,
     },
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{
@@ -106,7 +106,7 @@ fn fuzz(
 
     // Create an observation channel using the coverage map
     // We don't use the hitcounts (see the Cargo.toml, we use pcguard_edges)
-    let edges_observer = unsafe { std_edges_map_observer("edges") };
+    let edges_observer = unsafe { std_edges_map_observer("edges").track_indices() };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
@@ -147,7 +147,7 @@ fn fuzz(
     println!("We're a client, let's fuzz :)");
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_windows_asan/src/lib.rs
+++ b/fuzzers/libfuzzer_windows_asan/src/lib.rs
@@ -11,7 +11,7 @@ use libafl::{
     inputs::{BytesInput, HasTargetBytes},
     monitors::MultiMonitor,
     mutators::scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -61,12 +61,13 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
         };
 
     // Create an observation channel using the coverage map
-    let edges_observer = unsafe { HitcountsMapObserver::new(std_edges_map_observer("edges")) };
+    let edges_observer =
+        unsafe { HitcountsMapObserver::new(std_edges_map_observer("edges")).track_indices() };
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -112,11 +113,10 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut stages = tuple_list!(calibration, power);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = IndexesLenTimeMinimizerScheduler::new(StdWeightedScheduler::with_schedule(
-        &mut state,
+    let scheduler = IndexesLenTimeMinimizerScheduler::new(
         &edges_observer,
-        Some(PowerSchedule::FAST),
-    ));
+        StdWeightedScheduler::with_schedule(&mut state, &edges_observer, Some(PowerSchedule::FAST)),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/libfuzzer_windows_asan/src/lib.rs
+++ b/fuzzers/libfuzzer_windows_asan/src/lib.rs
@@ -11,7 +11,7 @@ use libafl::{
     inputs::{BytesInput, HasTargetBytes},
     monitors::MultiMonitor,
     mutators::scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },

--- a/fuzzers/qemu_cmin/src/fuzzer.rs
+++ b/fuzzers/qemu_cmin/src/fuzzer.rs
@@ -30,6 +30,7 @@ use libafl_bolts::{
 use libafl_qemu::{
     edges::{QemuEdgeCoverageChildHelper, EDGES_MAP_PTR, EDGES_MAP_SIZE},
     elf::EasyElf,
+    emu::Emulator,
     ArchExtras, CallingConvention, GuestAddr, GuestReg, MmapPerms, Qemu, QemuExitReason,
     QemuExitReasonError, QemuForkExecutor, QemuHooks, QemuShutdownCause, Regs,
 };
@@ -63,10 +64,10 @@ impl From<Version> for Str {
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 #[command(
-    name = format!("qemu_cmin-{}",env!("CPU_TARGET")),
-    version = Version::default(),
-    about,
-    long_about = "Tool for generating minimizing corpus using QEMU instrumentation"
+name = format ! ("qemu_cmin-{}", env ! ("CPU_TARGET")),
+version = Version::default(),
+about,
+long_about = "Tool for generating minimizing corpus using QEMU instrumentation"
 )]
 pub struct FuzzerOptions {
     #[arg(long, help = "Output directory")]
@@ -171,7 +172,7 @@ pub fn fuzz() -> Result<(), Error> {
         ))
     };
 
-    let mut feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let mut feedback = MaxMapFeedback::new(&edges_observer);
 
     #[allow(clippy::let_unit_value)]
     let mut objective = ();

--- a/fuzzers/qemu_launcher/src/instance.rs
+++ b/fuzzers/qemu_launcher/src/instance.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver, VariableMapObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, PowerQueueScheduler,
     },

--- a/fuzzers/qemu_systemmode/src/fuzzer_breakpoint.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer_breakpoint.rs
@@ -13,7 +13,7 @@ use libafl::{
     inputs::BytesInput,
     monitors::MultiMonitor,
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
-    observers::{HitcountsMapObserver, TimeObserver, VariableMapObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{CalibrationStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -157,6 +157,7 @@ pub fn fuzz() {
                 edges_map_mut_slice(),
                 addr_of_mut!(MAX_EDGES_NUM),
             ))
+            .track_indices()
         };
 
         // Create an observation channel to keep track of the execution time
@@ -166,7 +167,7 @@ pub fn fuzz() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, true),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );
@@ -194,7 +195,8 @@ pub fn fuzz() {
         });
 
         // A minimization+queue policy to get testcasess from the corpus
-        let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+        let scheduler =
+            IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
@@ -206,7 +208,7 @@ pub fn fuzz() {
 
         // Setup an havoc mutator with a mutational stage
         let mutator = StdScheduledMutator::new(havoc_mutations());
-        let calibration_feedback = MaxMapFeedback::tracking(&edges_observer, true, true);
+        let calibration_feedback = MaxMapFeedback::new(&edges_observer);
         let mut stages = tuple_list!(
             StdMutationalStage::new(mutator),
             CalibrationStage::new(&calibration_feedback)

--- a/fuzzers/qemu_systemmode/src/fuzzer_classic.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer_classic.rs
@@ -13,7 +13,7 @@ use libafl::{
     inputs::{BytesInput, HasTargetBytes},
     monitors::MultiMonitor,
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
-    observers::{HitcountsMapObserver, TimeObserver, VariableMapObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::StdMutationalStage,
     state::{HasCorpus, StdState},
@@ -164,6 +164,7 @@ pub fn fuzz() {
                 edges_map_mut_slice(),
                 addr_of_mut!(MAX_EDGES_NUM),
             ))
+            .track_indices()
         };
 
         // Create an observation channel to keep track of the execution time
@@ -201,7 +202,8 @@ pub fn fuzz() {
         });
 
         // A minimization+queue policy to get testcasess from the corpus
-        let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+        let scheduler =
+            IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/qemu_systemmode/src/fuzzer_classic.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer_classic.rs
@@ -173,7 +173,7 @@ pub fn fuzz() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, true),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );

--- a/fuzzers/qemu_systemmode/src/fuzzer_sync_exit.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer_sync_exit.rs
@@ -13,7 +13,7 @@ use libafl::{
     inputs::BytesInput,
     monitors::MultiMonitor,
     mutators::scheduled::{havoc_mutations, StdScheduledMutator},
-    observers::{HitcountsMapObserver, TimeObserver, VariableMapObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{CalibrationStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -98,6 +98,7 @@ pub fn fuzz() {
                 edges_map_mut_slice(),
                 addr_of_mut!(MAX_EDGES_NUM),
             ))
+            .track_indices()
         };
 
         // Create an observation channel to keep track of the execution time
@@ -107,7 +108,7 @@ pub fn fuzz() {
         // This one is composed by two Feedbacks in OR
         let mut feedback = feedback_or!(
             // New maximization map feedback linked to the edges observer and the feedback state
-            MaxMapFeedback::tracking(&edges_observer, true, true),
+            MaxMapFeedback::new(&edges_observer),
             // Time feedback, this one does not need a feedback state
             TimeFeedback::with_observer(&time_observer)
         );
@@ -135,7 +136,8 @@ pub fn fuzz() {
         });
 
         // A minimization+queue policy to get testcasess from the corpus
-        let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+        let scheduler =
+            IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
         // A fuzzer with feedbacks and a corpus scheduler
         let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
@@ -147,7 +149,7 @@ pub fn fuzz() {
 
         // Setup an havoc mutator with a mutational stage
         let mutator = StdScheduledMutator::new(havoc_mutations());
-        let calibration_feedback = MaxMapFeedback::tracking(&edges_observer, true, true);
+        let calibration_feedback = MaxMapFeedback::new(&edges_observer);
         let mut stages = tuple_list!(
             StdMutationalStage::new(mutator),
             CalibrationStage::new(&calibration_feedback)

--- a/fuzzers/tutorial/src/lib.rs
+++ b/fuzzers/tutorial/src/lib.rs
@@ -15,7 +15,7 @@ use libafl::{
     fuzzer::StdFuzzer,
     inputs::HasTargetBytes,
     monitors::MultiMonitor,
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{powersched::PowerSchedule, PowerQueueScheduler},
     stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage},
     state::{HasCorpus, StdState},
@@ -81,12 +81,13 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
         };
 
     // Create an observation channel using the coverage map
-    let edges_observer = HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+    let edges_observer =
+        HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") }).track_indices();
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
 
     let calibration = CalibrationStage::new(&map_feedback);
 
@@ -132,11 +133,10 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut stages = tuple_list!(calibration, power);
 
     // A minimization+queue policy to get testcasess from the corpus
-    let scheduler = PacketLenMinimizerScheduler::new(PowerQueueScheduler::new(
-        &mut state,
+    let scheduler = PacketLenMinimizerScheduler::new(
         &edges_observer,
-        PowerSchedule::FAST,
-    ));
+        PowerQueueScheduler::new(&mut state, &edges_observer, PowerSchedule::FAST),
+    );
 
     // A fuzzer with feedbacks and a corpus scheduler
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/fuzzers/tutorial/src/lib.rs
+++ b/fuzzers/tutorial/src/lib.rs
@@ -15,7 +15,7 @@ use libafl::{
     fuzzer::StdFuzzer,
     inputs::HasTargetBytes,
     monitors::MultiMonitor,
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{powersched::PowerSchedule, PowerQueueScheduler},
     stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage},
     state::{HasCorpus, StdState},

--- a/fuzzers/tutorial/src/metadata.rs
+++ b/fuzzers/tutorial/src/metadata.rs
@@ -32,8 +32,8 @@ where
     }
 }
 
-pub type PacketLenMinimizerScheduler<CS> =
-    MinimizerScheduler<CS, PacketLenTestcaseScore, MapIndexesMetadata>;
+pub type PacketLenMinimizerScheduler<CS, O> =
+    MinimizerScheduler<CS, PacketLenTestcaseScore, MapIndexesMetadata, O>;
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct PacketLenFeedback {

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -45,7 +45,7 @@ errors_backtrace = ["libafl_bolts/errors_backtrace"]
 corpus_btreemap = []
 
 ## Enables gzip compression in certain parts of the lib
-gzip = ["libafl_bolts/gzip"] 
+gzip = ["libafl_bolts/gzip"]
 
 ## If set, will use the `fork()` syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on `Windows`).
 fork = ["libafl_bolts/derive"]
@@ -133,7 +133,7 @@ agpl = ["nautilus"]
 nautilus = ["grammartec", "std", "serde_json/std"]
 
 [build-dependencies]
-reqwest = { version = "0.11", features = ["blocking"], optional = true}
+reqwest = { version = "0.11", features = ["blocking"], optional = true }
 rustversion = "1.0"
 zip = { version = "0.6", optional = true }
 
@@ -148,15 +148,15 @@ libafl_derive = { version = "0.11.2", path = "../libafl_derive", optional = true
 
 rustversion = "1.0"
 tuple_list = { version = "0.1.3" }
-hashbrown =  { version = "0.14", features = ["serde", "ahash"], default-features=false } # A faster hashmap, nostd compatible
+hashbrown = { version = "0.14", features = ["serde", "ahash"], default-features = false } # A faster hashmap, nostd compatible
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] } # serialization lib
 postcard = { version = "1.0", features = ["alloc"], default-features = false } # no_std compatible serde serialization format
-bincode = {version = "1.3", optional = true }
+bincode = { version = "1.3", optional = true }
 c2rust-bitfields = { version = "0.18", features = ["no_std"] }
-ahash = { version = "0.8", default-features=false } # The hash function already used in hashbrown
+ahash = { version = "0.8", default-features = false } # The hash function already used in hashbrown
 meminterval = { version = "0.4", features = ["serde"] }
-backtrace = {version = "0.3", optional = true} # Used to get the stacktrace in StacktraceObserver
+backtrace = { version = "0.3", optional = true } # Used to get the stacktrace in StacktraceObserver
 typed-builder = { version = "0.16", optional = true } # Implement the builder pattern at compiletime
 
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
@@ -167,7 +167,7 @@ libm = "0.2.2"
 ratatui = { version = "0.23.0", default-features = false, features = ['crossterm'], optional = true } # Commandline rendering, for TUI Monitor
 crossterm = { version = "0.27.0", optional = true }
 
-prometheus-client = { version= "0.21", optional = true} # For the prometheus monitor
+prometheus-client = { version = "0.21", optional = true } # For the prometheus monitor
 tide = { version = "0.16.0", optional = true }
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 futures = { version = "0.3.24", optional = true }
@@ -185,6 +185,9 @@ libcasr = { version = "2.7", optional = true }
 bitvec = { version = "1.0", optional = true, features = ["serde"] } # used for string range storage
 
 arrayvec = { version = "0.7.4", optional = true, default-features = false } # used for fixed-len collects
+
+const_format = "0.2.32" # used for providing helpful compiler output
+const_panic = "0.2.8" # similarly, for formatting const panic output
 
 # optional-dev deps (change when target.'cfg(accessible(::std))'.test-dependencies will be stable)
 serial_test = { version = "2", optional = true, default-features = false, features = ["logging"] }

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -49,32 +49,25 @@ where
 ///
 /// Algorithm based on WMOPT: <https://hexhive.epfl.ch/publications/files/21ISSTA2.pdf>
 #[derive(Debug)]
-pub struct MapCorpusMinimizer<E, O, T, TS>
-where
-    E: UsesState,
-    E::State: HasCorpus + HasMetadata,
-    TS: TestcaseScore<E::State>,
-{
+pub struct MapCorpusMinimizer<E, O, T, TS, A> {
     obs_name: String,
-    phantom: PhantomData<(E, O, T, TS)>,
+    phantom: PhantomData<(E, O, T, TS, A)>,
 }
 
 /// Standard corpus minimizer, which weights inputs by length and time.
-pub type StdCorpusMinimizer<E, O, T> =
-    MapCorpusMinimizer<E, O, T, LenTimeMulTestcaseScore<<E as UsesState>::State>>;
+pub type StdCorpusMinimizer<E, O, T, A> =
+    MapCorpusMinimizer<E, O, T, LenTimeMulTestcaseScore<<E as UsesState>::State>, A>;
 
-impl<E, O, T, TS> MapCorpusMinimizer<E, O, T, TS>
+impl<E, O, T, TS, A> MapCorpusMinimizer<E, O, T, TS, A>
 where
     E: UsesState,
     E::State: HasCorpus + HasMetadata,
     TS: TestcaseScore<E::State>,
+    A: Named,
 {
     /// Constructs a new `MapCorpusMinimizer` from a provided observer. This observer will be used
     /// in the future to get observed maps from an executed input.
-    pub fn new(obs: &O) -> Self
-    where
-        O: Named,
-    {
+    pub fn new(obs: &A) -> Self {
         Self {
             obs_name: obs.name().to_string(),
             phantom: PhantomData,
@@ -82,10 +75,11 @@ where
     }
 }
 
-impl<E, O, T, TS> CorpusMinimizer<E> for MapCorpusMinimizer<E, O, T, TS>
+impl<E, O, T, TS, A> CorpusMinimizer<E> for MapCorpusMinimizer<E, O, T, TS, A>
 where
     E: UsesState,
     for<'a> O: MapObserver<Entry = T> + AsIter<'a, Item = T>,
+    A: AsRef<O>,
     E::State: HasMetadata + HasCorpus + HasExecutions,
     T: Copy + Hash + Eq,
     TS: TestcaseScore<E::State>,
@@ -165,10 +159,11 @@ where
             )?;
 
             let seed_expr = Bool::fresh_const(&ctx, "seed");
-            let obs: &O = executor
+            let obs = executor
                 .observers()
-                .match_name::<O>(&self.obs_name)
-                .expect("Observer must be present.");
+                .match_name::<A>(&self.obs_name)
+                .expect("Observer must be present.")
+                .as_ref();
 
             // Store coverage, mapping coverage map indices to hit counts (if present) and the
             // associated seeds for the map indices with those hit counts.

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -49,16 +49,16 @@ where
 ///
 /// Algorithm based on WMOPT: <https://hexhive.epfl.ch/publications/files/21ISSTA2.pdf>
 #[derive(Debug)]
-pub struct MapCorpusMinimizer<E, O, T, TS, A> {
+pub struct MapCorpusMinimizer<A, E, O, T, TS> {
     obs_name: String,
-    phantom: PhantomData<(E, O, T, TS, A)>,
+    phantom: PhantomData<(A, E, O, T, TS)>,
 }
 
 /// Standard corpus minimizer, which weights inputs by length and time.
-pub type StdCorpusMinimizer<E, O, T, A> =
-    MapCorpusMinimizer<E, O, T, LenTimeMulTestcaseScore<<E as UsesState>::State>, A>;
+pub type StdCorpusMinimizer<A, E, O, T> =
+    MapCorpusMinimizer<A, E, O, T, LenTimeMulTestcaseScore<<E as UsesState>::State>>;
 
-impl<E, O, T, TS, A> MapCorpusMinimizer<E, O, T, TS, A>
+impl<A, E, O, T, TS> MapCorpusMinimizer<A, E, O, T, TS>
 where
     E: UsesState,
     E::State: HasCorpus + HasMetadata,
@@ -75,7 +75,7 @@ where
     }
 }
 
-impl<E, O, T, TS, A> CorpusMinimizer<E> for MapCorpusMinimizer<E, O, T, TS, A>
+impl<A, E, O, T, TS> CorpusMinimizer<E> for MapCorpusMinimizer<A, E, O, T, TS>
 where
     E: UsesState,
     for<'a> O: MapObserver<Entry = T> + AsIter<'a, Item = T>,

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -67,7 +67,7 @@ where
 {
     /// Constructs a new `MapCorpusMinimizer` from a provided observer. This observer will be used
     /// in the future to get observed maps from an executed input.
-    pub fn new(obs: &A) -> Self {
+    pub fn new(obs: &C) -> Self {
         Self {
             obs_name: obs.name().to_string(),
             phantom: PhantomData,

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -49,21 +49,21 @@ where
 ///
 /// Algorithm based on WMOPT: <https://hexhive.epfl.ch/publications/files/21ISSTA2.pdf>
 #[derive(Debug)]
-pub struct MapCorpusMinimizer<A, E, O, T, TS> {
+pub struct MapCorpusMinimizer<C, E, O, T, TS> {
     obs_name: String,
-    phantom: PhantomData<(A, E, O, T, TS)>,
+    phantom: PhantomData<(C, E, O, T, TS)>,
 }
 
 /// Standard corpus minimizer, which weights inputs by length and time.
-pub type StdCorpusMinimizer<A, E, O, T> =
-    MapCorpusMinimizer<A, E, O, T, LenTimeMulTestcaseScore<<E as UsesState>::State>>;
+pub type StdCorpusMinimizer<C, E, O, T> =
+    MapCorpusMinimizer<C, E, O, T, LenTimeMulTestcaseScore<<E as UsesState>::State>>;
 
-impl<A, E, O, T, TS> MapCorpusMinimizer<A, E, O, T, TS>
+impl<C, E, O, T, TS> MapCorpusMinimizer<C, E, O, T, TS>
 where
     E: UsesState,
     E::State: HasCorpus + HasMetadata,
     TS: TestcaseScore<E::State>,
-    A: Named,
+    C: Named,
 {
     /// Constructs a new `MapCorpusMinimizer` from a provided observer. This observer will be used
     /// in the future to get observed maps from an executed input.
@@ -75,11 +75,11 @@ where
     }
 }
 
-impl<A, E, O, T, TS> CorpusMinimizer<E> for MapCorpusMinimizer<A, E, O, T, TS>
+impl<C, E, O, T, TS> CorpusMinimizer<E> for MapCorpusMinimizer<C, E, O, T, TS>
 where
     E: UsesState,
     for<'a> O: MapObserver<Entry = T> + AsIter<'a, Item = T>,
-    A: AsRef<O>,
+    C: AsRef<O>,
     E::State: HasMetadata + HasCorpus + HasExecutions,
     T: Copy + Hash + Eq,
     TS: TestcaseScore<E::State>,
@@ -161,7 +161,7 @@ where
             let seed_expr = Bool::fresh_const(&ctx, "seed");
             let obs = executor
                 .observers()
-                .match_name::<A>(&self.obs_name)
+                .match_name::<C>(&self.obs_name)
                 .expect("Observer must be present.")
                 .as_ref();
 

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -1499,7 +1499,7 @@ where
 }
 
 /// A manager-like llmp client that converts between input types
-pub struct LlmpEventConverter<IC, ICB, DI, S, SP>
+pub struct LlmpEventConverter<DI, IC, ICB, S, SP>
 where
     S: UsesInput,
     SP: ShMemProvider + 'static,
@@ -1517,7 +1517,7 @@ where
     phantom: PhantomData<S>,
 }
 
-impl<IC, ICB, DI, S, SP> core::fmt::Debug for LlmpEventConverter<IC, ICB, DI, S, SP>
+impl<DI, IC, ICB, S, SP> core::fmt::Debug for LlmpEventConverter<DI, IC, ICB, S, SP>
 where
     SP: ShMemProvider + 'static,
     S: UsesInput,
@@ -1539,7 +1539,7 @@ where
     }
 }
 
-impl<IC, ICB, DI, S, SP> LlmpEventConverter<IC, ICB, DI, S, SP>
+impl<DI, IC, ICB, S, SP> LlmpEventConverter<DI, IC, ICB, S, SP>
 where
     S: UsesInput + HasExecutions + HasMetadata,
     SP: ShMemProvider + 'static,
@@ -1734,7 +1734,7 @@ where
     }
 }
 
-impl<IC, ICB, DI, S, SP> UsesState for LlmpEventConverter<IC, ICB, DI, S, SP>
+impl<DI, IC, ICB, S, SP> UsesState for LlmpEventConverter<DI, IC, ICB, S, SP>
 where
     S: State,
     SP: ShMemProvider,
@@ -1745,7 +1745,7 @@ where
     type State = S;
 }
 
-impl<IC, ICB, DI, S, SP> EventFirer for LlmpEventConverter<IC, ICB, DI, S, SP>
+impl<DI, IC, ICB, S, SP> EventFirer for LlmpEventConverter<DI, IC, ICB, S, SP>
 where
     S: State,
     SP: ShMemProvider,

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -973,7 +973,7 @@ mod tests {
                 executions: _,
                 forward_id: _,
             } => {
-                let o: tuple_list_type!(StdMapObserver::<u32, false>) =
+                let o: tuple_list_type!(StdMapObserver::<u32, false, false, false>) =
                     postcard::from_bytes(observers_buf.as_ref().unwrap()).unwrap();
                 assert_eq!("test", o.0.name());
             }

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -973,7 +973,7 @@ mod tests {
                 executions: _,
                 forward_id: _,
             } => {
-                let o: tuple_list_type!(StdMapObserver::<u32, false, false, false>) =
+                let o: tuple_list_type!(StdMapObserver::<u32, false>) =
                     postcard::from_bytes(observers_buf.as_ref().unwrap()).unwrap();
                 assert_eq!("test", o.0.name());
             }

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -636,13 +636,14 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
 
     /// Builds `ForkserverExecutor` downsizing the coverage map to fit exaclty the AFL++ map size.
     #[allow(clippy::pedantic)]
-    pub fn build_dynamic_map<MO, OT, S>(
+    pub fn build_dynamic_map<MO, OT, S, A>(
         &mut self,
-        mut map_observer: MO,
+        mut map_observer: A,
         other_observers: OT,
-    ) -> Result<ForkserverExecutor<(MO, OT), S, SP>, Error>
+    ) -> Result<ForkserverExecutor<(A, OT), S, SP>, Error>
     where
-        MO: Observer<S> + MapObserver + Truncate, // TODO maybe enforce Entry = u8 for the cov map
+        MO: MapObserver + Truncate, // TODO maybe enforce Entry = u8 for the cov map
+        A: Observer<S> + AsRef<MO> + AsMut<MO>,
         OT: ObserversTuple<S> + Prepend<MO, PreprendResult = OT>,
         S: UsesInput,
         S::Input: Input + HasTargetBytes,
@@ -660,10 +661,10 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
         );
 
         if let Some(dynamic_map_size) = self.map_size {
-            map_observer.truncate(dynamic_map_size);
+            map_observer.as_mut().truncate(dynamic_map_size);
         }
 
-        let observers: (MO, OT) = other_observers.prepend(map_observer);
+        let observers = (map_observer, other_observers);
 
         if self.uses_shmem_testcase && map.is_none() {
             return Err(Error::illegal_state(

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -636,7 +636,7 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
 
     /// Builds `ForkserverExecutor` downsizing the coverage map to fit exaclty the AFL++ map size.
     #[allow(clippy::pedantic)]
-    pub fn build_dynamic_map<MO, OT, S, A>(
+    pub fn build_dynamic_map<A, MO, OT, S>(
         &mut self,
         mut map_observer: A,
         other_observers: OT,

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -23,7 +23,7 @@ use crate::{
     feedbacks::{Feedback, HasObserverName},
     inputs::UsesInput,
     monitors::{AggregatorOps, UserStats, UserStatsValue},
-    observers::{MapObserver, Observer, ObserversTuple, UsesObserver},
+    observers::{MapObserver, Observer, ObserversTuple, TrackingHinted UsesObserver},
     state::State,
     Error, HasMetadata, HasNamedMetadata,
 };
@@ -377,8 +377,6 @@ where
 /// The most common AFL-like feedback type
 #[derive(Clone, Debug)]
 pub struct MapFeedback<N, O, R, S, T> {
-    /// Indexes used in the last observation
-    indexes: bool,
     /// New indexes observed in the last observation
     novelties: Option<Vec<usize>>,
     /// Name identifier of this instance
@@ -402,7 +400,7 @@ where
 impl<N, O, R, S, T> Feedback<S> for MapFeedback<N, O, R, S, T>
 where
     N: IsNovel<T>,
-    O: MapObserver<Entry = T> + for<'it> AsIter<'it, Item = T>,
+    O: MapObserver<Entry = T> + for<'it> AsIter<'it, Item = T> + TrackingHinted,
     R: Reducer<T>,
     S: State + HasNamedMetadata,
     T: Default + Copy + Serialize + for<'de> Deserialize<'de> + PartialEq + Debug + 'static,
@@ -473,7 +471,7 @@ where
         }
 
         let history_map = map_state.history_map.as_mut_slice();
-        if self.indexes {
+        if O::INDICES {
             let mut indices = Vec::new();
 
             for (i, value) in observer
@@ -542,7 +540,7 @@ where
 #[rustversion::nightly]
 impl<O, S> Feedback<S> for MapFeedback<DifferentIsNovel, O, MaxReducer, S, u8>
 where
-    O: MapObserver<Entry = u8> + AsSlice<Entry = u8>,
+    O: MapObserver<Entry = u8> + AsSlice<Entry = u8> + TrackingHinted,
     for<'it> O: AsIter<'it, Item = u8>,
     S: State + HasNamedMetadata,
 {
@@ -686,7 +684,7 @@ impl<N, O, R, S, T> MapFeedback<N, O, R, S, T>
 where
     T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
     R: Reducer<T>,
-    O: MapObserver<Entry = T>,
+    O: MapObserver<Entry = T> + TrackingHinted,
     for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     S: UsesInput + HasNamedMetadata,
@@ -695,21 +693,7 @@ where
     #[must_use]
     pub fn new(map_observer: &O) -> Self {
         Self {
-            indexes: false,
-            novelties: None,
-            name: map_observer.name().to_string(),
-            observer_name: map_observer.name().to_string(),
-            stats_name: create_stats_name(map_observer.name()),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Create new `MapFeedback` specifying if it must track indexes of used entries and/or novelties
-    #[must_use]
-    pub fn tracking(map_observer: &O, track_indexes: bool, track_novelties: bool) -> Self {
-        Self {
-            indexes: track_indexes,
-            novelties: if track_novelties { Some(vec![]) } else { None },
+            novelties: if O::NOVELTIES { Some(vec![]) } else { None },
             name: map_observer.name().to_string(),
             observer_name: map_observer.name().to_string(),
             stats_name: create_stats_name(map_observer.name()),
@@ -721,8 +705,7 @@ where
     #[must_use]
     pub fn with_names(name: &'static str, observer_name: &'static str) -> Self {
         Self {
-            indexes: false,
-            novelties: None,
+            novelties: if O::NOVELTIES { Some(vec![]) } else { None },
             name: name.to_string(),
             observer_name: observer_name.to_string(),
             stats_name: create_stats_name(name),
@@ -736,29 +719,10 @@ where
     #[must_use]
     pub fn with_name(name: &'static str, map_observer: &O) -> Self {
         Self {
-            indexes: false,
-            novelties: None,
+            novelties: if O::NOVELTIES { Some(vec![]) } else { None },
             name: name.to_string(),
             observer_name: map_observer.name().to_string(),
             stats_name: create_stats_name(name),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Create new `MapFeedback` specifying if it must track indexes of used entries and/or novelties
-    #[must_use]
-    pub fn with_names_tracking(
-        name: &'static str,
-        observer_name: &'static str,
-        track_indexes: bool,
-        track_novelties: bool,
-    ) -> Self {
-        Self {
-            indexes: track_indexes,
-            novelties: if track_novelties { Some(vec![]) } else { None },
-            observer_name: observer_name.to_string(),
-            stats_name: create_stats_name(name),
-            name: name.to_string(),
             phantom: PhantomData,
         }
     }

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -28,7 +28,7 @@ use crate::{
     Error, HasMetadata, HasNamedMetadata,
 };
 
-/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from [`HitcountsMapObserver`].
+/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[crate::observers::HitcountsMapObserver].
 pub type AflMapFeedback<C, O, S, T> = MapFeedback<C, DifferentIsNovel, O, OrReducer, S, T>;
 
 /// A [`MapFeedback`] that strives to maximize the map contents.

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -23,7 +23,7 @@ use crate::{
     feedbacks::{Feedback, HasObserverName},
     inputs::UsesInput,
     monitors::{AggregatorOps, UserStats, UserStatsValue},
-    observers::{MapObserver, Observer, ObserversTuple, TrackingHinted UsesObserver},
+    observers::{MapObserver, Observer, ObserversTuple, TrackingHinted, UsesObserver},
     state::State,
     Error, HasMetadata, HasNamedMetadata,
 };
@@ -393,7 +393,6 @@ pub struct MapFeedback<N, O, R, S, T, A> {
 impl<N, O, R, S, T, A> UsesObserver<S> for MapFeedback<N, O, R, S, T, A>
 where
     S: UsesInput,
-    O: Observer<S>,
     A: AsRef<O> + Observer<S>,
 {
     type Observer = A;
@@ -673,12 +672,8 @@ impl<N, O, R, S, T, A> Named for MapFeedback<N, O, R, S, T, A> {
 
 impl<N, O, R, S, T, A> HasObserverName for MapFeedback<N, O, R, S, T, A>
 where
-    T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
-    R: Reducer<T>,
-    N: IsNovel<T>,
-    O: MapObserver<Entry = T>,
-    for<'it> O: AsIter<'it, Item = T>,
-    S: HasNamedMetadata,
+    O: Named,
+    A: AsRef<O>,
 {
     #[inline]
     fn observer_name(&self) -> &str {

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -23,12 +23,12 @@ use crate::{
     feedbacks::{Feedback, HasObserverName},
     inputs::UsesInput,
     monitors::{AggregatorOps, UserStats, UserStatsValue},
-    observers::{MapObserver, Observer, ObserversTuple, TrackingHinted, UsesObserver},
+    observers::{CanTrack, MapObserver, Observer, ObserversTuple, UsesObserver},
     state::State,
-    Error, HasMetadata, HasNamedMetadata,
+    Error, HasMetadata, HasNamedMetadata, 
 };
 
-/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from ``HitcountsMapObserver``.
+/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from [`HitcountsMapObserver`].
 pub type AflMapFeedback<O, S, T, A> = MapFeedback<DifferentIsNovel, O, OrReducer, S, T, A>;
 
 /// A [`MapFeedback`] that strives to maximize the map contents.
@@ -411,7 +411,7 @@ where
     R: Reducer<T>,
     S: State + HasNamedMetadata,
     T: Default + Copy + Serialize + for<'de> Deserialize<'de> + PartialEq + Debug + 'static,
-    A: AsRef<O> + TrackingHinted,
+    A: AsRef<O> + CanTrack,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
         // Initialize `MapFeedbackMetadata` with an empty vector and add it to the state.
@@ -554,7 +554,7 @@ where
     O: MapObserver<Entry = u8> + AsSlice<Entry = u8>,
     for<'it> O: AsIter<'it, Item = u8>,
     S: State + HasNamedMetadata,
-    A: AsRef<O> + TrackingHinted,
+    A: AsRef<O> + CanTrack,
 {
     #[allow(clippy::wrong_self_convention)]
     #[allow(clippy::needless_range_loop)]
@@ -699,7 +699,7 @@ where
     for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     S: UsesInput + HasNamedMetadata,
-    A: AsRef<O> + TrackingHinted,
+    A: AsRef<O> + CanTrack,
 {
     /// Create new `MapFeedback`
     #[must_use]

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -28,7 +28,7 @@ use crate::{
     Error, HasMetadata, HasNamedMetadata,
 };
 
-/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[crate::observers::HitcountsMapObserver].
+/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
 pub type AflMapFeedback<C, O, S, T> = MapFeedback<C, DifferentIsNovel, O, OrReducer, S, T>;
 
 /// A [`MapFeedback`] that strives to maximize the map contents.

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -175,6 +175,7 @@ fn saturating_next_power_of_two<T: PrimInt>(n: T) -> T {
 /// Consider as novelty if the reduced value is different from the old value.
 #[derive(Clone, Debug)]
 pub struct DifferentIsNovel {}
+
 impl<T> IsNovel<T> for DifferentIsNovel
 where
     T: PartialEq + Default + Copy + 'static,
@@ -188,6 +189,7 @@ where
 /// Only consider as novel the values which are at least the next pow2 class of the old value
 #[derive(Clone, Debug)]
 pub struct NextPow2IsNovel {}
+
 impl<T> IsNovel<T> for NextPow2IsNovel
 where
     T: PrimInt + Default + Copy + 'static,
@@ -208,6 +210,7 @@ where
 /// Only consider `T::one()` or `T::max_value()`, if they are bigger than the old value, as novel
 #[derive(Clone, Debug)]
 pub struct OneOrFilledIsNovel {}
+
 impl<T> IsNovel<T> for OneOrFilledIsNovel
 where
     T: PrimInt + Default + Copy + 'static,
@@ -240,6 +243,7 @@ impl AsSlice for MapIndexesMetadata {
         self.list.as_slice()
     }
 }
+
 impl AsMutSlice for MapIndexesMetadata {
     type Entry = usize;
     /// Convert to a slice
@@ -287,6 +291,7 @@ impl AsSlice for MapNoveltiesMetadata {
         self.list.as_slice()
     }
 }
+
 impl AsMutSlice for MapNoveltiesMetadata {
     type Entry = usize;
     /// Convert to a slice
@@ -295,6 +300,7 @@ impl AsMutSlice for MapNoveltiesMetadata {
         self.list.as_mut_slice()
     }
 }
+
 impl MapNoveltiesMetadata {
     /// Creates a new [`struct@MapNoveltiesMetadata`]
     #[must_use]
@@ -740,7 +746,10 @@ where
     {
         let mut interesting = false;
         // TODO Replace with match_name_type when stable
-        let observer = observers.match_name::<O>(&self.observer_name).unwrap();
+        let observer = observers
+            .match_name::<A>(&self.observer_name)
+            .unwrap()
+            .as_ref();
 
         let map_state = state
             .named_metadata_map_mut()

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -25,7 +25,7 @@ use crate::{
     monitors::{AggregatorOps, UserStats, UserStatsValue},
     observers::{CanTrack, MapObserver, Observer, ObserversTuple, UsesObserver},
     state::State,
-    Error, HasMetadata, HasNamedMetadata, 
+    Error, HasMetadata, HasNamedMetadata,
 };
 
 /// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from [`HitcountsMapObserver`].

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -411,7 +411,7 @@ where
     R: Reducer<T>,
     S: State + HasNamedMetadata,
     T: Default + Copy + Serialize + for<'de> Deserialize<'de> + PartialEq + Debug + 'static,
-    C: AsRef<O> + CanTrack,
+    C: CanTrack + AsRef<O>,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
         // Initialize `MapFeedbackMetadata` with an empty vector and add it to the state.
@@ -554,7 +554,7 @@ where
     O: MapObserver<Entry = u8> + AsSlice<Entry = u8>,
     for<'it> O: AsIter<'it, Item = u8>,
     S: State + HasNamedMetadata,
-    C: AsRef<O> + CanTrack,
+    C: CanTrack + AsRef<O>,
 {
     #[allow(clippy::wrong_self_convention)]
     #[allow(clippy::needless_range_loop)]
@@ -699,7 +699,7 @@ where
     for<'it> O: AsIter<'it, Item = T>,
     N: IsNovel<T>,
     S: UsesInput + HasNamedMetadata,
-    C: AsRef<O> + CanTrack,
+    C: CanTrack + AsRef<O>,
 {
     /// Create new `MapFeedback`
     #[must_use]

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -29,23 +29,23 @@ use crate::{
 };
 
 /// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from [`HitcountsMapObserver`].
-pub type AflMapFeedback<O, S, T, A> = MapFeedback<DifferentIsNovel, O, OrReducer, S, T, A>;
+pub type AflMapFeedback<A, O, S, T> = MapFeedback<A, DifferentIsNovel, O, OrReducer, S, T>;
 
 /// A [`MapFeedback`] that strives to maximize the map contents.
-pub type MaxMapFeedback<O, S, T, A> = MapFeedback<DifferentIsNovel, O, MaxReducer, S, T, A>;
+pub type MaxMapFeedback<A, O, S, T> = MapFeedback<A, DifferentIsNovel, O, MaxReducer, S, T>;
 /// A [`MapFeedback`] that strives to minimize the map contents.
-pub type MinMapFeedback<O, S, T, A> = MapFeedback<DifferentIsNovel, O, MinReducer, S, T, A>;
+pub type MinMapFeedback<A, O, S, T> = MapFeedback<A, DifferentIsNovel, O, MinReducer, S, T>;
 
 /// A [`MapFeedback`] that always returns `true` for `is_interesting`. Useful for tracing all executions.
-pub type AlwaysInterestingMapFeedback<O, S, T, A> = MapFeedback<AllIsNovel, O, NopReducer, S, T, A>;
+pub type AlwaysInterestingMapFeedback<A, O, S, T> = MapFeedback<A, AllIsNovel, O, NopReducer, S, T>;
 
 /// A [`MapFeedback`] that strives to maximize the map contents,
 /// but only, if a value is larger than `pow2` of the previous.
-pub type MaxMapPow2Feedback<O, S, T, A> = MapFeedback<NextPow2IsNovel, O, MaxReducer, S, T, A>;
+pub type MaxMapPow2Feedback<A, O, S, T> = MapFeedback<A, NextPow2IsNovel, O, MaxReducer, S, T>;
 /// A [`MapFeedback`] that strives to maximize the map contents,
 /// but only, if a value is larger than `pow2` of the previous.
-pub type MaxMapOneOrFilledFeedback<O, S, T, A> =
-    MapFeedback<OneOrFilledIsNovel, O, MaxReducer, S, T, A>;
+pub type MaxMapOneOrFilledFeedback<A, O, S, T> =
+    MapFeedback<A, OneOrFilledIsNovel, O, MaxReducer, S, T>;
 
 /// A `Reducer` function is used to aggregate values for the novelty search
 pub trait Reducer<T>: 'static
@@ -383,7 +383,7 @@ where
 
 /// The most common AFL-like feedback type
 #[derive(Clone, Debug)]
-pub struct MapFeedback<N, O, R, S, T, A> {
+pub struct MapFeedback<A, N, O, R, S, T> {
     /// New indexes observed in the last observation
     novelties: Option<Vec<usize>>,
     /// Name identifier of this instance
@@ -393,10 +393,10 @@ pub struct MapFeedback<N, O, R, S, T, A> {
     /// Name of the feedback as shown in the `UserStats`
     stats_name: String,
     /// Phantom Data of Reducer
-    phantom: PhantomData<(N, O, R, S, T, A)>,
+    phantom: PhantomData<(A, N, O, R, S, T)>,
 }
 
-impl<N, O, R, S, T, A> UsesObserver<S> for MapFeedback<N, O, R, S, T, A>
+impl<A, N, O, R, S, T> UsesObserver<S> for MapFeedback<A, N, O, R, S, T>
 where
     S: UsesInput,
     A: AsRef<O> + Observer<S>,
@@ -404,7 +404,7 @@ where
     type Observer = A;
 }
 
-impl<N, O, R, S, T, A> Feedback<S> for MapFeedback<N, O, R, S, T, A>
+impl<A, N, O, R, S, T> Feedback<S> for MapFeedback<A, N, O, R, S, T>
 where
     N: IsNovel<T>,
     O: MapObserver<Entry = T> + for<'it> AsIter<'it, Item = T>,
@@ -549,7 +549,7 @@ where
 
 /// Specialize for the common coverage map size, maximization of u8s
 #[rustversion::nightly]
-impl<O, S, A> Feedback<S> for MapFeedback<DifferentIsNovel, O, MaxReducer, S, u8, A>
+impl<A, O, S> Feedback<S> for MapFeedback<A, DifferentIsNovel, O, MaxReducer, S, u8>
 where
     O: MapObserver<Entry = u8> + AsSlice<Entry = u8>,
     for<'it> O: AsIter<'it, Item = u8>,
@@ -669,14 +669,14 @@ where
     }
 }
 
-impl<N, O, R, S, T, A> Named for MapFeedback<N, O, R, S, T, A> {
+impl<A, N, O, R, S, T> Named for MapFeedback<A, N, O, R, S, T> {
     #[inline]
     fn name(&self) -> &str {
         self.name.as_str()
     }
 }
 
-impl<N, O, R, S, T, A> HasObserverName for MapFeedback<N, O, R, S, T, A>
+impl<A, N, O, R, S, T> HasObserverName for MapFeedback<A, N, O, R, S, T>
 where
     O: Named,
     A: AsRef<O>,
@@ -691,7 +691,7 @@ fn create_stats_name(name: &str) -> String {
     name.to_lowercase()
 }
 
-impl<N, O, R, S, T, A> MapFeedback<N, O, R, S, T, A>
+impl<A, N, O, R, S, T> MapFeedback<A, N, O, R, S, T>
 where
     T: PartialEq + Default + Copy + 'static + Serialize + DeserializeOwned + Debug,
     R: Reducer<T>,

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -100,7 +100,7 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// use libafl::schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler};
 /// # use libafl::state::StdState;
 /// # use libafl_bolts::serdeany::RegistryBuilder;
-///
+/// #
 /// # #[cfg(any(not(feature = "serdeany_autoreg"), miri))]
 /// # unsafe { MapFeedbackMetadata::<u8>::register() }
 ///
@@ -167,7 +167,7 @@ pub mod macros {
     /// # struct MyCustomScheduler<O> {
     /// #     phantom: PhantomData<O>,
     /// # }
-    ///
+    /// #
     /// impl<O> MyCustomScheduler<O> where O: TrackingHinted {
     ///     pub fn new() -> Self {
     ///         require_index_tracking!("MyCustomScheduler", O);
@@ -218,7 +218,7 @@ pub mod macros {
     /// # struct MyCustomScheduler<O> {
     /// #     phantom: PhantomData<O>,
     /// # }
-    ///
+    /// #
     /// impl<O> MyCustomScheduler<O> where O: TrackingHinted {
     ///     pub fn new() -> Self {
     ///         require_novelties_tracking!("MyCustomScheduler", O);

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -142,100 +142,111 @@ pub trait TrackingHinted {
     ) -> Self::Output<NEW_INDICES, NEW_NOVELTIES>;
 }
 
-/// Use in the constructor of your component which requires index tracking of a [`MapObserver`]. See
-/// [`TrackingHinted`] for details.
-///
-/// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
-/// tracking, use this in your constructor:
-/// ```
-/// # use libafl::observers::TrackingHinted;
-/// # use libafl::require_index_tracking;
-/// #
-/// # struct MyCustomScheduler<O> {
-/// #     phantom: PhantomData<O>,
-/// # }
-///
-/// impl<O> MyCustomScheduler where O: TrackingHinted {
-///     pub fn new() -> Self {
-///         require_index_tracking!("MyCustomScheduler", O);
-///         todo!("Construct your type")
-///     }
-/// }
-/// ```
-#[macro_export]
-macro_rules! require_index_tracking {
-    ($name: literal, $obs: ident) => {
-        struct SanityCheck<O: TrackingHinted> {
-            phantom: PhantomData<O>,
-        }
+/// Module which holds the necessary functions and types for map-relevant macros, namely
+/// [`crate::require_index_tracking`] and [`crate::require_novelties_tracking`].
+pub mod macros {
+    pub use const_format::str_repeat;
+    pub use const_panic::{concat_panic, FmtArg};
 
-        impl<O: TrackingHinted> SanityCheck<O> {
-            const TRACKING_SANITY: () = {
-                const LINE_OFFSET: usize = line!().ilog10() as usize + 2;
-                const SPACING: &str = const_format::str_repeat!(" ", LINE_OFFSET);
-                if !O::INDICES {
-                    const_panic::concat_panic!(const_panic::FmtArg::DISPLAY; "\n",
-                        SPACING, "|\n",
-                        SPACING, "= note: index tracking is required by ", $name, "\n",
-                        SPACING, "= note: see the documentation of TrackingHinted for details\n",
-                        SPACING, "|\n",
-                        SPACING, "= hint: call `.with_tracking::<true, ...>()` on the provided observer\n",
-                        SPACING, "|\n",
-                        SPACING, "| ",
-                    );
-                }
-            };
-        }
-        let _: () = SanityCheck::<$obs>::TRACKING_SANITY; // check that tracking is enabled for this map
-    };
-}
+    /// Use in the constructor of your component which requires index tracking of a [`MapObserver`]. See
+    /// [`TrackingHinted`] for details.
+    ///
+    /// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
+    /// tracking, use this in your constructor:
+    /// ```
+    /// # use libafl::observers::TrackingHinted;
+    /// # use libafl::require_index_tracking;
+    /// #
+    /// # struct MyCustomScheduler<O> {
+    /// #     phantom: PhantomData<O>,
+    /// # }
+    ///
+    /// impl<O> MyCustomScheduler where O: TrackingHinted {
+    ///     pub fn new() -> Self {
+    ///         require_index_tracking!("MyCustomScheduler", O);
+    ///         todo!("Construct your type")
+    ///     }
+    /// }
+    /// ```
+    #[macro_export]
+    macro_rules! require_index_tracking {
+        ($name: literal, $obs: ident) => {
+            struct SanityCheck<O: $crate::observers::TrackingHinted> {
+                phantom: ::core::marker::PhantomData<O>,
+            }
 
-/// Use in the constructor of your component which requires novelties tracking of a [`MapObserver`].
-/// See [`TrackingHinted`] for details on the concept.
-///
-/// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
-/// tracking, use this in your constructor:
-/// ```
-/// # use libafl::observers::TrackingHinted;
-/// # use libafl::require_novelties_tracking;
-/// #
-/// # struct MyCustomScheduler<O> {
-/// #     phantom: PhantomData<O>,
-/// # }
-///
-/// impl<O> MyCustomScheduler where O: TrackingHinted {
-///     pub fn new() -> Self {
-///         require_novelties_tracking!("MyCustomScheduler", O);
-///         todo!("Construct your type")
-///     }
-/// }
-/// ```
-#[macro_export]
-macro_rules! require_novelties_tracking {
-    ($name: literal, $obs: ident) => {
-        struct SanityCheck<O: TrackingHinted> {
-            phantom: PhantomData<O>,
-        }
+            impl<O: $crate::observers::TrackingHinted> SanityCheck<O> {
+                const TRACKING_SANITY: () = {
+                    const LINE_OFFSET: usize = line!().ilog10() as usize + 2;
+                    const SPACING: &str = $crate::observers::map::macros::str_repeat!(" ", LINE_OFFSET);
+                    if !O::INDICES {
+                        $crate::observers::map::macros::concat_panic!(
+                            $crate::observers::map::macros::FmtArg::DISPLAY;
+                            "\n",
+                            SPACING, "|\n",
+                            SPACING, "= note: index tracking is required by ", $name, "\n",
+                            SPACING, "= note: see the documentation of TrackingHinted for details\n",
+                            SPACING, "|\n",
+                            SPACING, "= hint: call `.with_tracking::<true, ...>()` on the map observer present in the following error notes\n",
+                            SPACING, "|\n",
+                            SPACING, "| ",
+                        );
+                    }
+                };
+            }
+            let _: () = SanityCheck::<$obs>::TRACKING_SANITY; // check that tracking is enabled for this map
+        };
+    }
 
-        impl<O: TrackingHinted> SanityCheck<O> {
-            const TRACKING_SANITY: () = {
-                const LINE_OFFSET: usize = line!().ilog10() as usize + 2;
-                const SPACING: &str = const_format::str_repeat!(" ", LINE_OFFSET);
-                if !O::NOVELTIES {
-                    const_panic::concat_panic!(const_panic::FmtArg::DISPLAY; "\n",
-                        SPACING, "|\n",
-                        SPACING, "= note: novelty tracking is required by ", $name, "\n",
-                        SPACING, "= note: see the documentation of TrackingHinted for details\n",
-                        SPACING, "|\n",
-                        SPACING, "= hint: call `.with_tracking::<..., true>()` on the provided observer\n",
-                        SPACING, "|\n",
-                        SPACING, "| ",
-                    );
-                }
-            };
-        }
-        let _: () = SanityCheck::<$obs>::TRACKING_SANITY; // check that tracking is enabled for this map
-    };
+    /// Use in the constructor of your component which requires novelties tracking of a [`MapObserver`].
+    /// See [`TrackingHinted`] for details on the concept.
+    ///
+    /// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
+    /// tracking, use this in your constructor:
+    /// ```
+    /// # use libafl::observers::TrackingHinted;
+    /// # use libafl::require_novelties_tracking;
+    /// #
+    /// # struct MyCustomScheduler<O> {
+    /// #     phantom: PhantomData<O>,
+    /// # }
+    ///
+    /// impl<O> MyCustomScheduler where O: TrackingHinted {
+    ///     pub fn new() -> Self {
+    ///         require_novelties_tracking!("MyCustomScheduler", O);
+    ///         todo!("Construct your type")
+    ///     }
+    /// }
+    /// ```
+    #[macro_export]
+    macro_rules! require_novelties_tracking {
+        ($name: literal, $obs: ident) => {
+            struct SanityCheck<O: $crate::observers::TrackingHinted> {
+                phantom: ::core::marker::PhantomData<O>,
+            }
+
+            impl<O: $crate::observers::TrackingHinted> SanityCheck<O> {
+                const TRACKING_SANITY: () = {
+                    const LINE_OFFSET: usize = line!().ilog10() as usize + 2;
+                    const SPACING: &str = $crate::observers::map::macros::str_repeat!(" ", LINE_OFFSET);
+                    if !O::NOVELTIES {
+                        $crate::observers::map::macros::concat_panic!(
+                            $crate::observers::map::macros::FmtArg::DISPLAY;
+                            "\n",
+                            SPACING, "|\n",
+                            SPACING, "= note: novelty tracking is required by ", $name, "\n",
+                            SPACING, "= note: see the documentation of TrackingHinted for details\n",
+                            SPACING, "|\n",
+                            SPACING, "= hint: call `.with_tracking::<..., true>()` on the map observer present in the following error notes\n",
+                            SPACING, "|\n",
+                            SPACING, "| ",
+                        );
+                    }
+                };
+            }
+            let _: () = SanityCheck::<$obs>::TRACKING_SANITY; // check that tracking is enabled for this map
+        };
+    }
 }
 
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -92,12 +92,16 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// For example, if you are using [`crate::schedulers::MinimizerScheduler`]:
 /// ```
 /// # use libafl::corpus::InMemoryCorpus;
-/// # use libafl::feedbacks::Feedback;
+/// # use libafl::feedbacks::{Feedback, MapFeedbackMetadata};
 /// use libafl::feedbacks::MaxMapFeedback;
 /// # use libafl::inputs::BytesInput;
 /// use libafl::observers::{StdMapObserver, TrackingHinted};
 /// use libafl::schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler};
 /// # use libafl::state::StdState;
+/// # use libafl_bolts::serdeany::RegistryBuilder;
+///
+/// # #[cfg(any(not(feature = "serdeany_autoreg"), miri))]
+/// # unsafe { MapFeedbackMetadata::<u8>::register() }
 ///
 /// use libafl_bolts::ownedref::OwnedMutSlice;
 /// # use libafl_bolts::rands::StdRand;

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -81,11 +81,12 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 }
 
 /// Trait marker which indicates that this [`MapObserver`] is tracked for indices or novelties.
-/// Implementors of feedbacks similar to [`MapFeedback`] may wish to use this to
+/// Implementors of feedbacks similar to [`crate::feedbacks::MapFeedback`] may wish to use this to
 /// ensure that edge metadata is recorded as is appropriate for the provided observer.
 ///
 /// If you get a type constraint failure for your map due to this type being unfulfilled, you must
-/// call [`TrackingHint::with_tracking`] **at the initialisation site of your map**.
+/// call [`TrackingHinted::with_index_tracking`] or [`TrackingHinted::with_novelty_tracking`] **at
+/// the initialisation site of your map**.
 ///
 /// This trait allows various components which interact with map metadata to ensure that the
 /// information they need is actually recorded by the map feedback.
@@ -153,8 +154,8 @@ pub mod macros {
     pub use const_format::str_repeat;
     pub use const_panic::{concat_panic, FmtArg};
 
-    /// Use in the constructor of your component which requires index tracking of a [`MapObserver`]. See
-    /// [`TrackingHinted`] for details.
+    /// Use in the constructor of your component which requires index tracking of a
+    /// [`super::MapObserver`]. See [`super::TrackingHinted`] for details.
     ///
     /// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
     /// tracking, use this in your constructor:
@@ -204,8 +205,8 @@ pub mod macros {
         };
     }
 
-    /// Use in the constructor of your component which requires novelties tracking of a [`MapObserver`].
-    /// See [`TrackingHinted`] for details on the concept.
+    /// Use in the constructor of your component which requires novelties tracking of a
+    /// [`super::MapObserver`]. See [`super::TrackingHinted`] for details on the concept.
     ///
     /// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
     /// tracking, use this in your constructor:

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -85,7 +85,7 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// ensure that edge metadata is recorded as is appropriate for the provided observer.
 ///
 /// If you get a type constraint failure for your map due to this type being unfulfilled, you must
-/// call [`TrackingHinted::with_index_tracking`] or [`TrackingHinted::with_novelty_tracking`] **at
+/// call [`TrackingHinted::track_indices`] or [`TrackingHinted::track_novelties`] **at
 /// the initialisation site of your map**.
 ///
 /// This trait allows various components which interact with map metadata to ensure that the
@@ -111,7 +111,7 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// let edges_observer = StdMapObserver::from_ownedref("edges", OwnedMutSlice::from(vec![0u8; 16]));
 /// // inform the feedback to track indices (required by IndexesLenTimeMinimizerScheduler), but not novelties
 /// // this *MUST* be done before it is passed to MaxMapFeedback!
-/// let edges_observer = edges_observer.with_index_tracking();
+/// let edges_observer = edges_observer.track_indices();
 ///
 /// // init the feedback
 /// let mut feedback = MaxMapFeedback::new(&edges_observer);
@@ -134,7 +134,7 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 pub trait TrackingHinted {
     /// The resulting type of enabling index tracking.
     type WithIndexTracking: TrackingHinted;
-    /// The resulting type of enabling index tracking.
+    /// The resulting type of enabling novelty tracking.
     type WithNoveltiesTracking: TrackingHinted;
 
     /// Whether indices should be tracked for this [`MapObserver`].
@@ -143,9 +143,9 @@ pub trait TrackingHinted {
     const NOVELTIES: bool;
 
     /// Convert this map observer into one that tracks indices.
-    fn with_index_tracking(self) -> Self::WithIndexTracking;
+    fn track_indices(self) -> Self::WithIndexTracking;
     /// Convert this map observer into one that tracks novelties.
-    fn with_novelty_tracking(self) -> Self::WithNoveltiesTracking;
+    fn track_novelties(self) -> Self::WithNoveltiesTracking;
 }
 
 /// Struct which wraps [`MapObserver`] instances to explicitly give them tracking data.
@@ -164,11 +164,11 @@ impl<T, const ITH: bool, const NTH: bool> TrackingHinted for ExplicitTracking<T,
     const INDICES: bool = ITH;
     const NOVELTIES: bool = NTH;
 
-    fn with_index_tracking(self) -> Self::WithIndexTracking {
+    fn track_indices(self) -> Self::WithIndexTracking {
         ExplicitTracking::<T, true, NTH>(self.0)
     }
 
-    fn with_novelty_tracking(self) -> Self::WithNoveltiesTracking {
+    fn track_novelties(self) -> Self::WithNoveltiesTracking {
         ExplicitTracking::<T, ITH, true>(self.0)
     }
 }
@@ -292,7 +292,7 @@ pub mod macros {
                             SPACING, "= note: index tracking is required by ", $name, "\n",
                             SPACING, "= note: see the documentation of TrackingHinted for details\n",
                             SPACING, "|\n",
-                            SPACING, "= hint: call `.with_index_tracking()` on the map observer present in the following error notes\n",
+                            SPACING, "= hint: call `.track_indices()` on the map observer present in the following error notes\n",
                             SPACING, "|\n",
                             SPACING, "| ",
                         );
@@ -343,7 +343,7 @@ pub mod macros {
                             SPACING, "= note: novelty tracking is required by ", $name, "\n",
                             SPACING, "= note: see the documentation of TrackingHinted for details\n",
                             SPACING, "|\n",
-                            SPACING, "= hint: call `.with_novelty_tracking()` on the map observer present in the following error notes\n",
+                            SPACING, "= hint: call `.track_novelties()` on the map observer present in the following error notes\n",
                             SPACING, "|\n",
                             SPACING, "| ",
                         );
@@ -402,11 +402,11 @@ where
     const INDICES: bool = false;
     const NOVELTIES: bool = false;
 
-    fn with_index_tracking(self) -> Self::WithIndexTracking {
+    fn track_indices(self) -> Self::WithIndexTracking {
         ExplicitTracking::<Self, true, false>(self)
     }
 
-    fn with_novelty_tracking(self) -> Self::WithNoveltiesTracking {
+    fn track_novelties(self) -> Self::WithNoveltiesTracking {
         ExplicitTracking::<Self, false, true>(self)
     }
 }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -258,17 +258,17 @@ pub mod macros {
     /// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
     /// tracking, use this in your constructor:
     /// ```
-    /// # use libafl::observers::TrackingHinted;
+    /// # use libafl::observers::{MapObserver, TrackingHinted};
     /// # use libafl::require_index_tracking;
     /// # use core::marker::PhantomData;
     /// #
-    /// # struct MyCustomScheduler<O> {
-    /// #     phantom: PhantomData<O>,
+    /// # struct MyCustomScheduler<O, A> {
+    /// #     phantom: PhantomData<(O, A)>,
     /// # }
     /// #
-    /// impl<O> MyCustomScheduler<O> where O: TrackingHinted {
-    ///     pub fn new() -> Self {
-    ///         require_index_tracking!("MyCustomScheduler", O);
+    /// impl<O, A> MyCustomScheduler<O, A> where O: MapObserver, A: AsRef<O> + TrackingHinted {
+    ///     pub fn new(obs: &A) -> Self {
+    ///         require_index_tracking!("MyCustomScheduler", A);
     ///         todo!("Construct your type")
     ///     }
     /// }
@@ -309,17 +309,17 @@ pub mod macros {
     /// As an example, if you are developing the type `MyCustomScheduler<O>` which requires novelty
     /// tracking, use this in your constructor:
     /// ```
-    /// # use libafl::observers::TrackingHinted;
+    /// # use libafl::observers::{MapObserver, TrackingHinted};
     /// # use libafl::require_novelties_tracking;
     /// # use core::marker::PhantomData;
     /// #
-    /// # struct MyCustomScheduler<O> {
-    /// #     phantom: PhantomData<O>,
+    /// # struct MyCustomScheduler<O, A> {
+    /// #     phantom: PhantomData<(O, A)>,
     /// # }
     /// #
-    /// impl<O> MyCustomScheduler<O> where O: TrackingHinted {
-    ///     pub fn new() -> Self {
-    ///         require_novelties_tracking!("MyCustomScheduler", O);
+    /// impl<O, A> MyCustomScheduler<O, A> where O: MapObserver, A: AsRef<O> + TrackingHinted {
+    ///     pub fn new(obs: &A) -> Self {
+    ///         require_novelties_tracking!("MyCustomScheduler", A);
     ///         todo!("Construct your type")
     ///     }
     /// }
@@ -356,6 +356,14 @@ pub mod macros {
 }
 
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
+///
+/// When referring to this type in a constraint (e.g. `O: MapObserver`), ensure that you only refer
+/// to instances of a second type, e.g. `A: AsRef<O>`. Map observer instances are passed around in
+/// a way that may be potentially wrapped by e.g. [`ExplicitTracking`] as a way to encode metadata
+/// into the type. This is an unfortunate additional requirement that we can't get around without
+/// specialization.
+///
+/// See [`crate::require_index_tracking`] for an example of how to do so.
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
 pub trait MapObserver:

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -103,6 +103,9 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// #
 /// # #[cfg(any(not(feature = "serdeany_autoreg"), miri))]
 /// # unsafe { MapFeedbackMetadata::<u8>::register() }
+/// # #[cfg(not(feature = "std"))]
+/// # #[no_mangle]
+/// # pub extern "C" fn external_current_millis() -> u64 { 0 }
 ///
 /// use libafl_bolts::ownedref::OwnedMutSlice;
 /// # use libafl_bolts::rands::StdRand;

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -95,7 +95,7 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 /// # use libafl::feedbacks::Feedback;
 /// use libafl::feedbacks::MaxMapFeedback;
 /// # use libafl::inputs::BytesInput;
-/// use libafl::observers::{StdMapObserver, TrackingHint};
+/// use libafl::observers::{StdMapObserver, TrackingHinted};
 /// use libafl::schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler};
 /// # use libafl::state::StdState;
 ///
@@ -157,12 +157,13 @@ pub mod macros {
     /// ```
     /// # use libafl::observers::TrackingHinted;
     /// # use libafl::require_index_tracking;
+    /// # use core::marker::PhantomData;
     /// #
     /// # struct MyCustomScheduler<O> {
     /// #     phantom: PhantomData<O>,
     /// # }
     ///
-    /// impl<O> MyCustomScheduler where O: TrackingHinted {
+    /// impl<O> MyCustomScheduler<O> where O: TrackingHinted {
     ///     pub fn new() -> Self {
     ///         require_index_tracking!("MyCustomScheduler", O);
     ///         todo!("Construct your type")
@@ -207,12 +208,13 @@ pub mod macros {
     /// ```
     /// # use libafl::observers::TrackingHinted;
     /// # use libafl::require_novelties_tracking;
+    /// # use core::marker::PhantomData;
     /// #
     /// # struct MyCustomScheduler<O> {
     /// #     phantom: PhantomData<O>,
     /// # }
     ///
-    /// impl<O> MyCustomScheduler where O: TrackingHinted {
+    /// impl<O> MyCustomScheduler<O> where O: TrackingHinted {
     ///     pub fn new() -> Self {
     ///         require_novelties_tracking!("MyCustomScheduler", O);
     ///         todo!("Construct your type")

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -115,8 +115,8 @@ fn hash_slice<T>(slice: &[T]) -> u64 {
 ///
 /// // init the feedback
 /// let mut feedback = MaxMapFeedback::new(&edges_observer);
-///
-/// // init the state
+/// #
+/// # // init the state
 /// # let mut state = StdState::new(
 /// #     StdRand::with_seed(0),
 /// #     InMemoryCorpus::<BytesInput>::new(),

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -352,8 +352,13 @@ where
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
-pub struct StdMapObserver<'a, T, const DIFFERENTIAL: bool, const ITH: bool, const NTH: bool>
-where
+pub struct StdMapObserver<
+    'a,
+    T,
+    const DIFFERENTIAL: bool,
+    const ITH: bool = false,
+    const NTH: bool = false,
+> where
     T: Default + Copy + 'static + Serialize,
 {
     map: OwnedMutSlice<'a, T>,

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -386,7 +386,7 @@ pub mod macros {
                     )
                 };
                 const TRACKING_SANITY: bool = {
-                    if !O::INDICES {
+                    if !O::NOVELTIES {
                         panic!("{}", Self::MESSAGE)
                     } else {
                         true
@@ -825,6 +825,7 @@ where
         self.map.as_slice()
     }
 }
+
 impl<'a, T, const DIFFERENTIAL: bool> AsMutSlice for StdMapObserver<'a, T, DIFFERENTIAL>
 where
     T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
@@ -1310,6 +1311,7 @@ where
         self.map.as_slice()
     }
 }
+
 impl<'a, T, const N: usize> AsMutSlice for ConstMapObserver<'a, T, N>
 where
     T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
@@ -1649,6 +1651,7 @@ where
         &self.map.as_slice()[..cnt]
     }
 }
+
 impl<'a, T> AsMutSlice for VariableMapObserver<'a, T>
 where
     T: 'static
@@ -2158,6 +2161,7 @@ where
         self.base.as_slice()
     }
 }
+
 impl<M> AsMutSlice for HitcountsIterableMapObserver<M>
 where
     M: MapObserver + AsMutSlice,

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -246,10 +246,35 @@ where
     }
 }
 
+impl<S, T, OTA, OTB, const ITH: bool, const NTH: bool> DifferentialObserver<OTA, OTB, S>
+    for ExplicitTracking<T, ITH, NTH>
+where
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
+    T: DifferentialObserver<OTA, OTB, S>,
+{
+    fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
+        self.as_mut().pre_observe_first(observers)
+    }
+
+    fn post_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
+        self.as_mut().post_observe_first(observers)
+    }
+
+    fn pre_observe_second(&mut self, observers: &mut OTB) -> Result<(), Error> {
+        self.as_mut().pre_observe_second(observers)
+    }
+
+    fn post_observe_second(&mut self, observers: &mut OTB) -> Result<(), Error> {
+        self.as_mut().post_observe_second(observers)
+    }
+}
+
 /// Module which holds the necessary functions and types for map-relevant macros, namely
 /// [`crate::require_index_tracking`] and [`crate::require_novelties_tracking`].
 pub mod macros {
-    pub use const_format::str_repeat;
+    pub use const_format::{concatcp, str_repeat};
     pub use const_panic::{concat_panic, FmtArg};
 
     /// Use in the constructor of your component which requires index tracking of a
@@ -281,25 +306,37 @@ pub mod macros {
             }
 
             impl<O: $crate::observers::TrackingHinted> SanityCheck<O> {
-                const TRACKING_SANITY: () = {
+                #[rustfmt::skip]
+                const MESSAGE: &'static str = {
                     const LINE_OFFSET: usize = line!().ilog10() as usize + 2;
                     const SPACING: &str = $crate::observers::map::macros::str_repeat!(" ", LINE_OFFSET);
+                    $crate::observers::map::macros::concatcp!(
+                        "\n",
+                        SPACING, "|\n",
+                        SPACING, "= note: index tracking is required by ", $name, "\n",
+                        SPACING, "= note: see the documentation of TrackingHinted for details\n",
+                        SPACING, "|\n",
+                        SPACING, "= hint: call `.track_indices()` on the map observer passed to ", $name, " at the point where it is defined\n",
+                        SPACING, "|\n",
+                        SPACING, "| ",
+                    )
+                };
+                const TRACKING_SANITY: bool = {
                     if !O::INDICES {
-                        $crate::observers::map::macros::concat_panic!(
-                            $crate::observers::map::macros::FmtArg::DISPLAY;
-                            "\n",
-                            SPACING, "|\n",
-                            SPACING, "= note: index tracking is required by ", $name, "\n",
-                            SPACING, "= note: see the documentation of TrackingHinted for details\n",
-                            SPACING, "|\n",
-                            SPACING, "= hint: call `.track_indices()` on the map observer present in the following error notes\n",
-                            SPACING, "|\n",
-                            SPACING, "| ",
-                        );
+                        panic!("{}", Self::MESSAGE)
+                    } else {
+                        true
                     }
                 };
+
+                #[inline(always)]
+                fn check_sanity() {
+                    if !Self::TRACKING_SANITY {
+                        unreachable!("{}", Self::MESSAGE);
+                    }
+                }
             }
-            let _: () = SanityCheck::<$obs>::TRACKING_SANITY; // check that tracking is enabled for this map
+            SanityCheck::<$obs>::check_sanity(); // check that tracking is enabled for this map
         };
     }
 
@@ -332,25 +369,38 @@ pub mod macros {
             }
 
             impl<O: $crate::observers::TrackingHinted> SanityCheck<O> {
-                const TRACKING_SANITY: () = {
+                #[rustfmt::skip]
+                const MESSAGE: &'static str = {
                     const LINE_OFFSET: usize = line!().ilog10() as usize + 2;
-                    const SPACING: &str = $crate::observers::map::macros::str_repeat!(" ", LINE_OFFSET);
-                    if !O::NOVELTIES {
-                        $crate::observers::map::macros::concat_panic!(
-                            $crate::observers::map::macros::FmtArg::DISPLAY;
-                            "\n",
-                            SPACING, "|\n",
-                            SPACING, "= note: novelty tracking is required by ", $name, "\n",
-                            SPACING, "= note: see the documentation of TrackingHinted for details\n",
-                            SPACING, "|\n",
-                            SPACING, "= hint: call `.track_novelties()` on the map observer present in the following error notes\n",
-                            SPACING, "|\n",
-                            SPACING, "| ",
-                        );
+                    const SPACING: &str =
+                        $crate::observers::map::macros::str_repeat!(" ", LINE_OFFSET);
+                    $crate::observers::map::macros::concatcp!(
+                        "\n",
+                        SPACING, "|\n",
+                        SPACING, "= note: novelty tracking is required by ", $name, "\n",
+                        SPACING, "= note: see the documentation of TrackingHinted for details\n",
+                        SPACING, "|\n",
+                        SPACING, "= hint: call `.track_novelties()` on the map observer passed to ", $name, " at the point where it is defined\n",
+                        SPACING, "|\n",
+                        SPACING, "| ",
+                    )
+                };
+                const TRACKING_SANITY: bool = {
+                    if !O::INDICES {
+                        panic!("{}", Self::MESSAGE)
+                    } else {
+                        true
                     }
                 };
+
+                #[inline(always)]
+                fn check_sanity() {
+                    if !Self::TRACKING_SANITY {
+                        unreachable!("{}", Self::MESSAGE);
+                    }
+                }
             }
-            let _: () = SanityCheck::<$obs>::TRACKING_SANITY; // check that tracking is enabled for this map
+            SanityCheck::<$obs>::check_sanity(); // check that tracking is enabled for this map
         };
     }
 }
@@ -358,16 +408,16 @@ pub mod macros {
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
 ///
 /// When referring to this type in a constraint (e.g. `O: MapObserver`), ensure that you only refer
-/// to instances of a second type, e.g. `A: AsRef<O>`. Map observer instances are passed around in
-/// a way that may be potentially wrapped by e.g. [`ExplicitTracking`] as a way to encode metadata
-/// into the type. This is an unfortunate additional requirement that we can't get around without
-/// specialization.
+/// to instances of a second type, e.g. `A: AsRef<O>` or `A: AsMut<O>`. Map observer instances are
+/// passed around in a way that may be potentially wrapped by e.g. [`ExplicitTracking`] as a way to
+/// encode metadata into the type. This is an unfortunate additional requirement that we can't get
+/// around without specialization.
 ///
 /// See [`crate::require_index_tracking`] for an example of how to do so.
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
 pub trait MapObserver:
-    HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self>
+    HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self> + AsMut<Self>
 // where
 //     for<'it> &'it Self: IntoIterator<Item = &'it Self::Entry>
 {
@@ -653,6 +703,15 @@ where
     T: Default + Copy + 'static + Serialize,
 {
     fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for StdMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: Default + Copy + 'static + Serialize,
+{
+    fn as_mut(&mut self) -> &mut Self {
         self
     }
 }
@@ -1150,6 +1209,15 @@ where
     }
 }
 
+impl<'a, T, const N: usize> AsMut<Self> for ConstMapObserver<'a, T, N>
+where
+    T: Default + Copy + 'static + Serialize,
+{
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl<'a, T, const N: usize> MapObserver for ConstMapObserver<'a, T, N>
 where
     T: Bounded
@@ -1471,6 +1539,15 @@ where
     }
 }
 
+impl<'a, T> AsMut<Self> for VariableMapObserver<'a, T>
+where
+    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+{
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl<'a, T> MapObserver for VariableMapObserver<'a, T>
 where
     T: Bounded
@@ -1634,8 +1711,8 @@ where
 
 /// Map observer with AFL-like hitcounts postprocessing
 ///
-/// [`MapObserver`]s that are not slice-backed,
-/// such as [`MultiMapObserver`], can use [`HitcountsIterableMapObserver`] instead.
+/// [`MapObserver`]s that are not slice-backed, such as [`MultiMapObserver`], can use
+/// [`HitcountsIterableMapObserver`] instead.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "M: serde::de::DeserializeOwned")]
 pub struct HitcountsMapObserver<M>
@@ -1734,6 +1811,15 @@ where
     }
 }
 
+impl<M> AsMut<Self> for HitcountsMapObserver<M>
+where
+    M: MapObserver<Entry = u8>,
+{
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl<M> MapObserver for HitcountsMapObserver<M>
 where
     M: MapObserver<Entry = u8>,
@@ -1816,7 +1902,7 @@ where
 
 impl<M> HitcountsMapObserver<M>
 where
-    M: Serialize + serde::de::DeserializeOwned,
+    M: MapObserver,
 {
     /// Creates a new [`MapObserver`]
     pub fn new(base: M) -> Self {
@@ -1989,6 +2075,16 @@ where
     for<'it> M: AsIterMut<'it, Item = u8>,
 {
     fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<M> AsMut<Self> for HitcountsIterableMapObserver<M>
+where
+    M: MapObserver<Entry = u8>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
+{
+    fn as_mut(&mut self) -> &mut Self {
         self
     }
 }
@@ -2243,6 +2339,15 @@ where
     T: 'static + Default + Copy + Serialize + Debug,
 {
     fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for MultiMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: 'static + Default + Copy + Serialize + Debug,
+{
+    fn as_mut(&mut self) -> &mut Self {
         self
     }
 }
@@ -2607,6 +2712,15 @@ where
     T: 'static + Default + Copy + Serialize,
 {
     fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<T> AsMut<Self> for OwnedMapObserver<T>
+where
+    T: 'static + Default + Copy + Serialize,
+{
+    fn as_mut(&mut self) -> &mut Self {
         self
     }
 }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -295,8 +295,8 @@ pub mod macros {
     /// # }
     /// #
     /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: AsRef<O> + CanTrack {
-    ///     pub fn new(obs: &A) -> Self {
-    ///         require_index_tracking!("MyCustomScheduler", A);
+    ///     pub fn new(obs: &C) -> Self {
+    ///         require_index_tracking!("MyCustomScheduler", C);
     ///         todo!("Construct your type")
     ///     }
     /// }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -354,12 +354,12 @@ pub mod macros {
     /// # use core::marker::PhantomData;
     /// #
     /// # struct MyCustomScheduler<C, O> {
-    /// #     phantom: PhantomData<(O, A)>,
+    /// #     phantom: PhantomData<(C, O)>,
     /// # }
     /// #
     /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: AsRef<O> + CanTrack {
-    ///     pub fn new(obs: &A) -> Self {
-    ///         require_novelties_tracking!("MyCustomScheduler", A);
+    ///     pub fn new(obs: &C) -> Self {
+    ///         require_novelties_tracking!("MyCustomScheduler", C);
     ///         todo!("Construct your type")
     ///     }
     /// }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -294,7 +294,7 @@ pub mod macros {
     /// #     phantom: PhantomData<(C, O)>,
     /// # }
     /// #
-    /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: AsRef<O> + CanTrack {
+    /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: CanTrack + AsRef<O> {
     ///     pub fn new(obs: &C) -> Self {
     ///         require_index_tracking!("MyCustomScheduler", C);
     ///         todo!("Construct your type")
@@ -357,7 +357,7 @@ pub mod macros {
     /// #     phantom: PhantomData<(C, O)>,
     /// # }
     /// #
-    /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: AsRef<O> + CanTrack {
+    /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: CanTrack + AsRef<O> {
     ///     pub fn new(obs: &C) -> Self {
     ///         require_novelties_tracking!("MyCustomScheduler", C);
     ///         todo!("Construct your type")

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -1,5 +1,6 @@
 //! The `MapObserver` provides access a map, usually injected into the target
 
+use ahash::RandomState;
 use alloc::{
     string::{String, ToString},
     vec::Vec,
@@ -12,21 +13,19 @@ use core::{
     mem::size_of,
     slice::{self, Iter, IterMut},
 };
-
-use ahash::RandomState;
 use libafl_bolts::{
-    ownedref::{OwnedMutPtr, OwnedMutSlice},
-    AsIter, AsIterMut, AsMutSlice, AsSlice, HasLen, Named, Truncate,
+    AsIter,
+    AsIterMut, AsMutSlice, AsSlice, HasLen, Named, ownedref::{OwnedMutPtr, OwnedMutSlice}, Truncate,
 };
 use meminterval::IntervalTree;
 use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    Error,
     executors::ExitKind,
     inputs::UsesInput,
     observers::{DifferentialObserver, Observer, ObserversTuple},
-    Error,
 };
 
 /// Hitcounts class lookup
@@ -186,8 +185,8 @@ impl<T, const ITH: bool, const NTH: bool> AsMut<T> for ExplicitTracking<T, ITH, 
 }
 
 impl<T, const ITH: bool, const NTH: bool> Named for ExplicitTracking<T, ITH, NTH>
-where
-    T: Named,
+    where
+        T: Named,
 {
     fn name(&self) -> &str {
         self.0.name()
@@ -195,9 +194,9 @@ where
 }
 
 impl<S, T, const ITH: bool, const NTH: bool> Observer<S> for ExplicitTracking<T, ITH, NTH>
-where
-    S: UsesInput,
-    T: Observer<S>,
+    where
+        S: UsesInput,
+        T: Observer<S>,
 {
     fn flush(&mut self) -> Result<(), Error> {
         self.0.flush()
@@ -238,21 +237,21 @@ where
     }
 
     fn observe_stdout(&mut self, stdout: &[u8]) {
-        self.0.observe_stdout(stdout)
+        self.0.observe_stdout(stdout);
     }
 
     fn observe_stderr(&mut self, stderr: &[u8]) {
-        self.0.observe_stderr(stderr)
+        self.0.observe_stderr(stderr);
     }
 }
 
 impl<S, T, OTA, OTB, const ITH: bool, const NTH: bool> DifferentialObserver<OTA, OTB, S>
-    for ExplicitTracking<T, ITH, NTH>
-where
-    OTA: ObserversTuple<S>,
-    OTB: ObserversTuple<S>,
-    S: UsesInput,
-    T: DifferentialObserver<OTA, OTB, S>,
+for ExplicitTracking<T, ITH, NTH>
+    where
+        OTA: ObserversTuple<S>,
+        OTB: ObserversTuple<S>,
+        S: UsesInput,
+        T: DifferentialObserver<OTA, OTB, S>,
 {
     fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
         self.as_mut().pre_observe_first(observers)
@@ -417,7 +416,7 @@ pub mod macros {
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
 pub trait MapObserver:
-    HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self> + AsMut<Self>
+HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self> + AsMut<Self>
 // where
 //     for<'it> &'it Self: IntoIterator<Item = &'it Self::Entry>
 {
@@ -453,8 +452,8 @@ pub trait MapObserver:
 }
 
 impl<M> TrackingHinted for M
-where
-    M: MapObserver,
+    where
+        M: MapObserver,
 {
     type WithIndexTracking = ExplicitTracking<Self, true, false>;
     type WithNoveltiesTracking = ExplicitTracking<Self, false, true>;
@@ -473,8 +472,8 @@ where
 /// A Simple iterator calling `MapObserver::get`
 #[derive(Debug)]
 pub struct MapObserverSimpleIterator<'a, O>
-where
-    O: 'a + MapObserver,
+    where
+        O: 'a + MapObserver,
 {
     index: usize,
     observer: *const O,
@@ -482,8 +481,8 @@ where
 }
 
 impl<'a, O> Iterator for MapObserverSimpleIterator<'a, O>
-where
-    O: 'a + MapObserver,
+    where
+        O: 'a + MapObserver,
 {
     type Item = &'a O::Entry;
     fn next(&mut self) -> Option<Self::Item> {
@@ -502,8 +501,8 @@ where
 /// A Simple iterator calling `MapObserver::get_mut`
 #[derive(Debug)]
 pub struct MapObserverSimpleIteratorMut<'a, O>
-where
-    O: 'a + MapObserver,
+    where
+        O: 'a + MapObserver,
 {
     index: usize,
     observer: *mut O,
@@ -511,8 +510,8 @@ where
 }
 
 impl<'a, O> Iterator for MapObserverSimpleIteratorMut<'a, O>
-where
-    O: 'a + MapObserver,
+    where
+        O: 'a + MapObserver,
 {
     type Item = &'a O::Entry;
     fn next(&mut self) -> Option<Self::Item> {
@@ -535,8 +534,8 @@ where
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct StdMapObserver<'a, T, const DIFFERENTIAL: bool>
-where
-    T: Default + Copy + 'static + Serialize,
+    where
+        T: Default + Copy + 'static + Serialize,
 {
     map: OwnedMutSlice<'a, T>,
     initial: T,
@@ -544,9 +543,9 @@ where
 }
 
 impl<'a, S, T> Observer<S> for StdMapObserver<'a, T, false>
-where
-    S: UsesInput,
-    T: Bounded
+    where
+        S: UsesInput,
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -562,9 +561,9 @@ where
 }
 
 impl<'a, S, T> Observer<S> for StdMapObserver<'a, T, true>
-where
-    S: UsesInput,
-    T: Bounded
+    where
+        S: UsesInput,
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -572,12 +571,11 @@ where
         + Serialize
         + serde::de::DeserializeOwned
         + Debug,
-{
-}
+{}
 
 impl<'a, T, const DIFFERENTIAL: bool> Named for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -586,8 +584,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> HasLen for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -596,8 +594,8 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIter<'it> for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -616,8 +614,8 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIterMut<'it> for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -636,8 +634,8 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator for &'it StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -656,9 +654,9 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator
-    for &'it mut StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+for &'it mut StdMapObserver<'a, T, DIFFERENTIAL>
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -677,8 +675,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -699,8 +697,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize,
+    where
+        T: Default + Copy + 'static + Serialize,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -708,8 +706,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize,
+    where
+        T: Default + Copy + 'static + Serialize,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -717,8 +715,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MapObserver for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -799,8 +797,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> Truncate for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -815,8 +813,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsSlice for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -827,8 +825,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsMutSlice for StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -839,8 +837,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     ///
@@ -849,8 +847,8 @@ where
     /// The map must not move in memory!
     #[must_use]
     unsafe fn maybe_differential<S>(name: S, map: &'a mut [T]) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         let len = map.len();
         let ptr = map.as_mut_ptr();
@@ -860,8 +858,8 @@ where
     /// Creates a new [`MapObserver`] from an [`OwnedMutSlice`]
     #[must_use]
     fn maybe_differential_from_mut_slice<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         StdMapObserver {
             name: name.into(),
@@ -873,8 +871,8 @@ where
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]
     fn maybe_differential_owned<S>(name: S, map: Vec<T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self {
             map: OwnedMutSlice::from(map),
@@ -889,8 +887,8 @@ where
     /// Will dereference the owned slice with up to len elements.
     #[must_use]
     fn maybe_differential_from_ownedref<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self {
             map,
@@ -904,8 +902,8 @@ where
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     unsafe fn maybe_differential_from_mut_ptr<S>(name: S, map_ptr: *mut T, len: usize) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_from_mut_slice(
             name,
@@ -930,8 +928,8 @@ where
 }
 
 impl<'a, T> StdMapObserver<'a, T, false>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     ///
@@ -940,16 +938,16 @@ where
     /// Hence, the map may never move in memory.
     #[must_use]
     pub unsafe fn new<S>(name: S, map: &'a mut [T]) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential(name, map)
     }
 
     /// Creates a new [`MapObserver`] from an [`OwnedMutSlice`]
     pub fn from_mut_slice<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_from_mut_slice(name, map)
     }
@@ -957,8 +955,8 @@ where
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]
     pub fn owned<S>(name: S, map: Vec<T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_owned(name, map)
     }
@@ -969,8 +967,8 @@ where
     /// Will dereference the owned slice with up to len elements.
     #[must_use]
     pub fn from_ownedref<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_from_ownedref(name, map)
     }
@@ -980,16 +978,16 @@ where
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     pub unsafe fn from_mut_ptr<S>(name: S, map_ptr: *mut T, len: usize) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_from_mut_ptr(name, map_ptr, len)
     }
 }
 
 impl<'a, T> StdMapObserver<'a, T, true>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`] in differential mode
     ///
@@ -998,8 +996,8 @@ where
     /// The map must not move in memory!
     #[must_use]
     pub unsafe fn differential<S>(name: S, map: &'a mut [T]) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential(name, map)
     }
@@ -1007,8 +1005,8 @@ where
     /// Creates a new [`MapObserver`] with an owned map in differential mode
     #[must_use]
     pub fn differential_owned<S>(name: S, map: Vec<T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_owned(name, map)
     }
@@ -1019,8 +1017,8 @@ where
     /// Will dereference the owned slice with up to len elements.
     #[must_use]
     pub fn differential_from_ownedref<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_from_ownedref(name, map)
     }
@@ -1030,19 +1028,19 @@ where
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     pub unsafe fn differential_from_mut_ptr<S>(name: S, map_ptr: *mut T, len: usize) -> Self
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         Self::maybe_differential_from_mut_ptr(name, map_ptr, len)
     }
 }
 
 impl<'a, OTA, OTB, S, T> DifferentialObserver<OTA, OTB, S> for StdMapObserver<'a, T, true>
-where
-    OTA: ObserversTuple<S>,
-    OTB: ObserversTuple<S>,
-    S: UsesInput,
-    T: Bounded
+    where
+        OTA: ObserversTuple<S>,
+        OTB: ObserversTuple<S>,
+        S: UsesInput,
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1050,8 +1048,7 @@ where
         + Serialize
         + serde::de::DeserializeOwned
         + Debug,
-{
-}
+{}
 
 /// Use a const size to speedup `Feedback::is_interesting` when the user can
 /// know the size of the map at compile time.
@@ -1059,8 +1056,8 @@ where
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct ConstMapObserver<'a, T, const N: usize>
-where
-    T: Default + Copy + 'static + Serialize,
+    where
+        T: Default + Copy + 'static + Serialize,
 {
     map: OwnedMutSlice<'a, T>,
     initial: T,
@@ -1068,10 +1065,10 @@ where
 }
 
 impl<'a, S, T, const N: usize> Observer<S> for ConstMapObserver<'a, T, N>
-where
-    S: UsesInput,
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
-    Self: MapObserver,
+    where
+        S: UsesInput,
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+        Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -1080,8 +1077,8 @@ where
 }
 
 impl<'a, T, const N: usize> Named for ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -1090,8 +1087,8 @@ where
 }
 
 impl<'a, T, const N: usize> HasLen for ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -1100,8 +1097,8 @@ where
 }
 
 impl<'a, 'it, T, const N: usize> AsIter<'it> for ConstMapObserver<'a, T, N>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1120,8 +1117,8 @@ where
 }
 
 impl<'a, 'it, T, const N: usize> AsIterMut<'it> for ConstMapObserver<'a, T, N>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1140,8 +1137,8 @@ where
 }
 
 impl<'a, 'it, T, const N: usize> IntoIterator for &'it ConstMapObserver<'a, T, N>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1160,8 +1157,8 @@ where
 }
 
 impl<'a, 'it, T, const N: usize> IntoIterator for &'it mut ConstMapObserver<'a, T, N>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1180,8 +1177,8 @@ where
 }
 
 impl<'a, T, const N: usize> ConstMapObserver<'a, T, N>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1202,8 +1199,8 @@ where
 }
 
 impl<'a, T, const N: usize> AsRef<Self> for ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize,
+    where
+        T: Default + Copy + 'static + Serialize,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -1211,8 +1208,8 @@ where
 }
 
 impl<'a, T, const N: usize> AsMut<Self> for ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize,
+    where
+        T: Default + Copy + 'static + Serialize,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -1220,8 +1217,8 @@ where
 }
 
 impl<'a, T, const N: usize> MapObserver for ConstMapObserver<'a, T, N>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1302,8 +1299,8 @@ where
 }
 
 impl<'a, T, const N: usize> AsSlice for ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[inline]
@@ -1313,8 +1310,8 @@ where
 }
 
 impl<'a, T, const N: usize> AsMutSlice for ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[inline]
@@ -1324,8 +1321,8 @@ where
 }
 
 impl<'a, T, const N: usize> ConstMapObserver<'a, T, N>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     ///
@@ -1372,8 +1369,8 @@ where
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct VariableMapObserver<'a, T>
-where
-    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+    where
+        T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
 {
     map: OwnedMutSlice<'a, T>,
     size: OwnedMutPtr<usize>,
@@ -1382,9 +1379,9 @@ where
 }
 
 impl<'a, S, T> Observer<S> for VariableMapObserver<'a, T>
-where
-    S: UsesInput,
-    T: Default
+    where
+        S: UsesInput,
+        T: Default
         + Copy
         + 'static
         + Serialize
@@ -1392,7 +1389,7 @@ where
         + Debug
         + Bounded
         + PartialEq,
-    Self: MapObserver,
+        Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -1401,8 +1398,8 @@ where
 }
 
 impl<'a, T> Named for VariableMapObserver<'a, T>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Bounded + PartialEq,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Bounded + PartialEq,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -1411,8 +1408,8 @@ where
 }
 
 impl<'a, T> HasLen for VariableMapObserver<'a, T>
-where
-    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
+    where
+        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -1421,8 +1418,8 @@ where
 }
 
 impl<'a, 'it, T> AsIter<'it> for VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1443,8 +1440,8 @@ where
 }
 
 impl<'a, 'it, T> AsIterMut<'it> for VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1465,8 +1462,8 @@ where
 }
 
 impl<'a, 'it, T> IntoIterator for &'it VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1487,8 +1484,8 @@ where
 }
 
 impl<'a, 'it, T> IntoIterator for &'it mut VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1509,8 +1506,8 @@ where
 }
 
 impl<'a, T> VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1533,8 +1530,8 @@ where
 }
 
 impl<'a, T> AsRef<Self> for VariableMapObserver<'a, T>
-where
-    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+    where
+        T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -1542,8 +1539,8 @@ where
 }
 
 impl<'a, T> AsMut<Self> for VariableMapObserver<'a, T>
-where
-    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+    where
+        T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -1551,8 +1548,8 @@ where
 }
 
 impl<'a, T> MapObserver for VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1632,8 +1629,8 @@ where
 }
 
 impl<'a, T> AsSlice for VariableMapObserver<'a, T>
-where
-    T: Bounded
+    where
+        T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1653,8 +1650,8 @@ where
 }
 
 impl<'a, T> AsMutSlice for VariableMapObserver<'a, T>
-where
-    T: 'static
+    where
+        T: 'static
         + Default
         + Copy
         + Serialize
@@ -1672,8 +1669,8 @@ where
 }
 
 impl<'a, T> VariableMapObserver<'a, T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
 {
     /// Creates a new [`MapObserver`] from an [`OwnedMutSlice`]
     ///
@@ -1719,16 +1716,16 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "M: serde::de::DeserializeOwned")]
 pub struct HitcountsMapObserver<M>
-where
-    M: Serialize,
+    where
+        M: Serialize,
 {
     base: M,
 }
 
 impl<S, M> Observer<S> for HitcountsMapObserver<M>
-where
-    M: MapObserver<Entry = u8> + Observer<S> + AsMutSlice<Entry = u8>,
-    S: UsesInput,
+    where
+        M: MapObserver<Entry=u8> + Observer<S> + AsMutSlice<Entry=u8>,
+        S: UsesInput,
 {
     #[inline]
     fn pre_exec(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
@@ -1786,8 +1783,8 @@ where
 }
 
 impl<M> Named for HitcountsMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -1796,8 +1793,8 @@ where
 }
 
 impl<M> HasLen for HitcountsMapObserver<M>
-where
-    M: MapObserver,
+    where
+        M: MapObserver,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -1806,8 +1803,8 @@ where
 }
 
 impl<M> AsRef<Self> for HitcountsMapObserver<M>
-where
-    M: MapObserver<Entry = u8>,
+    where
+        M: MapObserver<Entry=u8>,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -1815,8 +1812,8 @@ where
 }
 
 impl<M> AsMut<Self> for HitcountsMapObserver<M>
-where
-    M: MapObserver<Entry = u8>,
+    where
+        M: MapObserver<Entry=u8>,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -1824,8 +1821,8 @@ where
 }
 
 impl<M> MapObserver for HitcountsMapObserver<M>
-where
-    M: MapObserver<Entry = u8>,
+    where
+        M: MapObserver<Entry=u8>,
 {
     type Entry = u8;
 
@@ -1873,8 +1870,8 @@ where
 }
 
 impl<M> Truncate for HitcountsMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
 {
     fn truncate(&mut self, new_len: usize) {
         self.base.truncate(new_len);
@@ -1882,8 +1879,8 @@ where
 }
 
 impl<M> AsSlice for HitcountsMapObserver<M>
-where
-    M: MapObserver + AsSlice,
+    where
+        M: MapObserver + AsSlice,
 {
     type Entry = <M as AsSlice>::Entry;
     #[inline]
@@ -1893,8 +1890,8 @@ where
 }
 
 impl<M> AsMutSlice for HitcountsMapObserver<M>
-where
-    M: MapObserver + AsMutSlice,
+    where
+        M: MapObserver + AsMutSlice,
 {
     type Entry = <M as AsMutSlice>::Entry;
     #[inline]
@@ -1904,8 +1901,8 @@ where
 }
 
 impl<M> HitcountsMapObserver<M>
-where
-    M: MapObserver,
+    where
+        M: MapObserver,
 {
     /// Creates a new [`MapObserver`]
     pub fn new(base: M) -> Self {
@@ -1915,8 +1912,8 @@ where
 }
 
 impl<'it, M> AsIter<'it> for HitcountsMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item = u8>,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item=u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
@@ -1927,8 +1924,8 @@ where
 }
 
 impl<'it, M> AsIterMut<'it> for HitcountsMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item = u8>,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item=u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIterMut<'it>>::IntoIter;
@@ -1939,9 +1936,9 @@ where
 }
 
 impl<'it, M> IntoIterator for &'it HitcountsMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    &'it M: IntoIterator<Item = &'it u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        &'it M: IntoIterator<Item=&'it u8>,
 {
     type Item = &'it u8;
     type IntoIter = <&'it M as IntoIterator>::IntoIter;
@@ -1952,9 +1949,9 @@ where
 }
 
 impl<'it, M> IntoIterator for &'it mut HitcountsMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    &'it mut M: IntoIterator<Item = &'it mut u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        &'it mut M: IntoIterator<Item=&'it mut u8>,
 {
     type Item = &'it mut u8;
     type IntoIter = <&'it mut M as IntoIterator>::IntoIter;
@@ -1965,9 +1962,9 @@ where
 }
 
 impl<M> HitcountsMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    for<'it> &'it M: IntoIterator<Item = &'it u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        for<'it> &'it M: IntoIterator<Item=&'it u8>,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> <&M as IntoIterator>::IntoIter {
@@ -1976,9 +1973,9 @@ where
 }
 
 impl<M> HitcountsMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    for<'it> &'it mut M: IntoIterator<Item = &'it mut u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        for<'it> &'it mut M: IntoIterator<Item=&'it mut u8>,
 {
     /// Returns a mutable iterator over the map.
     pub fn iter_mut(&mut self) -> <&mut M as IntoIterator>::IntoIter {
@@ -1987,14 +1984,14 @@ where
 }
 
 impl<M, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for HitcountsMapObserver<M>
-where
-    M: DifferentialObserver<OTA, OTB, S>
-        + MapObserver<Entry = u8>
+    where
+        M: DifferentialObserver<OTA, OTB, S>
+        + MapObserver<Entry=u8>
         + Serialize
-        + AsMutSlice<Entry = u8>,
-    OTA: ObserversTuple<S>,
-    OTB: ObserversTuple<S>,
-    S: UsesInput,
+        + AsMutSlice<Entry=u8>,
+        OTA: ObserversTuple<S>,
+        OTB: ObserversTuple<S>,
+        S: UsesInput,
 {
     fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
         self.base.pre_observe_first(observers)
@@ -2019,17 +2016,17 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "M: serde::de::DeserializeOwned")]
 pub struct HitcountsIterableMapObserver<M>
-where
-    M: Serialize,
+    where
+        M: Serialize,
 {
     base: M,
 }
 
 impl<S, M> Observer<S> for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver<Entry = u8> + Observer<S>,
-    for<'it> M: AsIterMut<'it, Item = u8>,
-    S: UsesInput,
+    where
+        M: MapObserver<Entry=u8> + Observer<S>,
+        for<'it> M: AsIterMut<'it, Item=u8>,
+        S: UsesInput,
 {
     #[inline]
     fn pre_exec(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
@@ -2053,8 +2050,8 @@ where
 }
 
 impl<M> Named for HitcountsIterableMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -2063,8 +2060,8 @@ where
 }
 
 impl<M> HasLen for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver,
+    where
+        M: MapObserver,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -2073,9 +2070,9 @@ where
 }
 
 impl<M> AsRef<Self> for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver<Entry = u8>,
-    for<'it> M: AsIterMut<'it, Item = u8>,
+    where
+        M: MapObserver<Entry=u8>,
+        for<'it> M: AsIterMut<'it, Item=u8>,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -2083,9 +2080,9 @@ where
 }
 
 impl<M> AsMut<Self> for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver<Entry = u8>,
-    for<'it> M: AsIterMut<'it, Item = u8>,
+    where
+        M: MapObserver<Entry=u8>,
+        for<'it> M: AsIterMut<'it, Item=u8>,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -2093,9 +2090,9 @@ where
 }
 
 impl<M> MapObserver for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver<Entry = u8>,
-    for<'it> M: AsIterMut<'it, Item = u8>,
+    where
+        M: MapObserver<Entry=u8>,
+        for<'it> M: AsIterMut<'it, Item=u8>,
 {
     type Entry = u8;
 
@@ -2143,8 +2140,8 @@ where
 }
 
 impl<M> Truncate for HitcountsIterableMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
 {
     fn truncate(&mut self, new_len: usize) {
         self.base.truncate(new_len);
@@ -2152,8 +2149,8 @@ where
 }
 
 impl<M> AsSlice for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver + AsSlice,
+    where
+        M: MapObserver + AsSlice,
 {
     type Entry = <M as AsSlice>::Entry;
     #[inline]
@@ -2163,8 +2160,8 @@ where
 }
 
 impl<M> AsMutSlice for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver + AsMutSlice,
+    where
+        M: MapObserver + AsMutSlice,
 {
     type Entry = <M as AsMutSlice>::Entry;
     #[inline]
@@ -2174,8 +2171,8 @@ where
 }
 
 impl<M> HitcountsIterableMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     pub fn new(base: M) -> Self {
@@ -2185,8 +2182,8 @@ where
 }
 
 impl<'it, M> AsIter<'it> for HitcountsIterableMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item = u8>,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item=u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
@@ -2197,8 +2194,8 @@ where
 }
 
 impl<'it, M> AsIterMut<'it> for HitcountsIterableMapObserver<M>
-where
-    M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item = u8>,
+    where
+        M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item=u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIterMut<'it>>::IntoIter;
@@ -2209,9 +2206,9 @@ where
 }
 
 impl<'it, M> IntoIterator for &'it HitcountsIterableMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    &'it M: IntoIterator<Item = &'it u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        &'it M: IntoIterator<Item=&'it u8>,
 {
     type Item = &'it u8;
     type IntoIter = <&'it M as IntoIterator>::IntoIter;
@@ -2222,9 +2219,9 @@ where
 }
 
 impl<'it, M> IntoIterator for &'it mut HitcountsIterableMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    &'it mut M: IntoIterator<Item = &'it mut u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        &'it mut M: IntoIterator<Item=&'it mut u8>,
 {
     type Item = &'it mut u8;
     type IntoIter = <&'it mut M as IntoIterator>::IntoIter;
@@ -2235,9 +2232,9 @@ where
 }
 
 impl<M> HitcountsIterableMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    for<'it> &'it M: IntoIterator<Item = &'it u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        for<'it> &'it M: IntoIterator<Item=&'it u8>,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> <&M as IntoIterator>::IntoIter {
@@ -2246,9 +2243,9 @@ where
 }
 
 impl<M> HitcountsIterableMapObserver<M>
-where
-    M: Serialize + serde::de::DeserializeOwned,
-    for<'it> &'it mut M: IntoIterator<Item = &'it mut u8>,
+    where
+        M: Serialize + serde::de::DeserializeOwned,
+        for<'it> &'it mut M: IntoIterator<Item=&'it mut u8>,
 {
     /// Returns a mutable iterator over the map.
     pub fn iter_mut(&mut self) -> <&mut M as IntoIterator>::IntoIter {
@@ -2257,12 +2254,12 @@ where
 }
 
 impl<M, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for HitcountsIterableMapObserver<M>
-where
-    M: MapObserver<Entry = u8> + Observer<S> + DifferentialObserver<OTA, OTB, S>,
-    for<'it> M: AsIterMut<'it, Item = u8>,
-    OTA: ObserversTuple<S>,
-    OTB: ObserversTuple<S>,
-    S: UsesInput,
+    where
+        M: MapObserver<Entry=u8> + Observer<S> + DifferentialObserver<OTA, OTB, S>,
+        for<'it> M: AsIterMut<'it, Item=u8>,
+        OTA: ObserversTuple<S>,
+        OTB: ObserversTuple<S>,
+        S: UsesInput,
 {
     fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
         self.base.pre_observe_first(observers)
@@ -2286,8 +2283,8 @@ where
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct MultiMapObserver<'a, T, const DIFFERENTIAL: bool>
-where
-    T: 'static + Default + Copy + Serialize + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + Debug,
 {
     maps: Vec<OwnedMutSlice<'a, T>>,
     intervals: IntervalTree<usize, usize>,
@@ -2298,10 +2295,10 @@ where
 }
 
 impl<'a, S, T> Observer<S> for MultiMapObserver<'a, T, false>
-where
-    S: UsesInput,
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-    Self: MapObserver,
+    where
+        S: UsesInput,
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+        Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -2310,17 +2307,17 @@ where
 }
 
 impl<'a, S, T> Observer<S> for MultiMapObserver<'a, T, true>
-where
-    S: UsesInput,
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-    Self: MapObserver,
+    where
+        S: UsesInput,
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+        Self: MapObserver,
 {
     // in differential mode, we are *not* responsible for resetting the map!
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> Named for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -2329,8 +2326,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> HasLen for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -2339,8 +2336,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + Debug,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -2348,8 +2345,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + Debug,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -2357,8 +2354,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MapObserver for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static
+    where
+        T: 'static
         + Bounded
         + PartialEq
         + Default
@@ -2454,8 +2451,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Creates a new [`MultiMapObserver`], maybe in differential mode
     #[must_use]
@@ -2479,8 +2476,8 @@ where
 }
 
 impl<'a, T> MultiMapObserver<'a, T, true>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Creates a new [`MultiMapObserver`] in differential mode
     #[must_use]
@@ -2490,8 +2487,8 @@ where
 }
 
 impl<'a, T> MultiMapObserver<'a, T, false>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Creates a new [`MultiMapObserver`]
     #[must_use]
@@ -2527,9 +2524,9 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIter<'it> for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-    'a: 'it,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+        'a: 'it,
 {
     type Item = T;
     type IntoIter = Flatten<Iter<'it, OwnedMutSlice<'a, T>>>;
@@ -2540,9 +2537,9 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIterMut<'it> for MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-    'a: 'it,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+        'a: 'it,
 {
     type Item = T;
     type IntoIter = Flatten<IterMut<'it, OwnedMutSlice<'a, T>>>;
@@ -2553,9 +2550,9 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator
-    for &'it MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+for &'it MultiMapObserver<'a, T, DIFFERENTIAL>
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <Iter<'it, T> as Iterator>::Item;
     type IntoIter = Flatten<Iter<'it, OwnedMutSlice<'a, T>>>;
@@ -2566,9 +2563,9 @@ where
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator
-    for &'it mut MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+for &'it mut MultiMapObserver<'a, T, DIFFERENTIAL>
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <IterMut<'it, T> as Iterator>::Item;
     type IntoIter = Flatten<IterMut<'it, OwnedMutSlice<'a, T>>>;
@@ -2579,8 +2576,8 @@ where
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MultiMapObserver<'a, T, DIFFERENTIAL>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
@@ -2594,22 +2591,21 @@ where
 }
 
 impl<'a, T, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for MultiMapObserver<'a, T, true>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-    Self: MapObserver,
-    OTA: ObserversTuple<S>,
-    OTB: ObserversTuple<S>,
-    S: UsesInput,
-{
-}
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+        Self: MapObserver,
+        OTA: ObserversTuple<S>,
+        OTB: ObserversTuple<S>,
+        S: UsesInput,
+{}
 
 /// Exact copy of `StdMapObserver` that owns its map
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize,
+    where
+        T: 'static + Default + Copy + Serialize,
 {
     map: Vec<T>,
     initial: T,
@@ -2617,10 +2613,10 @@ where
 }
 
 impl<S, T> Observer<S> for OwnedMapObserver<T>
-where
-    S: UsesInput,
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-    Self: MapObserver,
+    where
+        S: UsesInput,
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+        Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -2629,8 +2625,8 @@ where
 }
 
 impl<T> Named for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -2639,8 +2635,8 @@ where
 }
 
 impl<T> HasLen for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -2649,8 +2645,8 @@ where
 }
 
 impl<'it, T> AsIter<'it> for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = T;
     type IntoIter = Iter<'it, T>;
@@ -2661,8 +2657,8 @@ where
 }
 
 impl<'it, T> AsIterMut<'it> for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = T;
     type IntoIter = IterMut<'it, T>;
@@ -2673,8 +2669,8 @@ where
 }
 
 impl<'it, T> IntoIterator for &'it OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <Iter<'it, T> as Iterator>::Item;
     type IntoIter = Iter<'it, T>;
@@ -2685,8 +2681,8 @@ where
 }
 
 impl<'it, T> IntoIterator for &'it mut OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <IterMut<'it, T> as Iterator>::Item;
     type IntoIter = IterMut<'it, T>;
@@ -2697,8 +2693,8 @@ where
 }
 
 impl<T> OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> Iter<'_, T> {
@@ -2712,8 +2708,8 @@ where
 }
 
 impl<T> AsRef<Self> for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize,
+    where
+        T: 'static + Default + Copy + Serialize,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -2721,8 +2717,8 @@ where
 }
 
 impl<T> AsMut<Self> for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize,
+    where
+        T: 'static + Default + Copy + Serialize,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -2730,8 +2726,8 @@ where
 }
 
 impl<T> MapObserver for OwnedMapObserver<T>
-where
-    T: 'static
+    where
+        T: 'static
         + Bounded
         + PartialEq
         + Default
@@ -2811,8 +2807,8 @@ where
 }
 
 impl<T> AsSlice for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -2823,8 +2819,8 @@ where
 }
 
 impl<T> AsMutSlice for OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -2835,8 +2831,8 @@ where
 }
 
 impl<T> OwnedMapObserver<T>
-where
-    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
+    where
+        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -1,6 +1,5 @@
 //! The `MapObserver` provides access a map, usually injected into the target
 
-use ahash::RandomState;
 use alloc::{
     string::{String, ToString},
     vec::Vec,
@@ -13,19 +12,21 @@ use core::{
     mem::size_of,
     slice::{self, Iter, IterMut},
 };
+
+use ahash::RandomState;
 use libafl_bolts::{
-    AsIter,
-    AsIterMut, AsMutSlice, AsSlice, HasLen, Named, ownedref::{OwnedMutPtr, OwnedMutSlice}, Truncate,
+    ownedref::{OwnedMutPtr, OwnedMutSlice},
+    AsIter, AsIterMut, AsMutSlice, AsSlice, HasLen, Named, Truncate,
 };
 use meminterval::IntervalTree;
 use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Error,
     executors::ExitKind,
     inputs::UsesInput,
     observers::{DifferentialObserver, Observer, ObserversTuple},
+    Error,
 };
 
 /// Hitcounts class lookup
@@ -185,8 +186,8 @@ impl<T, const ITH: bool, const NTH: bool> AsMut<T> for ExplicitTracking<T, ITH, 
 }
 
 impl<T, const ITH: bool, const NTH: bool> Named for ExplicitTracking<T, ITH, NTH>
-    where
-        T: Named,
+where
+    T: Named,
 {
     fn name(&self) -> &str {
         self.0.name()
@@ -194,9 +195,9 @@ impl<T, const ITH: bool, const NTH: bool> Named for ExplicitTracking<T, ITH, NTH
 }
 
 impl<S, T, const ITH: bool, const NTH: bool> Observer<S> for ExplicitTracking<T, ITH, NTH>
-    where
-        S: UsesInput,
-        T: Observer<S>,
+where
+    S: UsesInput,
+    T: Observer<S>,
 {
     fn flush(&mut self) -> Result<(), Error> {
         self.0.flush()
@@ -246,12 +247,12 @@ impl<S, T, const ITH: bool, const NTH: bool> Observer<S> for ExplicitTracking<T,
 }
 
 impl<S, T, OTA, OTB, const ITH: bool, const NTH: bool> DifferentialObserver<OTA, OTB, S>
-for ExplicitTracking<T, ITH, NTH>
-    where
-        OTA: ObserversTuple<S>,
-        OTB: ObserversTuple<S>,
-        S: UsesInput,
-        T: DifferentialObserver<OTA, OTB, S>,
+    for ExplicitTracking<T, ITH, NTH>
+where
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
+    T: DifferentialObserver<OTA, OTB, S>,
 {
     fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
         self.as_mut().pre_observe_first(observers)
@@ -416,7 +417,7 @@ pub mod macros {
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
 pub trait MapObserver:
-HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self> + AsMut<Self>
+    HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self> + AsMut<Self>
 // where
 //     for<'it> &'it Self: IntoIterator<Item = &'it Self::Entry>
 {
@@ -452,8 +453,8 @@ HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self> + AsMut<S
 }
 
 impl<M> TrackingHinted for M
-    where
-        M: MapObserver,
+where
+    M: MapObserver,
 {
     type WithIndexTracking = ExplicitTracking<Self, true, false>;
     type WithNoveltiesTracking = ExplicitTracking<Self, false, true>;
@@ -472,8 +473,8 @@ impl<M> TrackingHinted for M
 /// A Simple iterator calling `MapObserver::get`
 #[derive(Debug)]
 pub struct MapObserverSimpleIterator<'a, O>
-    where
-        O: 'a + MapObserver,
+where
+    O: 'a + MapObserver,
 {
     index: usize,
     observer: *const O,
@@ -481,8 +482,8 @@ pub struct MapObserverSimpleIterator<'a, O>
 }
 
 impl<'a, O> Iterator for MapObserverSimpleIterator<'a, O>
-    where
-        O: 'a + MapObserver,
+where
+    O: 'a + MapObserver,
 {
     type Item = &'a O::Entry;
     fn next(&mut self) -> Option<Self::Item> {
@@ -501,8 +502,8 @@ impl<'a, O> Iterator for MapObserverSimpleIterator<'a, O>
 /// A Simple iterator calling `MapObserver::get_mut`
 #[derive(Debug)]
 pub struct MapObserverSimpleIteratorMut<'a, O>
-    where
-        O: 'a + MapObserver,
+where
+    O: 'a + MapObserver,
 {
     index: usize,
     observer: *mut O,
@@ -510,8 +511,8 @@ pub struct MapObserverSimpleIteratorMut<'a, O>
 }
 
 impl<'a, O> Iterator for MapObserverSimpleIteratorMut<'a, O>
-    where
-        O: 'a + MapObserver,
+where
+    O: 'a + MapObserver,
 {
     type Item = &'a O::Entry;
     fn next(&mut self) -> Option<Self::Item> {
@@ -534,8 +535,8 @@ impl<'a, O> Iterator for MapObserverSimpleIteratorMut<'a, O>
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct StdMapObserver<'a, T, const DIFFERENTIAL: bool>
-    where
-        T: Default + Copy + 'static + Serialize,
+where
+    T: Default + Copy + 'static + Serialize,
 {
     map: OwnedMutSlice<'a, T>,
     initial: T,
@@ -543,9 +544,9 @@ pub struct StdMapObserver<'a, T, const DIFFERENTIAL: bool>
 }
 
 impl<'a, S, T> Observer<S> for StdMapObserver<'a, T, false>
-    where
-        S: UsesInput,
-        T: Bounded
+where
+    S: UsesInput,
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -561,9 +562,9 @@ impl<'a, S, T> Observer<S> for StdMapObserver<'a, T, false>
 }
 
 impl<'a, S, T> Observer<S> for StdMapObserver<'a, T, true>
-    where
-        S: UsesInput,
-        T: Bounded
+where
+    S: UsesInput,
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -571,11 +572,12 @@ impl<'a, S, T> Observer<S> for StdMapObserver<'a, T, true>
         + Serialize
         + serde::de::DeserializeOwned
         + Debug,
-{}
+{
+}
 
 impl<'a, T, const DIFFERENTIAL: bool> Named for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -584,8 +586,8 @@ impl<'a, T, const DIFFERENTIAL: bool> Named for StdMapObserver<'a, T, DIFFERENTI
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> HasLen for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -594,8 +596,8 @@ impl<'a, T, const DIFFERENTIAL: bool> HasLen for StdMapObserver<'a, T, DIFFERENT
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIter<'it> for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -614,8 +616,8 @@ impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIter<'it> for StdMapObserver<'a, T,
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIterMut<'it> for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -634,8 +636,8 @@ impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIterMut<'it> for StdMapObserver<'a,
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator for &'it StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -654,9 +656,9 @@ impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator for &'it StdMapObserver<
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator
-for &'it mut StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+    for &'it mut StdMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -675,8 +677,8 @@ for &'it mut StdMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -697,8 +699,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize,
+where
+    T: Default + Copy + 'static + Serialize,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -706,8 +708,8 @@ impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for StdMapObserver<'a, T, DIFF
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize,
+where
+    T: Default + Copy + 'static + Serialize,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -715,8 +717,8 @@ impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for StdMapObserver<'a, T, DIFF
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MapObserver for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -797,8 +799,8 @@ impl<'a, T, const DIFFERENTIAL: bool> MapObserver for StdMapObserver<'a, T, DIFF
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> Truncate for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -813,8 +815,8 @@ impl<'a, T, const DIFFERENTIAL: bool> Truncate for StdMapObserver<'a, T, DIFFERE
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsSlice for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -825,8 +827,8 @@ impl<'a, T, const DIFFERENTIAL: bool> AsSlice for StdMapObserver<'a, T, DIFFEREN
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsMutSlice for StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -837,8 +839,8 @@ impl<'a, T, const DIFFERENTIAL: bool> AsMutSlice for StdMapObserver<'a, T, DIFFE
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     ///
@@ -847,8 +849,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
     /// The map must not move in memory!
     #[must_use]
     unsafe fn maybe_differential<S>(name: S, map: &'a mut [T]) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let len = map.len();
         let ptr = map.as_mut_ptr();
@@ -858,8 +860,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
     /// Creates a new [`MapObserver`] from an [`OwnedMutSlice`]
     #[must_use]
     fn maybe_differential_from_mut_slice<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         StdMapObserver {
             name: name.into(),
@@ -871,8 +873,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]
     fn maybe_differential_owned<S>(name: S, map: Vec<T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self {
             map: OwnedMutSlice::from(map),
@@ -887,8 +889,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
     /// Will dereference the owned slice with up to len elements.
     #[must_use]
     fn maybe_differential_from_ownedref<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self {
             map,
@@ -902,8 +904,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     unsafe fn maybe_differential_from_mut_ptr<S>(name: S, map_ptr: *mut T, len: usize) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_from_mut_slice(
             name,
@@ -928,8 +930,8 @@ impl<'a, T, const DIFFERENTIAL: bool> StdMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, T> StdMapObserver<'a, T, false>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     ///
@@ -938,16 +940,16 @@ impl<'a, T> StdMapObserver<'a, T, false>
     /// Hence, the map may never move in memory.
     #[must_use]
     pub unsafe fn new<S>(name: S, map: &'a mut [T]) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential(name, map)
     }
 
     /// Creates a new [`MapObserver`] from an [`OwnedMutSlice`]
     pub fn from_mut_slice<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_from_mut_slice(name, map)
     }
@@ -955,8 +957,8 @@ impl<'a, T> StdMapObserver<'a, T, false>
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]
     pub fn owned<S>(name: S, map: Vec<T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_owned(name, map)
     }
@@ -967,8 +969,8 @@ impl<'a, T> StdMapObserver<'a, T, false>
     /// Will dereference the owned slice with up to len elements.
     #[must_use]
     pub fn from_ownedref<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_from_ownedref(name, map)
     }
@@ -978,16 +980,16 @@ impl<'a, T> StdMapObserver<'a, T, false>
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     pub unsafe fn from_mut_ptr<S>(name: S, map_ptr: *mut T, len: usize) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_from_mut_ptr(name, map_ptr, len)
     }
 }
 
 impl<'a, T> StdMapObserver<'a, T, true>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`] in differential mode
     ///
@@ -996,8 +998,8 @@ impl<'a, T> StdMapObserver<'a, T, true>
     /// The map must not move in memory!
     #[must_use]
     pub unsafe fn differential<S>(name: S, map: &'a mut [T]) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential(name, map)
     }
@@ -1005,8 +1007,8 @@ impl<'a, T> StdMapObserver<'a, T, true>
     /// Creates a new [`MapObserver`] with an owned map in differential mode
     #[must_use]
     pub fn differential_owned<S>(name: S, map: Vec<T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_owned(name, map)
     }
@@ -1017,8 +1019,8 @@ impl<'a, T> StdMapObserver<'a, T, true>
     /// Will dereference the owned slice with up to len elements.
     #[must_use]
     pub fn differential_from_ownedref<S>(name: S, map: OwnedMutSlice<'a, T>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_from_ownedref(name, map)
     }
@@ -1028,19 +1030,19 @@ impl<'a, T> StdMapObserver<'a, T, true>
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     pub unsafe fn differential_from_mut_ptr<S>(name: S, map_ptr: *mut T, len: usize) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         Self::maybe_differential_from_mut_ptr(name, map_ptr, len)
     }
 }
 
 impl<'a, OTA, OTB, S, T> DifferentialObserver<OTA, OTB, S> for StdMapObserver<'a, T, true>
-    where
-        OTA: ObserversTuple<S>,
-        OTB: ObserversTuple<S>,
-        S: UsesInput,
-        T: Bounded
+where
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1048,7 +1050,8 @@ impl<'a, OTA, OTB, S, T> DifferentialObserver<OTA, OTB, S> for StdMapObserver<'a
         + Serialize
         + serde::de::DeserializeOwned
         + Debug,
-{}
+{
+}
 
 /// Use a const size to speedup `Feedback::is_interesting` when the user can
 /// know the size of the map at compile time.
@@ -1056,8 +1059,8 @@ impl<'a, OTA, OTB, S, T> DifferentialObserver<OTA, OTB, S> for StdMapObserver<'a
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct ConstMapObserver<'a, T, const N: usize>
-    where
-        T: Default + Copy + 'static + Serialize,
+where
+    T: Default + Copy + 'static + Serialize,
 {
     map: OwnedMutSlice<'a, T>,
     initial: T,
@@ -1065,10 +1068,10 @@ pub struct ConstMapObserver<'a, T, const N: usize>
 }
 
 impl<'a, S, T, const N: usize> Observer<S> for ConstMapObserver<'a, T, N>
-    where
-        S: UsesInput,
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
-        Self: MapObserver,
+where
+    S: UsesInput,
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+    Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -1077,8 +1080,8 @@ impl<'a, S, T, const N: usize> Observer<S> for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> Named for ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -1087,8 +1090,8 @@ impl<'a, T, const N: usize> Named for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> HasLen for ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -1097,8 +1100,8 @@ impl<'a, T, const N: usize> HasLen for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, 'it, T, const N: usize> AsIter<'it> for ConstMapObserver<'a, T, N>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1117,8 +1120,8 @@ impl<'a, 'it, T, const N: usize> AsIter<'it> for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, 'it, T, const N: usize> AsIterMut<'it> for ConstMapObserver<'a, T, N>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1137,8 +1140,8 @@ impl<'a, 'it, T, const N: usize> AsIterMut<'it> for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, 'it, T, const N: usize> IntoIterator for &'it ConstMapObserver<'a, T, N>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1157,8 +1160,8 @@ impl<'a, 'it, T, const N: usize> IntoIterator for &'it ConstMapObserver<'a, T, N
 }
 
 impl<'a, 'it, T, const N: usize> IntoIterator for &'it mut ConstMapObserver<'a, T, N>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1177,8 +1180,8 @@ impl<'a, 'it, T, const N: usize> IntoIterator for &'it mut ConstMapObserver<'a, 
 }
 
 impl<'a, T, const N: usize> ConstMapObserver<'a, T, N>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1199,8 +1202,8 @@ impl<'a, T, const N: usize> ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> AsRef<Self> for ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize,
+where
+    T: Default + Copy + 'static + Serialize,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -1208,8 +1211,8 @@ impl<'a, T, const N: usize> AsRef<Self> for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> AsMut<Self> for ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize,
+where
+    T: Default + Copy + 'static + Serialize,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -1217,8 +1220,8 @@ impl<'a, T, const N: usize> AsMut<Self> for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> MapObserver for ConstMapObserver<'a, T, N>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1299,8 +1302,8 @@ impl<'a, T, const N: usize> MapObserver for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> AsSlice for ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[inline]
@@ -1310,8 +1313,8 @@ impl<'a, T, const N: usize> AsSlice for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> AsMutSlice for ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[inline]
@@ -1321,8 +1324,8 @@ impl<'a, T, const N: usize> AsMutSlice for ConstMapObserver<'a, T, N>
 }
 
 impl<'a, T, const N: usize> ConstMapObserver<'a, T, N>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     ///
@@ -1369,8 +1372,8 @@ impl<'a, T, const N: usize> ConstMapObserver<'a, T, N>
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct VariableMapObserver<'a, T>
-    where
-        T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+where
+    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
 {
     map: OwnedMutSlice<'a, T>,
     size: OwnedMutPtr<usize>,
@@ -1379,9 +1382,9 @@ pub struct VariableMapObserver<'a, T>
 }
 
 impl<'a, S, T> Observer<S> for VariableMapObserver<'a, T>
-    where
-        S: UsesInput,
-        T: Default
+where
+    S: UsesInput,
+    T: Default
         + Copy
         + 'static
         + Serialize
@@ -1389,7 +1392,7 @@ impl<'a, S, T> Observer<S> for VariableMapObserver<'a, T>
         + Debug
         + Bounded
         + PartialEq,
-        Self: MapObserver,
+    Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -1398,8 +1401,8 @@ impl<'a, S, T> Observer<S> for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> Named for VariableMapObserver<'a, T>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Bounded + PartialEq,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Bounded + PartialEq,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -1408,8 +1411,8 @@ impl<'a, T> Named for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> HasLen for VariableMapObserver<'a, T>
-    where
-        T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -1418,8 +1421,8 @@ impl<'a, T> HasLen for VariableMapObserver<'a, T>
 }
 
 impl<'a, 'it, T> AsIter<'it> for VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1440,8 +1443,8 @@ impl<'a, 'it, T> AsIter<'it> for VariableMapObserver<'a, T>
 }
 
 impl<'a, 'it, T> AsIterMut<'it> for VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1462,8 +1465,8 @@ impl<'a, 'it, T> AsIterMut<'it> for VariableMapObserver<'a, T>
 }
 
 impl<'a, 'it, T> IntoIterator for &'it VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1484,8 +1487,8 @@ impl<'a, 'it, T> IntoIterator for &'it VariableMapObserver<'a, T>
 }
 
 impl<'a, 'it, T> IntoIterator for &'it mut VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1506,8 +1509,8 @@ impl<'a, 'it, T> IntoIterator for &'it mut VariableMapObserver<'a, T>
 }
 
 impl<'a, T> VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1530,8 +1533,8 @@ impl<'a, T> VariableMapObserver<'a, T>
 }
 
 impl<'a, T> AsRef<Self> for VariableMapObserver<'a, T>
-    where
-        T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+where
+    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -1539,8 +1542,8 @@ impl<'a, T> AsRef<Self> for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> AsMut<Self> for VariableMapObserver<'a, T>
-    where
-        T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+where
+    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -1548,8 +1551,8 @@ impl<'a, T> AsMut<Self> for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> MapObserver for VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1629,8 +1632,8 @@ impl<'a, T> MapObserver for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> AsSlice for VariableMapObserver<'a, T>
-    where
-        T: Bounded
+where
+    T: Bounded
         + PartialEq
         + Default
         + Copy
@@ -1650,8 +1653,8 @@ impl<'a, T> AsSlice for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> AsMutSlice for VariableMapObserver<'a, T>
-    where
-        T: 'static
+where
+    T: 'static
         + Default
         + Copy
         + Serialize
@@ -1669,8 +1672,8 @@ impl<'a, T> AsMutSlice for VariableMapObserver<'a, T>
 }
 
 impl<'a, T> VariableMapObserver<'a, T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + PartialEq + Bounded,
 {
     /// Creates a new [`MapObserver`] from an [`OwnedMutSlice`]
     ///
@@ -1716,16 +1719,16 @@ impl<'a, T> VariableMapObserver<'a, T>
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "M: serde::de::DeserializeOwned")]
 pub struct HitcountsMapObserver<M>
-    where
-        M: Serialize,
+where
+    M: Serialize,
 {
     base: M,
 }
 
 impl<S, M> Observer<S> for HitcountsMapObserver<M>
-    where
-        M: MapObserver<Entry=u8> + Observer<S> + AsMutSlice<Entry=u8>,
-        S: UsesInput,
+where
+    M: MapObserver<Entry = u8> + Observer<S> + AsMutSlice<Entry = u8>,
+    S: UsesInput,
 {
     #[inline]
     fn pre_exec(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
@@ -1783,8 +1786,8 @@ impl<S, M> Observer<S> for HitcountsMapObserver<M>
 }
 
 impl<M> Named for HitcountsMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -1793,8 +1796,8 @@ impl<M> Named for HitcountsMapObserver<M>
 }
 
 impl<M> HasLen for HitcountsMapObserver<M>
-    where
-        M: MapObserver,
+where
+    M: MapObserver,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -1803,8 +1806,8 @@ impl<M> HasLen for HitcountsMapObserver<M>
 }
 
 impl<M> AsRef<Self> for HitcountsMapObserver<M>
-    where
-        M: MapObserver<Entry=u8>,
+where
+    M: MapObserver<Entry = u8>,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -1812,8 +1815,8 @@ impl<M> AsRef<Self> for HitcountsMapObserver<M>
 }
 
 impl<M> AsMut<Self> for HitcountsMapObserver<M>
-    where
-        M: MapObserver<Entry=u8>,
+where
+    M: MapObserver<Entry = u8>,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -1821,8 +1824,8 @@ impl<M> AsMut<Self> for HitcountsMapObserver<M>
 }
 
 impl<M> MapObserver for HitcountsMapObserver<M>
-    where
-        M: MapObserver<Entry=u8>,
+where
+    M: MapObserver<Entry = u8>,
 {
     type Entry = u8;
 
@@ -1870,8 +1873,8 @@ impl<M> MapObserver for HitcountsMapObserver<M>
 }
 
 impl<M> Truncate for HitcountsMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
 {
     fn truncate(&mut self, new_len: usize) {
         self.base.truncate(new_len);
@@ -1879,8 +1882,8 @@ impl<M> Truncate for HitcountsMapObserver<M>
 }
 
 impl<M> AsSlice for HitcountsMapObserver<M>
-    where
-        M: MapObserver + AsSlice,
+where
+    M: MapObserver + AsSlice,
 {
     type Entry = <M as AsSlice>::Entry;
     #[inline]
@@ -1890,8 +1893,8 @@ impl<M> AsSlice for HitcountsMapObserver<M>
 }
 
 impl<M> AsMutSlice for HitcountsMapObserver<M>
-    where
-        M: MapObserver + AsMutSlice,
+where
+    M: MapObserver + AsMutSlice,
 {
     type Entry = <M as AsMutSlice>::Entry;
     #[inline]
@@ -1901,8 +1904,8 @@ impl<M> AsMutSlice for HitcountsMapObserver<M>
 }
 
 impl<M> HitcountsMapObserver<M>
-    where
-        M: MapObserver,
+where
+    M: MapObserver,
 {
     /// Creates a new [`MapObserver`]
     pub fn new(base: M) -> Self {
@@ -1912,8 +1915,8 @@ impl<M> HitcountsMapObserver<M>
 }
 
 impl<'it, M> AsIter<'it> for HitcountsMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item=u8>,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item = u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
@@ -1924,8 +1927,8 @@ impl<'it, M> AsIter<'it> for HitcountsMapObserver<M>
 }
 
 impl<'it, M> AsIterMut<'it> for HitcountsMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item=u8>,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item = u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIterMut<'it>>::IntoIter;
@@ -1936,9 +1939,9 @@ impl<'it, M> AsIterMut<'it> for HitcountsMapObserver<M>
 }
 
 impl<'it, M> IntoIterator for &'it HitcountsMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        &'it M: IntoIterator<Item=&'it u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    &'it M: IntoIterator<Item = &'it u8>,
 {
     type Item = &'it u8;
     type IntoIter = <&'it M as IntoIterator>::IntoIter;
@@ -1949,9 +1952,9 @@ impl<'it, M> IntoIterator for &'it HitcountsMapObserver<M>
 }
 
 impl<'it, M> IntoIterator for &'it mut HitcountsMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        &'it mut M: IntoIterator<Item=&'it mut u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    &'it mut M: IntoIterator<Item = &'it mut u8>,
 {
     type Item = &'it mut u8;
     type IntoIter = <&'it mut M as IntoIterator>::IntoIter;
@@ -1962,9 +1965,9 @@ impl<'it, M> IntoIterator for &'it mut HitcountsMapObserver<M>
 }
 
 impl<M> HitcountsMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        for<'it> &'it M: IntoIterator<Item=&'it u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    for<'it> &'it M: IntoIterator<Item = &'it u8>,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> <&M as IntoIterator>::IntoIter {
@@ -1973,9 +1976,9 @@ impl<M> HitcountsMapObserver<M>
 }
 
 impl<M> HitcountsMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        for<'it> &'it mut M: IntoIterator<Item=&'it mut u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    for<'it> &'it mut M: IntoIterator<Item = &'it mut u8>,
 {
     /// Returns a mutable iterator over the map.
     pub fn iter_mut(&mut self) -> <&mut M as IntoIterator>::IntoIter {
@@ -1984,14 +1987,14 @@ impl<M> HitcountsMapObserver<M>
 }
 
 impl<M, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for HitcountsMapObserver<M>
-    where
-        M: DifferentialObserver<OTA, OTB, S>
-        + MapObserver<Entry=u8>
+where
+    M: DifferentialObserver<OTA, OTB, S>
+        + MapObserver<Entry = u8>
         + Serialize
-        + AsMutSlice<Entry=u8>,
-        OTA: ObserversTuple<S>,
-        OTB: ObserversTuple<S>,
-        S: UsesInput,
+        + AsMutSlice<Entry = u8>,
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
 {
     fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
         self.base.pre_observe_first(observers)
@@ -2016,17 +2019,17 @@ impl<M, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for HitcountsMapObserver<
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound = "M: serde::de::DeserializeOwned")]
 pub struct HitcountsIterableMapObserver<M>
-    where
-        M: Serialize,
+where
+    M: Serialize,
 {
     base: M,
 }
 
 impl<S, M> Observer<S> for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver<Entry=u8> + Observer<S>,
-        for<'it> M: AsIterMut<'it, Item=u8>,
-        S: UsesInput,
+where
+    M: MapObserver<Entry = u8> + Observer<S>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
+    S: UsesInput,
 {
     #[inline]
     fn pre_exec(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
@@ -2050,8 +2053,8 @@ impl<S, M> Observer<S> for HitcountsIterableMapObserver<M>
 }
 
 impl<M> Named for HitcountsIterableMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -2060,8 +2063,8 @@ impl<M> Named for HitcountsIterableMapObserver<M>
 }
 
 impl<M> HasLen for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver,
+where
+    M: MapObserver,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -2070,9 +2073,9 @@ impl<M> HasLen for HitcountsIterableMapObserver<M>
 }
 
 impl<M> AsRef<Self> for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver<Entry=u8>,
-        for<'it> M: AsIterMut<'it, Item=u8>,
+where
+    M: MapObserver<Entry = u8>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -2080,9 +2083,9 @@ impl<M> AsRef<Self> for HitcountsIterableMapObserver<M>
 }
 
 impl<M> AsMut<Self> for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver<Entry=u8>,
-        for<'it> M: AsIterMut<'it, Item=u8>,
+where
+    M: MapObserver<Entry = u8>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -2090,9 +2093,9 @@ impl<M> AsMut<Self> for HitcountsIterableMapObserver<M>
 }
 
 impl<M> MapObserver for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver<Entry=u8>,
-        for<'it> M: AsIterMut<'it, Item=u8>,
+where
+    M: MapObserver<Entry = u8>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
 {
     type Entry = u8;
 
@@ -2140,8 +2143,8 @@ impl<M> MapObserver for HitcountsIterableMapObserver<M>
 }
 
 impl<M> Truncate for HitcountsIterableMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned + Truncate,
 {
     fn truncate(&mut self, new_len: usize) {
         self.base.truncate(new_len);
@@ -2149,8 +2152,8 @@ impl<M> Truncate for HitcountsIterableMapObserver<M>
 }
 
 impl<M> AsSlice for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver + AsSlice,
+where
+    M: MapObserver + AsSlice,
 {
     type Entry = <M as AsSlice>::Entry;
     #[inline]
@@ -2160,8 +2163,8 @@ impl<M> AsSlice for HitcountsIterableMapObserver<M>
 }
 
 impl<M> AsMutSlice for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver + AsMutSlice,
+where
+    M: MapObserver + AsMutSlice,
 {
     type Entry = <M as AsMutSlice>::Entry;
     #[inline]
@@ -2171,8 +2174,8 @@ impl<M> AsMutSlice for HitcountsIterableMapObserver<M>
 }
 
 impl<M> HitcountsIterableMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
+where
+    M: Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`]
     pub fn new(base: M) -> Self {
@@ -2182,8 +2185,8 @@ impl<M> HitcountsIterableMapObserver<M>
 }
 
 impl<'it, M> AsIter<'it> for HitcountsIterableMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item=u8>,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item = u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
@@ -2194,8 +2197,8 @@ impl<'it, M> AsIter<'it> for HitcountsIterableMapObserver<M>
 }
 
 impl<'it, M> AsIterMut<'it> for HitcountsIterableMapObserver<M>
-    where
-        M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item=u8>,
+where
+    M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item = u8>,
 {
     type Item = u8;
     type IntoIter = <M as AsIterMut<'it>>::IntoIter;
@@ -2206,9 +2209,9 @@ impl<'it, M> AsIterMut<'it> for HitcountsIterableMapObserver<M>
 }
 
 impl<'it, M> IntoIterator for &'it HitcountsIterableMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        &'it M: IntoIterator<Item=&'it u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    &'it M: IntoIterator<Item = &'it u8>,
 {
     type Item = &'it u8;
     type IntoIter = <&'it M as IntoIterator>::IntoIter;
@@ -2219,9 +2222,9 @@ impl<'it, M> IntoIterator for &'it HitcountsIterableMapObserver<M>
 }
 
 impl<'it, M> IntoIterator for &'it mut HitcountsIterableMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        &'it mut M: IntoIterator<Item=&'it mut u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    &'it mut M: IntoIterator<Item = &'it mut u8>,
 {
     type Item = &'it mut u8;
     type IntoIter = <&'it mut M as IntoIterator>::IntoIter;
@@ -2232,9 +2235,9 @@ impl<'it, M> IntoIterator for &'it mut HitcountsIterableMapObserver<M>
 }
 
 impl<M> HitcountsIterableMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        for<'it> &'it M: IntoIterator<Item=&'it u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    for<'it> &'it M: IntoIterator<Item = &'it u8>,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> <&M as IntoIterator>::IntoIter {
@@ -2243,9 +2246,9 @@ impl<M> HitcountsIterableMapObserver<M>
 }
 
 impl<M> HitcountsIterableMapObserver<M>
-    where
-        M: Serialize + serde::de::DeserializeOwned,
-        for<'it> &'it mut M: IntoIterator<Item=&'it mut u8>,
+where
+    M: Serialize + serde::de::DeserializeOwned,
+    for<'it> &'it mut M: IntoIterator<Item = &'it mut u8>,
 {
     /// Returns a mutable iterator over the map.
     pub fn iter_mut(&mut self) -> <&mut M as IntoIterator>::IntoIter {
@@ -2254,12 +2257,12 @@ impl<M> HitcountsIterableMapObserver<M>
 }
 
 impl<M, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for HitcountsIterableMapObserver<M>
-    where
-        M: MapObserver<Entry=u8> + Observer<S> + DifferentialObserver<OTA, OTB, S>,
-        for<'it> M: AsIterMut<'it, Item=u8>,
-        OTA: ObserversTuple<S>,
-        OTB: ObserversTuple<S>,
-        S: UsesInput,
+where
+    M: MapObserver<Entry = u8> + Observer<S> + DifferentialObserver<OTA, OTB, S>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
 {
     fn pre_observe_first(&mut self, observers: &mut OTA) -> Result<(), Error> {
         self.base.pre_observe_first(observers)
@@ -2283,8 +2286,8 @@ impl<M, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for HitcountsIterableMapO
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct MultiMapObserver<'a, T, const DIFFERENTIAL: bool>
-    where
-        T: 'static + Default + Copy + Serialize + Debug,
+where
+    T: 'static + Default + Copy + Serialize + Debug,
 {
     maps: Vec<OwnedMutSlice<'a, T>>,
     intervals: IntervalTree<usize, usize>,
@@ -2295,10 +2298,10 @@ pub struct MultiMapObserver<'a, T, const DIFFERENTIAL: bool>
 }
 
 impl<'a, S, T> Observer<S> for MultiMapObserver<'a, T, false>
-    where
-        S: UsesInput,
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-        Self: MapObserver,
+where
+    S: UsesInput,
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -2307,17 +2310,17 @@ impl<'a, S, T> Observer<S> for MultiMapObserver<'a, T, false>
 }
 
 impl<'a, S, T> Observer<S> for MultiMapObserver<'a, T, true>
-    where
-        S: UsesInput,
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-        Self: MapObserver,
+where
+    S: UsesInput,
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    Self: MapObserver,
 {
     // in differential mode, we are *not* responsible for resetting the map!
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> Named for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -2326,8 +2329,8 @@ impl<'a, T, const DIFFERENTIAL: bool> Named for MultiMapObserver<'a, T, DIFFEREN
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> HasLen for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -2336,8 +2339,8 @@ impl<'a, T, const DIFFERENTIAL: bool> HasLen for MultiMapObserver<'a, T, DIFFERE
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + Debug,
+where
+    T: 'static + Default + Copy + Serialize + Debug,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -2345,8 +2348,8 @@ impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for MultiMapObserver<'a, T, DI
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + Debug,
+where
+    T: 'static + Default + Copy + Serialize + Debug,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -2354,8 +2357,8 @@ impl<'a, T, const DIFFERENTIAL: bool> AsMut<Self> for MultiMapObserver<'a, T, DI
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MapObserver for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static
+where
+    T: 'static
         + Bounded
         + PartialEq
         + Default
@@ -2451,8 +2454,8 @@ impl<'a, T, const DIFFERENTIAL: bool> MapObserver for MultiMapObserver<'a, T, DI
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Creates a new [`MultiMapObserver`], maybe in differential mode
     #[must_use]
@@ -2476,8 +2479,8 @@ impl<'a, T, const DIFFERENTIAL: bool> MultiMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, T> MultiMapObserver<'a, T, true>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Creates a new [`MultiMapObserver`] in differential mode
     #[must_use]
@@ -2487,8 +2490,8 @@ impl<'a, T> MultiMapObserver<'a, T, true>
 }
 
 impl<'a, T> MultiMapObserver<'a, T, false>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Creates a new [`MultiMapObserver`]
     #[must_use]
@@ -2524,9 +2527,9 @@ impl<'a, T> MultiMapObserver<'a, T, false>
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIter<'it> for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-        'a: 'it,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    'a: 'it,
 {
     type Item = T;
     type IntoIter = Flatten<Iter<'it, OwnedMutSlice<'a, T>>>;
@@ -2537,9 +2540,9 @@ impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIter<'it> for MultiMapObserver<'a, 
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIterMut<'it> for MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-        'a: 'it,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    'a: 'it,
 {
     type Item = T;
     type IntoIter = Flatten<IterMut<'it, OwnedMutSlice<'a, T>>>;
@@ -2550,9 +2553,9 @@ impl<'a, 'it, T, const DIFFERENTIAL: bool> AsIterMut<'it> for MultiMapObserver<'
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator
-for &'it MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    for &'it MultiMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <Iter<'it, T> as Iterator>::Item;
     type IntoIter = Flatten<Iter<'it, OwnedMutSlice<'a, T>>>;
@@ -2563,9 +2566,9 @@ for &'it MultiMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, 'it, T, const DIFFERENTIAL: bool> IntoIterator
-for &'it mut MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    for &'it mut MultiMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <IterMut<'it, T> as Iterator>::Item;
     type IntoIter = Flatten<IterMut<'it, OwnedMutSlice<'a, T>>>;
@@ -2576,8 +2579,8 @@ for &'it mut MultiMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, T, const DIFFERENTIAL: bool> MultiMapObserver<'a, T, DIFFERENTIAL>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
@@ -2591,21 +2594,22 @@ impl<'a, T, const DIFFERENTIAL: bool> MultiMapObserver<'a, T, DIFFERENTIAL>
 }
 
 impl<'a, T, OTA, OTB, S> DifferentialObserver<OTA, OTB, S> for MultiMapObserver<'a, T, true>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-        Self: MapObserver,
-        OTA: ObserversTuple<S>,
-        OTB: ObserversTuple<S>,
-        S: UsesInput,
-{}
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    Self: MapObserver,
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
+{
+}
 
 /// Exact copy of `StdMapObserver` that owns its map
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(bound = "T: serde::de::DeserializeOwned")]
 #[allow(clippy::unsafe_derive_deserialize)]
 pub struct OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize,
+where
+    T: 'static + Default + Copy + Serialize,
 {
     map: Vec<T>,
     initial: T,
@@ -2613,10 +2617,10 @@ pub struct OwnedMapObserver<T>
 }
 
 impl<S, T> Observer<S> for OwnedMapObserver<T>
-    where
-        S: UsesInput,
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
-        Self: MapObserver,
+where
+    S: UsesInput,
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+    Self: MapObserver,
 {
     #[inline]
     fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
@@ -2625,8 +2629,8 @@ impl<S, T> Observer<S> for OwnedMapObserver<T>
 }
 
 impl<T> Named for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn name(&self) -> &str {
@@ -2635,8 +2639,8 @@ impl<T> Named for OwnedMapObserver<T>
 }
 
 impl<T> HasLen for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -2645,8 +2649,8 @@ impl<T> HasLen for OwnedMapObserver<T>
 }
 
 impl<'it, T> AsIter<'it> for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = T;
     type IntoIter = Iter<'it, T>;
@@ -2657,8 +2661,8 @@ impl<'it, T> AsIter<'it> for OwnedMapObserver<T>
 }
 
 impl<'it, T> AsIterMut<'it> for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = T;
     type IntoIter = IterMut<'it, T>;
@@ -2669,8 +2673,8 @@ impl<'it, T> AsIterMut<'it> for OwnedMapObserver<T>
 }
 
 impl<'it, T> IntoIterator for &'it OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <Iter<'it, T> as Iterator>::Item;
     type IntoIter = Iter<'it, T>;
@@ -2681,8 +2685,8 @@ impl<'it, T> IntoIterator for &'it OwnedMapObserver<T>
 }
 
 impl<'it, T> IntoIterator for &'it mut OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = <IterMut<'it, T> as Iterator>::Item;
     type IntoIter = IterMut<'it, T>;
@@ -2693,8 +2697,8 @@ impl<'it, T> IntoIterator for &'it mut OwnedMapObserver<T>
 }
 
 impl<T> OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     /// Returns an iterator over the map.
     pub fn iter(&self) -> Iter<'_, T> {
@@ -2708,8 +2712,8 @@ impl<T> OwnedMapObserver<T>
 }
 
 impl<T> AsRef<Self> for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize,
+where
+    T: 'static + Default + Copy + Serialize,
 {
     fn as_ref(&self) -> &Self {
         self
@@ -2717,8 +2721,8 @@ impl<T> AsRef<Self> for OwnedMapObserver<T>
 }
 
 impl<T> AsMut<Self> for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize,
+where
+    T: 'static + Default + Copy + Serialize,
 {
     fn as_mut(&mut self) -> &mut Self {
         self
@@ -2726,8 +2730,8 @@ impl<T> AsMut<Self> for OwnedMapObserver<T>
 }
 
 impl<T> MapObserver for OwnedMapObserver<T>
-    where
-        T: 'static
+where
+    T: 'static
         + Bounded
         + PartialEq
         + Default
@@ -2807,8 +2811,8 @@ impl<T> MapObserver for OwnedMapObserver<T>
 }
 
 impl<T> AsSlice for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -2819,8 +2823,8 @@ impl<T> AsSlice for OwnedMapObserver<T>
 }
 
 impl<T> AsMutSlice for OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Entry = T;
     #[must_use]
@@ -2831,8 +2835,8 @@ impl<T> AsMutSlice for OwnedMapObserver<T>
 }
 
 impl<T> OwnedMapObserver<T>
-    where
-        T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
+where
+    T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned,
 {
     /// Creates a new [`MapObserver`] with an owned map
     #[must_use]

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -358,7 +358,8 @@ pub mod macros {
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
-pub trait MapObserver: HasLen + Named + Serialize + serde::de::DeserializeOwned
+pub trait MapObserver:
+    HasLen + Named + Serialize + serde::de::DeserializeOwned + AsRef<Self>
 // where
 //     for<'it> &'it Self: IntoIterator<Item = &'it Self::Entry>
 {
@@ -636,6 +637,15 @@ where
     /// Returns a mutable iterator over the map.
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         <&mut Self as IntoIterator>::into_iter(self)
+    }
+}
+
+impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for StdMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: Default + Copy + 'static + Serialize,
+{
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 
@@ -1123,6 +1133,15 @@ where
     }
 }
 
+impl<'a, T, const N: usize> AsRef<Self> for ConstMapObserver<'a, T, N>
+where
+    T: Default + Copy + 'static + Serialize,
+{
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl<'a, T, const N: usize> MapObserver for ConstMapObserver<'a, T, N>
 where
     T: Bounded
@@ -1435,6 +1454,15 @@ where
     }
 }
 
+impl<'a, T> AsRef<Self> for VariableMapObserver<'a, T>
+where
+    T: Default + Copy + 'static + Serialize + PartialEq + Bounded,
+{
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl<'a, T> MapObserver for VariableMapObserver<'a, T>
 where
     T: Bounded
@@ -1689,6 +1717,15 @@ where
     }
 }
 
+impl<M> AsRef<Self> for HitcountsMapObserver<M>
+where
+    M: MapObserver<Entry = u8>,
+{
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl<M> MapObserver for HitcountsMapObserver<M>
 where
     M: MapObserver<Entry = u8>,
@@ -1938,6 +1975,16 @@ where
     }
 }
 
+impl<M> AsRef<Self> for HitcountsIterableMapObserver<M>
+where
+    M: MapObserver<Entry = u8>,
+    for<'it> M: AsIterMut<'it, Item = u8>,
+{
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl<M> MapObserver for HitcountsIterableMapObserver<M>
 where
     M: MapObserver<Entry = u8>,
@@ -2180,6 +2227,15 @@ where
     #[inline]
     fn len(&self) -> usize {
         self.len
+    }
+}
+
+impl<'a, T, const DIFFERENTIAL: bool> AsRef<Self> for MultiMapObserver<'a, T, DIFFERENTIAL>
+where
+    T: 'static + Default + Copy + Serialize + Debug,
+{
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 
@@ -2535,6 +2591,15 @@ where
     /// Returns a mutable iterator over the map.
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         <&mut Self as IntoIterator>::into_iter(self)
+    }
+}
+
+impl<T> AsRef<Self> for OwnedMapObserver<T>
+where
+    T: 'static + Default + Copy + Serialize,
+{
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -290,11 +290,11 @@ pub mod macros {
     /// # use libafl::require_index_tracking;
     /// # use core::marker::PhantomData;
     /// #
-    /// # struct MyCustomScheduler<A, O> {
-    /// #     phantom: PhantomData<(A, O)>,
+    /// # struct MyCustomScheduler<C, O> {
+    /// #     phantom: PhantomData<(C, O)>,
     /// # }
     /// #
-    /// impl<A, O> MyCustomScheduler<A, O> where O: MapObserver, A: AsRef<O> + CanTrack {
+    /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: AsRef<O> + CanTrack {
     ///     pub fn new(obs: &A) -> Self {
     ///         require_index_tracking!("MyCustomScheduler", A);
     ///         todo!("Construct your type")
@@ -353,11 +353,11 @@ pub mod macros {
     /// # use libafl::require_novelties_tracking;
     /// # use core::marker::PhantomData;
     /// #
-    /// # struct MyCustomScheduler<A, O> {
+    /// # struct MyCustomScheduler<C, O> {
     /// #     phantom: PhantomData<(O, A)>,
     /// # }
     /// #
-    /// impl<A, O> MyCustomScheduler<A, O> where O: MapObserver, A: AsRef<O> + CanTrack {
+    /// impl<C, O> MyCustomScheduler<C, O> where O: MapObserver, C: AsRef<O> + CanTrack {
     ///     pub fn new(obs: &A) -> Self {
     ///         require_novelties_tracking!("MyCustomScheduler", A);
     ///         todo!("Construct your type")
@@ -411,7 +411,7 @@ pub mod macros {
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
 ///
 /// When referring to this type in a constraint (e.g. `O: MapObserver`), ensure that you only refer
-/// to instances of a second type, e.g. `A: AsRef<O>` or `A: AsMut<O>`. Map observer instances are
+/// to instances of a second type, e.g. `C: AsRef<O>` or `A: AsMut<O>`. Map observer instances are
 /// passed around in a way that may be potentially wrapped by e.g. [`ExplicitTracking`] as a way to
 /// encode metadata into the type. This is an unfortunate additional requirement that we can't get
 /// around without specialization.

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -290,11 +290,11 @@ pub mod macros {
     /// # use libafl::require_index_tracking;
     /// # use core::marker::PhantomData;
     /// #
-    /// # struct MyCustomScheduler<O, A> {
-    /// #     phantom: PhantomData<(O, A)>,
+    /// # struct MyCustomScheduler<A, O> {
+    /// #     phantom: PhantomData<(A, O)>,
     /// # }
     /// #
-    /// impl<O, A> MyCustomScheduler<O, A> where O: MapObserver, A: AsRef<O> + CanTrack {
+    /// impl<A, O> MyCustomScheduler<A, O> where O: MapObserver, A: AsRef<O> + CanTrack {
     ///     pub fn new(obs: &A) -> Self {
     ///         require_index_tracking!("MyCustomScheduler", A);
     ///         todo!("Construct your type")
@@ -353,11 +353,11 @@ pub mod macros {
     /// # use libafl::require_novelties_tracking;
     /// # use core::marker::PhantomData;
     /// #
-    /// # struct MyCustomScheduler<O, A> {
+    /// # struct MyCustomScheduler<A, O> {
     /// #     phantom: PhantomData<(O, A)>,
     /// # }
     /// #
-    /// impl<O, A> MyCustomScheduler<O, A> where O: MapObserver, A: AsRef<O> + CanTrack {
+    /// impl<A, O> MyCustomScheduler<A, O> where O: MapObserver, A: AsRef<O> + CanTrack {
     ///     pub fn new(obs: &A) -> Self {
     ///         require_novelties_tracking!("MyCustomScheduler", A);
     ///         todo!("Construct your type")

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -11,7 +11,7 @@ use crate::{
     corpus::{Corpus, CorpusId},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
-    observers::ObserversTuple,
+    observers::{ObserversTuple, TrackingHint},
     schedulers::{
         minimizer::{IsFavoredMetadata, MinimizerScheduler, DEFAULT_SKIP_NON_FAVORED_PROB},
         LenTimeMulTestcaseScore, Scheduler,
@@ -307,7 +307,12 @@ where
 
     /// Creates a new [`CoverageAccountingScheduler`] that wraps a `base` [`Scheduler`]
     /// and has a default probability to skip non-faved Testcases of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
-    pub fn new(state: &mut CS::State, base: CS, accounting_map: &'a [u32]) -> Self {
+    pub fn new<O: TrackingHint<true, NTH>, const NTH: bool>(
+        obs: &O,
+        state: &mut CS::State,
+        base: CS,
+        accounting_map: &'a [u32],
+    ) -> Self {
         match state.metadata_map().get::<TopAccountingMetadata>() {
             Some(meta) => {
                 if meta.max_accounting.len() != accounting_map.len() {
@@ -320,7 +325,7 @@ where
         }
         Self {
             accounting_map,
-            inner: MinimizerScheduler::new(base),
+            inner: MinimizerScheduler::new(obs, base),
             skip_non_favored_prob: DEFAULT_SKIP_NON_FAVORED_PROB,
         }
     }

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -11,7 +11,7 @@ use crate::{
     corpus::{Corpus, CorpusId},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
-    observers::{ObserversTuple, TrackingHinted},
+    observers::{CanTrack, ObserversTuple},
     schedulers::{
         minimizer::{IsFavoredMetadata, MinimizerScheduler, DEFAULT_SKIP_NON_FAVORED_PROB},
         LenTimeMulTestcaseScore, Scheduler,
@@ -134,7 +134,7 @@ where
     CS: Scheduler,
     CS::State: HasCorpus + HasMetadata + HasRand + Debug,
     <CS::State as UsesInput>::Input: HasLen,
-    O: TrackingHinted,
+    O: CanTrack,
 {
     fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
         self.update_accounting_score(state, idx)?;
@@ -197,7 +197,7 @@ where
     CS: Scheduler,
     CS::State: HasCorpus + HasMetadata + HasRand + Debug,
     <CS::State as UsesInput>::Input: HasLen,
-    O: TrackingHinted,
+    O: CanTrack,
 {
     /// Update the `Corpus` score
     #[allow(clippy::unused_self)]

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -310,7 +310,9 @@ where
 
     /// Creates a new [`CoverageAccountingScheduler`] that wraps a `base` [`Scheduler`]
     /// and has a default probability to skip non-faved Testcases of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
-    pub fn new(obs: &O, state: &mut CS::State, base: CS, accounting_map: &'a [u32]) -> Self {
+    ///
+    /// Provide the observer responsible for determining new indexes.
+    pub fn new(observer: &O, state: &mut CS::State, base: CS, accounting_map: &'a [u32]) -> Self {
         match state.metadata_map().get::<TopAccountingMetadata>() {
             Some(meta) => {
                 if meta.max_accounting.len() != accounting_map.len() {
@@ -323,14 +325,17 @@ where
         }
         Self {
             accounting_map,
-            inner: MinimizerScheduler::new(obs, base),
+            inner: MinimizerScheduler::new(observer, base),
             skip_non_favored_prob: DEFAULT_SKIP_NON_FAVORED_PROB,
         }
     }
 
     /// Creates a new [`CoverageAccountingScheduler`] that wraps a `base` [`Scheduler`]
     /// and has a non-default probability to skip non-faved Testcases using (`skip_non_favored_prob`).
+    ///
+    /// Provide the observer responsible for determining new indexes.
     pub fn with_skip_prob(
+        observer: &O,
         state: &mut CS::State,
         base: CS,
         skip_non_favored_prob: u64,
@@ -348,7 +353,7 @@ where
         }
         Self {
             accounting_map,
-            inner: MinimizerScheduler::with_skip_prob(base, skip_non_favored_prob),
+            inner: MinimizerScheduler::with_skip_prob(observer, base, skip_non_favored_prob),
             skip_non_favored_prob,
         }
     }

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -12,7 +12,7 @@ use crate::{
     corpus::{Corpus, CorpusId, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
-    observers::ObserversTuple,
+    observers::{ObserversTuple, TrackingHint},
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasRand, UsesState},
     Error, HasMetadata,
@@ -371,7 +371,7 @@ where
     /// and has a default probability to skip non-faved [`Testcase`]s of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
     /// This will remove the metadata `M` when it is no longer needed, after consumption. This might
     /// for example be a `MapIndexesMetadata`.
-    pub fn new(base: CS) -> Self {
+    pub fn new<O: TrackingHint<true, NTH>, const NTH: bool>(_obs: &O, base: CS) -> Self {
         Self {
             base,
             skip_non_favored_prob: DEFAULT_SKIP_NON_FAVORED_PROB,

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -12,7 +12,7 @@ use crate::{
     corpus::{Corpus, CorpusId, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
-    observers::{ObserversTuple, TrackingHint},
+    observers::{ObserversTuple, TrackingHinted},
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasRand, UsesState},
     Error, HasMetadata,
@@ -70,26 +70,27 @@ impl Default for TopRatedsMetadata {
 /// corpus that exercise all the requested features (e.g. all the coverage seen so far)
 /// prioritizing [`Testcase`]`s` using [`TestcaseScore`]
 #[derive(Debug, Clone)]
-pub struct MinimizerScheduler<CS, F, M> {
+pub struct MinimizerScheduler<CS, F, M, O> {
     base: CS,
     skip_non_favored_prob: u64,
     remove_metadata: bool,
-    phantom: PhantomData<(F, M)>,
+    phantom: PhantomData<(F, M, O)>,
 }
 
-impl<CS, F, M> UsesState for MinimizerScheduler<CS, F, M>
+impl<CS, F, M, O> UsesState for MinimizerScheduler<CS, F, M, O>
 where
     CS: UsesState,
 {
     type State = CS::State;
 }
 
-impl<CS, F, M> RemovableScheduler for MinimizerScheduler<CS, F, M>
+impl<CS, F, M, O> RemovableScheduler for MinimizerScheduler<CS, F, M, O>
 where
     CS: RemovableScheduler,
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
+    O: TrackingHinted,
 {
     /// Replaces the testcase at the given idx
     fn on_replace(
@@ -191,12 +192,13 @@ where
     }
 }
 
-impl<CS, F, M> Scheduler for MinimizerScheduler<CS, F, M>
+impl<CS, F, M, O> Scheduler for MinimizerScheduler<CS, F, M, O>
 where
     CS: Scheduler,
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
+    O: TrackingHinted,
 {
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add(&mut self, state: &mut CS::State, idx: CorpusId) -> Result<(), Error> {
@@ -246,13 +248,16 @@ where
     }
 }
 
-impl<CS, F, M> MinimizerScheduler<CS, F, M>
+impl<CS, F, M, O> MinimizerScheduler<CS, F, M, O>
 where
     CS: Scheduler,
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
+    O: TrackingHinted,
 {
+    const TRACKING_SANITY: () = assert!(O::INDICES, "\nIndex tracking is required by MinimizerScheduler\nhint: call `.with_tracking::<true, ...>()` on the observer you passed to MinimizerScheduler::new\nnote: see the documentation for TrackingHinted for details");
+
     /// Update the [`Corpus`] score using the [`MinimizerScheduler`]
     #[allow(clippy::unused_self)]
     #[allow(clippy::cast_possible_wrap)]
@@ -371,7 +376,8 @@ where
     /// and has a default probability to skip non-faved [`Testcase`]s of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
     /// This will remove the metadata `M` when it is no longer needed, after consumption. This might
     /// for example be a `MapIndexesMetadata`.
-    pub fn new<O: TrackingHint<true, NTH>, const NTH: bool>(_obs: &O, base: CS) -> Self {
+    pub fn new(_obs: &O, base: CS) -> Self {
+        let _: () = Self::TRACKING_SANITY; // check that tracking is enabled for this map
         Self {
             base,
             skip_non_favored_prob: DEFAULT_SKIP_NON_FAVORED_PROB,
@@ -405,10 +411,14 @@ where
 }
 
 /// A [`MinimizerScheduler`] with [`LenTimeMulTestcaseScore`] to prioritize quick and small [`Testcase`]`s`.
-pub type LenTimeMinimizerScheduler<CS, M> =
-    MinimizerScheduler<CS, LenTimeMulTestcaseScore<<CS as UsesState>::State>, M>;
+pub type LenTimeMinimizerScheduler<CS, M, O> =
+    MinimizerScheduler<CS, LenTimeMulTestcaseScore<<CS as UsesState>::State>, M, O>;
 
 /// A [`MinimizerScheduler`] with [`LenTimeMulTestcaseScore`] to prioritize quick and small [`Testcase`]`s`
 /// that exercise all the entries registered in the [`MapIndexesMetadata`].
-pub type IndexesLenTimeMinimizerScheduler<CS> =
-    MinimizerScheduler<CS, LenTimeMulTestcaseScore<<CS as UsesState>::State>, MapIndexesMetadata>;
+pub type IndexesLenTimeMinimizerScheduler<CS, O> = MinimizerScheduler<
+    CS,
+    LenTimeMulTestcaseScore<<CS as UsesState>::State>,
+    MapIndexesMetadata,
+    O,
+>;

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -13,6 +13,7 @@ use crate::{
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
     observers::{ObserversTuple, TrackingHinted},
+    require_index_tracking,
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasRand, UsesState},
     Error, HasMetadata,
@@ -256,8 +257,6 @@ where
     CS::State: HasCorpus + HasMetadata + HasRand,
     O: TrackingHinted,
 {
-    const TRACKING_SANITY: () = assert!(O::INDICES, "\nIndex tracking is required by MinimizerScheduler\nhint: call `.with_tracking::<true, ...>()` on the observer you passed to MinimizerScheduler::new\nnote: see the documentation for TrackingHinted for details");
-
     /// Update the [`Corpus`] score using the [`MinimizerScheduler`]
     #[allow(clippy::unused_self)]
     #[allow(clippy::cast_possible_wrap)]
@@ -377,7 +376,7 @@ where
     /// This will remove the metadata `M` when it is no longer needed, after consumption. This might
     /// for example be a `MapIndexesMetadata`.
     pub fn new(_obs: &O, base: CS) -> Self {
-        let _: () = Self::TRACKING_SANITY; // check that tracking is enabled for this map
+        require_index_tracking!("MinimizerScheduler", O);
         Self {
             base,
             skip_non_favored_prob: DEFAULT_SKIP_NON_FAVORED_PROB,

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -375,7 +375,9 @@ where
     /// and has a default probability to skip non-faved [`Testcase`]s of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
     /// This will remove the metadata `M` when it is no longer needed, after consumption. This might
     /// for example be a `MapIndexesMetadata`.
-    pub fn new(_obs: &O, base: CS) -> Self {
+    ///
+    /// When calling, pass the edges observer which will provided the indexes to minimize over.
+    pub fn new(_observer: &O, base: CS) -> Self {
         require_index_tracking!("MinimizerScheduler", O);
         Self {
             base,
@@ -388,7 +390,10 @@ where
     /// Creates a new [`MinimizerScheduler`] that wraps a `base` [`Scheduler`]
     /// and has a default probability to skip non-faved [`Testcase`]s of [`DEFAULT_SKIP_NON_FAVORED_PROB`].
     /// This method will prevent the metadata `M` from being removed at the end of scoring.
-    pub fn non_metadata_removing(base: CS) -> Self {
+    ///
+    /// When calling, pass the edges observer which will provided the indexes to minimize over.
+    pub fn non_metadata_removing(_observer: &O, base: CS) -> Self {
+        require_index_tracking!("MinimizerScheduler", O);
         Self {
             base,
             skip_non_favored_prob: DEFAULT_SKIP_NON_FAVORED_PROB,
@@ -399,7 +404,10 @@ where
 
     /// Creates a new [`MinimizerScheduler`] that wraps a `base` [`Scheduler`]
     /// and has a non-default probability to skip non-faved [`Testcase`]s using (`skip_non_favored_prob`).
-    pub fn with_skip_prob(base: CS, skip_non_favored_prob: u64) -> Self {
+    ///
+    /// When calling, pass the edges observer which will provided the indexes to minimize over.
+    pub fn with_skip_prob(_observer: &O, base: CS, skip_non_favored_prob: u64) -> Self {
+        require_index_tracking!("MinimizerScheduler", O);
         Self {
             base,
             skip_non_favored_prob,

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -12,7 +12,7 @@ use crate::{
     corpus::{Corpus, CorpusId, Testcase},
     feedbacks::MapIndexesMetadata,
     inputs::UsesInput,
-    observers::{ObserversTuple, TrackingHinted},
+    observers::{CanTrack, ObserversTuple},
     require_index_tracking,
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasRand, UsesState},
@@ -91,7 +91,7 @@ where
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
-    O: TrackingHinted,
+    O: CanTrack,
 {
     /// Replaces the testcase at the given idx
     fn on_replace(
@@ -199,7 +199,7 @@ where
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
-    O: TrackingHinted,
+    O: CanTrack,
 {
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add(&mut self, state: &mut CS::State, idx: CorpusId) -> Result<(), Error> {
@@ -255,7 +255,7 @@ where
     F: TestcaseScore<CS::State>,
     M: AsSlice<Entry = usize> + SerdeAny + HasRefCnt,
     CS::State: HasCorpus + HasMetadata + HasRand,
-    O: TrackingHinted,
+    O: CanTrack,
 {
     /// Update the [`Corpus`] score using the [`MinimizerScheduler`]
     #[allow(clippy::unused_self)]

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -66,10 +66,11 @@ where
 }
 
 /// Defines the common metadata operations for the AFL-style schedulers
-pub trait AflScheduler<O, S>: Scheduler
+pub trait AflScheduler<O, S, A>: Scheduler
 where
     Self::State: HasCorpus + HasMetadata + HasTestcase,
     O: MapObserver,
+    A: AsRef<O>,
 {
     /// Return the last hash
     fn last_hash(&self) -> usize;
@@ -117,8 +118,9 @@ where
         OT: ObserversTuple<Self::State>,
     {
         let observer = observers
-            .match_name::<O>(self.map_observer_name())
-            .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?;
+            .match_name::<A>(self.map_observer_name())
+            .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+            .as_ref();
 
         let mut hash = observer.hash() as usize;
 

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -66,7 +66,7 @@ where
 }
 
 /// Defines the common metadata operations for the AFL-style schedulers
-pub trait AflScheduler<O, S, A>: Scheduler
+pub trait AflScheduler<A, O, S>: Scheduler
 where
     Self::State: HasCorpus + HasMetadata + HasTestcase,
     O: MapObserver,

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -66,11 +66,11 @@ where
 }
 
 /// Defines the common metadata operations for the AFL-style schedulers
-pub trait AflScheduler<A, O, S>: Scheduler
+pub trait AflScheduler<C, O, S>: Scheduler
 where
     Self::State: HasCorpus + HasMetadata + HasTestcase,
     O: MapObserver,
-    A: AsRef<O>,
+    C: AsRef<O>,
 {
     /// Return the last hash
     fn last_hash(&self) -> usize;
@@ -118,7 +118,7 @@ where
         OT: ObserversTuple<Self::State>,
     {
         let observer = observers
-            .match_name::<A>(self.map_observer_name())
+            .match_name::<C>(self.map_observer_name())
             .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
             .as_ref();
 

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -185,7 +185,7 @@ where
     type State = S;
 }
 
-impl<O, S> RemovableScheduler for PowerQueueScheduler<O, S>
+impl<O, S, A> RemovableScheduler for PowerQueueScheduler<O, S, A>
 where
     S: State + HasTestcase + HasMetadata + HasCorpus,
     O: MapObserver,

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -171,21 +171,21 @@ pub enum PowerSchedule {
 /// Note that this corpus is merely holding the metadata necessary for the power calculation
 /// and here we DON'T actually calculate the power (we do it in the stage)
 #[derive(Clone, Debug)]
-pub struct PowerQueueScheduler<O, S, A> {
+pub struct PowerQueueScheduler<A, O, S> {
     strat: PowerSchedule,
     map_observer_name: String,
     last_hash: usize,
     phantom: PhantomData<(O, S, A)>,
 }
 
-impl<O, S, A> UsesState for PowerQueueScheduler<O, S, A>
+impl<A, O, S> UsesState for PowerQueueScheduler<A, O, S>
 where
     S: State,
 {
     type State = S;
 }
 
-impl<O, S, A> RemovableScheduler for PowerQueueScheduler<O, S, A>
+impl<A, O, S> RemovableScheduler for PowerQueueScheduler<A, O, S>
 where
     S: State + HasTestcase + HasMetadata + HasCorpus,
     O: MapObserver,
@@ -212,7 +212,7 @@ where
     }
 }
 
-impl<O, S, A> AflScheduler<O, S, A> for PowerQueueScheduler<O, S, A>
+impl<A, O, S> AflScheduler<A, O, S> for PowerQueueScheduler<A, O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase + State,
     O: MapObserver,
@@ -231,7 +231,7 @@ where
     }
 }
 
-impl<O, S, A> Scheduler for PowerQueueScheduler<O, S, A>
+impl<A, O, S> Scheduler for PowerQueueScheduler<A, O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase + State,
     O: MapObserver,
@@ -291,7 +291,7 @@ where
     }
 }
 
-impl<O, S, A> PowerQueueScheduler<O, S, A>
+impl<A, O, S> PowerQueueScheduler<A, O, S>
 where
     S: HasMetadata,
     O: MapObserver,

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -171,25 +171,25 @@ pub enum PowerSchedule {
 /// Note that this corpus is merely holding the metadata necessary for the power calculation
 /// and here we DON'T actually calculate the power (we do it in the stage)
 #[derive(Clone, Debug)]
-pub struct PowerQueueScheduler<A, O, S> {
+pub struct PowerQueueScheduler<C, O, S> {
     strat: PowerSchedule,
     map_observer_name: String,
     last_hash: usize,
-    phantom: PhantomData<(O, S, A)>,
+    phantom: PhantomData<(C, O, S)>,
 }
 
-impl<A, O, S> UsesState for PowerQueueScheduler<A, O, S>
+impl<C, O, S> UsesState for PowerQueueScheduler<C, O, S>
 where
     S: State,
 {
     type State = S;
 }
 
-impl<A, O, S> RemovableScheduler for PowerQueueScheduler<A, O, S>
+impl<C, O, S> RemovableScheduler for PowerQueueScheduler<C, O, S>
 where
     S: State + HasTestcase + HasMetadata + HasCorpus,
     O: MapObserver,
-    A: AsRef<O>,
+    C: AsRef<O>,
 {
     /// This will *NOT* neutralize the effect of this removed testcase from the global data such as `SchedulerMetadata`
     fn on_remove(
@@ -212,11 +212,11 @@ where
     }
 }
 
-impl<A, O, S> AflScheduler<A, O, S> for PowerQueueScheduler<A, O, S>
+impl<C, O, S> AflScheduler<C, O, S> for PowerQueueScheduler<C, O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase + State,
     O: MapObserver,
-    A: AsRef<O>,
+    C: AsRef<O>,
 {
     fn last_hash(&self) -> usize {
         self.last_hash
@@ -231,11 +231,11 @@ where
     }
 }
 
-impl<A, O, S> Scheduler for PowerQueueScheduler<A, O, S>
+impl<C, O, S> Scheduler for PowerQueueScheduler<C, O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase + State,
     O: MapObserver,
-    A: AsRef<O>,
+    C: AsRef<O>,
 {
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add(&mut self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
@@ -291,15 +291,15 @@ where
     }
 }
 
-impl<A, O, S> PowerQueueScheduler<A, O, S>
+impl<C, O, S> PowerQueueScheduler<C, O, S>
 where
     S: HasMetadata,
     O: MapObserver,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
 {
     /// Create a new [`PowerQueueScheduler`]
     #[must_use]
-    pub fn new(state: &mut S, map_observer: &A, strat: PowerSchedule) -> Self {
+    pub fn new(state: &mut S, map_observer: &C, strat: PowerSchedule) -> Self {
         if !state.has_metadata::<SchedulerMetadata>() {
             state.add_metadata::<SchedulerMetadata>(SchedulerMetadata::new(Some(strat)));
         }

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -92,30 +92,30 @@ libafl_bolts::impl_serdeany!(WeightedScheduleMetadata);
 
 /// A corpus scheduler using power schedules with weighted queue item selection algo.
 #[derive(Clone, Debug)]
-pub struct WeightedScheduler<A, F, O, S> {
+pub struct WeightedScheduler<C, F, O, S> {
     table_invalidated: bool,
     strat: Option<PowerSchedule>,
     map_observer_name: String,
     last_hash: usize,
-    phantom: PhantomData<(A, F, O, S)>,
+    phantom: PhantomData<(C, F, O, S)>,
 }
 
-impl<A, F, O, S> WeightedScheduler<A, F, O, S>
+impl<C, F, O, S> WeightedScheduler<C, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
     S: HasCorpus + HasMetadata + HasRand,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
 {
     /// Create a new [`WeightedScheduler`] without any power schedule
     #[must_use]
-    pub fn new(state: &mut S, map_observer: &A) -> Self {
+    pub fn new(state: &mut S, map_observer: &C) -> Self {
         Self::with_schedule(state, map_observer, None)
     }
 
     /// Create a new [`WeightedScheduler`]
     #[must_use]
-    pub fn with_schedule(state: &mut S, map_observer: &A, strat: Option<PowerSchedule>) -> Self {
+    pub fn with_schedule(state: &mut S, map_observer: &C, strat: Option<PowerSchedule>) -> Self {
         let _ = state.metadata_or_insert_with(|| SchedulerMetadata::new(strat));
         let _ = state.metadata_or_insert_with(WeightedScheduleMetadata::new);
 
@@ -219,19 +219,19 @@ where
     }
 }
 
-impl<A, F, O, S> UsesState for WeightedScheduler<A, F, O, S>
+impl<C, F, O, S> UsesState for WeightedScheduler<C, F, O, S>
 where
     S: State,
 {
     type State = S;
 }
 
-impl<A, F, O, S> RemovableScheduler for WeightedScheduler<A, F, O, S>
+impl<C, F, O, S> RemovableScheduler for WeightedScheduler<C, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
     S: HasCorpus + HasMetadata + HasRand + HasTestcase + State,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
 {
     /// This will *NOT* neutralize the effect of this removed testcase from the global data such as `SchedulerMetadata`
     fn on_remove(
@@ -256,12 +256,12 @@ where
     }
 }
 
-impl<A, F, O, S> AflScheduler<A, O, S> for WeightedScheduler<A, F, O, S>
+impl<C, F, O, S> AflScheduler<C, O, S> for WeightedScheduler<C, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
     S: HasCorpus + HasMetadata + HasTestcase + HasRand + State,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
 {
     fn last_hash(&self) -> usize {
         self.last_hash
@@ -276,12 +276,12 @@ where
     }
 }
 
-impl<A, F, O, S> Scheduler for WeightedScheduler<A, F, O, S>
+impl<C, F, O, S> Scheduler for WeightedScheduler<C, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
     S: HasCorpus + HasMetadata + HasRand + HasTestcase + State,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
 {
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add(&mut self, state: &mut S, idx: CorpusId) -> Result<(), Error> {
@@ -361,4 +361,4 @@ where
 }
 
 /// The standard corpus weight, same as in `AFL++`
-pub type StdWeightedScheduler<A, O, S> = WeightedScheduler<A, CorpusWeightTestcaseScore<S>, O, S>;
+pub type StdWeightedScheduler<C, O, S> = WeightedScheduler<C, CorpusWeightTestcaseScore<S>, O, S>;

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -92,7 +92,7 @@ libafl_bolts::impl_serdeany!(WeightedScheduleMetadata);
 
 /// A corpus scheduler using power schedules with weighted queue item selection algo.
 #[derive(Clone, Debug)]
-pub struct WeightedScheduler<F, O, S> {
+pub struct WeightedScheduler<F, O, S, A> {
     table_invalidated: bool,
     strat: Option<PowerSchedule>,
     map_observer_name: String,
@@ -226,7 +226,7 @@ where
     type State = S;
 }
 
-impl<F, O, S> RemovableScheduler for WeightedScheduler<F, O, S>
+impl<F, O, S, A> RemovableScheduler for WeightedScheduler<F, O, S, A>
 where
     F: TestcaseScore<S>,
     O: MapObserver,

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -1,4 +1,4 @@
-//! The queue corpus scheduler with weighted queue item selection from aflpp (`https://github.com/AFLplusplus/AFLplusplus/blob/1d4f1e48797c064ee71441ba555b29fc3f467983/src/afl-fuzz-queue.c#L32`)
+//! The queue corpus scheduler with weighted queue item selection [from AFL++](https://github.com/AFLplusplus/AFLplusplus/blob/1d4f1e48797c064ee71441ba555b29fc3f467983/src/afl-fuzz-queue.c#L32).
 //! This queue corpus scheduler needs calibration stage.
 
 use alloc::string::{String, ToString};
@@ -92,15 +92,15 @@ libafl_bolts::impl_serdeany!(WeightedScheduleMetadata);
 
 /// A corpus scheduler using power schedules with weighted queue item selection algo.
 #[derive(Clone, Debug)]
-pub struct WeightedScheduler<F, O, S, A> {
+pub struct WeightedScheduler<A, F, O, S> {
     table_invalidated: bool,
     strat: Option<PowerSchedule>,
     map_observer_name: String,
     last_hash: usize,
-    phantom: PhantomData<(F, O, S, A)>,
+    phantom: PhantomData<(A, F, O, S)>,
 }
 
-impl<F, O, S, A> WeightedScheduler<F, O, S, A>
+impl<A, F, O, S> WeightedScheduler<A, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
@@ -219,14 +219,14 @@ where
     }
 }
 
-impl<F, O, S, A> UsesState for WeightedScheduler<F, O, S, A>
+impl<A, F, O, S> UsesState for WeightedScheduler<A, F, O, S>
 where
     S: State,
 {
     type State = S;
 }
 
-impl<F, O, S, A> RemovableScheduler for WeightedScheduler<F, O, S, A>
+impl<A, F, O, S> RemovableScheduler for WeightedScheduler<A, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
@@ -256,7 +256,7 @@ where
     }
 }
 
-impl<F, O, S, A> AflScheduler<O, S, A> for WeightedScheduler<F, O, S, A>
+impl<A, F, O, S> AflScheduler<A, O, S> for WeightedScheduler<A, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
@@ -276,7 +276,7 @@ where
     }
 }
 
-impl<F, O, S, A> Scheduler for WeightedScheduler<F, O, S, A>
+impl<A, F, O, S> Scheduler for WeightedScheduler<A, F, O, S>
 where
     F: TestcaseScore<S>,
     O: MapObserver,
@@ -360,5 +360,5 @@ where
     }
 }
 
-/// The standard corpus weight, same as aflpp
-pub type StdWeightedScheduler<O, S, A> = WeightedScheduler<CorpusWeightTestcaseScore<S>, O, S, A>;
+/// The standard corpus weight, same as in `AFL++`
+pub type StdWeightedScheduler<A, O, S> = WeightedScheduler<A, CorpusWeightTestcaseScore<S>, O, S>;

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -64,31 +64,32 @@ impl UnstableEntriesMetadata {
 
 /// The calibration stage will measure the average exec time and the target's stability for this input.
 #[derive(Clone, Debug)]
-pub struct CalibrationStage<O, OT, S> {
+pub struct CalibrationStage<O, OT, S, A> {
     map_observer_name: String,
     map_name: String,
     stage_max: usize,
     /// If we should track stability
     track_stability: bool,
     restart_helper: ExecutionCountRestartHelper,
-    phantom: PhantomData<(O, OT, S)>,
+    phantom: PhantomData<(O, OT, S, A)>,
 }
 
 const CAL_STAGE_START: usize = 4; // AFL++'s CAL_CYCLES_FAST + 1
 const CAL_STAGE_MAX: usize = 8; // AFL++'s CAL_CYCLES + 1
 
-impl<O, OT, S> UsesState for CalibrationStage<O, OT, S>
+impl<O, OT, S, A> UsesState for CalibrationStage<O, OT, S, A>
 where
     S: State,
 {
     type State = S;
 }
 
-impl<E, EM, O, OT, Z> Stage<E, EM, Z> for CalibrationStage<O, OT, E::State>
+impl<E, EM, O, OT, Z, A> Stage<E, EM, Z> for CalibrationStage<O, OT, E::State, A>
 where
     E: Executor<EM, Z> + HasObservers<Observers = OT>,
     EM: EventFirer<State = E::State>,
     O: MapObserver,
+    A: AsRef<O>,
     for<'de> <O as MapObserver>::Entry: Serialize + Deserialize<'de> + 'static,
     OT: ObserversTuple<E::State>,
     E::State: HasCorpus + HasMetadata + HasNamedMetadata + HasExecutions,
@@ -147,8 +148,9 @@ where
 
         let map_first = &executor
             .observers()
-            .match_name::<O>(&self.map_observer_name)
+            .match_name::<A>(&self.map_observer_name)
             .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+            .as_ref()
             .to_vec();
 
         let mut unstable_entries: Vec<usize> = vec![];
@@ -190,8 +192,9 @@ where
             if self.track_stability {
                 let map = &executor
                     .observers()
-                    .match_name::<O>(&self.map_observer_name)
+                    .match_name::<A>(&self.map_observer_name)
                     .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+                    .as_ref()
                     .to_vec();
 
                 let history_map = &mut state
@@ -246,8 +249,9 @@ where
         if state.has_metadata::<SchedulerMetadata>() {
             let map = executor
                 .observers()
-                .match_name::<O>(&self.map_observer_name)
-                .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?;
+                .match_name::<A>(&self.map_observer_name)
+                .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+                .as_ref();
 
             let mut bitmap_size = map.count_bytes();
             assert!(bitmap_size != 0);
@@ -335,9 +339,10 @@ where
     }
 }
 
-impl<O, OT, S> CalibrationStage<O, OT, S>
+impl<O, OT, S, A> CalibrationStage<O, OT, S, A>
 where
     O: MapObserver,
+    A: AsRef<O>,
     OT: ObserversTuple<S>,
     S: HasCorpus + HasMetadata + HasNamedMetadata,
 {
@@ -345,8 +350,9 @@ where
     #[must_use]
     pub fn new<F>(map_feedback: &F) -> Self
     where
-        F: HasObserverName + Named + UsesObserver<S, Observer = O>,
+        F: HasObserverName + Named + UsesObserver<S, Observer = A>,
         for<'it> O: AsIter<'it, Item = O::Entry>,
+        A: AsRef<O>,
     {
         Self {
             map_observer_name: map_feedback.observer_name().to_string(),
@@ -362,8 +368,9 @@ where
     #[must_use]
     pub fn ignore_stability<F>(map_feedback: &F) -> Self
     where
-        F: HasObserverName + Named + UsesObserver<S, Observer = O>,
+        F: HasObserverName + Named + UsesObserver<S, Observer = A>,
         for<'it> O: AsIter<'it, Item = O::Entry>,
+        A: AsRef<O>,
     {
         Self {
             map_observer_name: map_feedback.observer_name().to_string(),

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -64,7 +64,7 @@ impl UnstableEntriesMetadata {
 
 /// The calibration stage will measure the average exec time and the target's stability for this input.
 #[derive(Clone, Debug)]
-pub struct CalibrationStage<O, OT, S, A> {
+pub struct CalibrationStage<A, O, OT, S> {
     map_observer_name: String,
     map_name: String,
     stage_max: usize,
@@ -77,14 +77,14 @@ pub struct CalibrationStage<O, OT, S, A> {
 const CAL_STAGE_START: usize = 4; // AFL++'s CAL_CYCLES_FAST + 1
 const CAL_STAGE_MAX: usize = 8; // AFL++'s CAL_CYCLES + 1
 
-impl<O, OT, S, A> UsesState for CalibrationStage<O, OT, S, A>
+impl<A, O, OT, S> UsesState for CalibrationStage<A, O, OT, S>
 where
     S: State,
 {
     type State = S;
 }
 
-impl<E, EM, O, OT, Z, A> Stage<E, EM, Z> for CalibrationStage<O, OT, E::State, A>
+impl<A, E, EM, O, OT, Z> Stage<E, EM, Z> for CalibrationStage<A, O, OT, E::State>
 where
     E: Executor<EM, Z> + HasObservers<Observers = OT>,
     EM: EventFirer<State = E::State>,
@@ -339,7 +339,7 @@ where
     }
 }
 
-impl<O, OT, S, A> CalibrationStage<O, OT, S, A>
+impl<A, O, OT, S> CalibrationStage<A, O, OT, S>
 where
     O: MapObserver,
     A: AsRef<O>,

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -54,20 +54,20 @@ impl Ord for Earlier {
 
 /// The mutational stage using power schedules
 #[derive(Clone, Debug)]
-pub struct ColorizationStage<EM, O, E, Z, A> {
+pub struct ColorizationStage<A, E, EM, O, Z> {
     map_observer_name: String,
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(EM, O, E, Z, A)>,
+    phantom: PhantomData<(A, E, EM, O, E, Z)>,
 }
 
-impl<EM, O, E, Z, A> UsesState for ColorizationStage<EM, O, E, Z, A>
+impl<A, E, EM, O, Z> UsesState for ColorizationStage<A, E, EM, O, Z>
 where
     E: UsesState,
 {
     type State = E::State;
 }
 
-impl<EM, O, E, Z, A> Named for ColorizationStage<EM, O, E, Z, A>
+impl<A, E, EM, O, Z> Named for ColorizationStage<A, E, EM, O, Z>
 where
     E: UsesState,
 {
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl<E, EM, O, Z, A> Stage<E, EM, Z> for ColorizationStage<EM, O, E, Z, A>
+impl<A, E, EM, O, Z> Stage<E, EM, Z> for ColorizationStage<A, E, EM, O, Z>
 where
     EM: UsesState<State = E::State> + EventFirer,
     E: HasObservers + Executor<EM, Z>,
@@ -151,7 +151,7 @@ impl TaintMetadata {
 
 libafl_bolts::impl_serdeany!(TaintMetadata);
 
-impl<EM, O, E, Z, A> ColorizationStage<EM, O, E, Z, A>
+impl<A, E, EM, O, Z> ColorizationStage<A, E, EM, O, Z>
 where
     EM: UsesState<State = E::State> + EventFirer,
     O: MapObserver,

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -54,20 +54,20 @@ impl Ord for Earlier {
 
 /// The mutational stage using power schedules
 #[derive(Clone, Debug)]
-pub struct ColorizationStage<EM, O, E, Z> {
+pub struct ColorizationStage<EM, O, E, Z, A> {
     map_observer_name: String,
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(E, EM, O, Z)>,
+    phantom: PhantomData<(EM, O, E, Z, A)>,
 }
 
-impl<EM, O, E, Z> UsesState for ColorizationStage<EM, O, E, Z>
+impl<EM, O, E, Z, A> UsesState for ColorizationStage<EM, O, E, Z, A>
 where
     E: UsesState,
 {
     type State = E::State;
 }
 
-impl<EM, O, E, Z> Named for ColorizationStage<EM, O, E, Z>
+impl<EM, O, E, Z, A> Named for ColorizationStage<EM, O, E, Z, A>
 where
     E: UsesState,
 {
@@ -76,13 +76,14 @@ where
     }
 }
 
-impl<E, EM, O, Z> Stage<E, EM, Z> for ColorizationStage<EM, O, E, Z>
+impl<E, EM, O, Z, A> Stage<E, EM, Z> for ColorizationStage<EM, O, E, Z, A>
 where
     EM: UsesState<State = E::State> + EventFirer,
     E: HasObservers + Executor<EM, Z>,
     E::State: HasCorpus + HasMetadata + HasRand + HasNamedMetadata,
     E::Input: HasBytesVec,
     O: MapObserver,
+    A: AsRef<O> + Named,
     Z: UsesState<State = E::State>,
 {
     #[inline]
@@ -150,10 +151,11 @@ impl TaintMetadata {
 
 libafl_bolts::impl_serdeany!(TaintMetadata);
 
-impl<EM, O, E, Z> ColorizationStage<EM, O, E, Z>
+impl<EM, O, E, Z, A> ColorizationStage<EM, O, E, Z, A>
 where
     EM: UsesState<State = E::State> + EventFirer,
     O: MapObserver,
+    A: AsRef<O> + Named,
     E: HasObservers + Executor<EM, Z>,
     E::State: HasCorpus + HasMetadata + HasRand,
     E::Input: HasBytesVec,
@@ -297,9 +299,9 @@ where
 
     #[must_use]
     /// Creates a new [`ColorizationStage`]
-    pub fn new(map_observer_name: &O) -> Self {
+    pub fn new(map_observer: &A) -> Self {
         Self {
-            map_observer_name: map_observer_name.name().to_string(),
+            map_observer_name: map_observer.name().to_string(),
             phantom: PhantomData,
         }
     }
@@ -319,8 +321,9 @@ where
 
         let observer = executor
             .observers()
-            .match_name::<O>(name)
-            .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?;
+            .match_name::<A>(name)
+            .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+            .as_ref();
 
         let hash = observer.hash() as usize;
 

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -54,20 +54,20 @@ impl Ord for Earlier {
 
 /// The mutational stage using power schedules
 #[derive(Clone, Debug)]
-pub struct ColorizationStage<A, E, EM, O, Z> {
+pub struct ColorizationStage<C, E, EM, O, Z> {
     map_observer_name: String,
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(A, E, EM, O, E, Z)>,
+    phantom: PhantomData<(C, E, EM, O, E, Z)>,
 }
 
-impl<A, E, EM, O, Z> UsesState for ColorizationStage<A, E, EM, O, Z>
+impl<C, E, EM, O, Z> UsesState for ColorizationStage<C, E, EM, O, Z>
 where
     E: UsesState,
 {
     type State = E::State;
 }
 
-impl<A, E, EM, O, Z> Named for ColorizationStage<A, E, EM, O, Z>
+impl<C, E, EM, O, Z> Named for ColorizationStage<C, E, EM, O, Z>
 where
     E: UsesState,
 {
@@ -76,14 +76,14 @@ where
     }
 }
 
-impl<A, E, EM, O, Z> Stage<E, EM, Z> for ColorizationStage<A, E, EM, O, Z>
+impl<C, E, EM, O, Z> Stage<E, EM, Z> for ColorizationStage<C, E, EM, O, Z>
 where
     EM: UsesState<State = E::State> + EventFirer,
     E: HasObservers + Executor<EM, Z>,
     E::State: HasCorpus + HasMetadata + HasRand + HasNamedMetadata,
     E::Input: HasBytesVec,
     O: MapObserver,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
     Z: UsesState<State = E::State>,
 {
     #[inline]
@@ -151,11 +151,11 @@ impl TaintMetadata {
 
 libafl_bolts::impl_serdeany!(TaintMetadata);
 
-impl<A, E, EM, O, Z> ColorizationStage<A, E, EM, O, Z>
+impl<C, E, EM, O, Z> ColorizationStage<C, E, EM, O, Z>
 where
     EM: UsesState<State = E::State> + EventFirer,
     O: MapObserver,
-    A: AsRef<O> + Named,
+    C: AsRef<O> + Named,
     E: HasObservers + Executor<EM, Z>,
     E::State: HasCorpus + HasMetadata + HasRand,
     E::Input: HasBytesVec,
@@ -299,7 +299,7 @@ where
 
     #[must_use]
     /// Creates a new [`ColorizationStage`]
-    pub fn new(map_observer: &A) -> Self {
+    pub fn new(map_observer: &C) -> Self {
         Self {
             map_observer_name: map_observer.name().to_string(),
             phantom: PhantomData,
@@ -321,7 +321,7 @@ where
 
         let observer = executor
             .observers()
-            .match_name::<A>(name)
+            .match_name::<C>(name)
             .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
             .as_ref();
 

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -14,7 +14,7 @@ use crate::{
     feedbacks::map::MapNoveltiesMetadata,
     inputs::{BytesInput, GeneralizedInputMetadata, GeneralizedItem, HasBytesVec, UsesInput},
     mark_feature_time,
-    observers::{MapObserver, ObserversTuple, TrackingHinted},
+    observers::{CanTrack, MapObserver, ObserversTuple},
     require_novelties_tracking,
     stages::{RetryRestartHelper, Stage},
     start_timer,
@@ -65,7 +65,7 @@ where
 impl<E, EM, O, Z, A> Stage<E, EM, Z> for GeneralizationStage<EM, O, E::Observers, Z, A>
 where
     O: MapObserver,
-    A: AsRef<O> + TrackingHinted,
+    A: AsRef<O> + CanTrack,
     E: Executor<EM, Z> + HasObservers,
     E::Observers: ObserversTuple<E::State>,
     E::State:
@@ -337,7 +337,7 @@ impl<EM, O, OT, Z, A> GeneralizationStage<EM, O, OT, Z, A>
 where
     EM: UsesState,
     O: MapObserver,
-    A: AsRef<O> + TrackingHinted,
+    A: AsRef<O> + CanTrack,
     OT: ObserversTuple<EM::State>,
     EM::State: UsesInput<Input = BytesInput> + HasExecutions + HasMetadata + HasCorpus,
 {

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -14,7 +14,8 @@ use crate::{
     feedbacks::map::MapNoveltiesMetadata,
     inputs::{BytesInput, GeneralizedInputMetadata, GeneralizedItem, HasBytesVec, UsesInput},
     mark_feature_time,
-    observers::{MapObserver, ObserversTuple},
+    observers::{MapObserver, ObserversTuple, TrackingHinted},
+    require_novelties_tracking,
     stages::{RetryRestartHelper, Stage},
     start_timer,
     state::{HasCorpus, HasExecutions, UsesState},
@@ -41,19 +42,19 @@ fn find_next_char(list: &[Option<u8>], mut idx: usize, ch: u8) -> usize {
 
 /// A stage that runs a tracer executor
 #[derive(Clone, Debug)]
-pub struct GeneralizationStage<EM, O, OT, Z> {
+pub struct GeneralizationStage<EM, O, OT, Z, A> {
     map_observer_name: String,
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(EM, O, OT, Z)>,
+    phantom: PhantomData<(EM, O, OT, Z, A)>,
 }
 
-impl<EM, O, OT, Z> Named for GeneralizationStage<EM, O, OT, Z> {
+impl<EM, O, OT, Z, A> Named for GeneralizationStage<EM, O, OT, Z, A> {
     fn name(&self) -> &str {
         "GeneralizationStage"
     }
 }
 
-impl<EM, O, OT, Z> UsesState for GeneralizationStage<EM, O, OT, Z>
+impl<EM, O, OT, Z, A> UsesState for GeneralizationStage<EM, O, OT, Z, A>
 where
     EM: UsesState,
     EM::State: UsesInput<Input = BytesInput>,
@@ -61,9 +62,10 @@ where
     type State = EM::State;
 }
 
-impl<E, EM, O, Z> Stage<E, EM, Z> for GeneralizationStage<EM, O, E::Observers, Z>
+impl<E, EM, O, Z, A> Stage<E, EM, Z> for GeneralizationStage<EM, O, E::Observers, Z, A>
 where
     O: MapObserver,
+    A: AsRef<O> + TrackingHinted,
     E: Executor<EM, Z> + HasObservers,
     E::Observers: ObserversTuple<E::State>,
     E::State:
@@ -331,18 +333,20 @@ where
     }
 }
 
-impl<EM, O, OT, Z> GeneralizationStage<EM, O, OT, Z>
+impl<EM, O, OT, Z, A> GeneralizationStage<EM, O, OT, Z, A>
 where
     EM: UsesState,
     O: MapObserver,
+    A: AsRef<O> + TrackingHinted,
     OT: ObserversTuple<EM::State>,
     EM::State: UsesInput<Input = BytesInput> + HasExecutions + HasMetadata + HasCorpus,
 {
     /// Create a new [`GeneralizationStage`].
     #[must_use]
-    pub fn new(map_observer: &O) -> Self {
+    pub fn new(map_observer: &A) -> Self {
+        require_novelties_tracking!("GeneralizationStage", A);
         Self {
-            map_observer_name: map_observer.name().to_string(),
+            map_observer_name: map_observer.as_ref().name().to_string(),
             phantom: PhantomData,
         }
     }
@@ -387,8 +391,9 @@ where
 
         let cnt = executor
             .observers()
-            .match_name::<O>(&self.map_observer_name)
+            .match_name::<A>(&self.map_observer_name)
             .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+            .as_ref()
             .how_many_set(novelties);
 
         Ok(cnt == novelties.len())

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -42,19 +42,19 @@ fn find_next_char(list: &[Option<u8>], mut idx: usize, ch: u8) -> usize {
 
 /// A stage that runs a tracer executor
 #[derive(Clone, Debug)]
-pub struct GeneralizationStage<A, EM, O, OT, Z> {
+pub struct GeneralizationStage<C, EM, O, OT, Z> {
     map_observer_name: String,
     #[allow(clippy::type_complexity)]
-    phantom: PhantomData<(EM, O, OT, Z, A)>,
+    phantom: PhantomData<(C, EM, O, OT, Z)>,
 }
 
-impl<A, EM, O, OT, Z> Named for GeneralizationStage<A, EM, O, OT, Z> {
+impl<C, EM, O, OT, Z> Named for GeneralizationStage<C, EM, O, OT, Z> {
     fn name(&self) -> &str {
         "GeneralizationStage"
     }
 }
 
-impl<A, EM, O, OT, Z> UsesState for GeneralizationStage<A, EM, O, OT, Z>
+impl<C, EM, O, OT, Z> UsesState for GeneralizationStage<C, EM, O, OT, Z>
 where
     EM: UsesState,
     EM::State: UsesInput<Input = BytesInput>,
@@ -62,10 +62,10 @@ where
     type State = EM::State;
 }
 
-impl<A, E, EM, O, Z> Stage<E, EM, Z> for GeneralizationStage<A, EM, O, E::Observers, Z>
+impl<C, E, EM, O, Z> Stage<E, EM, Z> for GeneralizationStage<C, EM, O, E::Observers, Z>
 where
     O: MapObserver,
-    A: AsRef<O> + CanTrack,
+    C: AsRef<O> + CanTrack,
     E: Executor<EM, Z> + HasObservers,
     E::Observers: ObserversTuple<E::State>,
     E::State:
@@ -333,18 +333,18 @@ where
     }
 }
 
-impl<A, EM, O, OT, Z> GeneralizationStage<A, EM, O, OT, Z>
+impl<C, EM, O, OT, Z> GeneralizationStage<C, EM, O, OT, Z>
 where
     EM: UsesState,
     O: MapObserver,
-    A: AsRef<O> + CanTrack,
+    C: AsRef<O> + CanTrack,
     OT: ObserversTuple<EM::State>,
     EM::State: UsesInput<Input = BytesInput> + HasExecutions + HasMetadata + HasCorpus,
 {
     /// Create a new [`GeneralizationStage`].
     #[must_use]
-    pub fn new(map_observer: &A) -> Self {
-        require_novelties_tracking!("GeneralizationStage", A);
+    pub fn new(map_observer: &C) -> Self {
+        require_novelties_tracking!("GeneralizationStage", C);
         Self {
             map_observer_name: map_observer.as_ref().name().to_string(),
             phantom: PhantomData,
@@ -391,7 +391,7 @@ where
 
         let cnt = executor
             .observers()
-            .match_name::<A>(&self.map_observer_name)
+            .match_name::<C>(&self.map_observer_name)
             .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
             .as_ref()
             .how_many_set(novelties);

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -42,19 +42,19 @@ fn find_next_char(list: &[Option<u8>], mut idx: usize, ch: u8) -> usize {
 
 /// A stage that runs a tracer executor
 #[derive(Clone, Debug)]
-pub struct GeneralizationStage<EM, O, OT, Z, A> {
+pub struct GeneralizationStage<A, EM, O, OT, Z> {
     map_observer_name: String,
     #[allow(clippy::type_complexity)]
     phantom: PhantomData<(EM, O, OT, Z, A)>,
 }
 
-impl<EM, O, OT, Z, A> Named for GeneralizationStage<EM, O, OT, Z, A> {
+impl<A, EM, O, OT, Z> Named for GeneralizationStage<A, EM, O, OT, Z> {
     fn name(&self) -> &str {
         "GeneralizationStage"
     }
 }
 
-impl<EM, O, OT, Z, A> UsesState for GeneralizationStage<EM, O, OT, Z, A>
+impl<A, EM, O, OT, Z> UsesState for GeneralizationStage<A, EM, O, OT, Z>
 where
     EM: UsesState,
     EM::State: UsesInput<Input = BytesInput>,
@@ -62,7 +62,7 @@ where
     type State = EM::State;
 }
 
-impl<E, EM, O, Z, A> Stage<E, EM, Z> for GeneralizationStage<EM, O, E::Observers, Z, A>
+impl<A, E, EM, O, Z> Stage<E, EM, Z> for GeneralizationStage<A, EM, O, E::Observers, Z>
 where
     O: MapObserver,
     A: AsRef<O> + CanTrack,
@@ -333,7 +333,7 @@ where
     }
 }
 
-impl<EM, O, OT, Z, A> GeneralizationStage<EM, O, OT, Z, A>
+impl<A, EM, O, OT, Z> GeneralizationStage<A, EM, O, OT, Z>
 where
     EM: UsesState,
     O: MapObserver,

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -65,7 +65,7 @@ where
 impl<C, E, EM, O, Z> Stage<E, EM, Z> for GeneralizationStage<C, EM, O, E::Observers, Z>
 where
     O: MapObserver,
-    C: AsRef<O> + CanTrack,
+    C: CanTrack + AsRef<O>,
     E: Executor<EM, Z> + HasObservers,
     E::Observers: ObserversTuple<E::State>,
     E::State:
@@ -337,7 +337,7 @@ impl<C, EM, O, OT, Z> GeneralizationStage<C, EM, O, OT, Z>
 where
     EM: UsesState,
     O: MapObserver,
-    C: AsRef<O> + CanTrack,
+    C: CanTrack + AsRef<O>,
     OT: ObserversTuple<EM::State>,
     EM::State: UsesInput<Input = BytesInput> + HasExecutions + HasMetadata + HasCorpus,
 {

--- a/libafl/src/stages/sync.rs
+++ b/libafl/src/stages/sync.rs
@@ -239,7 +239,7 @@ impl SyncFromBrokerMetadata {
 
 /// A stage that loads testcases from disk to sync with other fuzzers such as AFL++
 #[derive(Debug)]
-pub struct SyncFromBrokerStage<IC, ICB, DI, S, SP>
+pub struct SyncFromBrokerStage<DI, IC, ICB, S, SP>
 where
     SP: ShMemProvider + 'static,
     S: UsesInput,
@@ -247,10 +247,10 @@ where
     ICB: InputConverter<From = DI, To = S::Input>,
     DI: Input,
 {
-    client: LlmpEventConverter<IC, ICB, DI, S, SP>,
+    client: LlmpEventConverter<DI, IC, ICB, S, SP>,
 }
 
-impl<IC, ICB, DI, S, SP> UsesState for SyncFromBrokerStage<IC, ICB, DI, S, SP>
+impl<DI, IC, ICB, S, SP> UsesState for SyncFromBrokerStage<DI, IC, ICB, S, SP>
 where
     SP: ShMemProvider + 'static,
     S: State,
@@ -261,7 +261,7 @@ where
     type State = S;
 }
 
-impl<E, EM, IC, ICB, DI, S, SP, Z> Stage<E, EM, Z> for SyncFromBrokerStage<IC, ICB, DI, S, SP>
+impl<E, EM, IC, ICB, DI, S, SP, Z> Stage<E, EM, Z> for SyncFromBrokerStage<DI, IC, ICB, S, SP>
 where
     EM: UsesState<State = S> + EventFirer,
     S: State + HasExecutions + HasCorpus + HasRand + HasMetadata + HasTestcase,
@@ -343,7 +343,7 @@ where
     }
 }
 
-impl<IC, ICB, DI, S, SP> SyncFromBrokerStage<IC, ICB, DI, S, SP>
+impl<DI, IC, ICB, S, SP> SyncFromBrokerStage<DI, IC, ICB, S, SP>
 where
     SP: ShMemProvider + 'static,
     S: UsesInput,
@@ -353,7 +353,7 @@ where
 {
     /// Creates a new [`SyncFromBrokerStage`]
     #[must_use]
-    pub fn new(client: LlmpEventConverter<IC, ICB, DI, S, SP>) -> Self {
+    pub fn new(client: LlmpEventConverter<DI, IC, ICB, S, SP>) -> Self {
         Self { client }
     }
 }

--- a/libafl_bolts/README.md
+++ b/libafl_bolts/README.md
@@ -28,7 +28,7 @@ For bugs, feel free to open issues or contact us directly. Thank you for your su
 
 Even though we will gladly assist you in finishing up your PR, try to
 - keep all the crates compiling with *stable* rust (hide the eventual non-stable code under [`cfg`s](https://github.com/AFLplusplus/LibAFL/blob/main/libafl/build.rs#L26))
-- run `cargo fmt` on your code before pushing
+- run `cargo nightly fmt` on your code before pushing
 - check the output of `cargo clippy --all` or `./clippy.sh`
 - run `cargo build --no-default-features` to check for `no_std` compatibility (and possibly add `#[cfg(feature = "std")]`) to hide parts of your code.
 

--- a/libafl_frida/build.rs
+++ b/libafl_frida/build.rs
@@ -7,10 +7,8 @@ fn main() {
     }
 
     // Force linking against libc++
-    cc::Build::new()
-        .cpp(true)
-        .file("src/stub.cpp")
-        .compile("libcppstub.a");
+    #[cfg(unix)]
+    println!("cargo:rustc-link-lib=dylib=c++");
 
     // Build the test harness
     // clang++ -shared -fPIC -O0 -o test_harness.so test_harness.cpp

--- a/libafl_frida/build.rs
+++ b/libafl_frida/build.rs
@@ -7,8 +7,10 @@ fn main() {
     }
 
     // Force linking against libc++
-    #[cfg(unix)]
-    println!("cargo:rustc-link-lib=dylib=c++");
+    cc::Build::new()
+        .cpp(true)
+        .file("src/stub.cpp")
+        .compile("libcppstub.a");
 
     // Build the test harness
     // clang++ -shared -fPIC -O0 -o test_harness.so test_harness.cpp

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/corpus.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/corpus.rs
@@ -189,9 +189,7 @@ where
         match self._get(id, &self.mapping.enabled) {
             Ok(input) => Ok(input),
             Err(Error::KeyNotFound(..)) => return self._get(id, &self.mapping.disabled),
-            Err(e) => {
-                Err(e)
-            }
+            Err(e) => Err(e),
         }
     }
     fn current(&self) -> &Option<CorpusId> {
@@ -362,7 +360,7 @@ where
     fn get_from_all(&self, id: CorpusId) -> Result<&RefCell<Testcase<Self::Input>>, Error> {
         self.get(id)
     }
-    
+
     // This just calls Self::nth as ArtifactCorpus disregards disabled entries
     fn nth_from_all(&self, nth: usize) -> CorpusId {
         self.nth(nth)

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/feedbacks.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/feedbacks.rs
@@ -171,4 +171,4 @@ where
     }
 }
 
-pub type ShrinkMapFeedback<O, S, T, A> = MinMapFeedback<MappedEdgeMapObserver<O, T>, S, usize, A>;
+pub type ShrinkMapFeedback<A, O, S, T> = MinMapFeedback<A, MappedEdgeMapObserver<O, T>, S, usize>;

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/feedbacks.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/feedbacks.rs
@@ -171,4 +171,4 @@ where
     }
 }
 
-pub type ShrinkMapFeedback<A, O, S, T> = MinMapFeedback<A, MappedEdgeMapObserver<O, T>, S, usize>;
+pub type ShrinkMapFeedback<C, O, S, T> = MinMapFeedback<C, MappedEdgeMapObserver<O, T>, S, usize>;

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/feedbacks.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/feedbacks.rs
@@ -171,4 +171,4 @@ where
     }
 }
 
-pub type ShrinkMapFeedback<O, S, T> = MinMapFeedback<MappedEdgeMapObserver<O, T>, S, usize>;
+pub type ShrinkMapFeedback<O, S, T, A> = MinMapFeedback<MappedEdgeMapObserver<O, T>, S, usize, A>;

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs
@@ -168,7 +168,7 @@ macro_rules! fuzz_with {
                 I2SRandReplace, StdScheduledMutator, StringCategoryRandMutator, StringSubcategoryRandMutator,
                 StringCategoryTokenReplaceMutator, StringSubcategoryTokenReplaceMutator, Tokens, tokens_mutations
             },
-            observers::{stacktrace::BacktraceObserver, TimeObserver},
+            observers::{stacktrace::BacktraceObserver, TimeObserver, TrackingHinted},
             schedulers::{
                 IndexesLenTimeMinimizerScheduler, powersched::PowerSchedule, PowerQueueScheduler,
             },
@@ -198,7 +198,7 @@ macro_rules! fuzz_with {
             let grimoire_metadata = should_use_grimoire(&mut state, &$options, &mutator_status)?;
             let grimoire = grimoire_metadata.should();
 
-            let edges_observer = edge_maker();
+            let edges_observer = edge_maker().track_indices().track_novelties();
             let size_edges_observer = MappedEdgeMapObserver::new(edge_maker(), SizeValueObserver::default());
 
             let keep_observer = LibfuzzerKeepFeedback::new();
@@ -220,8 +220,8 @@ macro_rules! fuzz_with {
             );
 
             // New maximization map feedback linked to the edges observer
-            let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, true);
-            let shrinking_map_feedback = ShrinkMapFeedback::tracking(&size_edges_observer, false, false);
+            let map_feedback = MaxMapFeedback::new(&edges_observer);
+            let shrinking_map_feedback = ShrinkMapFeedback::new(&size_edges_observer);
 
             // Set up a generalization stage for grimoire
             let generalization = GeneralizationStage::new(&edges_observer);
@@ -412,7 +412,7 @@ macro_rules! fuzz_with {
             let grimoire = IfStage::new(|_, _, _, _| Ok(grimoire.into()), (StdMutationalStage::transforming(grimoire_mutator), ()));
 
             // A minimization+queue policy to get testcasess from the corpus
-            let scheduler = IndexesLenTimeMinimizerScheduler::new(PowerQueueScheduler::new(&mut state, &edges_observer, PowerSchedule::FAST));
+            let scheduler = IndexesLenTimeMinimizerScheduler::new(&edges_observer, PowerQueueScheduler::new(&mut state, &edges_observer, PowerSchedule::FAST));
 
             // A fuzzer with feedbacks and a corpus scheduler
             let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/lib.rs
@@ -168,7 +168,7 @@ macro_rules! fuzz_with {
                 I2SRandReplace, StdScheduledMutator, StringCategoryRandMutator, StringSubcategoryRandMutator,
                 StringCategoryTokenReplaceMutator, StringSubcategoryTokenReplaceMutator, Tokens, tokens_mutations
             },
-            observers::{stacktrace::BacktraceObserver, TimeObserver, TrackingHinted},
+            observers::{stacktrace::BacktraceObserver, TimeObserver, CanTrack},
             schedulers::{
                 IndexesLenTimeMinimizerScheduler, powersched::PowerSchedule, PowerQueueScheduler,
             },

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
@@ -105,7 +105,7 @@ pub fn merge(
     let edges_observer =
         MappedEdgeMapObserver::new(edges_observer, SizeTimeValueObserver::new(time));
 
-    let map_feedback = MinMapFeedback::tracking(&edges_observer, false, true);
+    let map_feedback = MinMapFeedback::new(&edges_observer);
 
     // Create an OOM observer to monitor if an OOM has occurred
     let oom_observer = OomObserver::new(options.rss_limit(), options.malloc_limit());

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
@@ -55,6 +55,18 @@ where
     }
 }
 
+impl<M, O> AsRef<Self> for MappedEdgeMapObserver<M, O> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<M, O> AsMut<Self> for MappedEdgeMapObserver<M, O> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 impl<M, O> HasLen for MappedEdgeMapObserver<M, O>
 where
     M: HasLen,

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -15,7 +15,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::StdMutationalStage,
     state::{HasCorpus, StdState},
@@ -126,8 +126,10 @@ impl<'a> ForkserverBytesCoverageSugar<'a> {
             std::env::set_var("AFL_MAP_SIZE", format!("{MAP_SIZE}"));
 
             // Create an observation channel using the coverage map
-            let edges_observer =
-                unsafe { HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_map)) };
+            let edges_observer = unsafe {
+                HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_map))
+                    .track_indices()
+            };
 
             // Create an observation channel to keep track of the execution time
             let time_observer = TimeObserver::new("time");
@@ -136,7 +138,7 @@ impl<'a> ForkserverBytesCoverageSugar<'a> {
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::tracking(&edges_observer, true, false),
+                MaxMapFeedback::new(&edges_observer),
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::with_observer(&time_observer)
             );
@@ -164,7 +166,8 @@ impl<'a> ForkserverBytesCoverageSugar<'a> {
             let mut tokens = Tokens::new();
 
             // A minimization+queue policy to get testcasess from the corpus
-            let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+            let scheduler =
+                IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
             // A fuzzer with feedbacks and a corpus scheduler
             let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -15,7 +15,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::Tokens,
     },
-    observers::{HitcountsMapObserver, StdMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::StdMutationalStage,
     state::{HasCorpus, StdState},

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -18,7 +18,7 @@ use libafl::{
         scheduled::{havoc_mutations, tokens_mutations, StdScheduledMutator},
         token_mutations::{I2SRandReplace, Tokens},
     },
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -143,7 +143,8 @@ where
                               _core_id| {
             // Create an observation channel using the coverage map
             let edges_observer =
-                HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") });
+                HitcountsMapObserver::new(unsafe { std_edges_map_observer("edges") })
+                    .track_indices();
 
             // Create an observation channel to keep track of the execution time
             let time_observer = TimeObserver::new("time");
@@ -154,7 +155,7 @@ where
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::tracking(&edges_observer, true, false),
+                MaxMapFeedback::new(&edges_observer),
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::with_observer(&time_observer)
             );
@@ -186,7 +187,8 @@ where
             }
 
             // A minimization+queue policy to get testcasess from the corpus
-            let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+            let scheduler =
+                IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
             // A fuzzer with feedbacks and a corpus scheduler
             let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -21,7 +21,7 @@ use libafl::{
         token_mutations::Tokens,
         I2SRandReplace,
     },
-    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
+    observers::{CanTrack, HitcountsMapObserver, TimeObserver, VariableMapObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -21,7 +21,7 @@ use libafl::{
         token_mutations::Tokens,
         I2SRandReplace,
     },
-    observers::{HitcountsMapObserver, TimeObserver, VariableMapObserver},
+    observers::{HitcountsMapObserver, TimeObserver, TrackingHinted, VariableMapObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
@@ -156,6 +156,7 @@ where
                     edges_map_mut_slice(),
                     addr_of_mut!(edges::MAX_EDGES_NUM),
                 ))
+                .track_indices()
             };
 
             // Create an observation channel to keep track of the execution time
@@ -168,7 +169,7 @@ where
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::tracking(&edges_observer, true, false),
+                MaxMapFeedback::new(&edges_observer),
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::with_observer(&time_observer)
             );
@@ -200,7 +201,8 @@ where
             }
 
             // A minimization+queue policy to get testcasess from the corpus
-            let scheduler = IndexesLenTimeMinimizerScheduler::new(QueueScheduler::new());
+            let scheduler =
+                IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 
             // A fuzzer with feedbacks and a corpus scheduler
             let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);

--- a/libafl_targets/src/coverage.rs
+++ b/libafl_targets/src/coverage.rs
@@ -97,7 +97,7 @@ pub unsafe fn edges_map_mut_slice<'a>() -> OwnedMutSlice<'a, u8> {
 ///
 /// # Safety
 /// This will dereference [`edges_map_mut_ptr`] and crash if it is not a valid address.
-pub unsafe fn std_edges_map_observer<'a, S>(name: S) -> StdMapObserver<'a, u8, false>
+pub unsafe fn std_edges_map_observer<'a, S>(name: S) -> StdMapObserver<'a, u8, false, false, false>
 where
     S: Into<String>,
 {

--- a/libafl_targets/src/coverage.rs
+++ b/libafl_targets/src/coverage.rs
@@ -97,7 +97,7 @@ pub unsafe fn edges_map_mut_slice<'a>() -> OwnedMutSlice<'a, u8> {
 ///
 /// # Safety
 /// This will dereference [`edges_map_mut_ptr`] and crash if it is not a valid address.
-pub unsafe fn std_edges_map_observer<'a, S>(name: S) -> StdMapObserver<'a, u8, false, false, false>
+pub unsafe fn std_edges_map_observer<'a, S>(name: S) -> StdMapObserver<'a, u8, false>
 where
     S: Into<String>,
 {

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -159,6 +159,18 @@ mod observers {
         }
     }
 
+    impl<const DIFFERENTIAL: bool> AsRef<Self> for CountersMultiMapObserver<DIFFERENTIAL> {
+        fn as_ref(&self) -> &Self {
+            self
+        }
+    }
+
+    impl<const DIFFERENTIAL: bool> AsMut<Self> for CountersMultiMapObserver<DIFFERENTIAL> {
+        fn as_mut(&mut self) -> &mut Self {
+            self
+        }
+    }
+
     impl<const DIFFERENTIAL: bool> MapObserver for CountersMultiMapObserver<DIFFERENTIAL> {
         type Entry = u8;
 

--- a/scripts/build_all_fuzzers.sh
+++ b/scripts/build_all_fuzzers.sh
@@ -15,19 +15,8 @@ else
     export PROFILE_DIR=debug
 fi
 
-if [[ -n "${RUN_QEMU_FUZZER}" ]]; then
-    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep "qemu")
-    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep "qemu")
-elif [[ -n "${RUN_BABY_FUZZER}" ]]; then
-    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep "baby")
-    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep "baby")
-elif [[ -n "${RUN_LIBPNG_FUZZER}" ]]; then
-    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep "libpng")
-    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep "libpng")
-else
-    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep -v "qemu" | grep -v "baby" | grep -v "libpng")
-    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep -v "qemu" | grep -v "baby" | grep -v "libpng")
-fi
+fuzzers=$(echo "$fuzzers" | tr ' ' '\n')
+backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n')
 
 libafl=$(pwd)
 
@@ -56,7 +45,7 @@ done
 for fuzzer in $(echo "$fuzzers" "$backtrace_fuzzers");
 do
     # skip nyx test on non-linux platforms
-    if [[ $fuzzer == *"nyx_"* ]] && [[ $(uname -s) != "Linux" ]]; then
+    if [[ $fuzzer == *"nyx_"* ]]; then
         continue
     fi
 

--- a/scripts/build_all_fuzzers.sh
+++ b/scripts/build_all_fuzzers.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/.." || exit 1
+# TODO: This should be rewritten in rust, a Makefile, or some platform-independent language
+
+if [[ -z "${RUN_ON_CI}" ]]; then
+    fuzzers=$(find ./fuzzers -mindepth 1 -maxdepth 1 -type d)
+    backtrace_fuzzers=$(find ./fuzzers/backtrace_baby_fuzzers -mindepth 1 -maxdepth 1 -type d)
+else
+    cargo build -p build_and_test_fuzzers
+    fuzzers=$(cargo run -p build_and_test_fuzzers -- "remotes/origin/main" "HEAD^")
+    backtrace_fuzzers=""
+    export PROFILE=dev
+    export PROFILE_DIR=debug
+fi
+
+if [[ -n "${RUN_QEMU_FUZZER}" ]]; then
+    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep "qemu")
+    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep "qemu")
+elif [[ -n "${RUN_BABY_FUZZER}" ]]; then
+    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep "baby")
+    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep "baby")
+elif [[ -n "${RUN_LIBPNG_FUZZER}" ]]; then
+    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep "libpng")
+    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep "libpng")
+else
+    fuzzers=$(echo "$fuzzers" | tr ' ' '\n' | grep -v "qemu" | grep -v "baby" | grep -v "libpng")
+    backtrace_fuzzers=$(echo "$backtrace_fuzzers" | tr ' ' '\n' | grep -v "qemu" | grep -v "baby" | grep -v "libpng")
+fi
+
+libafl=$(pwd)
+
+# build with a shared target dir for all fuzzers. this should speed up
+# compilation a bit, and allows for easier artifact management (caching and
+# cargo clean).
+export CARGO_TARGET_DIR="$libafl/target"
+mkdir -p "$CARGO_TARGET_DIR"
+
+git submodule init && git submodule update
+
+# override default profile settings for speed
+# export RUSTFLAGS="-C prefer-dynamic"
+for profile in DEV RELEASE; # loop for all profiles
+do
+    export CARGO_PROFILE_"$profile"_OPT_LEVEL=z # optimize for size
+    # runs into shared target dir bug:
+    # [pid 351769] openat(AT_FDCWD, "LibAFL/target/release/deps/libc-dbff77a14da5d893.libc.5deb7d4a-cgu.0.rcgu.dwo", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+    # error: failed to build archive: No such file or directory
+    # export CARGO_PROFILE_"$profile"_SPLIT_DEBUGINFO=unpacked # minimize debug info
+    # export CARGO_PROFILE_"$profile"_PANIC=abort
+    export CARGO_PROFILE_"$profile"_INCREMENTAL=true
+done
+
+# shellcheck disable=SC2116
+for fuzzer in $(echo "$fuzzers" "$backtrace_fuzzers");
+do
+    # skip nyx test on non-linux platforms
+    if [[ $fuzzer == *"nyx_"* ]] && [[ $(uname -s) != "Linux" ]]; then
+        continue
+    fi
+
+    cd "$fuzzer" || exit 1
+    # Clippy checks
+    echo "[*] Checking fmt for $fuzzer"
+    cargo fmt --all || exit 1
+
+    if [ -e ./Makefile.toml ]; then
+        echo "[*] Building $fuzzer"
+        cargo make build || exit 1
+        echo "[+] Done building $fuzzer"
+    else
+        echo "[*] Building $fuzzer"
+        cargo build || exit 1
+        echo "[+] Done building $fuzzer"
+    fi
+
+    # no cleaning -- this is a local test, we want to cache here
+    cd "$libafl" || exit 1
+    echo ""
+done

--- a/scripts/build_all_fuzzers.sh
+++ b/scripts/build_all_fuzzers.sh
@@ -38,7 +38,7 @@ do
     # error: failed to build archive: No such file or directory
     # export CARGO_PROFILE_"$profile"_SPLIT_DEBUGINFO=unpacked # minimize debug info
     # export CARGO_PROFILE_"$profile"_PANIC=abort
-    export CARGO_PROFILE_"$profile"_INCREMENTAL=true
+    # export CARGO_PROFILE_"$profile"_INCREMENTAL=true
 done
 
 # shellcheck disable=SC2116

--- a/scripts/build_all_fuzzers.sh
+++ b/scripts/build_all_fuzzers.sh
@@ -52,7 +52,7 @@ do
     cd "$fuzzer" || exit 1
     # Clippy checks
     echo "[*] Checking fmt for $fuzzer"
-    cargo fmt --all || exit 1
+    cargo +nightly fmt --all || exit 1
 
     if [ -e ./Makefile.toml ]; then
         echo "[*] Building $fuzzer"


### PR DESCRIPTION
This comes from a suggestion in the discord to type-enforce whether indices/novelties should be tracked.

It turns out that you cannot infer whether it needs to be or not based purely on usage. This is a limitation of Rust -- I have tried many, many different ways of doing this now with no avail (pure type encoding, GAT encoding, associated constant encoding, [even this nightmare-fuel syntax](https://github.com/rust-lang/rust/issues/60551#issuecomment-855861197)), but we can encode the metadata -- it just has to be manually performed by the user.

I added some docs and only modified `MapFeedback` and `MinimizerScheduler` for the sake of demonstration. Play around with `libfuzzer_stb_image` to see how the compiler output feels and such when intentionally disabling index tracking.