### PR TITLE
fix(Dockerfile): allow running commands with docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,3 +135,4 @@ COPY fuzzers fuzzers
 # RUN ./scripts/test_all_fuzzers.sh --no-fmt
 
 ENTRYPOINT [ "/bin/bash", "-c" ]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,4 +134,4 @@ COPY fuzzers fuzzers
 
 # RUN ./scripts/test_all_fuzzers.sh --no-fmt
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/bash", "-c" ]


### PR DESCRIPTION
According to
<https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2109#note_47480476> adding the "-c" to the ENTRYPOINT is necessary to be able to run commands like `docker run libafl "cargo build"`