### PR TITLE
Change AnyMap API, add unsafe_ assert

### DIFF
--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -478,7 +478,7 @@ where
     Z: Evaluator<E, EM>,
     Z::State: HasCorpus + HasRand + HasNamedMetadata,
 {
-    /// Creates a new tranforming mutational stage
+    /// Creates a new transforming mutational stage
     #[must_use]
     pub fn transforming(state: &mut Z::State, mutator: M, name: &str) -> Self {
         let _ = state.named_metadata_or_insert_with(name, TuneableMutationalStageMetadata::default);

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -176,7 +176,7 @@ pub trait HasMetadata {
     where
         M: SerdeAny,
     {
-        self.metadata_map_mut().or_insert_with::<M>(default)
+        self.metadata_map_mut().get_or_insert_with::<M>(default)
     }
 
     /// Remove a metadata from the metadata map
@@ -258,7 +258,7 @@ pub trait HasNamedMetadata {
         M: SerdeAny,
     {
         self.named_metadata_map_mut()
-            .or_insert_with::<M>(name, default)
+            .get_or_insert_with::<M>(name, default)
     }
 
     /// Check for a metadata


### PR DESCRIPTION
Changes non-metadata `or_insert_with` APIs to be `get_or_insert_with` to follow normal hashmap conventions.

This also adds an assert to make `unsafe_stable_anymap` safe(r)