### PR TITLE
Fix typo in setup_libxml2.sh

### DIFF
--- a/fuzzers/nyx_libxml2_standalone/setup_libxml2.sh
+++ b/fuzzers/nyx_libxml2_standalone/setup_libxml2.sh
@@ -36,4 +36,4 @@ python3 "../../libafl_nyx/packer/packer/nyx_packer.py" \
     --fast_reload_mode \
     --purge || exit
 
-python3 ../../libafl_nyx/packer/packer/nyx_config_gen.py /tmp/nyx_libxml2/ Kernel || kernel
+python3 ../../libafl_nyx/packer/packer/nyx_config_gen.py /tmp/nyx_libxml2/ Kernel || exit


### PR DESCRIPTION
exit for a non-zero exit code