### PR TITLE
child_status == 137 is strange

### DIFF
--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -1465,7 +1465,7 @@ where
                         log::error!("Failed to detach from broker: {err}");
                     }
                     #[cfg(unix)]
-                    if child_status == 137 {
+                    if child_status == 9 {
                         panic!("Target received SIGKILL!. This could indicate the target crashed due to OOM, user sent SIGKILL, or the target was in an unrecoverable situation and could not save state to restart");
                     }
                     // Storing state in the last round did not work

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -1464,6 +1464,10 @@ where
                     if let Err(err) = mgr.detach_from_broker(self.broker_port) {
                         log::error!("Failed to detach from broker: {err}");
                     }
+                    #[cfg(unix)]
+                    if child_status == 137 {
+                        panic!("Target received SIGKILL!. This could indicate the target crashed due to OOM, user sent SIGKILL, or the target was in an unrecoverable situation and could not save state to restart");
+                    }
                     // Storing state in the last round did not work
                     panic!("Fuzzer-respawner: Storing state in crashed fuzzer instance did not work, no point to spawn the next client! This can happen if the child calls `exit()`, in that case make sure it uses `abort()`, if it got killed unrecoverable (OOM), or if there is a bug in the fuzzer itself. (Child exited with: {child_status})");
                 }

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -1464,12 +1464,6 @@ where
                     if let Err(err) = mgr.detach_from_broker(self.broker_port) {
                         log::error!("Failed to detach from broker: {err}");
                     }
-                    #[cfg(unix)]
-                    if child_status == 137 {
-                        // Out of Memory, see https://tldp.org/LDP/abs/html/exitcodes.html
-                        // and https://github.com/AFLplusplus/LibAFL/issues/32 for discussion.
-                        panic!("Fuzzer-respawner: The fuzzed target crashed with an out of memory error! Fix your harness, or switch to another executor (for example, a forkserver).");
-                    }
                     // Storing state in the last round did not work
                     panic!("Fuzzer-respawner: Storing state in crashed fuzzer instance did not work, no point to spawn the next client! This can happen if the child calls `exit()`, in that case make sure it uses `abort()`, if it got killed unrecoverable (OOM), or if there is a bug in the fuzzer itself. (Child exited with: {child_status})");
                 }


### PR DESCRIPTION
If I understand correctly. Here this line wants to say child_status == 9.
137 is the exit code for shell not for what you get in wait_status().

Another problem is error code 9 shouldn't always mean there was an oom. it should simply mean that SIGKILL was delivered to the process.
(Because you can send `kill -9 <PID>`, then, that's SIGKILL, too.)
and I don't think you can tell if a process was killed by OOM or not unless you check dmesg