### PR TITLE
Make NopState public so that it can be used as reproducer

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -693,7 +693,7 @@ mod tests {
         fuzzer::test::NopFuzzer,
         inputs::BytesInput,
         monitors::SimpleMonitor,
-        state::test::NopState,
+        state::NopState,
     };
 
     #[test]

--- a/libafl/src/executors/inprocess_fork.rs
+++ b/libafl/src/executors/inprocess_fork.rs
@@ -560,7 +560,7 @@ mod tests {
                 inprocess_fork::GenericInProcessForkExecutor, Executor,
             },
             fuzzer::test::NopFuzzer,
-            state::test::NopState,
+            state::NopState,
         };
 
         let provider = StdShMemProvider::new().unwrap();

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -174,7 +174,7 @@ pub mod test {
         executors::{Executor, ExitKind},
         fuzzer::test::NopFuzzer,
         inputs::{BytesInput, HasTargetBytes},
-        state::{test::NopState, HasExecutions, State, UsesState},
+        state::{HasExecutions, NopState, State, UsesState},
     };
 
     /// A simple executor that does nothing.

--- a/libafl/src/feedbacks/differential.rs
+++ b/libafl/src/feedbacks/differential.rs
@@ -163,7 +163,7 @@ mod tests {
         feedbacks::{differential::DiffResult, DiffFeedback, Feedback},
         inputs::{BytesInput, UsesInput},
         observers::Observer,
-        state::{test::NopState, State, UsesState},
+        state::{NopState, State, UsesState},
     };
 
     #[derive(Debug)]

--- a/libafl/src/mutators/tuneable.rs
+++ b/libafl/src/mutators/tuneable.rs
@@ -376,7 +376,7 @@ mod test {
     use crate::{
         inputs::BytesInput,
         mutators::{ByteRandMutator, ScheduledMutator},
-        state::test::NopState,
+        state::NopState,
     };
 
     #[test]

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use libafl_bolts::{
-    rands::Rand,
+    rands::{Rand, StdRand},
     serdeany::{NamedSerdeAnyMap, SerdeAny, SerdeAnyMap},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -998,149 +998,139 @@ impl<I, C, R, SC> HasScalabilityMonitor for StdState<I, C, R, SC> {
     }
 }
 
+/// A very simple state without any bells or whistles, for testing.
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct NopState<I> {
+    metadata: SerdeAnyMap,
+    execution: usize,
+    rand: StdRand,
+    phantom: PhantomData<I>,
+}
+
+impl<I> NopState<I> {
+    /// Create a new State that does nothing (for tests)
+    #[must_use]
+    pub fn new() -> Self {
+        NopState {
+            metadata: SerdeAnyMap::new(),
+            execution: 0,
+            rand: StdRand::default(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<I> UsesInput for NopState<I>
+where
+    I: Input,
+{
+    type Input = I;
+}
+
+impl<I> HasExecutions for NopState<I> {
+    fn executions(&self) -> &usize {
+        &self.execution
+    }
+
+    fn executions_mut(&mut self) -> &mut usize {
+        &mut self.execution
+    }
+}
+
+impl<I> HasLastReportTime for NopState<I> {
+    fn last_report_time(&self) -> &Option<Duration> {
+        unimplemented!();
+    }
+
+    fn last_report_time_mut(&mut self) -> &mut Option<Duration> {
+        unimplemented!();
+    }
+}
+
+impl<I> HasMetadata for NopState<I> {
+    fn metadata_map(&self) -> &SerdeAnyMap {
+        &self.metadata
+    }
+
+    fn metadata_map_mut(&mut self) -> &mut SerdeAnyMap {
+        &mut self.metadata
+    }
+}
+
+impl<I> HasRand for NopState<I> {
+    type Rand = StdRand;
+
+    fn rand(&self) -> &Self::Rand {
+        &self.rand
+    }
+
+    fn rand_mut(&mut self) -> &mut Self::Rand {
+        &mut self.rand
+    }
+}
+
+impl<I> State for NopState<I> where I: Input {}
+
+impl<I> HasCurrentCorpusIdx for NopState<I> {
+    fn set_corpus_idx(&mut self, _idx: CorpusId) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn clear_corpus_idx(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn current_corpus_idx(&self) -> Result<Option<CorpusId>, Error> {
+        Ok(None)
+    }
+}
+
+impl<I> HasCurrentStage for NopState<I> {
+    fn set_stage(&mut self, _idx: usize) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn clear_stage(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn current_stage(&self) -> Result<Option<usize>, Error> {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "introspection")]
+impl<I> HasClientPerfMonitor for NopState<I> {
+    fn introspection_monitor(&self) -> &ClientPerfMonitor {
+        unimplemented!();
+    }
+
+    fn introspection_monitor_mut(&mut self) -> &mut ClientPerfMonitor {
+        unimplemented!();
+    }
+}
+
+#[cfg(feature = "scalability_introspection")]
+impl<I> HasScalabilityMonitor for NopState<I> {
+    fn scalability_monitor(&self) -> &ScalabilityMonitor {
+        unimplemented!();
+    }
+
+    fn scalability_monitor_mut(&mut self) -> &mut ScalabilityMonitor {
+        unimplemented!();
+    }
+}
+
 #[cfg(test)]
 pub mod test {
-    use core::{marker::PhantomData, time::Duration};
+    use libafl_bolts::rands::StdRand;
 
-    use libafl_bolts::{rands::StdRand, serdeany::SerdeAnyMap, Error};
-    use serde::{Deserialize, Serialize};
-
+    use super::StdState;
     use crate::{
-        corpus::{CorpusId, HasCurrentCorpusIdx, InMemoryCorpus},
-        inputs::{Input, NopInput, UsesInput},
+        corpus::InMemoryCorpus,
+        inputs::{Input, NopInput},
         stages::test::{test_resume, test_resume_stages},
-        state::{
-            HasCurrentStage, HasExecutions, HasLastReportTime, HasMetadata, HasRand, State,
-            StdState,
-        },
     };
-    #[cfg(feature = "introspection")]
-    use crate::{monitors::ClientPerfMonitor, state::HasClientPerfMonitor};
-    #[cfg(feature = "scalability_introspection")]
-    use crate::{monitors::ScalabilityMonitor, state::HasScalabilityMonitor};
-
-    /// A very simple state without any bells or whistles, for testing.
-    #[derive(Debug, Serialize, Deserialize, Default)]
-    pub struct NopState<I> {
-        metadata: SerdeAnyMap,
-        execution: usize,
-        rand: StdRand,
-        phantom: PhantomData<I>,
-    }
-
-    impl<I> NopState<I> {
-        /// Create a new State that does nothing (for tests)
-        #[must_use]
-        pub fn new() -> Self {
-            NopState {
-                metadata: SerdeAnyMap::new(),
-                execution: 0,
-                rand: StdRand::default(),
-                phantom: PhantomData,
-            }
-        }
-    }
-
-    impl<I> UsesInput for NopState<I>
-    where
-        I: Input,
-    {
-        type Input = I;
-    }
-
-    impl<I> HasExecutions for NopState<I> {
-        fn executions(&self) -> &usize {
-            &self.execution
-        }
-
-        fn executions_mut(&mut self) -> &mut usize {
-            &mut self.execution
-        }
-    }
-
-    impl<I> HasLastReportTime for NopState<I> {
-        fn last_report_time(&self) -> &Option<Duration> {
-            unimplemented!();
-        }
-
-        fn last_report_time_mut(&mut self) -> &mut Option<Duration> {
-            unimplemented!();
-        }
-    }
-
-    impl<I> HasMetadata for NopState<I> {
-        fn metadata_map(&self) -> &SerdeAnyMap {
-            &self.metadata
-        }
-
-        fn metadata_map_mut(&mut self) -> &mut SerdeAnyMap {
-            &mut self.metadata
-        }
-    }
-
-    impl<I> HasRand for NopState<I> {
-        type Rand = StdRand;
-
-        fn rand(&self) -> &Self::Rand {
-            &self.rand
-        }
-
-        fn rand_mut(&mut self) -> &mut Self::Rand {
-            &mut self.rand
-        }
-    }
-
-    impl<I> State for NopState<I> where I: Input {}
-
-    impl<I> HasCurrentCorpusIdx for NopState<I> {
-        fn set_corpus_idx(&mut self, _idx: CorpusId) -> Result<(), Error> {
-            Ok(())
-        }
-
-        fn clear_corpus_idx(&mut self) -> Result<(), Error> {
-            Ok(())
-        }
-
-        fn current_corpus_idx(&self) -> Result<Option<CorpusId>, Error> {
-            Ok(None)
-        }
-    }
-
-    impl<I> HasCurrentStage for NopState<I> {
-        fn set_stage(&mut self, _idx: usize) -> Result<(), Error> {
-            Ok(())
-        }
-
-        fn clear_stage(&mut self) -> Result<(), Error> {
-            Ok(())
-        }
-
-        fn current_stage(&self) -> Result<Option<usize>, Error> {
-            Ok(None)
-        }
-    }
-
-    #[cfg(feature = "introspection")]
-    impl<I> HasClientPerfMonitor for NopState<I> {
-        fn introspection_monitor(&self) -> &ClientPerfMonitor {
-            unimplemented!();
-        }
-
-        fn introspection_monitor_mut(&mut self) -> &mut ClientPerfMonitor {
-            unimplemented!();
-        }
-    }
-
-    #[cfg(feature = "scalability_introspection")]
-    impl<I> HasScalabilityMonitor for NopState<I> {
-        fn scalability_monitor(&self) -> &ScalabilityMonitor {
-            unimplemented!();
-        }
-
-        fn scalability_monitor_mut(&mut self) -> &mut ScalabilityMonitor {
-            unimplemented!();
-        }
-    }
 
     #[must_use]
     pub fn test_std_state<I: Input>() -> StdState<I, InMemoryCorpus<I>, StdRand, InMemoryCorpus<I>>


### PR DESCRIPTION
This is likely incomplete (my IDE doesn't work when libafl_qemu is in the workspace :face_with_spiral_eyes:) but should revert changes which over-aggressively made NopState a testing-only feature: https://github.com/AFLplusplus/LibAFL/commit/ba8ca6723b7adbc46ce19b9dce4f46a41e8dd3bc