### PR TITLE
Print PID when you create a new Llmp Sender.

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -122,7 +122,7 @@ llmp_bind_public = ["libafl_bolts/llmp_bind_public"]
 llmp_compression = ["libafl_bolts/llmp_compression"]
 
 ## Enables debug output for LLMP (also needs a `logger` installed)
-llmp_debug = ["libafl_bolts/llmp_debug"]
+llmp_debug = ["std", "libafl_bolts/llmp_debug"]
 
 ## Reduces the initial map size for llmp
 llmp_small_maps = ["libafl_bolts/llmp_small_maps"] # reduces initial map size for llmp

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -76,7 +76,7 @@ llmp_bind_public = ["alloc"]
 llmp_compression = ["alloc", "gzip"]
 
 ## Enables debug output for LLMP (also needs a `logger` installed)
-llmp_debug = ["alloc"]
+llmp_debug = ["alloc", "std"]
 
 ## Reduces the initial map size for llmp
 llmp_small_maps = ["alloc"]

--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -883,7 +883,11 @@ where
         keep_pages_forever: bool,
     ) -> Result<Self, Error> {
         #[cfg(feature = "llmp_debug")]
-        log::info!("PID: {:#?} Initializing LlmpSender {:#?}", std::process::id(), id);
+        log::info!(
+            "PID: {:#?} Initializing LlmpSender {:#?}",
+            std::process::id(),
+            id
+        );
         Ok(Self {
             id,
             last_msg_sent: ptr::null_mut(),
@@ -951,7 +955,11 @@ where
         )?;
         ret.id = Self::client_id_from_env(env_name)?.unwrap_or_default();
         #[cfg(feature = "llmp_debug")]
-        log::info!("PID: {:#?} Initializing LlmpSender from on_existing_from_env {:#?}", std::process::id(), &ret.id);
+        log::info!(
+            "PID: {:#?} Initializing LlmpSender from on_existing_from_env {:#?}",
+            std::process::id(),
+            &ret.id
+        );
         Ok(ret)
     }
 
@@ -1019,9 +1027,13 @@ where
             None => ptr::null_mut(),
         };
 
-        let client_id =  unsafe { (*out_shmem.page()).sender_id };
+        let client_id = unsafe { (*out_shmem.page()).sender_id };
         #[cfg(feature = "llmp_debug")]
-        log::info!("PID: {:#?} Initializing LlmpSender from on_existing_shmem {:#?}", std::process::id(), &client_id);
+        log::info!(
+            "PID: {:#?} Initializing LlmpSender from on_existing_shmem {:#?}",
+            std::process::id(),
+            &client_id
+        );
         Ok(Self {
             id: client_id,
             last_msg_sent,

--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -882,6 +882,8 @@ where
         id: ClientId,
         keep_pages_forever: bool,
     ) -> Result<Self, Error> {
+        #[cfg(feature = "llmp_debug")]
+        log::info!("PID: {:#?} Initializing LlmpSender {:#?}", std::process::id(), id);
         Ok(Self {
             id,
             last_msg_sent: ptr::null_mut(),
@@ -948,6 +950,8 @@ where
             msg_sent_offset,
         )?;
         ret.id = Self::client_id_from_env(env_name)?.unwrap_or_default();
+        #[cfg(feature = "llmp_debug")]
+        log::info!("PID: {:#?} Initializing LlmpSender from on_existing_from_env {:#?}", std::process::id(), &ret.id);
         Ok(ret)
     }
 
@@ -1015,8 +1019,11 @@ where
             None => ptr::null_mut(),
         };
 
+        let client_id =  unsafe { (*out_shmem.page()).sender_id };
+        #[cfg(feature = "llmp_debug")]
+        log::info!("PID: {:#?} Initializing LlmpSender from on_existing_shmem {:#?}", std::process::id(), &client_id);
         Ok(Self {
-            id: unsafe { (*out_shmem.page()).sender_id },
+            id: client_id,
             last_msg_sent,
             out_shmems: vec![out_shmem],
             // drop pages to the broker if it already read them

--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -255,27 +255,40 @@ create_wrapper!(backdoor, (pc: GuestAddr));
 #[cfg(emulation_mode = "usermode")]
 static mut PRE_SYSCALL_HOOKS: Vec<Pin<Box<(PreSyscallHookId, FatPtr)>>> = vec![];
 #[cfg(emulation_mode = "usermode")]
-create_wrapper!(pre_syscall, (sys_num: i32,
-    a0: GuestAddr,
-    a1: GuestAddr,
-    a2: GuestAddr,
-    a3: GuestAddr,
-    a4: GuestAddr,
-    a5: GuestAddr,
-    a6: GuestAddr,
-    a7: GuestAddr), SyscallHookResult);
+create_wrapper!(
+    pre_syscall,
+    (
+        sys_num: i32,
+        a0: GuestAddr,
+        a1: GuestAddr,
+        a2: GuestAddr,
+        a3: GuestAddr,
+        a4: GuestAddr,
+        a5: GuestAddr,
+        a6: GuestAddr,
+        a7: GuestAddr
+    ),
+    SyscallHookResult
+);
 #[cfg(emulation_mode = "usermode")]
 static mut POST_SYSCALL_HOOKS: Vec<Pin<Box<(PostSyscallHookId, FatPtr)>>> = vec![];
 #[cfg(emulation_mode = "usermode")]
-create_wrapper!(post_syscall, (res: GuestAddr, sys_num: i32,
-    a0: GuestAddr,
-    a1: GuestAddr,
-    a2: GuestAddr,
-    a3: GuestAddr,
-    a4: GuestAddr,
-    a5: GuestAddr,
-    a6: GuestAddr,
-    a7: GuestAddr), GuestAddr);
+create_wrapper!(
+    post_syscall,
+    (
+        res: GuestAddr,
+        sys_num: i32,
+        a0: GuestAddr,
+        a1: GuestAddr,
+        a2: GuestAddr,
+        a3: GuestAddr,
+        a4: GuestAddr,
+        a5: GuestAddr,
+        a6: GuestAddr,
+        a7: GuestAddr
+    ),
+    GuestAddr
+);
 #[cfg(emulation_mode = "usermode")]
 static mut NEW_THREAD_HOOKS: Vec<Pin<Box<(NewThreadHookId, FatPtr)>>> = vec![];
 #[cfg(emulation_mode = "usermode")]
@@ -291,20 +304,44 @@ create_post_gen_wrapper!(block, (addr: GuestAddr, len: GuestUsize), 1, BlockHook
 create_exec_wrapper!(block, (id: u64), 0, 1, BlockHookId);
 
 static mut READ_HOOKS: Vec<Pin<Box<HookState<5, ReadHookId>>>> = vec![];
-create_gen_wrapper!(read, (pc: GuestAddr, info: MemAccessInfo), u64, 5, ReadHookId);
+create_gen_wrapper!(
+    read,
+    (pc: GuestAddr, info: MemAccessInfo),
+    u64,
+    5,
+    ReadHookId
+);
 create_exec_wrapper!(read, (id: u64, addr: GuestAddr), 0, 5, ReadHookId);
 create_exec_wrapper!(read, (id: u64, addr: GuestAddr), 1, 5, ReadHookId);
 create_exec_wrapper!(read, (id: u64, addr: GuestAddr), 2, 5, ReadHookId);
 create_exec_wrapper!(read, (id: u64, addr: GuestAddr), 3, 5, ReadHookId);
-create_exec_wrapper!(read, (id: u64, addr: GuestAddr, size: usize), 4, 5, ReadHookId);
+create_exec_wrapper!(
+    read,
+    (id: u64, addr: GuestAddr, size: usize),
+    4,
+    5,
+    ReadHookId
+);
 
 static mut WRITE_HOOKS: Vec<Pin<Box<HookState<5, WriteHookId>>>> = vec![];
-create_gen_wrapper!(write, (pc: GuestAddr, info: MemAccessInfo), u64, 5, WriteHookId);
+create_gen_wrapper!(
+    write,
+    (pc: GuestAddr, info: MemAccessInfo),
+    u64,
+    5,
+    WriteHookId
+);
 create_exec_wrapper!(write, (id: u64, addr: GuestAddr), 0, 5, WriteHookId);
 create_exec_wrapper!(write, (id: u64, addr: GuestAddr), 1, 5, WriteHookId);
 create_exec_wrapper!(write, (id: u64, addr: GuestAddr), 2, 5, WriteHookId);
 create_exec_wrapper!(write, (id: u64, addr: GuestAddr), 3, 5, WriteHookId);
-create_exec_wrapper!(write, (id: u64, addr: GuestAddr, size: usize), 4, 5, WriteHookId);
+create_exec_wrapper!(
+    write,
+    (id: u64, addr: GuestAddr, size: usize),
+    4,
+    5,
+    WriteHookId
+);
 
 static mut CMP_HOOKS: Vec<Pin<Box<HookState<4, CmpHookId>>>> = vec![];
 create_gen_wrapper!(cmp, (pc: GuestAddr, size: usize), u64, 4, CmpHookId);


### PR DESCRIPTION
Point 3 here #1850
https://github.com/AFLplusplus/LibAFL/issues/1850#issuecomment-1971307249

While it is not possible to swap client_id with pid, because it is not no-std friendly.
I instead simply printed the pid and client id on the creation of LlmpSender.

Without this kind of info, it is literally IMPOSSIBLE to find the correspondence between the client_id and the pid, making it impossible to attach with gdb (because you don't know pid!)