### PR TITLE
SerdeAnyMap: add `unsafe_stable_anymap` feature that uses `type_name` instead of `TypeId::of`

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -63,6 +63,13 @@ xxh3 = ["xxhash-rust"]
 
 #! ### SerdeAny features
 
+## With this feature, the AnyMap uses [`type_name`](https://doc.rust-lang.org/std/any/fn.type_name.html)
+## instead of [`TypeId::of`](https://doc.rust-lang.org/std/any/struct.TypeId.html#method.of) for deserialization.
+## With this feature, stored state may remain deserializable across multiple compilations of LibAFL.
+## This is **unsafe** and may lead to type confusions. Only use when you know what you are doing/ you have tests in place.
+## The rust doc specifically states that "multiple types may map to the same type name"!
+unsafe_stable_anymap = []
+
 ## Automatically register all `#[derive(SerdeAny)]` types at startup.
 serdeany_autoreg = ["ctor"]
 

--- a/libafl_bolts/src/serdeany.rs
+++ b/libafl_bolts/src/serdeany.rs
@@ -3,6 +3,10 @@
 use alloc::boxed::Box;
 #[cfg(feature = "unsafe_stable_anymap")]
 use alloc::string::{String, ToString};
+#[cfg(feature = "unsafe_stable_anymap")]
+use core::any::type_name;
+#[cfg(not(feature = "unsafe_stable_anymap"))]
+use core::any::TypeId;
 use core::{any::Any, fmt::Debug};
 
 use serde::{de::DeserializeSeed, Deserialize, Deserializer, Serialize, Serializer};
@@ -24,8 +28,6 @@ fn type_repr<T>() -> TypeRepr
 where
     T: 'static,
 {
-    use core::any::TypeId;
-
     unpack_type_id(TypeId::of::<T>())
 }
 
@@ -34,22 +36,16 @@ fn type_repr_owned<T>() -> TypeRepr
 where
     T: 'static,
 {
-    use core::any::TypeId;
-
     unpack_type_id(TypeId::of::<T>())
 }
 
 #[cfg(feature = "unsafe_stable_anymap")]
 fn type_repr_owned<T>() -> TypeRepr {
-    use core::any::type_name;
-
     type_name::<T>().to_string()
 }
 
 #[cfg(feature = "unsafe_stable_anymap")]
 fn type_repr<T>() -> &'static str {
-    use core::any::type_name;
-
     type_name::<T>()
 }
 
@@ -477,7 +473,7 @@ pub mod serdeany_registry {
             }
         }
 
-        /// Get an element of a given type contained in this map by [`TypeId`], as mut.
+        /// Get an element of a given type contained in this map by type `T`, as mut.
         #[must_use]
         #[inline]
         pub fn get_mut<T>(&mut self, name: &str) -> Option<&mut T>

--- a/libafl_bolts/src/serdeany.rs
+++ b/libafl_bolts/src/serdeany.rs
@@ -20,7 +20,7 @@ pub type TypeRepr = u128;
 pub type TypeRepr = String;
 
 #[cfg(not(feature = "unsafe_stable_anymap"))]
-fn type_repr_of<'a, T>() -> TypeRepr
+fn type_repr_of<T>() -> TypeRepr
 where
     T: 'static,
 {
@@ -30,7 +30,7 @@ where
 }
 
 #[cfg(not(feature = "unsafe_stable_anymap"))]
-fn type_repr_owned<'a, T>() -> TypeRepr
+fn type_repr_owned<T>() -> TypeRepr
 where
     T: 'static,
 {

--- a/libafl_bolts/src/serdeany.rs
+++ b/libafl_bolts/src/serdeany.rs
@@ -20,7 +20,7 @@ pub type TypeRepr = u128;
 pub type TypeRepr = String;
 
 #[cfg(not(feature = "unsafe_stable_anymap"))]
-fn type_repr_of<T>() -> TypeRepr
+fn type_repr<T>() -> TypeRepr
 where
     T: 'static,
 {
@@ -47,7 +47,7 @@ fn type_repr_owned<T>() -> TypeRepr {
 }
 
 #[cfg(feature = "unsafe_stable_anymap")]
-fn type_repr_of<T>() -> &'static str {
+fn type_repr<T>() -> &'static str {
     use core::any::type_name;
 
     type_name::<T>()
@@ -125,7 +125,7 @@ pub mod serdeany_registry {
     use super::{SerdeAny, TypeRepr};
     use crate::{
         hash_std,
-        serdeany::{type_repr_of, type_repr_owned, DeserializeCallback, DeserializeCallbackSeed},
+        serdeany::{type_repr, type_repr_owned, DeserializeCallback, DeserializeCallbackSeed},
         Error,
     };
 
@@ -265,7 +265,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -281,7 +281,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -297,7 +297,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -339,7 +339,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -398,7 +398,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -446,7 +446,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -465,7 +465,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -484,7 +484,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -512,7 +512,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -538,7 +538,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -610,7 +610,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -677,7 +677,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 
@@ -691,7 +691,7 @@ pub mod serdeany_registry {
         where
             T: crate::serdeany::SerdeAny,
         {
-            let type_repr = type_repr_of::<T>();
+            let type_repr = type_repr::<T>();
             #[cfg(not(feature = "unsafe_stable_anymap"))]
             let type_repr = &type_repr;
 


### PR DESCRIPTION
While _technically_ unsound, this just might give us a build-agnostic anymap which would pre pretty nice to have to store and load state.