### PR TITLE
Fix error handling in libafl_qemu_build

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -307,8 +307,6 @@ pub fn build(
 
         if let Some(j) = jobs {
             cmd.arg(&format!("{j}")).env("V", "1");
-        } else {
-            cmd.arg("-j");
         }
         assert!(
             cmd.status().expect("Invoking Make Failed").success(),


### PR DESCRIPTION
This doesn't fix the entire problem, but fixes it for my use case.
It also sets the environment variables for the `make` part of the build as well to ensure that the correct compiler is picked up here:

https://github.com/AFLplusplus/qemu-libafl-bridge/blob/ce4dbbc51390f86bad0a6e6cec52e5ed9cc34c85/linker_interceptor.py#L7-L9

Related to #2035 