### PR TITLE
Use tee, not redirect

### DIFF
--- a/fuzzers/baby_fuzzer_swap_differential/Makefile.toml
+++ b/fuzzers/baby_fuzzer_swap_differential/Makefile.toml
@@ -36,7 +36,7 @@ windows_alias = "unsupported"
 [tasks.test_unix]
 script_runner = "@shell"
 script='''
-timeout 30s ${CARGO_TARGET_DIR}/${PROFILE_DIR}/${FUZZER_NAME} >fuzz_stdout.log || true
+timeout 30s ${CARGO_TARGET_DIR}/${PROFILE_DIR}/${FUZZER_NAME} | tee fuzz_stdout.log || true
 if grep -qa "objectives: 1" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else

--- a/fuzzers/forkserver_libafl_cc/Makefile.toml
+++ b/fuzzers/forkserver_libafl_cc/Makefile.toml
@@ -110,7 +110,7 @@ windows_alias = "unsupported"
 [tasks.test_unix]
 script_runner = "@shell"
 script='''
-timeout 30s ${CARGO_TARGET_DIR}/${PROFILE_DIR}/${CARGO_MAKE_PROJECT_NAME} ./${FUZZER_NAME} ./corpus/ -t 1000 >fuzz_stdout.log || true
+timeout 30s ${CARGO_TARGET_DIR}/${PROFILE_DIR}/${CARGO_MAKE_PROJECT_NAME} ./${FUZZER_NAME} ./corpus/ -t 1000 | tee fuzz_stdout.log || true
 if grep -qa "objectives: 1" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else

--- a/fuzzers/frida_libpng/Makefile.toml
+++ b/fuzzers/frida_libpng/Makefile.toml
@@ -110,7 +110,7 @@ windows_alias = "test_windows"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 30s ./${FUZZER_NAME} -F LLVMFuzzerTestOneInput -H ./libpng-harness.so -l ./libpng-harness.so >fuzz_stdout.log 2>/dev/null || true
+timeout 30s ./${FUZZER_NAME} -F LLVMFuzzerTestOneInput -H ./libpng-harness.so -l ./libpng-harness.so | tee fuzz_stdout.log 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else
@@ -125,7 +125,7 @@ dependencies = [ "fuzzer", "harness" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 30s ./${FUZZER_NAME} -F LLVMFuzzerTestOneInput -H ./libpng-harness.so -l ./libpng-harness.so >fuzz_stdout.log 2>/dev/null || true
+timeout 30s ./${FUZZER_NAME} -F LLVMFuzzerTestOneInput -H ./libpng-harness.so -l ./libpng-harness.so | tee fuzz_stdout.log 2>/dev/null || true
 '''
 dependencies = [ "fuzzer", "harness" ]
 

--- a/fuzzers/fuzzbench/Makefile.toml
+++ b/fuzzers/fuzzbench/Makefile.toml
@@ -82,7 +82,7 @@ rm -rf libafl_unix_shmem_server || true
 mkdir in || true
 echo a > in/a
 # Allow sigterm as exit code 
-timeout 31s ./${FUZZER_NAME} -o out -i in >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} -o out -i in | tee fuzz_stdout.log || true
 if grep -qa "objectives: 1" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else

--- a/fuzzers/fuzzbench_ctx/Makefile.toml
+++ b/fuzzers/fuzzbench_ctx/Makefile.toml
@@ -82,7 +82,7 @@ rm -rf libafl_unix_shmem_server || true
 mkdir in || true
 echo a > in/a
 # Allow sigterm as exit code 
-timeout 31s ./${FUZZER_NAME} -o out -i in >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} -o out -i in | tee fuzz_stdout.log || true
 if grep -qa "objectives: 1" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else

--- a/fuzzers/fuzzbench_text/Makefile.toml
+++ b/fuzzers/fuzzbench_text/Makefile.toml
@@ -83,7 +83,7 @@ rm -rf libafl_unix_shmem_server || true
 mkdir in || true
 echo a > in/a
 # Allow sigterm as exit code 
-timeout 31s ./${FUZZER_NAME} -o out -i in >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} -o out -i in | tee fuzz_stdout.log || true
 cat fuzz_stdout.log
 if grep -qa "objectives: 1" fuzz_stdout.log; then
     echo "Fuzzer is working"

--- a/fuzzers/libfuzzer_libmozjpeg/Makefile.toml
+++ b/fuzzers/libfuzzer_libmozjpeg/Makefile.toml
@@ -99,7 +99,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then

--- a/fuzzers/libfuzzer_libpng/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng/Makefile.toml
@@ -161,7 +161,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
@@ -177,7 +177,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 '''

--- a/fuzzers/libfuzzer_libpng_accounting/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_accounting/Makefile.toml
@@ -98,7 +98,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus >fuzz_stdout.log 2>/dev/null || true
+timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus | tee fuzz_stdout.log 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else
@@ -112,7 +112,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus >fuzz_stdout.log 2>/dev/null || true
+timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus | tee fuzz_stdout.log 2>/dev/null || true
 '''
 dependencies = [ "fuzzer" ]
 

--- a/fuzzers/libfuzzer_libpng_aflpp_ui/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_aflpp_ui/Makefile.toml
@@ -171,7 +171,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout --foreground 11s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout --foreground 11s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout --foreground 10s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 '''

--- a/fuzzers/libfuzzer_libpng_centralized/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_centralized/Makefile.toml
@@ -98,7 +98,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null | tee fuzz_stdout.log || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else
@@ -112,7 +112,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null | tee fuzz_stdout.log || true
 '''
 dependencies = [ "fuzzer" ]
 

--- a/fuzzers/libfuzzer_libpng_cmin/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_cmin/Makefile.toml
@@ -161,7 +161,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log &
+timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
@@ -177,7 +177,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log &
+timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 '''

--- a/fuzzers/libfuzzer_libpng_launcher/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_launcher/Makefile.toml
@@ -99,7 +99,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME}.coverage --broker-port 21337 --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME}.coverage --broker-port 21337 --cores 0 --input ./corpus 2>/dev/null | tee fuzz_stdout.log || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else
@@ -113,7 +113,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null | tee fuzz_stdout.log || true
 '''
 dependencies = [ "fuzzer" ]
 

--- a/fuzzers/libfuzzer_libpng_norestart/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_norestart/Makefile.toml
@@ -104,7 +104,7 @@ rm -rf libafl_unix_shmem_server || true
 rm -rf corpus/ || true
 mkdir corpus/ || true
 cp seeds/* corpus/ || true
-timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} --cores 0 --input ./corpus 2>/dev/null | tee fuzz_stdout.log || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else

--- a/fuzzers/libfuzzer_libpng_tcp_manager/Makefile.toml
+++ b/fuzzers/libfuzzer_libpng_tcp_manager/Makefile.toml
@@ -161,7 +161,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
@@ -177,7 +177,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 '''

--- a/fuzzers/libfuzzer_stb_image/Makefile.toml
+++ b/fuzzers/libfuzzer_stb_image/Makefile.toml
@@ -62,7 +62,7 @@ windows_alias = "test_windows"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 if grep -qa "corpus: 30" fuzz_stdout.log; then
@@ -78,7 +78,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-(timeout 31s ./${FUZZER_NAME} >fuzz_stdout.log 2>/dev/null || true) &
+(timeout 31s ./${FUZZER_NAME} | tee fuzz_stdout.log 2>/dev/null || true) &
 sleep 0.2
 timeout 30s ./${FUZZER_NAME} >/dev/null 2>/dev/null || true
 '''

--- a/fuzzers/libfuzzer_stb_image_sugar/Makefile.toml
+++ b/fuzzers/libfuzzer_stb_image_sugar/Makefile.toml
@@ -60,7 +60,7 @@ windows_alias = "test_windows"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} 2>/dev/null >fuzz_stdout.log || true
+timeout 31s ./${FUZZER_NAME} 2>/dev/null | tee fuzz_stdout.log || true
 echo "The test is skipped. See https://github.com/AFLplusplus/LibAFL/issues/1176"
 '''
 dependencies = [ "fuzzer" ]

--- a/fuzzers/nautilus_sync/Makefile.toml
+++ b/fuzzers/nautilus_sync/Makefile.toml
@@ -106,7 +106,7 @@ windows_alias = "unsupported"
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 >fuzz_stdout.log 2>/dev/null || true
+timeout 31s ./${FUZZER_NAME} --cores 0 | tee fuzz_stdout.log 2>/dev/null || true
 if grep -qa "corpus: 8" fuzz_stdout.log; then
     echo "Fuzzer is working"
 else
@@ -120,7 +120,7 @@ dependencies = [ "fuzzer" ]
 script_runner = "@shell"
 script='''
 rm -rf libafl_unix_shmem_server || true
-timeout 31s ./${FUZZER_NAME} --cores 0 >fuzz_stdout.log 2>/dev/null || true
+timeout 31s ./${FUZZER_NAME} --cores 0 | tee fuzz_stdout.log 2>/dev/null || true
 '''
 dependencies = [ "fuzzer" ]
 


### PR DESCRIPTION
This allows us to visually inspect fuzzer output in CI to check that local behaviour matches remote.