### PR TITLE
Fix GuestMaps iterator in LibAFL QEMU.

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/bindings.rs
+++ b/libafl_qemu/libafl_qemu_build/src/bindings.rs
@@ -45,6 +45,9 @@ const WRAPPER_HEADER: &str = r#"
 #include "user/safe-syscall.h"
 #include "qemu/selfmap.h"
 #include "cpu_loop-common.h"
+#include "qemu/selfmap.h"
+
+#include "libafl/user.h"
 
 #else
 
@@ -55,8 +58,8 @@ const WRAPPER_HEADER: &str = r#"
 #include "sysemu/tcg.h"
 #include "sysemu/replay.h"
 
-#include "libafl_extras/syx-snapshot/device-save.h"
-#include "libafl_extras/syx-snapshot/syx-snapshot.h"
+#include "libafl/syx-snapshot/device-save.h"
+#include "libafl/syx-snapshot/syx-snapshot.h"
 
 #endif
 
@@ -76,9 +79,9 @@ const WRAPPER_HEADER: &str = r#"
 
 #include "qemu/plugin-memory.h"
 
-#include "libafl_extras/exit.h"
-#include "libafl_extras/hook.h"
-#include "libafl_extras/jit.h"
+#include "libafl/exit.h"
+#include "libafl/hook.h"
+#include "libafl/jit.h"
 
 "#;
 
@@ -142,6 +145,8 @@ pub fn generate(
         .allowlist_type("libafl_exit_reason_sync_backdoor")
         .allowlist_type("libafl_exit_reason_breakpoint")
         .allowlist_type("Syx.*")
+        .allowlist_type("libafl_mapinfo")
+        .allowlist_type("IntervalTreeRoot")
         .allowlist_function("qemu_user_init")
         .allowlist_function("target_mmap")
         .allowlist_function("target_mprotect")
@@ -159,6 +164,8 @@ pub fn generate(
         .allowlist_function("syx_.*")
         .allowlist_function("device_list_all")
         .allowlist_function("libafl_.*")
+        .allowlist_function("read_self_maps")
+        .allowlist_function("free_self_maps")
         .blocklist_function("main_loop_wait") // bindgen issue #1313
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
 

--- a/libafl_qemu/libafl_qemu_sys/src/usermode.rs
+++ b/libafl_qemu/libafl_qemu_sys/src/usermode.rs
@@ -1,10 +1,8 @@
-use core::ffi::c_void;
-
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use paste::paste;
 use strum_macros::EnumIter;
 
-use crate::{extern_c_checked, GuestAddr, MapInfo};
+use crate::{extern_c_checked, GuestAddr};
 
 extern_c_checked! {
     pub fn qemu_user_init(argc: i32, argv: *const *const u8, envp: *const *const u8) -> i32;
@@ -14,12 +12,6 @@ extern_c_checked! {
     pub fn libafl_load_addr() -> u64;
     pub fn libafl_get_brk() -> u64;
     pub fn libafl_set_brk(brk: u64) -> u64;
-
-    pub fn read_self_maps() -> *const c_void;
-    pub fn free_self_maps(map_info: *const c_void);
-
-    pub fn libafl_maps_first(root: *const c_void) -> *const c_void;
-    pub fn libafl_maps_next(node: *const c_void, ret: *mut MapInfo, is_root: bool) -> *const c_void;
 
     pub static exec_path: *const u8;
     pub static guest_base: usize;

--- a/libafl_qemu/src/emu/usermode.rs
+++ b/libafl_qemu/src/emu/usermode.rs
@@ -1,11 +1,11 @@
-use core::{ffi::c_void, mem::MaybeUninit, ptr::copy_nonoverlapping};
+use core::{mem::MaybeUninit, ptr::copy_nonoverlapping};
 use std::{cell::OnceCell, slice::from_raw_parts, str::from_utf8_unchecked};
 
 use libafl_qemu_sys::{
     exec_path, free_self_maps, guest_base, libafl_dump_core_hook, libafl_force_dfl, libafl_get_brk,
     libafl_load_addr, libafl_maps_first, libafl_maps_next, libafl_qemu_run, libafl_set_brk,
-    mmap_next_start, read_self_maps, strlen, GuestAddr, GuestUsize, MapInfo, MmapPerms,
-    VerifyAccess,
+    mmap_next_start, read_self_maps, strlen, GuestAddr, GuestUsize, IntervalTreeNode,
+    IntervalTreeRoot, MapInfo, MmapPerms, VerifyAccess,
 };
 use libc::c_int;
 #[cfg(feature = "python")]
@@ -27,8 +27,8 @@ pub enum HandlerError {
 
 #[cfg_attr(feature = "python", pyclass(unsendable))]
 pub struct GuestMaps {
-    maps_root: *const c_void,
-    maps_node: *const c_void,
+    maps_root: *mut IntervalTreeRoot,
+    maps_node: *mut IntervalTreeNode,
 }
 
 // Consider a private new only for Emulator
@@ -51,13 +51,14 @@ impl Iterator for GuestMaps {
 
     #[allow(clippy::uninit_assumed_init)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.maps_node.is_null() {
-            return None;
-        }
         unsafe {
             let mut ret = MaybeUninit::uninit();
-            self.maps_node = libafl_maps_next(self.maps_node, ret.as_mut_ptr(), false);
-            Some(ret.assume_init())
+            self.maps_node = libafl_maps_next(self.maps_node, ret.as_mut_ptr());
+            if !self.maps_node.is_null() {
+                Some(ret.assume_init().into())
+            } else {
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2031. It was an iterator implementation issue of `GuestMaps`.
Minor rework of the maps stuff by including native structs from QEMU instead of doing implicit raw pointer casting.

I will not work until libafl-qemu-bridge companion commit is merged.