### PR TITLE
Remove (almost) unused stage_idx

### DIFF
--- a/bindings/pylibafl/src/lib.rs
+++ b/bindings/pylibafl/src/lib.rs
@@ -46,9 +46,9 @@ class BaseStage:
         return Stage.new_py(self)
 
 class BaseMutator:
-    def mutate(self, state, input, stage_idx):
+    def mutate(self, state, input):
         pass
-    def post_exec(self, state, stage_idx, corpus_idx):
+    def post_exec(self, state, corpus_idx):
         pass
     def as_mutator(self):
         return Mutator.new_py(self)

--- a/fuzzers/push_stage_harness/src/main.rs
+++ b/fuzzers/push_stage_harness/src/main.rs
@@ -31,10 +31,11 @@ fn signals_set(idx: usize) {
     unsafe { SIGNALS[idx] = 1 };
 }
 
-#[allow(clippy::similar_names)]
+#[allow(clippy::similar_names, clippy::manual_assert)]
 pub fn main() {
     // Create an observation channel using the signals map
-    let observer = unsafe { StdMapObserver::new("signals", &mut SIGNALS) };
+    let observer =
+        unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS.as_mut_ptr(), SIGNALS.len()) };
 
     // Feedback to rate the interestingness of an input
     let mut feedback = MaxMapFeedback::new(&observer);
@@ -90,8 +91,6 @@ pub fn main() {
 
     let exit_kind = Rc::new(Cell::new(None));
 
-    let stage_idx = 0;
-
     let observers = tuple_list!(observer);
 
     let shared_state = PushStageSharedState::new(fuzzer, state, observers, mgr);
@@ -101,7 +100,6 @@ pub fn main() {
         mutator,
         Rc::new(RefCell::new(Some(shared_state))),
         exit_kind.clone(),
-        stage_idx,
     );
 
     // Loop, the input, getting a new entry from the push stage each iteration.

--- a/fuzzers/tutorial/src/mutator.rs
+++ b/fuzzers/tutorial/src/mutator.rs
@@ -19,11 +19,7 @@ impl<S> Mutator<PacketData, S> for LainMutator
 where
     S: HasRand,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut PacketData,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut PacketData) -> Result<MutationResult, Error> {
         // Lain uses its own instance of StdRand, but we want to keep it in sync with LibAFL's state.
         self.inner.rng_mut().set_seed(state.rand_mut().next());
         input.mutate(&mut self.inner, None);

--- a/fuzzers/tutorial/src/mutator.rs
+++ b/fuzzers/tutorial/src/mutator.rs
@@ -23,7 +23,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut PacketData,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         // Lain uses its own instance of StdRand, but we want to keep it in sync with LibAFL's state.
         self.inner.rng_mut().set_seed(state.rand_mut().next());

--- a/libafl/src/mutators/encoded_mutations.rs
+++ b/libafl/src/mutators/encoded_mutations.rs
@@ -25,12 +25,7 @@ use crate::{
 pub struct EncodedRandMutator;
 
 impl<S: HasRand> Mutator<EncodedInput, S> for EncodedRandMutator {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         if input.codes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -60,12 +55,7 @@ impl EncodedRandMutator {
 pub struct EncodedIncMutator;
 
 impl<S: HasRand> Mutator<EncodedInput, S> for EncodedIncMutator {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         if input.codes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -95,12 +85,7 @@ impl EncodedIncMutator {
 pub struct EncodedDecMutator;
 
 impl<S: HasRand> Mutator<EncodedInput, S> for EncodedDecMutator {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         if input.codes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -130,12 +115,7 @@ impl EncodedDecMutator {
 pub struct EncodedAddMutator;
 
 impl<S: HasRand> Mutator<EncodedInput, S> for EncodedAddMutator {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         if input.codes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -169,12 +149,7 @@ impl EncodedAddMutator {
 pub struct EncodedDeleteMutator;
 
 impl<S: HasRand> Mutator<EncodedInput, S> for EncodedDeleteMutator {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         let size = input.codes().len();
         if size <= 2 {
             return Ok(MutationResult::Skipped);
@@ -212,12 +187,7 @@ impl<S> Mutator<EncodedInput, S> for EncodedInsertCopyMutator
 where
     S: HasRand + HasMaxSize,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
         let size = input.codes().len();
         if size == 0 {
@@ -272,12 +242,7 @@ impl EncodedInsertCopyMutator {
 pub struct EncodedCopyMutator;
 
 impl<S: HasRand> Mutator<EncodedInput, S> for EncodedCopyMutator {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         let size = input.codes().len();
         if size <= 1 {
             return Ok(MutationResult::Skipped);
@@ -317,12 +282,7 @@ impl<S> Mutator<S::Input, S> for EncodedCrossoverInsertMutator
 where
     S: UsesInput<Input = EncodedInput> + HasRand + HasCorpus + HasMaxSize,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         let size = input.codes().len();
 
         // We don't want to use the testcase we're already using for splicing
@@ -391,12 +351,7 @@ impl<S> Mutator<S::Input, S> for EncodedCrossoverReplaceMutator
 where
     S: UsesInput<Input = EncodedInput> + HasRand + HasCorpus,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut EncodedInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut EncodedInput) -> Result<MutationResult, Error> {
         let size = input.codes().len();
         if size == 0 {
             return Ok(MutationResult::Skipped);

--- a/libafl/src/mutators/gramatron.rs
+++ b/libafl/src/mutators/gramatron.rs
@@ -36,7 +36,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut GramatronInput,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         if !input.terminals().is_empty() {
             let size = state.rand_mut().below(input.terminals().len() as u64 + 1) as usize;
@@ -109,7 +108,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut GramatronInput,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         if input.terminals().is_empty() {
             return Ok(MutationResult::Skipped);
@@ -180,7 +178,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut GramatronInput,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         if input.terminals().is_empty() {
             return Ok(MutationResult::Skipped);

--- a/libafl/src/mutators/grimoire.rs
+++ b/libafl/src/mutators/grimoire.rs
@@ -122,7 +122,6 @@ where
         &mut self,
         state: &mut S,
         generalised_meta: &mut GeneralizedInputMetadata,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         extend_with_random_generalized(
             state,
@@ -163,7 +162,6 @@ where
         &mut self,
         state: &mut S,
         generalised_meta: &mut GeneralizedInputMetadata,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         let mut mutated = MutationResult::Skipped;
 
@@ -236,7 +234,6 @@ where
         &mut self,
         state: &mut S,
         generalised_meta: &mut GeneralizedInputMetadata,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         let tokens_len = {
             let meta = state.metadata_map().get::<Tokens>();
@@ -347,7 +344,6 @@ where
         &mut self,
         state: &mut S,
         generalised_meta: &mut GeneralizedInputMetadata,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         let gen = generalised_meta.generalized_mut();
 

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -114,7 +114,6 @@ pub trait MultiMutator<I, S>: Named {
         &mut self,
         state: &mut S,
         input: &I,
-
         max_count: Option<usize>,
     ) -> Result<Vec<I>, Error>;
 

--- a/libafl/src/mutators/mopt_mutator.rs
+++ b/libafl/src/mutators/mopt_mutator.rs
@@ -404,23 +404,13 @@ where
     S: HasRand + HasMetadata + HasCorpus + HasSolutions,
 {
     #[inline]
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         self.finds_before = state.corpus().count() + state.solutions().count();
-        self.scheduled_mutate(state, input, stage_idx)
+        self.scheduled_mutate(state, input)
     }
 
     #[allow(clippy::cast_precision_loss)]
-    fn post_exec(
-        &mut self,
-        state: &mut S,
-        _stage_idx: i32,
-        _corpus_idx: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, state: &mut S, _corpus_idx: Option<CorpusId>) -> Result<(), Error> {
         let before = self.finds_before;
         let after = state.corpus().count() + state.solutions().count();
 
@@ -558,12 +548,7 @@ where
             phantom: PhantomData,
         })
     }
-    fn core_mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn core_mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let mut r = MutationResult::Skipped;
         let mopt = state.metadata_map_mut().get_mut::<MOpt>().unwrap();
         for i in 0..mopt.operator_num {
@@ -572,9 +557,7 @@ where
 
         for _i in 0..self.iterations(state, input) {
             let idx = self.schedule(state, input);
-            let outcome = self
-                .mutations_mut()
-                .get_and_mutate(idx, state, input, stage_idx)?;
+            let outcome = self.mutations_mut().get_and_mutate(idx, state, input)?;
             if outcome == MutationResult::Mutated {
                 r = MutationResult::Mutated;
             }
@@ -588,12 +571,7 @@ where
         Ok(r)
     }
 
-    fn pilot_mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn pilot_mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let mut r = MutationResult::Skipped;
         let swarm_now;
         {
@@ -608,9 +586,7 @@ where
 
         for _i in 0..self.iterations(state, input) {
             let idx = self.schedule(state, input);
-            let outcome = self
-                .mutations_mut()
-                .get_and_mutate(idx, state, input, stage_idx)?;
+            let outcome = self.mutations_mut().get_and_mutate(idx, state, input)?;
             if outcome == MutationResult::Mutated {
                 r = MutationResult::Mutated;
             }
@@ -675,16 +651,11 @@ where
             .unwrap()
     }
 
-    fn scheduled_mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn scheduled_mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let mode = self.mode;
         match mode {
-            MOptMode::Corefuzzing => self.core_mutate(state, input, stage_idx),
-            MOptMode::Pilotfuzzing => self.pilot_mutate(state, input, stage_idx),
+            MOptMode::Corefuzzing => self.core_mutate(state, input),
+            MOptMode::Pilotfuzzing => self.pilot_mutate(state, input),
         }
     }
 }

--- a/libafl/src/mutators/multi.rs
+++ b/libafl/src/mutators/multi.rs
@@ -40,24 +40,18 @@ where
         &mut self,
         state: &mut S,
         input: &mut MultipartInput<I>,
-        stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         if input.parts().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
             let selected = state.rand_mut().below(input.parts().len() as u64) as usize;
             let mutated = input.part_mut(selected).unwrap();
-            self.mutate(state, mutated, stage_idx)
+            self.mutate(state, mutated)
         }
     }
 
-    fn post_exec(
-        &mut self,
-        state: &mut S,
-        stage_idx: i32,
-        corpus_idx: Option<CorpusId>,
-    ) -> Result<(), Error> {
-        M::post_exec(self, state, stage_idx, corpus_idx)
+    fn post_exec(&mut self, state: &mut S, corpus_idx: Option<CorpusId>) -> Result<(), Error> {
+        M::post_exec(self, state, corpus_idx)
     }
 }
 
@@ -129,7 +123,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut MultipartInput<I>,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         // we can eat the slight bias; number of parts will be small
         let name_choice = state.rand_mut().next() as usize;
@@ -234,7 +227,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut MultipartInput<I>,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         // we can eat the slight bias; number of parts will be small
         let name_choice = state.rand_mut().next() as usize;

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -122,12 +122,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -162,12 +157,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -200,12 +190,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -239,12 +224,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -278,12 +258,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -317,12 +292,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
             Ok(MutationResult::Skipped)
         } else {
@@ -365,7 +335,7 @@ macro_rules! add_mutator_impl {
                 &mut self,
                 state: &mut S,
                 input: &mut I,
-                _stage_idx: i32,
+
             ) -> Result<MutationResult, Error> {
                 if input.bytes().len() < size_of::<$size>() {
                     Ok(MutationResult::Skipped)
@@ -428,12 +398,7 @@ macro_rules! interesting_mutator_impl {
             I: HasBytesVec,
         {
             #[allow(clippy::cast_sign_loss)]
-            fn mutate(
-                &mut self,
-                state: &mut S,
-                input: &mut I,
-                _stage_idx: i32,
-            ) -> Result<MutationResult, Error> {
+            fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
                 if input.bytes().len() < size_of::<$size>() {
                     Ok(MutationResult::Skipped)
                 } else {
@@ -480,12 +445,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size <= 2 {
             return Ok(MutationResult::Skipped);
@@ -522,12 +482,7 @@ where
     S: HasRand + HasMaxSize,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
         let size = input.bytes().len();
         if size == 0 || size >= max_size {
@@ -573,12 +528,7 @@ where
     S: HasRand + HasMaxSize,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
         let size = input.bytes().len();
         if size == 0 || size >= max_size {
@@ -631,12 +581,7 @@ where
     S: HasRand + HasMaxSize,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
         let size = input.bytes().len();
         if size >= max_size {
@@ -689,12 +634,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size == 0 {
             return Ok(MutationResult::Skipped);
@@ -732,12 +672,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size == 0 {
             return Ok(MutationResult::Skipped);
@@ -775,12 +710,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size <= 1 {
             return Ok(MutationResult::Skipped);
@@ -822,12 +752,7 @@ where
     S: HasRand + HasMaxSize,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size <= 1 || size >= state.max_size() {
             return Ok(MutationResult::Skipped);
@@ -887,12 +812,7 @@ where
     S: HasRand,
     I: HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size <= 1 {
             return Ok(MutationResult::Skipped);
@@ -1125,12 +1045,7 @@ where
     S: HasCorpus<Input = I> + HasRand + HasMaxSize,
     I: Input + HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut S::Input,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut S::Input) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         let max_size = state.max_size();
         if size >= max_size {
@@ -1213,12 +1128,7 @@ where
     S: HasCorpus<Input = I> + HasRand,
     I: Input + HasBytesVec,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut S::Input,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut S::Input) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
         if size == 0 {
             return Ok(MutationResult::Skipped);
@@ -1295,12 +1205,7 @@ where
     S::Input: HasBytesVec,
 {
     #[allow(clippy::cast_sign_loss)]
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut S::Input,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut S::Input) -> Result<MutationResult, Error> {
         // We don't want to use the testcase we're already using for splicing
         let idx = random_corpus_id!(state.corpus(), state.rand_mut());
         if let Some(cur) = state.corpus().current() {
@@ -1508,7 +1413,7 @@ mod tests {
                 for input in &inputs {
                     let mut mutant = input.clone();
                     match mutations
-                        .get_and_mutate(idx.into(), &mut state, &mut mutant, 0)
+                        .get_and_mutate(idx.into(), &mut state, &mut mutant)
                         .unwrap()
                     {
                         MutationResult::Mutated => new_testcases.push(mutant),
@@ -1534,7 +1439,7 @@ mod tests {
 
         for _ in 0..iters {
             let mut mutated = base.clone();
-            if mutator.mutate(&mut state, &mut mutated, 0)? == MutationResult::Skipped {
+            if mutator.mutate(&mut state, &mut mutated)? == MutationResult::Skipped {
                 continue;
             }
             let mut gaps = 0;
@@ -1588,7 +1493,7 @@ mod tests {
 
         for _ in 0..iters {
             let mut mutated = base.clone();
-            if mutator.mutate(&mut state, &mut mutated, 0)? == MutationResult::Skipped {
+            if mutator.mutate(&mut state, &mut mutated)? == MutationResult::Skipped {
                 continue;
             }
             let mut expansion = 0;
@@ -1637,7 +1542,7 @@ mod tests {
 
         for _ in 0..iters {
             let mut mutated = base.clone();
-            if mutator.mutate(&mut state, &mut mutated, 0)? == MutationResult::Skipped {
+            if mutator.mutate(&mut state, &mut mutated)? == MutationResult::Skipped {
                 continue;
             }
             let mut inserted = 0;
@@ -1687,7 +1592,7 @@ mod tests {
 
         for _ in 0..iters {
             let mut mutated = base.clone();
-            if mutator.mutate(&mut state, &mut mutated, 0)? == MutationResult::Skipped {
+            if mutator.mutate(&mut state, &mut mutated)? == MutationResult::Skipped {
                 continue;
             }
             let mut inserted = 10;

--- a/libafl/src/mutators/nautilus.rs
+++ b/libafl/src/mutators/nautilus.rs
@@ -35,7 +35,6 @@ impl<S> Mutator<NautilusInput, S> for NautilusRandomMutator<'_> {
         &mut self,
         _state: &mut S,
         input: &mut NautilusInput,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         // TODO get rid of tmp
         let mut tmp = vec![];
@@ -96,7 +95,6 @@ impl<S> Mutator<NautilusInput, S> for NautilusRecursionMutator<'_> {
         &mut self,
         _state: &mut S,
         input: &mut NautilusInput,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         // TODO don't calc recursions here
         if let Some(ref mut recursions) = input.tree.calc_recursions(self.ctx) {
@@ -162,7 +160,6 @@ where
         &mut self,
         state: &mut S,
         input: &mut NautilusInput,
-        _stage_idx: i32,
     ) -> Result<MutationResult, Error> {
         let meta = state
             .metadata_map()

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -93,19 +93,12 @@ where
 
     /// New default implementation for mutate.
     /// Implementations must forward `mutate()` to this method
-    fn scheduled_mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn scheduled_mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let mut r = MutationResult::Skipped;
         let num = self.iterations(state, input);
         for _ in 0..num {
             let idx = self.schedule(state, input);
-            let outcome = self
-                .mutations_mut()
-                .get_and_mutate(idx, state, input, stage_idx)?;
+            let outcome = self.mutations_mut().get_and_mutate(idx, state, input)?;
             if outcome == MutationResult::Mutated {
                 r = MutationResult::Mutated;
             }
@@ -157,13 +150,8 @@ where
     S: HasRand,
 {
     #[inline]
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
-        self.scheduled_mutate(state, input, stage_idx)
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
+        self.scheduled_mutate(state, input)
     }
 }
 
@@ -391,21 +379,11 @@ where
     S: HasRand + HasCorpus,
     SM: ScheduledMutator<I, MT, S>,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
-        self.scheduled_mutate(state, input, stage_idx)
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
+        self.scheduled_mutate(state, input)
     }
 
-    fn post_exec(
-        &mut self,
-        state: &mut S,
-        _stage_idx: i32,
-        corpus_idx: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(&mut self, state: &mut S, corpus_idx: Option<CorpusId>) -> Result<(), Error> {
         if let Some(idx) = corpus_idx {
             let mut testcase = (*state.corpus_mut().get(idx)?).borrow_mut();
             let mut log = Vec::<String>::new();
@@ -456,21 +434,14 @@ where
         state.rand_mut().below(MT::LEN as u64).into()
     }
 
-    fn scheduled_mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn scheduled_mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let mut r = MutationResult::Skipped;
         let num = self.iterations(state, input);
         self.mutation_log.clear();
         for _ in 0..num {
             let idx = self.schedule(state, input);
             self.mutation_log.push(idx);
-            let outcome = self
-                .mutations_mut()
-                .get_and_mutate(idx, state, input, stage_idx)?;
+            let outcome = self.mutations_mut().get_and_mutate(idx, state, input)?;
             if outcome == MutationResult::Mutated {
                 r = MutationResult::Mutated;
             }
@@ -542,7 +513,7 @@ mod tests {
         rand.set_seed(5);
 
         let mut splice = SpliceMutator::new();
-        splice.mutate(&mut state, &mut input, 0).unwrap();
+        splice.mutate(&mut state, &mut input).unwrap();
 
         log::trace!("{:?}", input.bytes());
 
@@ -584,8 +555,8 @@ mod tests {
 
         let mut equal_in_a_row = 0;
 
-        for i in 0..42 {
-            havoc.mutate(&mut state, &mut input, i).unwrap();
+        for _ in 0..42 {
+            havoc.mutate(&mut state, &mut input).unwrap();
 
             // Make sure we actually mutate something, at least sometimes
             equal_in_a_row = if input == input_prior {

--- a/libafl/src/mutators/string.rs
+++ b/libafl/src/mutators/string.rs
@@ -53,12 +53,7 @@ impl<S> MutatedTransformPost<S> for StringIdentificationMetadata
 where
     S: HasTestcase,
 {
-    fn post_exec(
-        self,
-        state: &mut S,
-        _stage_idx: i32,
-        corpus_idx: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(self, state: &mut S, corpus_idx: Option<CorpusId>) -> Result<(), Error> {
         if let Some(corpus_idx) = corpus_idx {
             let mut tc = state.testcase_mut(corpus_idx)?;
             tc.add_metadata(self);
@@ -288,12 +283,7 @@ impl<S> Mutator<UnicodeInput, S> for StringCategoryRandMutator
 where
     S: HasRand + HasMaxSize,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut UnicodeInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut UnicodeInput) -> Result<MutationResult, Error> {
         if input.0.bytes().is_empty() {
             return Ok(MutationResult::Skipped);
         }
@@ -351,12 +341,7 @@ impl<S> Mutator<UnicodeInput, S> for StringSubcategoryRandMutator
 where
     S: HasRand + HasMaxSize,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut UnicodeInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut UnicodeInput) -> Result<MutationResult, Error> {
         if input.0.bytes().is_empty() {
             return Ok(MutationResult::Skipped);
         }
@@ -402,12 +387,7 @@ impl<S> Mutator<UnicodeInput, S> for StringCategoryTokenReplaceMutator
 where
     S: HasRand + HasMaxSize + HasMetadata,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut UnicodeInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut UnicodeInput) -> Result<MutationResult, Error> {
         if input.0.bytes().is_empty() {
             return Ok(MutationResult::Skipped);
         }
@@ -466,12 +446,7 @@ impl<S> Mutator<UnicodeInput, S> for StringSubcategoryTokenReplaceMutator
 where
     S: HasRand + HasMaxSize + HasMetadata,
 {
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut UnicodeInput,
-        _stage_idx: i32,
-    ) -> Result<MutationResult, Error> {
+    fn mutate(&mut self, state: &mut S, input: &mut UnicodeInput) -> Result<MutationResult, Error> {
         if input.0.bytes().is_empty() {
             return Ok(MutationResult::Skipped);
         }
@@ -548,7 +523,7 @@ mod test {
             for _ in 0..(1 << 12) {
                 let metadata = extract_metadata(bytes.bytes());
                 let mut input = (bytes, metadata);
-                let _ = mutator.mutate(&mut state, &mut input, 0);
+                let _ = mutator.mutate(&mut state, &mut input);
                 println!("{:?}", core::str::from_utf8(input.0.bytes()).unwrap());
                 bytes = input.0;
             }
@@ -580,7 +555,7 @@ mod test {
             for _ in 0..(1 << 12) {
                 let metadata = extract_metadata(bytes.bytes());
                 let mut input = (bytes, metadata);
-                let _ = mutator.mutate(&mut state, &mut input, 0);
+                let _ = mutator.mutate(&mut state, &mut input);
                 println!("{:?}", core::str::from_utf8(input.0.bytes()).unwrap());
                 bytes = input.0;
             }

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -615,8 +615,8 @@ pub struct AFLppRedQueen {
     enable_transform: bool,
     enable_arith: bool,
     text_type: TextType,
-    /// We use this variable to check if we scheduled a new corpus_idx
-    /// - and, hence, need to recalculate `text_type``
+    /// We use this variable to check if we scheduled a new `corpus_idx`
+    /// - and, hence, need to recalculate `text_type`
     last_corpus_idx: Option<CorpusId>,
 }
 

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -1093,7 +1093,6 @@ where
         &mut self,
         state: &mut S,
         input: &I,
-
         max_count: Option<usize>,
     ) -> Result<Vec<I>, Error> {
         // TODO

--- a/libafl/src/mutators/tuneable.rs
+++ b/libafl/src/mutators/tuneable.rs
@@ -112,13 +112,8 @@ where
     S: HasRand + HasMetadata,
 {
     #[inline]
-    fn mutate(
-        &mut self,
-        state: &mut S,
-        input: &mut I,
-        stage_id: i32,
-    ) -> Result<MutationResult, Error> {
-        self.scheduled_mutate(state, input, stage_id)
+    fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
+        self.scheduled_mutate(state, input)
     }
 }
 

--- a/libafl/src/stages/mutational.rs
+++ b/libafl/src/stages/mutational.rs
@@ -26,12 +26,7 @@ use crate::{monitors::PerfFeature, state::HasClientPerfMonitor};
 pub trait MutatedTransformPost<S>: Sized {
     /// Perform any post-execution steps necessary for the transformed input (e.g., updating metadata)
     #[inline]
-    fn post_exec(
-        self,
-        state: &mut S,
-        stage_idx: i32,
-        corpus_idx: Option<CorpusId>,
-    ) -> Result<(), Error> {
+    fn post_exec(self, state: &mut S, corpus_idx: Option<CorpusId>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -134,11 +129,11 @@ where
         drop(testcase);
         mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
 
-        for i in 0..num {
+        for _ in 0..num {
             let mut input = input.clone();
 
             start_timer!(state);
-            let mutated = self.mutator_mut().mutate(state, &mut input, i as i32)?;
+            let mutated = self.mutator_mut().mutate(state, &mut input)?;
             mark_feature_time!(state, PerfFeature::Mutate);
 
             if mutated == MutationResult::Skipped {
@@ -150,8 +145,8 @@ where
             let (_, corpus_idx) = fuzzer.evaluate_input(state, executor, manager, untransformed)?;
 
             start_timer!(state);
-            self.mutator_mut().post_exec(state, i as i32, corpus_idx)?;
-            post.post_exec(state, i as i32, corpus_idx)?;
+            self.mutator_mut().post_exec(state, corpus_idx)?;
+            post.post_exec(state, corpus_idx)?;
             mark_feature_time!(state, PerfFeature::MutatePostExec);
         }
 
@@ -371,14 +366,14 @@ where
         };
         drop(testcase);
 
-        let generated = self.mutator.multi_mutate(state, &input, 0, None)?;
+        let generated = self.mutator.multi_mutate(state, &input, None)?;
         // println!("Generated {}", generated.len());
-        for (i, new_input) in generated.into_iter().enumerate() {
+        for new_input in generated {
             // Time is measured directly the `evaluate_input` function
             let (untransformed, post) = new_input.try_transform_into(state)?;
             let (_, corpus_idx) = fuzzer.evaluate_input(state, executor, manager, untransformed)?;
-            self.mutator.multi_post_exec(state, i as i32, corpus_idx)?;
-            post.post_exec(state, i as i32, corpus_idx)?;
+            self.mutator.multi_post_exec(state, corpus_idx)?;
+            post.post_exec(state, corpus_idx)?;
         }
         // println!("Found {}", found);
 

--- a/libafl/src/stages/push/mutational.rs
+++ b/libafl/src/stages/push/mutational.rs
@@ -53,8 +53,6 @@ where
     testcases_to_do: usize,
     testcases_done: usize,
 
-    stage_idx: i32,
-
     mutator: M,
 
     psh: PushStageHelper<CS, EM, OT, Z>,
@@ -150,9 +148,7 @@ where
         mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
 
         start_timer!(state);
-        self.mutator
-            .mutate(state, &mut input, self.stage_idx)
-            .unwrap();
+        self.mutator.mutate(state, &mut input).unwrap();
         mark_feature_time!(state, PerfFeature::Mutate);
 
         self.push_stage_helper_mut()
@@ -176,8 +172,7 @@ where
         fuzzer.process_execution(state, event_mgr, last_input, observers, &exit_kind, true)?;
 
         start_timer!(state);
-        self.mutator
-            .post_exec(state, self.stage_idx, self.current_corpus_idx)?;
+        self.mutator.post_exec(state, self.current_corpus_idx)?;
         mark_feature_time!(state, PerfFeature::MutatePostExec);
         self.testcases_done += 1;
 
@@ -234,7 +229,6 @@ where
         mutator: M,
         shared_state: Rc<RefCell<Option<PushStageSharedState<CS, EM, OT, Z>>>>,
         exit_kind: Rc<Cell<Option<ExitKind>>>,
-        stage_idx: i32,
     ) -> Self {
         Self {
             mutator,
@@ -242,7 +236,6 @@ where
             current_corpus_idx: None, // todo
             testcases_to_do: 0,
             testcases_done: 0,
-            stage_idx,
         }
     }
 }

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -100,7 +100,7 @@ where
             state.set_max_size(before_len);
 
             start_timer!(state);
-            let mutated = self.mutator_mut().mutate(state, &mut input, i as i32)?;
+            let mutated = self.mutator_mut().mutate(state, &mut input)?;
             mark_feature_time!(state, PerfFeature::Mutate);
 
             if mutated == MutationResult::Skipped {
@@ -148,7 +148,7 @@ where
             };
 
             start_timer!(state);
-            self.mutator_mut().post_exec(state, i as i32, corpus_idx)?;
+            self.mutator_mut().post_exec(state, corpus_idx)?;
             mark_feature_time!(state, PerfFeature::MutatePostExec);
 
             i = next_i;

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -199,36 +199,36 @@ where
             (Some(fuzz_time), Some(iters)) => {
                 // perform n iterations or fuzz for provided time, whichever comes first
                 let start_time = current_time();
-                for i in 1..=iters {
+                for _ in 1..=iters {
                     if current_time() - start_time >= fuzz_time {
                         break;
                     }
 
-                    self.perform_mutation(fuzzer, executor, state, manager, &input, i)?;
+                    self.perform_mutation(fuzzer, executor, state, manager, &input)?;
                 }
             }
             (Some(fuzz_time), None) => {
                 // fuzz for provided time
                 let start_time = current_time();
-                for i in 1.. {
+                for _ in 1.. {
                     if current_time() - start_time >= fuzz_time {
                         break;
                     }
 
-                    self.perform_mutation(fuzzer, executor, state, manager, &input, i)?;
+                    self.perform_mutation(fuzzer, executor, state, manager, &input)?;
                 }
             }
             (None, Some(iters)) => {
                 // perform n iterations
-                for i in 1..=iters {
-                    self.perform_mutation(fuzzer, executor, state, manager, &input, i)?;
+                for _ in 1..=iters {
+                    self.perform_mutation(fuzzer, executor, state, manager, &input)?;
                 }
             }
             (None, None) => {
                 // fall back to random
                 let iters = self.iterations(state)? - self.execs_since_progress_start(state)?;
-                for i in 1..=iters {
-                    self.perform_mutation(fuzzer, executor, state, manager, &input, i)?;
+                for _ in 1..=iters {
+                    self.perform_mutation(fuzzer, executor, state, manager, &input)?;
                 }
             }
         }
@@ -448,14 +448,11 @@ where
         state: &mut Z::State,
         manager: &mut EM,
         input: &I,
-        stage_idx: u64,
     ) -> Result<(), Error> {
         let mut input = input.clone();
 
         start_timer!(state);
-        let mutated = self
-            .mutator_mut()
-            .mutate(state, &mut input, stage_idx as i32)?;
+        let mutated = self.mutator_mut().mutate(state, &mut input)?;
         mark_feature_time!(state, PerfFeature::Mutate);
 
         if mutated == MutationResult::Skipped {
@@ -467,9 +464,8 @@ where
         let (_, corpus_idx) = fuzzer.evaluate_input(state, executor, manager, untransformed)?;
 
         start_timer!(state);
-        self.mutator_mut()
-            .post_exec(state, stage_idx as i32, corpus_idx)?;
-        post.post_exec(state, stage_idx as i32, corpus_idx)?;
+        self.mutator_mut().post_exec(state, corpus_idx)?;
+        post.post_exec(state, corpus_idx)?;
         mark_feature_time!(state, PerfFeature::MutatePostExec);
 
         Ok(())


### PR DESCRIPTION
This removes the `stage_idx` parameter from mutators that nothing uses