### PR TITLE
Don't use unwrap() in the crash handler

### DIFF
--- a/libafl/src/executors/hooks/unix.rs
+++ b/libafl/src/executors/hooks/unix.rs
@@ -205,12 +205,15 @@ pub mod unix_signal_handler {
                 {
                     let mut writer = std::io::BufWriter::new(&mut bsod);
                     let _ = writeln!(writer, "input: {:?}", input.generate_name(0));
-                    let _ = libafl_bolts::minibsod::generate_minibsod(
+                    let bsod = libafl_bolts::minibsod::generate_minibsod(
                         &mut writer,
                         signal,
                         _info,
                         _context.as_deref(),
                     );
+                    if bsod.is_err() {
+                        log::error!("generate_minibsod failed");
+                    }
                     let _ = writer.flush();
                 }
                 if let Ok(r) = std::str::from_utf8(&bsod) {
@@ -242,12 +245,15 @@ pub mod unix_signal_handler {
                     let mut bsod = Vec::new();
                     {
                         let mut writer = std::io::BufWriter::new(&mut bsod);
-                        let _ = libafl_bolts::minibsod::generate_minibsod(
+                        let bsod = libafl_bolts::minibsod::generate_minibsod(
                             &mut writer,
                             signal,
                             _info,
                             _context.as_deref(),
                         );
+                        if bsod.is_err() {
+                            log::error!("generate_minibsod failed");
+                        }
                         let _ = writer.flush();
                     }
                     if let Ok(r) = std::str::from_utf8(&bsod) {

--- a/libafl/src/executors/hooks/unix.rs
+++ b/libafl/src/executors/hooks/unix.rs
@@ -204,17 +204,18 @@ pub mod unix_signal_handler {
                 let mut bsod = Vec::new();
                 {
                     let mut writer = std::io::BufWriter::new(&mut bsod);
-                    writeln!(writer, "input: {:?}", input.generate_name(0)).unwrap();
-                    libafl_bolts::minibsod::generate_minibsod(
+                    let _ = writeln!(writer, "input: {:?}", input.generate_name(0));
+                    let _ = libafl_bolts::minibsod::generate_minibsod(
                         &mut writer,
                         signal,
                         _info,
                         _context.as_deref(),
-                    )
-                    .unwrap();
-                    writer.flush().unwrap();
+                    );
+                    let _ = writer.flush();
                 }
-                log::error!("{}", std::str::from_utf8(&bsod).unwrap());
+                if let Ok(r) = std::str::from_utf8(&bsod) {
+                    log::error!("{}", r);
+                }
             }
 
             run_observers_and_save_state::<E, EM, OF, Z>(
@@ -241,16 +242,17 @@ pub mod unix_signal_handler {
                     let mut bsod = Vec::new();
                     {
                         let mut writer = std::io::BufWriter::new(&mut bsod);
-                        libafl_bolts::minibsod::generate_minibsod(
+                        let _ = libafl_bolts::minibsod::generate_minibsod(
                             &mut writer,
                             signal,
                             _info,
                             _context.as_deref(),
-                        )
-                        .unwrap();
-                        writer.flush().unwrap();
+                        );
+                        let _ = writer.flush();
                     }
-                    log::error!("{}", std::str::from_utf8(&bsod).unwrap());
+                    if let Ok(r) = std::str::from_utf8(&bsod) {
+                        log::error!("{}", r);
+                    }
                 }
             }
 
@@ -258,7 +260,7 @@ pub mod unix_signal_handler {
                 log::error!("Type QUIT to restart the child");
                 let mut line = String::new();
                 while line.trim() != "QUIT" {
-                    std::io::stdin().read_line(&mut line).unwrap();
+                    let _ = std::io::stdin().read_line(&mut line);
                 }
             }
 

--- a/libafl/src/executors/hooks/windows.rs
+++ b/libafl/src/executors/hooks/windows.rs
@@ -64,7 +64,7 @@ pub mod windows_asan_handler {
                 log::error!("Type QUIT to restart the child");
                 let mut line = String::new();
                 while line.trim() != "QUIT" {
-                    std::io::stdin().read_line(&mut line).unwrap();
+                    std::io::stdin().read_line(&mut line);
                 }
             }
 
@@ -370,7 +370,7 @@ pub mod windows_exception_handler {
                 log::error!("Type QUIT to restart the child");
                 let mut line = String::new();
                 while line.trim() != "QUIT" {
-                    std::io::stdin().read_line(&mut line).unwrap();
+                    std::io::stdin().read_line(&mut line);
                 }
             }
 

--- a/libafl/src/executors/hooks/windows.rs
+++ b/libafl/src/executors/hooks/windows.rs
@@ -64,7 +64,7 @@ pub mod windows_asan_handler {
                 log::error!("Type QUIT to restart the child");
                 let mut line = String::new();
                 while line.trim() != "QUIT" {
-                    std::io::stdin().read_line(&mut line);
+                    let _ = std::io::stdin().read_line(&mut line);
                 }
             }
 
@@ -370,7 +370,7 @@ pub mod windows_exception_handler {
                 log::error!("Type QUIT to restart the child");
                 let mut line = String::new();
                 while line.trim() != "QUIT" {
-                    std::io::stdin().read_line(&mut line);
+                    let _ = std::io::stdin().read_line(&mut line);
                 }
             }
 


### PR DESCRIPTION
First you can do nothing if it fails.
second it leads to infinite recursion inside crash handler for me.