### PR TITLE
More usable ListFeedback

### DIFF
--- a/fuzzers/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/src/lib.rs
@@ -20,7 +20,7 @@ use libafl::{
     events::SimpleRestartingEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
-    feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
+    feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback, ListFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
     inputs::{BytesInput, HasTargetBytes},
     monitors::SimpleMonitor,
@@ -28,7 +28,7 @@ use libafl::{
         scheduled::havoc_mutations, token_mutations::I2SRandReplace, tokens_mutations,
         StdMOptMutator, StdScheduledMutator, Tokens,
     },
-    observers::{HitcountsMapObserver, TimeObserver},
+    observers::{HitcountsMapObserver, TimeObserver, ListObserver},
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
@@ -249,6 +249,10 @@ fn fuzz(
 
     let cmplog_observer = CmpLogObserver::new("cmplog", true);
 
+    let mut list = vec![3, 1, 2];
+    let list_observer = unsafe { ListObserver::new("fuck", &mut list) };
+    let list_feedback = ListFeedback::new(&list_observer);
+
     let map_feedback = MaxMapFeedback::tracking(&edges_observer, true, false);
 
     let calibration = CalibrationStage::new(&map_feedback);
@@ -258,6 +262,7 @@ fn fuzz(
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
         map_feedback,
+        list_feedback,
         // Time feedback, this one does not need a feedback state
         TimeFeedback::with_observer(&time_observer)
     );
@@ -329,7 +334,7 @@ fn fuzz(
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
     let mut executor = InProcessExecutor::with_timeout(
         &mut harness,
-        tuple_list!(edges_observer, time_observer),
+        tuple_list!(edges_observer, time_observer, list_observer),
         &mut fuzzer,
         &mut state,
         &mut mgr,
@@ -383,9 +388,9 @@ fn fuzz(
     #[cfg(unix)]
     {
         let null_fd = file_null.as_raw_fd();
-        dup2(null_fd, io::stdout().as_raw_fd())?;
+        // dup2(null_fd, io::stdout().as_raw_fd())?;
         if std::env::var("LIBAFL_FUZZBENCH_DEBUG").is_err() {
-            dup2(null_fd, io::stderr().as_raw_fd())?;
+            // dup2(null_fd, io::stderr().as_raw_fd())?;
         }
     }
     // reopen file to make sure we're at the end

--- a/fuzzers/tinyinst_simple/src/main.rs
+++ b/fuzzers/tinyinst_simple/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     // let args = vec!["test.exe".to_string(), "-f".to_string(), "@@".to_string()];
 
     let observer = unsafe { ListObserver::new("cov", &mut COVERAGE) };
-    let mut feedback = ListFeedback::with_observer(&observer);
+    let mut feedback = ListFeedback::new(&observer);
     #[cfg(windows)]
     let mut shmem_provider = Win32ShMemProvider::new().unwrap();
 

--- a/libafl/src/feedbacks/list.rs
+++ b/libafl/src/feedbacks/list.rs
@@ -10,8 +10,7 @@ use crate::{
     executors::ExitKind,
     feedbacks::Feedback,
     observers::{ListObserver, ObserversTuple},
-    prelude::HasNamedMetadata,
-    state::State,
+    state::{State, HasNamedMetadata},
 };
 
 /// The prefix for list metadata's name
@@ -102,12 +101,12 @@ where
             .named_metadata_map_mut()
             .get_mut::<ListFeedbackMetadata<T>>(&self.name)
             .unwrap();
-        for v in observer.list().iter() {
+        for v in observer.list() {
             if !history_set.set.contains(v) {
                 self.novelty.insert(*v);
             }
         }
-        Ok(self.novelty.len() > 0)
+        Ok(!self.novelty.is_empty())
     }
 
     fn append_metadata<EM, OT>(
@@ -126,7 +125,7 @@ where
             .get_mut::<ListFeedbackMetadata<T>>(&self.name)
             .unwrap();
 
-        for v in self.novelty.iter() {
+        for v in &self.novelty {
             history_set.set.insert(*v);
         }
         Ok(())

--- a/libafl/src/feedbacks/list.rs
+++ b/libafl/src/feedbacks/list.rs
@@ -10,7 +10,7 @@ use crate::{
     executors::ExitKind,
     feedbacks::Feedback,
     observers::{ListObserver, ObserversTuple},
-    state::{State, HasNamedMetadata},
+    state::{HasNamedMetadata, State},
 };
 
 /// The prefix for list metadata's name

--- a/libafl/src/feedbacks/list.rs
+++ b/libafl/src/feedbacks/list.rs
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<T> HasRefCnt for ListFeedbackMetadata<T> 
+impl<T> HasRefCnt for ListFeedbackMetadata<T>
 where
     T: Default + Copy + 'static + Serialize + Eq + Hash,
 {

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -28,9 +28,6 @@ use crate::{
     Error,
 };
 
-/// The prefix of the metadata names
-pub const MAPFEEDBACK_PREFIX: &str = "mapfeedback_metadata_";
-
 /// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from ``HitcountsMapObserver``.
 pub type AflMapFeedback<O, S, T> = MapFeedback<DifferentIsNovel, O, OrReducer, S, T>;
 
@@ -700,7 +697,7 @@ where
         Self {
             indexes: false,
             novelties: None,
-            name: MAPFEEDBACK_PREFIX.to_string() + map_observer.name(),
+            name: map_observer.name().to_string(),
             observer_name: map_observer.name().to_string(),
             stats_name: create_stats_name(map_observer.name()),
             phantom: PhantomData,
@@ -713,7 +710,7 @@ where
         Self {
             indexes: track_indexes,
             novelties: if track_novelties { Some(vec![]) } else { None },
-            name: MAPFEEDBACK_PREFIX.to_string() + map_observer.name(),
+            name: map_observer.name().to_string(),
             observer_name: map_observer.name().to_string(),
             stats_name: create_stats_name(map_observer.name()),
             phantom: PhantomData,

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -27,8 +27,6 @@ pub mod transferred;
 
 /// The module for list feedback
 pub mod list;
-pub use list::*;
-
 use alloc::string::{String, ToString};
 use core::{
     fmt::{self, Debug, Formatter},
@@ -36,6 +34,7 @@ use core::{
 };
 
 use libafl_bolts::Named;
+pub use list::*;
 #[cfg(feature = "nautilus")]
 pub use nautilus::*;
 use serde::{Deserialize, Serialize};
@@ -975,7 +974,6 @@ impl TimeFeedback {
         }
     }
 }
-
 
 /// The [`ConstFeedback`] reports the same value, always.
 /// It can be used to enable or disable feedback results through composition.

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -25,6 +25,10 @@ pub use new_hash_feedback::NewHashFeedbackMetadata;
 pub mod nautilus;
 pub mod transferred;
 
+/// The module for list feedback
+pub mod list;
+pub use list::*;
+
 use alloc::string::{String, ToString};
 use core::{
     fmt::{self, Debug, Formatter},
@@ -40,7 +44,7 @@ use crate::{
     corpus::Testcase,
     events::EventFirer,
     executors::ExitKind,
-    observers::{ListObserver, ObserversTuple, TimeObserver},
+    observers::{ObserversTuple, TimeObserver},
     state::State,
     Error,
 };
@@ -972,78 +976,6 @@ impl TimeFeedback {
     }
 }
 
-/// Consider interesting a testcase if the list in `ListObserver` is not empty.
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ListFeedback<T>
-where
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    name: String,
-    last_addr: usize,
-    phantom: PhantomData<T>,
-}
-
-impl<S, T> Feedback<S> for ListFeedback<T>
-where
-    S: State,
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    #[allow(clippy::wrong_self_convention)]
-    fn is_interesting<EM, OT>(
-        &mut self,
-        _state: &mut S,
-        _manager: &mut EM,
-        _input: &S::Input,
-        observers: &OT,
-        _exit_kind: &ExitKind,
-    ) -> Result<bool, Error>
-    where
-        EM: EventFirer<State = S>,
-        OT: ObserversTuple<S>,
-    {
-        // TODO Replace with match_name_type when stable
-        let observer = observers
-            .match_name::<ListObserver<T>>(self.name())
-            .unwrap();
-        // TODO register the list content in a testcase metadata
-        Ok(!observer.list().is_empty())
-    }
-}
-
-impl<T> Named for ListFeedback<T>
-where
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    #[inline]
-    fn name(&self) -> &str {
-        self.name.as_str()
-    }
-}
-
-impl<T> ListFeedback<T>
-where
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    /// Creates a new [`ListFeedback`], deciding if the value of a [`ListObserver`] with the given `name` of a run is interesting.
-    #[must_use]
-    pub fn new(name: &'static str) -> Self {
-        Self {
-            name: name.to_string(),
-            last_addr: 0,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Creates a new [`TimeFeedback`], deciding if the given [`ListObserver`] value of a run is interesting.
-    #[must_use]
-    pub fn with_observer(observer: &ListObserver<T>) -> Self {
-        Self {
-            name: observer.name().to_string(),
-            last_addr: 0,
-            phantom: PhantomData,
-        }
-    }
-}
 
 /// The [`ConstFeedback`] reports the same value, always.
 /// It can be used to enable or disable feedback results through composition.

--- a/libafl/src/observers/list.rs
+++ b/libafl/src/observers/list.rs
@@ -1,0 +1,73 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::fmt::Debug;
+
+use libafl_bolts::{ownedref::OwnedMutPtr, Error, Named};
+use serde::{Deserialize, Serialize};
+
+use crate::{inputs::UsesInput, observers::Observer};
+
+/// A simple observer with a list of things.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(bound = "T: serde::de::DeserializeOwned")]
+#[allow(clippy::unsafe_derive_deserialize)]
+pub struct ListObserver<T>
+where
+    T: Debug + Serialize,
+{
+    name: String,
+    /// The list
+    list: OwnedMutPtr<Vec<T>>,
+}
+
+impl<T> ListObserver<T>
+where
+    T: Debug + Serialize + serde::de::DeserializeOwned,
+{
+    /// Creates a new [`ListObserver`] with the given name.
+    ///
+    /// # Safety
+    /// Will dereference the list.
+    /// The list may not move in memory.
+    #[must_use]
+    pub unsafe fn new(name: &'static str, list: *mut Vec<T>) -> Self {
+        Self {
+            name: name.to_string(),
+            list: OwnedMutPtr::Ptr(list),
+        }
+    }
+
+    /// Get a list ref
+    #[must_use]
+    pub fn list(&self) -> &Vec<T> {
+        self.list.as_ref()
+    }
+
+    /// Get a list mut
+    #[must_use]
+    pub fn list_mut(&mut self) -> &mut Vec<T> {
+        self.list.as_mut()
+    }
+}
+
+impl<S, T> Observer<S> for ListObserver<T>
+where
+    S: UsesInput,
+    T: Debug + Serialize + serde::de::DeserializeOwned,
+{
+    fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
+        self.list.as_mut().clear();
+        Ok(())
+    }
+}
+
+impl<T> Named for ListObserver<T>
+where
+    T: Debug + Serialize + serde::de::DeserializeOwned,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -20,17 +20,17 @@ pub mod concolic;
 
 pub mod value;
 
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+/// List observer
+pub mod list;
+use alloc::string::{String, ToString};
 use core::{fmt::Debug, time::Duration};
 #[cfg(feature = "std")]
 use std::time::Instant;
 
 #[cfg(feature = "no_std")]
 use libafl_bolts::current_time;
-use libafl_bolts::{ownedref::OwnedMutPtr, tuples::MatchName, Named};
+use libafl_bolts::{tuples::MatchName, Named};
+pub use list::*;
 use serde::{Deserialize, Serialize};
 pub use value::*;
 
@@ -524,69 +524,6 @@ where
     OTB: ObserversTuple<S>,
     S: UsesInput,
 {
-}
-
-/// A simple observer with a list of things.
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(bound = "T: serde::de::DeserializeOwned")]
-#[allow(clippy::unsafe_derive_deserialize)]
-pub struct ListObserver<T>
-where
-    T: Debug + Serialize,
-{
-    name: String,
-    /// The list
-    list: OwnedMutPtr<Vec<T>>,
-}
-
-impl<T> ListObserver<T>
-where
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    /// Creates a new [`ListObserver`] with the given name.
-    ///
-    /// # Safety
-    /// Will dereference the list.
-    /// The list may not move in memory.
-    #[must_use]
-    pub unsafe fn new(name: &'static str, list: *mut Vec<T>) -> Self {
-        Self {
-            name: name.to_string(),
-            list: OwnedMutPtr::Ptr(list),
-        }
-    }
-
-    /// Get a list ref
-    #[must_use]
-    pub fn list(&self) -> &Vec<T> {
-        self.list.as_ref()
-    }
-
-    /// Get a list mut
-    #[must_use]
-    pub fn list_mut(&mut self) -> &mut Vec<T> {
-        self.list.as_mut()
-    }
-}
-
-impl<S, T> Observer<S> for ListObserver<T>
-where
-    S: UsesInput,
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
-        self.list.as_mut().clear();
-        Ok(())
-    }
-}
-
-impl<T> Named for ListObserver<T>
-where
-    T: Debug + Serialize + serde::de::DeserializeOwned,
-{
-    fn name(&self) -> &str {
-        &self.name
-    }
 }
 
 /// `Observer` Python bindings

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -530,6 +530,7 @@ where
 #[cfg(feature = "python")]
 #[allow(missing_docs)]
 pub mod pybind {
+    use alloc::vec::Vec;
     use core::ptr;
     use std::cell::UnsafeCell;
 
@@ -540,7 +541,6 @@ pub mod pybind {
     use pyo3::prelude::*;
     use serde::{Deserialize, Serialize};
 
-    use alloc::vec::Vec;
     use super::{Debug, Observer, ObserversTuple, String};
     use crate::{
         executors::{pybind::PythonExitKind, ExitKind},

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -540,7 +540,8 @@ pub mod pybind {
     use pyo3::prelude::*;
     use serde::{Deserialize, Serialize};
 
-    use super::{Debug, Observer, ObserversTuple, String, Vec};
+    use alloc::vec::Vec;
+    use super::{Debug, Observer, ObserversTuple, String};
     use crate::{
         executors::{pybind::PythonExitKind, ExitKind},
         inputs::{BytesInput, HasBytesVec},

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/report.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/report.rs
@@ -3,7 +3,7 @@ use std::ffi::c_int;
 use libafl::{
     events::{ProgressReporter, SimpleEventManager},
     executors::HasObservers,
-    feedbacks::{MapFeedbackMetadata, MAPFEEDBACK_PREFIX},
+    feedbacks::MapFeedbackMetadata,
     inputs::UsesInput,
     monitors::SimpleMonitor,
     stages::{HasCurrentStage, StagesTuple},
@@ -35,7 +35,7 @@ where
     ST: StagesTuple<E, EM, S, F>,
 {
     let meta = state
-        .named_metadata::<MapFeedbackMetadata<u8>>(&(MAPFEEDBACK_PREFIX.to_string() + "edges"))
+        .named_metadata::<MapFeedbackMetadata<u8>>("edges")
         .unwrap();
     let observed = meta.history_map.iter().filter(|&&e| e != 0).count();
     let total = meta.history_map.len();


### PR DESCRIPTION
ListFeedback does not have accompanying ListFeedbackMetadata.

This is because this feedback is supposed to be used with tinyinst where they implement break point coverage, and only novel edges will be given back to the fuzzer.
Therefore for tinyinst this is fine, because every observed value is novel, no need to record accumulated set of values in addition.

The problem is what if this pre-requisite does not hold anymore,
Now this PR addresses this problem. by keeping an metadata and update them accordingly.