### PR TITLE
fuzzbench_ctx: fix duplicate package warning

### DIFF
--- a/fuzzers/fuzzbench_ctx/Cargo.toml
+++ b/fuzzers/fuzzbench_ctx/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fuzzbench"
+name = "fuzzbench_ctx"
 version = "0.11.2"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"

--- a/fuzzers/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/fuzzbench_ctx/src/lib.rs
@@ -51,11 +51,11 @@ use libafl_bolts::{
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use libafl_targets::autotokens;
 use libafl_targets::{
-    edges_map_mut_ptr, edges_max_num, libfuzzer_initialize, libfuzzer_test_one_input,
-    std_edges_map_observer, CmpLogObserver, CtxHook, EDGES_MAP_SIZE,
+    edges_map_mut_ptr, libfuzzer_initialize, libfuzzer_test_one_input, CmpLogObserver, CtxHook,
+    EDGES_MAP_SIZE,
 };
 #[cfg(unix)]
-use nix::{self, unistd::dup};
+use nix::unistd::dup;
 
 /// The fuzzer main (as `no_mangle` C function)
 #[no_mangle]


### PR DESCRIPTION
Cargo previously complained when loading `libafl` as a git dependency:

```
warning: skipping duplicate package `fuzzbench` found at `~/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/55a300d/fuzzers/fuzzbench`
```