### PR TITLE
Clean up warnings in baby_fuzzers

### DIFF
--- a/fuzzers/baby_fuzzer_swap_differential/build.rs
+++ b/fuzzers/baby_fuzzer_swap_differential/build.rs
@@ -12,7 +12,7 @@ fn main() -> anyhow::Result<()> {
         let bindings = bindgen::builder()
             .header("first.h")
             .header("second.h")
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .generate()?;
 
         // Write the generated bindings to an output file.

--- a/fuzzers/baby_fuzzer_swap_differential/src/bin/libafl_cc.rs
+++ b/fuzzers/baby_fuzzer_swap_differential/src/bin/libafl_cc.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use libafl_cc::{ClangWrapper, CompilerWrapper, ToolWrapper};
+use libafl_cc::{ClangWrapper, ToolWrapper};
 
 pub fn main() {
     let args: Vec<String> = env::args().collect();

--- a/fuzzers/baby_fuzzer_with_forkexecutor/src/main.rs
+++ b/fuzzers/baby_fuzzer_with_forkexecutor/src/main.rs
@@ -1,6 +1,6 @@
 #[cfg(windows)]
 use std::ptr::write_volatile;
-use std::{path::PathBuf, ptr::write, time::Duration};
+use std::{path::PathBuf, ptr::write};
 
 use libafl::{
     corpus::{InMemoryCorpus, OnDiskCorpus},


### PR DESCRIPTION
This PR starts to address issue #1907, targeting the warnings coming up in `fuzzers/baby_fuzzer*`