### PR TITLE
Rename HasAFLSchedulerMetadata to simply AflScheduler

### DIFF
--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -66,7 +66,7 @@ where
 }
 
 /// Defines the common metadata operations for the AFL-style schedulers
-pub trait HasAFLSchedulerMetadata<O, S>: Scheduler
+pub trait AflScheduler<O, S>: Scheduler
 where
     Self::State: HasCorpus + HasMetadata + HasTestcase,
     O: MapObserver,

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -12,7 +12,7 @@ use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
     inputs::UsesInput,
     observers::{MapObserver, ObserversTuple},
-    schedulers::{HasAFLSchedulerMetadata, RemovableScheduler, Scheduler},
+    schedulers::{AflScheduler, RemovableScheduler, Scheduler},
     state::{HasCorpus, State, UsesState},
     Error, HasMetadata,
 };
@@ -210,7 +210,7 @@ where
     }
 }
 
-impl<O, S> HasAFLSchedulerMetadata<O, S> for PowerQueueScheduler<O, S>
+impl<O, S> AflScheduler<O, S> for PowerQueueScheduler<O, S>
 where
     S: HasCorpus + HasMetadata + HasTestcase + State,
     O: MapObserver,

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -16,7 +16,7 @@ use crate::{
     schedulers::{
         powersched::{PowerSchedule, SchedulerMetadata},
         testcase_score::{CorpusWeightTestcaseScore, TestcaseScore},
-        HasAFLSchedulerMetadata, RemovableScheduler, Scheduler,
+        AflScheduler, RemovableScheduler, Scheduler,
     },
     state::{HasCorpus, HasRand, State, UsesState},
     Error, HasMetadata,
@@ -254,7 +254,7 @@ where
     }
 }
 
-impl<F, O, S> HasAFLSchedulerMetadata<O, S> for WeightedScheduler<F, O, S>
+impl<F, O, S> AflScheduler<O, S> for WeightedScheduler<F, O, S>
 where
     F: TestcaseScore<S>,
     S: HasCorpus + HasMetadata + HasTestcase + HasRand + State,


### PR DESCRIPTION
@tokatoka please take a look - the `HasXYZ` traits are just for things that basically return the named value. So `HasAFLSchedulerMetadata` would need to return a `AFLSchedulerMetadata` struct or similar.

I feel like the new name makes more sense, what do you think?
