### PR TITLE
Fix reproducibility of the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL "maintainer"="afl++ team <afl@aflplus.plus>"
 LABEL "about"="LibAFL Docker image"
 
 # install sccache to cache subsequent builds of dependencies
-RUN cargo install sccache
+RUN cargo install --locked sccache
 
 ENV HOME=/root
 ENV SCCACHE_CACHE_SIZE="1G"


### PR DESCRIPTION
Add `--locked` flag when installing `sccache` in the first stages to ensure the image gets built when the base image's Rust version satisfies `sccache`'s MSRV.

Fixes #1923 :bug: