### PR TITLE
Fix cast to c_void of a non-executor object.

### DIFF
--- a/libafl/src/executors/inprocess/stateful.rs
+++ b/libafl/src/executors/inprocess/stateful.rs
@@ -1,8 +1,10 @@
 use alloc::boxed::Box;
 use core::{
     borrow::BorrowMut,
+    ffi::c_void,
     fmt::{self, Debug, Formatter},
     marker::PhantomData,
+    ptr,
     time::Duration,
 };
 
@@ -116,7 +118,11 @@ where
         input: &Self::Input,
     ) -> Result<ExitKind, Error> {
         *state.executions_mut() += 1;
-        self.inner.enter_target(fuzzer, state, mgr, input);
+        unsafe {
+            let executor_ptr = ptr::from_ref(self) as *const c_void;
+            self.inner
+                .enter_target(fuzzer, state, mgr, input, executor_ptr);
+        }
         self.inner.hooks.pre_exec_all(fuzzer, state, mgr, input);
 
         let ret = (self.harness_fn.borrow_mut())(input, &mut self.exposed_executor_state);


### PR DESCRIPTION
The refactoring made in #1900 introduced a wrong cast of the executor in the global state.
It was harmless in the end since it implements `HasObservers` and is only used as an implementor of this trait alone. But it could cause issues in the future if used as an `Executor` for example.