### PR TITLE
Fix os error printing in unix_shmem (#1406)

### DIFF
--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -590,11 +590,11 @@ pub mod unix_shmem {
 
         use alloc::string::ToString;
         use core::{ptr, slice};
-        use std::{io::Write, process};
+        use std::{io, io::Write, process};
 
         use libc::{
-            c_int, c_uchar, close, ftruncate, mmap, munmap, perror, shm_open, shm_unlink, shmat,
-            shmctl, shmdt, shmget,
+            c_int, c_uchar, close, ftruncate, mmap, munmap, shm_open, shm_unlink, shmat, shmctl,
+            shmdt, shmget,
         };
 
         use crate::{
@@ -648,19 +648,21 @@ pub mod unix_shmem {
                         0o600,
                     );
                     if shm_fd == -1 {
-                        perror(b"shm_open\0".as_ptr() as *const _);
-                        return Err(Error::unknown(format!(
-                            "Failed to shm_open map with id {filename_path:?}",
-                        )));
+                        return Err(Error::os_error(
+                            io::Error::last_os_error(),
+                            format!("Failed to shm_open map with id {filename_path:?}",),
+                        ));
                     }
 
                     /* configure the size of the shared memory segment */
                     if ftruncate(shm_fd, map_size.try_into()?) != 0 {
-                        perror(b"ftruncate\0".as_ptr() as *const _);
                         shm_unlink(filename_path.as_ptr() as *const _);
-                        return Err(Error::unknown(format!(
-                            "setup_shm(): ftruncate() failed for map with id {filename_path:?}",
-                        )));
+                        return Err(Error::os_error(
+                            io::Error::last_os_error(),
+                            format!(
+                                "setup_shm(): ftruncate() failed for map with id {filename_path:?}",
+                            ),
+                        ));
                     }
 
                     /* map the shared memory segment to the address space of the process */
@@ -673,12 +675,12 @@ pub mod unix_shmem {
                         0,
                     );
                     if map == libc::MAP_FAILED || map.is_null() {
-                        perror(b"mmap\0".as_ptr() as *const _);
                         close(shm_fd);
                         shm_unlink(filename_path.as_ptr() as *const _);
-                        return Err(Error::unknown(format!(
-                            "mmap() failed for map with id {filename_path:?}",
-                        )));
+                        return Err(Error::os_error(
+                            io::Error::last_os_error(),
+                            format!("mmap() failed for map with id {filename_path:?}",),
+                        ));
                     }
 
                     Ok(Self {
@@ -705,11 +707,11 @@ pub mod unix_shmem {
                         0,
                     );
                     if map == libc::MAP_FAILED || map.is_null() {
-                        perror(b"mmap\0".as_ptr() as *const _);
                         close(shm_fd);
-                        return Err(Error::unknown(format!(
-                            "mmap() failed for map with fd {shm_fd:?}"
-                        )));
+                        return Err(Error::os_error(
+                            io::Error::last_os_error(),
+                            format!("mmap() failed for map with fd {shm_fd:?}"),
+                        ));
                     }
 
                     Ok(Self {
@@ -852,10 +854,9 @@ pub mod unix_shmem {
                     let map = shmat(os_id, ptr::null(), 0) as *mut c_uchar;
 
                     if map as c_int == -1 || map.is_null() {
-                        perror(b"shmat\0".as_ptr() as *const _);
-                        shmctl(os_id, libc::IPC_RMID, ptr::null_mut());
-                        return Err(Error::unknown(
-                            "Failed to map the shared mapping".to_string(),
+                        return Err(Error::os_error(
+                            io::Error::last_os_error(),
+                            "Failed to map the shared mapping",
                         ));
                     }
 
@@ -874,10 +875,10 @@ pub mod unix_shmem {
                     let map = shmat(id_int, ptr::null(), 0) as *mut c_uchar;
 
                     if map.is_null() || map == ptr::null_mut::<c_uchar>().wrapping_sub(1) {
-                        perror(b"shmat\0".as_ptr() as *const _);
-                        return Err(Error::unknown(format!(
-                            "Failed to map the shared mapping with id {id_int}"
-                        )));
+                        return Err(Error::os_error(
+                            io::Error::last_os_error(),
+                            format!("Failed to map the shared mapping with id {id_int}"),
+                        ));
                     }
 
                     Ok(Self { id, map, map_size })


### PR DESCRIPTION
Use `std::io::Error::last_os_error` instead of `libc::perror` for error printing in unix_shmem.