### PR TITLE
Fix libafl_qemu doc build for docs.rs

### DIFF
--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [package.metadata.docs.rs]
-features = ["document-features"]
-all-features = true
+features = ["document-features", "default", "python", "x86_64", "usermode"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/libafl_qemu/libafl_qemu_sys/Cargo.toml
+++ b/libafl_qemu/libafl_qemu_sys/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["x86_64", "usermode"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -33,7 +33,7 @@ systemmode = []
 slirp = [ "systemmode", "libafl_qemu_build/slirp" ] # build qemu with host libslirp (for user networking)
 shared = [ "libafl_qemu_build/shared" ]
 
-clippy = [ "libafl_qemu_build/clippy" ] # special feature for clippy, don't use in normal projects§
+clippy = [ "libafl_qemu_build/clippy" ] # special feature for clippy, don't use in normal projects
 
 [dependencies]
 

--- a/libafl_qemu/libafl_qemu_sys/src/lib.rs
+++ b/libafl_qemu/libafl_qemu_sys/src/lib.rs
@@ -1,3 +1,10 @@
+/*!
+`libafl_qemu_sys` is the crate exporting C symbols from QEMU.
+Have a look at `libafl_qemu` for higher-level abstractions.
+
+__Warning__: The documentation is built by default for `x86_64` in `usermode`. To access the documentation of other architectures or systemmode, the documentation must be rebuilt with the right features.
+*/
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/libafl_qemu/src/lib.rs
+++ b/libafl_qemu/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(nightly, feature(used_with_arg))]
 //! Welcome to `LibAFL` QEMU
 //!
+//! __Warning__: The documentation is built by default for `x86_64` in `usermode`. To access the documentation of other architectures or `systemmode`, the documentation must be rebuilt with the right features.
 #![doc = include_str!("../../README.md")]
 /*! */
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]


### PR DESCRIPTION
Avoid building doc with all features. Use `x86_64` and `usermode` by default.
Add documentation about default features for documentation.