### PR TITLE
refactor(snapshot.rs): use const generics

### DIFF
--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -1162,6 +1162,12 @@ impl Qemu {
     }
 
     #[allow(clippy::missing_transmute_annotations)]
+    /// `exec` hooks get invoked on every read performed by the guest
+    /// 
+    /// `exec1`-`exec8` special case accesses of width 1-8
+    /// 
+    /// If there is no specialized hook for a given read width, the `exec_n` will be
+    /// called and its last argument will specify the access width
     pub fn add_read_hooks<T: Into<HookData>>(
         &self,
         data: T,

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -1161,13 +1161,19 @@ impl Qemu {
         }
     }
 
-    #[allow(clippy::missing_transmute_annotations)]
+    /// `data` can be used to pass data that can be accessed as the first argument in the `gen` and the `exec` functions
+    ///
+    /// `gen` gets passed the current programm counter, mutable access to a `TCGTemp` and information about the memory
+    /// access being performed.
+    ///  The `u64` return value is an id that gets passed to the `exec` functions as their second argument.
+    ///
     /// `exec` hooks get invoked on every read performed by the guest
     ///
     /// `exec1`-`exec8` special case accesses of width 1-8
     ///
     /// If there is no specialized hook for a given read width, the `exec_n` will be
     /// called and its last argument will specify the access width
+    #[allow(clippy::missing_transmute_annotations)]
     pub fn add_read_hooks<T: Into<HookData>>(
         &self,
         data: T,

--- a/libafl_qemu/src/emu.rs
+++ b/libafl_qemu/src/emu.rs
@@ -1163,9 +1163,9 @@ impl Qemu {
 
     #[allow(clippy::missing_transmute_annotations)]
     /// `exec` hooks get invoked on every read performed by the guest
-    /// 
+    ///
     /// `exec1`-`exec8` special case accesses of width 1-8
-    /// 
+    ///
     /// If there is no specialized hook for a given read width, the `exec_n` will be
     /// called and its last argument will specify the access width
     pub fn add_read_hooks<T: Into<HookData>>(

--- a/libafl_qemu/src/snapshot.rs
+++ b/libafl_qemu/src/snapshot.rs
@@ -498,10 +498,10 @@ where
             // The ASan helper, if present, will call the tracer hook for the snapshot helper as opt
             hooks.writes(
                 Hook::Empty,
-                Hook::Function(trace_write1_snapshot::<QT, S>),
-                Hook::Function(trace_write2_snapshot::<QT, S>),
-                Hook::Function(trace_write4_snapshot::<QT, S>),
-                Hook::Function(trace_write8_snapshot::<QT, S>),
+                Hook::Function(trace_write_snapshot::<QT, S, 1>),
+                Hook::Function(trace_write_snapshot::<QT, S, 2>),
+                Hook::Function(trace_write_snapshot::<QT, S, 4>),
+                Hook::Function(trace_write_snapshot::<QT, S, 8>),
                 Hook::Function(trace_write_n_snapshot::<QT, S>),
             );
         }
@@ -521,7 +521,7 @@ where
     }
 }
 
-pub fn trace_write1_snapshot<QT, S>(
+pub fn trace_write_snapshot<QT, S, const N: usize>(
     hooks: &mut QemuHooks<QT, S>,
     _state: Option<&mut S>,
     _id: u64,
@@ -531,46 +531,7 @@ pub fn trace_write1_snapshot<QT, S>(
     QT: QemuHelperTuple<S>,
 {
     let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
-    h.access(addr, 1);
-}
-
-pub fn trace_write2_snapshot<QT, S>(
-    hooks: &mut QemuHooks<QT, S>,
-    _state: Option<&mut S>,
-    _id: u64,
-    addr: GuestAddr,
-) where
-    S: UsesInput,
-    QT: QemuHelperTuple<S>,
-{
-    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
-    h.access(addr, 2);
-}
-
-pub fn trace_write4_snapshot<QT, S>(
-    hooks: &mut QemuHooks<QT, S>,
-    _state: Option<&mut S>,
-    _id: u64,
-    addr: GuestAddr,
-) where
-    S: UsesInput,
-    QT: QemuHelperTuple<S>,
-{
-    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
-    h.access(addr, 4);
-}
-
-pub fn trace_write8_snapshot<QT, S>(
-    hooks: &mut QemuHooks<QT, S>,
-    _state: Option<&mut S>,
-    _id: u64,
-    addr: GuestAddr,
-) where
-    S: UsesInput,
-    QT: QemuHelperTuple<S>,
-{
-    let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
-    h.access(addr, 8);
+    h.access(addr, N);
 }
 
 pub fn trace_write_n_snapshot<QT, S>(

--- a/libafl_qemu/src/snapshot.rs
+++ b/libafl_qemu/src/snapshot.rs
@@ -521,7 +521,7 @@ where
     }
 }
 
-pub fn trace_write_snapshot<QT, S, const N: usize>(
+pub fn trace_write_snapshot<QT, S, const SIZE: usize>(
     hooks: &mut QemuHooks<QT, S>,
     _state: Option<&mut S>,
     _id: u64,
@@ -531,7 +531,7 @@ pub fn trace_write_snapshot<QT, S, const N: usize>(
     QT: QemuHelperTuple<S>,
 {
     let h = hooks.match_helper_mut::<QemuSnapshotHelper>().unwrap();
-    h.access(addr, N);
+    h.access(addr, SIZE);
 }
 
 pub fn trace_write_n_snapshot<QT, S>(


### PR DESCRIPTION
Just a simple reduction in the amount of code that needs to be maintained.