### PR TITLE
Update setup_libxml2.sh of nyx_libxml2_standalone fuzzer

### DIFF
--- a/fuzzers/nyx_libxml2_standalone/setup_libxml2.sh
+++ b/fuzzers/nyx_libxml2_standalone/setup_libxml2.sh
@@ -35,3 +35,5 @@ python3 "../../libafl_nyx/packer/packer/nyx_packer.py" \
     -file "/tmp/input" \
     --fast_reload_mode \
     --purge || exit
+
+python3 ../../libafl_nyx/packer/packer/nyx_config_gen.py /tmp/nyx_libxml2/ Kernel || kernel


### PR DESCRIPTION
On testing this on my machine not all neccessary files for fuzzing with nyx where provided by the setup_libxml2.sh. Compared to the nyx_libxml2_parallel fuzzer this packer generation line was missing (as also pointed to by @richinseattle in the discord). After adding this the fuzzer was able to start.