### PR TITLE
libafl_bolts: some improvements to the `rands` module

### DIFF
--- a/libafl/src/mutators/gramatron.rs
+++ b/libafl/src/mutators/gramatron.rs
@@ -4,7 +4,10 @@ use alloc::vec::Vec;
 use core::cmp::max;
 
 use hashbrown::HashMap;
-use libafl_bolts::{rands::Rand, Named};
+use libafl_bolts::{
+    rands::{choose, Rand},
+    Named,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -117,7 +120,7 @@ where
 
         let insert_at = state.rand_mut().below(input.terminals().len() as u64) as usize;
 
-        let rand_num = state.rand_mut().next() as usize;
+        let rand_num = state.rand_mut().next();
 
         let mut other_testcase = state.corpus().get(idx)?.borrow_mut();
 
@@ -134,7 +137,7 @@ where
         meta.map.get(&input.terminals()[insert_at].state).map_or(
             Ok(MutationResult::Skipped),
             |splice_points| {
-                let from = splice_points[rand_num % splice_points.len()];
+                let from = *choose(splice_points, rand_num);
 
                 input.terminals_mut().truncate(insert_at);
                 input

--- a/libafl/src/mutators/grimoire.rs
+++ b/libafl/src/mutators/grimoire.rs
@@ -4,7 +4,10 @@
 use alloc::vec::Vec;
 use core::cmp::{max, min};
 
-use libafl_bolts::{rands::Rand, Named};
+use libafl_bolts::{
+    rands::{fast_bound, Rand},
+    Named,
+};
 
 use crate::{
     corpus::Corpus,
@@ -254,7 +257,7 @@ where
         }
 
         let stop_at_first = state.rand_mut().below(100) > 50;
-        let mut rand_idx = state.rand_mut().next() as usize;
+        let rand_idx = state.rand_mut().next();
 
         let meta = state.metadata_map().get::<Tokens>().unwrap();
         let token_1 = &meta.tokens()[token_find];
@@ -263,7 +266,7 @@ where
         let mut mutated = MutationResult::Skipped;
 
         let gen = generalised_meta.generalized_mut();
-        rand_idx %= gen.len();
+        let rand_idx = fast_bound(rand_idx, gen.len() as u64) as usize;
 
         'first: for item in &mut gen[..rand_idx] {
             if let GeneralizedItem::Bytes(bytes) = item {

--- a/libafl/src/mutators/grimoire.rs
+++ b/libafl/src/mutators/grimoire.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::cmp::{max, min};
 
 use libafl_bolts::{
-    rands::{fast_bound, Rand},
+    rands::{choose, fast_bound, Rand},
     Named,
 };
 
@@ -34,8 +34,8 @@ where
 
     if state.rand_mut().below(100) > CHOOSE_SUBINPUT_PROB {
         if state.rand_mut().below(100) < 50 {
-            let rand1 = state.rand_mut().next() as usize;
-            let rand2 = state.rand_mut().next() as usize;
+            let rand1 = state.rand_mut().next();
+            let rand2 = state.rand_mut().next();
 
             let other_testcase = state.corpus().get(idx)?.borrow();
             if let Some(other) = other_testcase
@@ -51,8 +51,8 @@ where
                 {
                     gap_indices.push(i);
                 }
-                let min_idx = gap_indices[rand1 % gap_indices.len()];
-                let max_idx = gap_indices[rand2 % gap_indices.len()];
+                let min_idx = *choose(&*gap_indices, rand1);
+                let max_idx = *choose(&*gap_indices, rand2);
                 let (mut min_idx, max_idx) = (min(min_idx, max_idx), max(min_idx, max_idx));
 
                 gap_indices.clear();
@@ -69,11 +69,11 @@ where
             }
         }
 
-        let rand1 = state.rand_mut().next() as usize;
+        let rand1 = state.rand_mut().next();
 
         if let Some(meta) = state.metadata_map().get::<Tokens>() {
             if !meta.tokens().is_empty() {
-                let tok = &meta.tokens()[rand1 % meta.tokens().len()];
+                let tok = choose(meta.tokens(), rand1);
                 if items.last() != Some(&GeneralizedItem::Gap) {
                     items.push(GeneralizedItem::Gap);
                 }

--- a/libafl/src/mutators/grimoire.rs
+++ b/libafl/src/mutators/grimoire.rs
@@ -20,7 +20,7 @@ use crate::{
 
 const RECURSIVE_REPLACEMENT_DEPTH: [usize; 6] = [2, 4, 8, 16, 32, 64];
 const MAX_RECURSIVE_REPLACEMENT_LEN: usize = 64 << 10;
-const CHOOSE_SUBINPUT_PROB: u64 = 50;
+const CHOOSE_SUBINPUT_PROB: f64 = 0.5;
 
 fn extend_with_random_generalized<S>(
     state: &mut S,
@@ -32,8 +32,8 @@ where
 {
     let idx = random_corpus_id!(state.corpus(), state.rand_mut());
 
-    if state.rand_mut().below(100) > CHOOSE_SUBINPUT_PROB {
-        if state.rand_mut().below(100) < 50 {
+    if state.rand_mut().coinflip(CHOOSE_SUBINPUT_PROB) {
+        if state.rand_mut().coinflip(0.5) {
             let rand1 = state.rand_mut().next();
             let rand2 = state.rand_mut().next();
 
@@ -256,7 +256,7 @@ where
             token_replace = state.rand_mut().below(tokens_len as u64) as usize;
         }
 
-        let stop_at_first = state.rand_mut().below(100) > 50;
+        let stop_at_first = state.rand_mut().coinflip(0.5);
         let rand_idx = state.rand_mut().next();
 
         let meta = state.metadata_map().get::<Tokens>().unwrap();

--- a/libafl/src/mutators/mopt_mutator.rs
+++ b/libafl/src/mutators/mopt_mutator.rs
@@ -202,7 +202,7 @@ impl MOpt {
             let mut total_x_now = 0.0;
             let mut x_sum = 0.0;
             for i in 0..self.operator_num {
-                self.x_now[swarm][i] = (self.rand.below(7000) as f64) * 0.0001 + 0.1;
+                self.x_now[swarm][i] = 0.7 * self.rand.next_float() + 0.1;
                 total_x_now += self.x_now[swarm][i];
                 self.v_now[swarm][i] = 0.1;
                 self.l_best[swarm][i] = 0.5;
@@ -215,12 +215,8 @@ impl MOpt {
 
             for i in 0..self.operator_num {
                 self.v_now[swarm][i] = self.w_now * self.v_now[swarm][i]
-                    + (self.rand.below(1000) as f64)
-                        * 0.001
-                        * (self.l_best[swarm][i] - self.x_now[swarm][i])
-                    + (self.rand.below(1000) as f64)
-                        * 0.001
-                        * (self.g_best[i] - self.x_now[swarm][i]);
+                    + self.rand.next_float() * (self.l_best[swarm][i] - self.x_now[swarm][i])
+                    + self.rand.next_float() * (self.g_best[i] - self.x_now[swarm][i]);
                 self.x_now[swarm][i] += self.v_now[swarm][i];
 
                 self.x_now[swarm][i] = self.x_now[swarm][i].clamp(V_MIN, V_MAX);
@@ -282,12 +278,8 @@ impl MOpt {
             for i in 0..self.operator_num {
                 self.probability_now[swarm][i] = 0.0;
                 self.v_now[swarm][i] = self.w_now * self.v_now[swarm][i]
-                    + (self.rand.below(1000) as f64)
-                        * 0.001
-                        * (self.l_best[swarm][i] - self.x_now[swarm][i])
-                    + (self.rand.below(1000) as f64)
-                        * 0.001
-                        * (self.g_best[i] - self.x_now[swarm][i]);
+                    + self.rand.next_float() * (self.l_best[swarm][i] - self.x_now[swarm][i])
+                    + self.rand.next_float() * (self.g_best[i] - self.x_now[swarm][i]);
                 self.x_now[swarm][i] += self.v_now[swarm][i];
 
                 self.x_now[swarm][i] = self.x_now[swarm][i].clamp(V_MIN, V_MAX);
@@ -328,8 +320,8 @@ impl MOpt {
         let operator_num = self.operator_num;
 
         // Fetch a random sele value
-        let select_prob: f64 = self.probability_now[self.swarm_now][operator_num - 1]
-            * ((self.rand.below(10000) as f64) * 0.0001);
+        let select_prob: f64 =
+            self.probability_now[self.swarm_now][operator_num - 1] * self.rand.next_float();
 
         for i in 0..operator_num {
             if i == 0 {

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -470,7 +470,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use libafl_bolts::rands::{Rand, StdRand, XkcdRand};
+    use libafl_bolts::rands::{StdRand, XkcdRand};
 
     use crate::{
         corpus::{Corpus, InMemoryCorpus, Testcase},
@@ -486,8 +486,7 @@ mod tests {
 
     #[test]
     fn test_mut_scheduled() {
-        // With the current impl, seed of 1 will result in a split at pos 2.
-        let mut rand = XkcdRand::with_seed(5);
+        let rand = XkcdRand::with_seed(0);
         let mut corpus: InMemoryCorpus<BytesInput> = InMemoryCorpus::new();
         corpus
             .add(Testcase::new(vec![b'a', b'b', b'c'].into()))
@@ -510,21 +509,17 @@ mod tests {
         )
         .unwrap();
 
-        rand.set_seed(5);
-
         let mut splice = SpliceMutator::new();
         splice.mutate(&mut state, &mut input).unwrap();
 
         log::trace!("{:?}", input.bytes());
 
         // The pre-seeded rand should have spliced at position 2.
-        // TODO: Maybe have a fixed rand for this purpose?
         assert_eq!(input.bytes(), &[b'a', b'b', b'f']);
     }
 
     #[test]
     fn test_havoc() {
-        // With the current impl, seed of 1 will result in a split at pos 2.
         let rand = StdRand::with_seed(0x1337);
         let mut corpus: InMemoryCorpus<BytesInput> = InMemoryCorpus::new();
         corpus

--- a/libafl/src/mutators/tuneable.rs
+++ b/libafl/src/mutators/tuneable.rs
@@ -165,8 +165,7 @@ where
             // We will sample using the mutation probabilities.
             // Doing this outside of the original if branch to make the borrow checker happy.
             #[allow(clippy::cast_precision_loss)]
-            let coin = state.rand_mut().next() as f32 / u64::MAX as f32;
-            debug_assert!(coin <= 1.0_f32);
+            let coin = state.rand_mut().next_float() as f32;
 
             let metadata = TuneableScheduledMutatorMetadata::get_mut(state).unwrap();
             let power = metadata
@@ -204,8 +203,7 @@ where
             // We will sample using the mutation probabilities.
             // Doing this outside of the original if branch to make the borrow checker happy.
             #[allow(clippy::cast_precision_loss)]
-            let coin = state.rand_mut().next() as f32 / u64::MAX as f32;
-            debug_assert!(coin <= 1.0_f32);
+            let coin = state.rand_mut().next_float() as f32;
 
             let metadata = TuneableScheduledMutatorMetadata::get_mut(state).unwrap();
             debug_assert_eq!(

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -112,7 +112,7 @@ where
     CS::State: Debug,
 {
     accounting_map: &'a [u32],
-    skip_non_favored_prob: u64,
+    skip_non_favored_prob: f64,
     inner: MinimizerScheduler<
         CS,
         LenTimeMulTestcaseScore<<CS as UsesState>::State>,
@@ -171,7 +171,7 @@ where
                 .borrow()
                 .has_metadata::<IsFavoredMetadata>();
             has
-        } && state.rand_mut().below(100) < self.skip_non_favored_prob
+        } && state.rand_mut().coinflip(self.skip_non_favored_prob)
         {
             idx = self.inner.base_mut().next(state)?;
         }
@@ -338,7 +338,7 @@ where
         observer: &O,
         state: &mut CS::State,
         base: CS,
-        skip_non_favored_prob: u64,
+        skip_non_favored_prob: f64,
         accounting_map: &'a [u32],
     ) -> Self {
         match state.metadata_map().get::<TopAccountingMetadata>() {

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Default probability to skip the non-favored values
-pub const DEFAULT_SKIP_NON_FAVORED_PROB: u64 = 95;
+pub const DEFAULT_SKIP_NON_FAVORED_PROB: f64 = 0.95;
 
 /// A testcase metadata saying if a testcase is favored
 #[derive(Debug, Serialize, Deserialize)]
@@ -73,7 +73,7 @@ impl Default for TopRatedsMetadata {
 #[derive(Debug, Clone)]
 pub struct MinimizerScheduler<CS, F, M, O> {
     base: CS,
-    skip_non_favored_prob: u64,
+    skip_non_favored_prob: f64,
     remove_metadata: bool,
     phantom: PhantomData<(F, M, O)>,
 }
@@ -231,7 +231,7 @@ where
                 .borrow()
                 .has_metadata::<IsFavoredMetadata>();
             has
-        } && state.rand_mut().below(100) < self.skip_non_favored_prob
+        } && state.rand_mut().coinflip(self.skip_non_favored_prob)
         {
             idx = self.base.next(state)?;
         }
@@ -406,7 +406,7 @@ where
     /// and has a non-default probability to skip non-faved [`Testcase`]s using (`skip_non_favored_prob`).
     ///
     /// When calling, pass the edges observer which will provided the indexes to minimize over.
-    pub fn with_skip_prob(_observer: &O, base: CS, skip_non_favored_prob: u64) -> Self {
+    pub fn with_skip_prob(_observer: &O, base: CS, skip_non_favored_prob: f64) -> Self {
         require_index_tracking!("MinimizerScheduler", O);
         Self {
             base,

--- a/libafl/src/schedulers/probabilistic_sampling.rs
+++ b/libafl/src/schedulers/probabilistic_sampling.rs
@@ -237,8 +237,8 @@ mod tests {
             super::ProbabilityMetadata::register();
         }
 
-        // the first 3 probabilities will be .69, .86, .44
-        let rand = StdRand::with_seed(12);
+        // the first 3 probabilities will be .76, .86, .36
+        let rand = StdRand::with_seed(2);
 
         let mut scheduler = UniformProbabilitySamplingScheduler::new();
 

--- a/libafl/src/schedulers/probabilistic_sampling.rs
+++ b/libafl/src/schedulers/probabilistic_sampling.rs
@@ -162,7 +162,7 @@ where
                 "No entries in corpus. This often implies the target is not properly instrumented.",
             )))
         } else {
-            let rand_prob: f64 = (state.rand_mut().below(100) as f64) / 100.0;
+            let rand_prob: f64 = state.rand_mut().next_float();
             let meta = state.metadata_map().get::<ProbabilityMetadata>().unwrap();
             let threshold = meta.total_probability * rand_prob;
             let mut k: f64 = 0.0;

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -316,8 +316,8 @@ where
         } else {
             let s = random_corpus_id!(state.corpus(), state.rand_mut());
 
-            // Choose a random value between 0.000000000 and 1.000000000
-            let probability = state.rand_mut().between(0, 1000000000) as f64 / 1000000000_f64;
+            // Choose a random value between 0.0 and 1.0
+            let probability = state.rand_mut().next_float();
 
             let wsmeta = state.metadata_mut::<WeightedScheduleMetadata>()?;
 

--- a/libafl_bolts/src/rands.rs
+++ b/libafl_bolts/src/rands.rs
@@ -69,6 +69,12 @@ pub trait Rand: Debug + Serialize + DeserializeOwned {
         u as f64 * MAX_DIV
     }
 
+    /// Returns true with specified probability
+    fn coinflip(&mut self, success_prob: f64) -> bool {
+        debug_assert!((0.0..=1.0).contains(&success_prob));
+        self.next_float() < success_prob
+    }
+
     /// Gets a value below the given 64 bit val (exclusive)
     fn below(&mut self, upper_bound_excl: u64) -> u64 {
         fast_bound(self.next(), upper_bound_excl)

--- a/libafl_bolts/src/rands.rs
+++ b/libafl_bolts/src/rands.rs
@@ -59,6 +59,16 @@ pub trait Rand: Debug + Serialize + DeserializeOwned {
     /// Gets the next 64 bit value
     fn next(&mut self) -> u64;
 
+    /// Gets a value between 0.0 (inclusive) and 1.0 (exclusive)
+    #[allow(clippy::cast_precision_loss)]
+    fn next_float(&mut self) -> f64 {
+        // both 2^53 and 2^-53 can be represented in f64 exactly
+        const MAX: u64 = 1u64 << 53;
+        const MAX_DIV: f64 = 1.0 / (MAX as f64);
+        let u = self.next() & MAX.wrapping_sub(1);
+        u as f64 * MAX_DIV
+    }
+
     /// Gets a value below the given 64 bit val (exclusive)
     fn below(&mut self, upper_bound_excl: u64) -> u64 {
         fast_bound(self.next(), upper_bound_excl)

--- a/utils/libafl_benches/benches/rand_speeds.rs
+++ b/utils/libafl_benches/benches/rand_speeds.rs
@@ -2,12 +2,12 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use libafl_bolts::rands::{
-    Lehmer64Rand, Rand, RomuDuoJrRand, RomuTrioRand, XorShift64Rand, Xoshiro256StarRand,
+    Lehmer64Rand, Rand, RomuDuoJrRand, RomuTrioRand, XorShift64Rand, Xoshiro256PlusPlusRand,
 };
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut xorshift = XorShift64Rand::with_seed(1);
-    let mut xoshiro = Xoshiro256StarRand::with_seed(1);
+    let mut xoshiro = Xoshiro256PlusPlusRand::with_seed(1);
     let mut romu = RomuDuoJrRand::with_seed(1);
     let mut lehmer = Lehmer64Rand::with_seed(1);
     let mut romu_trio = RomuTrioRand::with_seed(1);

--- a/utils/libafl_benches/benches/rand_speeds.rs
+++ b/utils/libafl_benches/benches/rand_speeds.rs
@@ -2,16 +2,19 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use libafl_bolts::rands::{
-    Lehmer64Rand, Rand, RomuDuoJrRand, RomuTrioRand, XorShift64Rand, Xoshiro256PlusPlusRand,
+    Lehmer64Rand, Rand, RomuDuoJrRand, RomuTrioRand, Sfc64Rand, XorShift64Rand,
+    Xoshiro256PlusPlusRand,
 };
 
 fn criterion_benchmark(c: &mut Criterion) {
+    let mut sfc64 = Sfc64Rand::with_seed(1);
     let mut xorshift = XorShift64Rand::with_seed(1);
     let mut xoshiro = Xoshiro256PlusPlusRand::with_seed(1);
     let mut romu = RomuDuoJrRand::with_seed(1);
     let mut lehmer = Lehmer64Rand::with_seed(1);
     let mut romu_trio = RomuTrioRand::with_seed(1);
 
+    c.bench_function("sfc64", |b| b.iter(|| black_box(sfc64.next())));
     c.bench_function("xorshift", |b| b.iter(|| black_box(xorshift.next())));
     c.bench_function("xoshiro", |b| b.iter(|| black_box(xoshiro.next())));
     c.bench_function("romu", |b| b.iter(|| black_box(romu.next())));


### PR DESCRIPTION
First, I'd like to thank you for an excellent library!

I started playing around with libafl and reading the source code, and quickly noticed that there are some things that could be improved in the `rands` module of `libafl_bolts`. I've tried to make the commits in this PR relatively self-contained:
- f5ef082f5e10966108d7ef4b3cce50f4c764a276 fixes seeding problems,
- 8298cb7bd6aa1ce8f26b6925c14b3b427dcc43e3 improves the speed of bounded number generation,
- 99515355a4535b46030251c532c7ebe1707c72fa, 40a45d6b4892ece167dba108540e7d14517d2879 and 19bbf443baec36ad605ff80bd9991acd0524e383 add convenient utility functions,
- fbea313c45274f5a0bb9053b2d13a6fc9903f9c4 adds SFC64 PRNG.

 Would gladly discuss and rework anything that raises concerns.