### PR TITLE
TransferFeedback for determining if a testcase was from another node

### DIFF
--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -28,6 +28,7 @@ use crate::{
         EventManagerId, EventProcessor, EventRestarter, HasEventManagerId, LogSeverity,
     },
     executors::{Executor, HasObservers},
+    feedbacks::transferred::TransferringMetadata,
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
     inputs::{Input, UsesInput},
     observers::ObserversTuple,
@@ -663,6 +664,9 @@ where
             } => {
                 log::info!("Received new Testcase from {client_id:?} ({client_config:?}, forward {forward_id:?})");
 
+                if let Ok(meta) = state.metadata_mut::<TransferringMetadata>() {
+                    meta.set_transferring(true);
+                }
                 let res =
                     if client_config.match_with(&self.configuration()) && observers_buf.is_some() {
                         let observers: E::Observers =
@@ -692,6 +696,10 @@ where
                             false,
                         )?
                     };
+                if let Ok(meta) = state.metadata_mut::<TransferringMetadata>() {
+                    meta.set_transferring(false);
+                }
+
                 if let Some(item) = res.1 {
                     if res.1.is_some() {
                         self.inner.fire(

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -458,7 +458,7 @@ where
 
 impl<S> TcpEventManager<S>
 where
-    S: State + HasExecutions,
+    S: State + HasExecutions + HasMetadata,
 {
     /// Create a manager from a raw TCP client specifying the client id
     pub fn existing<A: ToSocketAddrs>(

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -44,6 +44,7 @@ use crate::{
         EventProcessor, EventRestarter, HasCustomBufHandlers, HasEventManagerId, ProgressReporter,
     },
     executors::{Executor, HasObservers},
+    feedbacks::transferred::TransferringMetadata,
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
     inputs::{Input, UsesInput},
     monitors::Monitor,
@@ -559,6 +560,9 @@ where
             } => {
                 log::info!("Received new Testcase from {client_id:?} ({client_config:?}, forward {forward_id:?})");
 
+                if let Ok(meta) = state.metadata_mut::<TransferringMetadata>() {
+                    meta.set_transferring(true);
+                }
                 let _res = if client_config.match_with(&self.configuration)
                     && observers_buf.is_some()
                 {
@@ -578,6 +582,9 @@ where
                         state, executor, self, input, false,
                     )?
                 };
+                if let Ok(meta) = state.metadata_mut::<TransferringMetadata>() {
+                    meta.set_transferring(false);
+                }
                 if let Some(item) = _res.1 {
                     log::info!("Added received Testcase as item #{item}");
                 }

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -688,7 +688,7 @@ where
 
 impl<E, S, Z> EventProcessor<E, Z> for TcpEventManager<S>
 where
-    S: State + HasExecutions,
+    S: State + HasExecutions + HasMetadata,
     E: HasObservers<State = S> + Executor<Self, Z>,
     for<'a> E::Observers: Deserialize<'a>,
     Z: EvaluatorObservers<E::Observers, State = S> + ExecutionProcessor<E::Observers, State = S>,
@@ -881,7 +881,7 @@ impl<E, S, SP, Z> EventProcessor<E, Z> for TcpRestartingEventManager<S, SP>
 where
     E: HasObservers<State = S> + Executor<TcpEventManager<S>, Z>,
     for<'a> E::Observers: Deserialize<'a>,
-    S: State + HasExecutions,
+    S: State + HasExecutions + HasMetadata,
     SP: ShMemProvider + 'static,
     Z: EvaluatorObservers<E::Observers, State = S> + ExecutionProcessor<E::Observers>, //CE: CustomEvent<I>,
 {
@@ -985,7 +985,7 @@ pub fn setup_restarting_mgr_tcp<MT, S>(
 ) -> Result<(Option<S>, TcpRestartingEventManager<S, StdShMemProvider>), Error>
 where
     MT: Monitor + Clone,
-    S: State + HasExecutions,
+    S: State + HasExecutions + HasMetadata,
 {
     TcpRestartingMgr::builder()
         .shmem_provider(StdShMemProvider::new()?)
@@ -1046,7 +1046,7 @@ where
 impl<MT, S, SP> TcpRestartingMgr<MT, S, SP>
 where
     SP: ShMemProvider,
-    S: State + HasExecutions,
+    S: State + HasExecutions + HasMetadata,
     MT: Monitor + Clone,
 {
     /// Internal function, returns true when shuttdown is requested by a `SIGINT` signal

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -23,6 +23,8 @@ pub use new_hash_feedback::NewHashFeedbackMetadata;
 
 #[cfg(feature = "nautilus")]
 pub mod nautilus;
+pub mod transferred;
+
 use alloc::string::{String, ToString};
 use core::{
     fmt::{self, Debug, Formatter},

--- a/libafl/src/feedbacks/transferred.rs
+++ b/libafl/src/feedbacks/transferred.rs
@@ -1,0 +1,56 @@
+use libafl_bolts::{impl_serdeany, Error, Named};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    events::EventFirer, executors::ExitKind, feedbacks::Feedback, observers::ObserversTuple,
+    state::HasMetadata,
+};
+
+pub const TRANSFERRED_FEEDBACK_NAME: &str = "transferred_feedback_internal";
+
+#[derive(Copy, Clone, Deserialize, Serialize)]
+pub struct TransferringMetadata {
+    transferring: bool,
+}
+
+impl_serdeany!(TransferringMetadata);
+
+impl TransferringMetadata {
+    pub fn set_transferring(&mut self, transferring: bool) {
+        self.transferring = transferring;
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct TransferredFeedback;
+
+impl Named for TransferredFeedback {
+    fn name(&self) -> &str {
+        TRANSFERRED_FEEDBACK_NAME
+    }
+}
+
+impl<S> Feedback<S> for TransferredFeedback
+where
+    S: HasMetadata,
+{
+    fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
+        state.add_metadata(TransferringMetadata { transferring: true });
+        Ok(())
+    }
+
+    fn is_interesting<EM, OT>(
+        &mut self,
+        state: &mut S,
+        _manager: &mut EM,
+        _input: &S::Input,
+        _observers: &OT,
+        _exit_kind: &ExitKind,
+    ) -> Result<bool, Error>
+    where
+        EM: EventFirer<State = S>,
+        OT: ObserversTuple<S>,
+    {
+        Ok(state.metadata::<TransferringMetadata>()?.transferring)
+    }
+}

--- a/libafl/src/feedbacks/transferred.rs
+++ b/libafl/src/feedbacks/transferred.rs
@@ -12,7 +12,7 @@ use crate::{
     state::{HasMetadata, State},
 };
 
-/// Constant name of the [`TransferringMetdata`].
+/// Constant name of the [`TransferringMetadata`].
 pub const TRANSFERRED_FEEDBACK_NAME: &str = "transferred_feedback_internal";
 
 /// Metadata which denotes whether we are currently transferring an input. Implementors of

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -19,6 +19,7 @@ pub use stacktrace::*;
 pub mod concolic;
 
 pub mod value;
+pub mod transferred;
 
 use alloc::{
     string::{String, ToString},

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -19,7 +19,6 @@ pub use stacktrace::*;
 pub mod concolic;
 
 pub mod value;
-pub mod transferred;
 
 use alloc::{
     string::{String, ToString},


### PR DESCRIPTION
This is useful for short-circuiting potentially expensive objective feedbacks, as well as for creating nodes which just perform analysis on inputs rather than actually fuzzing.