### PR TITLE
Allow for AsIter(Mut)/AsSlice(Mut) to be implemented in safe Rust

### DIFF
--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -168,7 +168,7 @@ where
 
             // Store coverage, mapping coverage map indices to hit counts (if present) and the
             // associated seeds for the map indices with those hit counts.
-            for (i, e) in obs.as_iter().copied().enumerate() {
+            for (i, e) in obs.as_iter().map(|x| *x).enumerate() {
                 if e != obs.initial() {
                     cov_map
                         .entry(i)

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -9,7 +9,9 @@ use core::{
     ops::{BitAnd, BitOr, Deref, DerefMut},
 };
 
-use libafl_bolts::{AsIter, AsSlice, AsSliceMut, HasRefCnt, Named};
+#[rustversion::nightly]
+use libafl_bolts::AsSlice;
+use libafl_bolts::{AsIter, HasRefCnt, Named};
 use num_traits::PrimInt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -237,14 +239,14 @@ impl Deref for MapIndexesMetadata {
     type Target = [usize];
     /// Convert to a slice
     fn deref(&self) -> &[usize] {
-        self.list.as_slice()
+        &self.list
     }
 }
 
 impl DerefMut for MapIndexesMetadata {
     /// Convert to a slice
     fn deref_mut(&mut self) -> &mut [usize] {
-        self.list.as_slice_mut()
+        &mut self.list
     }
 }
 

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -484,7 +484,7 @@ where
 
             for (i, value) in observer
                 .as_iter()
-                .copied()
+                .map(|x| *x)
                 .enumerate()
                 .filter(|(_, value)| *value != initial)
             {
@@ -499,7 +499,7 @@ where
         } else {
             for (i, value) in observer
                 .as_iter()
-                .copied()
+                .map(|x| *x)
                 .enumerate()
                 .filter(|(_, value)| *value != initial)
             {
@@ -771,7 +771,7 @@ where
             novelties.clear();
             for (i, item) in observer
                 .as_iter()
-                .copied()
+                .map(|x| *x)
                 .enumerate()
                 .filter(|(_, item)| *item != initial)
             {
@@ -785,7 +785,7 @@ where
         } else {
             for (i, item) in observer
                 .as_iter()
-                .copied()
+                .map(|x| *x)
                 .enumerate()
                 .filter(|(_, item)| *item != initial)
             {

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -9,9 +9,7 @@ use core::{
     ops::{BitAnd, BitOr, Deref, DerefMut},
 };
 
-#[rustversion::nightly]
-use libafl_bolts::AsSlice;
-use libafl_bolts::{AsIter, HasRefCnt, Named};
+use libafl_bolts::{AsIter, AsSlice, AsSliceMut, HasRefCnt, Named};
 use num_traits::PrimInt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -6,7 +6,7 @@ use core::simd::prelude::SimdOrd;
 use core::{
     fmt::Debug,
     marker::PhantomData,
-    ops::{BitAnd, BitOr},
+    ops::{BitAnd, BitOr, Deref, DerefMut},
 };
 
 use libafl_bolts::{AsIter, AsSlice, AsSliceMut, HasRefCnt, Named};
@@ -233,18 +233,17 @@ pub struct MapIndexesMetadata {
 
 libafl_bolts::impl_serdeany!(MapIndexesMetadata);
 
-impl AsSlice for MapIndexesMetadata {
-    type Entry = usize;
+impl Deref for MapIndexesMetadata {
+    type Target = [usize];
     /// Convert to a slice
-    fn as_slice(&self) -> &[usize] {
+    fn deref(&self) -> &[usize] {
         self.list.as_slice()
     }
 }
 
-impl AsSliceMut for MapIndexesMetadata {
-    type Entry = usize;
+impl DerefMut for MapIndexesMetadata {
     /// Convert to a slice
-    fn as_slice_mut(&mut self) -> &mut [usize] {
+    fn deref_mut(&mut self) -> &mut [usize] {
         self.list.as_slice_mut()
     }
 }
@@ -280,21 +279,20 @@ pub struct MapNoveltiesMetadata {
 
 libafl_bolts::impl_serdeany!(MapNoveltiesMetadata);
 
-impl AsSlice for MapNoveltiesMetadata {
-    type Entry = usize;
+impl Deref for MapNoveltiesMetadata {
+    type Target = [usize];
     /// Convert to a slice
     #[must_use]
-    fn as_slice(&self) -> &[usize] {
-        self.list.as_slice()
+    fn deref(&self) -> &[usize] {
+        &self.list
     }
 }
 
-impl AsSliceMut for MapNoveltiesMetadata {
-    type Entry = usize;
+impl DerefMut for MapNoveltiesMetadata {
     /// Convert to a slice
     #[must_use]
-    fn as_slice_mut(&mut self) -> &mut [usize] {
-        self.list.as_slice_mut()
+    fn deref_mut(&mut self) -> &mut [usize] {
+        &mut self.list
     }
 }
 
@@ -548,8 +546,7 @@ where
 #[rustversion::nightly]
 impl<C, O, S> Feedback<S> for MapFeedback<C, DifferentIsNovel, O, MaxReducer, S, u8>
 where
-    O: MapObserver<Entry = u8> + AsSlice<Entry = u8>,
-    for<'it> O: AsIter<'it, Item = u8>,
+    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
     S: State + HasNamedMetadata,
     C: CanTrack + AsRef<O>,
 {

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -9,7 +9,9 @@ use core::{
     ops::{BitAnd, BitOr, Deref, DerefMut},
 };
 
-use libafl_bolts::{AsIter, AsSlice, AsSliceMut, HasRefCnt, Named};
+#[rustversion::nightly]
+use libafl_bolts::AsSlice;
+use libafl_bolts::{AsIter, HasRefCnt, Named};
 use num_traits::PrimInt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -476,7 +478,7 @@ where
             map_state.history_map.resize(len, observer.initial());
         }
 
-        let history_map = map_state.history_map.as_slice_mut();
+        let history_map = &mut map_state.history_map;
         if C::INDICES {
             let mut indices = Vec::new();
 

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -5,11 +5,12 @@ use core::{
     fmt::{self, Debug},
     marker::PhantomData,
 };
+use std::ops::{Deref, DerefMut};
 
 use libafl_bolts::{
     rands::Rand,
     tuples::{tuple_list, tuple_list_type, Merge, NamedTuple},
-    AsSlice, AsSliceMut, Named,
+    Named,
 };
 use serde::{Deserialize, Serialize};
 
@@ -45,18 +46,16 @@ pub struct LogMutationMetadata {
 
 libafl_bolts::impl_serdeany!(LogMutationMetadata);
 
-impl AsSlice for LogMutationMetadata {
-    type Entry = Cow<'static, str>;
-    #[must_use]
-    fn as_slice(&self) -> &[Cow<'static, str>] {
-        self.list.as_slice()
+impl Deref for LogMutationMetadata {
+    type Target = [Cow<'static, str>];
+    fn deref(&self) -> &[Cow<'static, str>] {
+        &self.list
     }
 }
-impl AsSliceMut for LogMutationMetadata {
-    type Entry = Cow<'static, str>;
+impl DerefMut for LogMutationMetadata {
     #[must_use]
-    fn as_slice_mut(&mut self) -> &mut [Cow<'static, str>] {
-        self.list.as_slice_mut()
+    fn deref_mut(&mut self) -> &mut [Cow<'static, str>] {
+        &mut self.list
     }
 }
 

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -4,8 +4,8 @@ use alloc::{borrow::Cow, vec::Vec};
 use core::{
     fmt::{self, Debug},
     marker::PhantomData,
+    ops::{Deref, DerefMut},
 };
-use std::ops::{Deref, DerefMut};
 
 use libafl_bolts::{
     rands::Rand,

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -6,7 +6,7 @@ use core::slice::from_raw_parts;
 use core::{
     fmt::Debug,
     mem::size_of,
-    ops::{Add, AddAssign},
+    ops::{Add, AddAssign, Deref},
     slice::Iter,
 };
 #[cfg(feature = "std")]
@@ -272,9 +272,9 @@ where
     }
 }
 
-impl AsSlice for Tokens {
-    type Entry = Vec<u8>;
-    fn as_slice(&self) -> &[Vec<u8>] {
+impl Deref for Tokens {
+    type Target = [Vec<u8>];
+    fn deref(&self) -> &[Vec<u8>] {
         self.tokens()
     }
 }

--- a/libafl/src/observers/cmp.rs
+++ b/libafl/src/observers/cmp.rs
@@ -1,11 +1,15 @@
 //! The `CmpObserver` provides access to the logged values of CMP instructions
 
 use alloc::{borrow::Cow, vec::Vec};
-use core::{fmt::Debug, marker::PhantomData};
+use core::{
+    fmt::Debug,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 use c2rust_bitfields::BitfieldStruct;
 use hashbrown::HashMap;
-use libafl_bolts::{ownedref::OwnedRefMut, serdeany::SerdeAny, AsSlice, AsSliceMut, Named};
+use libafl_bolts::{ownedref::OwnedRefMut, serdeany::SerdeAny, Named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{executors::ExitKind, inputs::UsesInput, observers::Observer, Error, HasMetadata};
@@ -83,21 +87,16 @@ pub struct CmpValuesMetadata {
 
 libafl_bolts::impl_serdeany!(CmpValuesMetadata);
 
-impl AsSlice for CmpValuesMetadata {
-    type Entry = CmpValues;
-    /// Convert to a slice
-    #[must_use]
-    fn as_slice(&self) -> &[CmpValues] {
-        self.list.as_slice()
+impl Deref for CmpValuesMetadata {
+    type Target = [CmpValues];
+    fn deref(&self) -> &[CmpValues] {
+        &self.list
     }
 }
 
-impl AsSliceMut for CmpValuesMetadata {
-    type Entry = CmpValues;
-    /// Convert to a slice
-    #[must_use]
-    fn as_slice_mut(&mut self) -> &mut [CmpValues] {
-        self.list.as_slice_mut()
+impl DerefMut for CmpValuesMetadata {
+    fn deref_mut(&mut self) -> &mut [CmpValues] {
+        &mut self.list
     }
 }
 

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -598,6 +598,7 @@ where
         + Debug,
 {
     type Item = T;
+    type Ref = &'it T;
     type IntoIter = Iter<'it, T>;
 
     fn as_iter(&'it self) -> Self::IntoIter {
@@ -1127,6 +1128,7 @@ where
         + Debug,
 {
     type Item = T;
+    type Ref = &'it Self::Item;
     type IntoIter = Iter<'it, T>;
 
     fn as_iter(&'it self) -> Self::IntoIter {
@@ -1474,6 +1476,7 @@ where
         + Bounded,
 {
     type Item = T;
+    type Ref = &'it Self::Item;
     type IntoIter = Iter<'it, T>;
 
     fn as_iter(&'it self) -> Self::IntoIter {
@@ -1988,6 +1991,7 @@ where
     M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item = u8>,
 {
     type Item = u8;
+    type Ref = <M as AsIter<'it>>::Ref;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
 
     fn as_iter(&'it self) -> Self::IntoIter {
@@ -2259,6 +2263,7 @@ where
     M: Named + Serialize + serde::de::DeserializeOwned + AsIter<'it, Item = u8>,
 {
     type Item = u8;
+    type Ref = <M as AsIter<'it>>::Ref;
     type IntoIter = <M as AsIter<'it>>::IntoIter;
 
     fn as_iter(&'it self) -> Self::IntoIter {
@@ -2611,6 +2616,7 @@ where
     'a: 'it,
 {
     type Item = T;
+    type Ref = &'it T;
     type IntoIter = Flatten<Iter<'it, OwnedMutSlice<'a, T>>>;
 
     fn as_iter(&'it self) -> Self::IntoIter {
@@ -2732,6 +2738,7 @@ where
     T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
     type Item = T;
+    type Ref = &'it T;
     type IntoIter = Iter<'it, T>;
 
     fn as_iter(&'it self) -> Self::IntoIter {

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -416,8 +416,8 @@ pub trait MapObserver:
     /// Get the value at `idx`
     fn get(&self, idx: usize) -> Self::Entry;
 
-    /// Get the value at `idx` (mutable)
-    fn get_mut(&mut self, idx: usize) -> &mut Self::Entry;
+    /// Set the value at `idx`
+    fn set(&mut self, idx: usize, val: Self::Entry);
 
     /// Get the number of usable entries in the map (all by default)
     fn usable_count(&self) -> usize;
@@ -488,7 +488,7 @@ where
     }
 }
 
-/// A Simple iterator calling `MapObserver::get_mut`
+/// A Simple iterator calling `MapObserver::get`
 #[derive(Debug)]
 pub struct MapObserverSimpleIteratorMut<'a, O>
 where
@@ -503,7 +503,7 @@ impl<'a, O> Iterator for MapObserverSimpleIteratorMut<'a, O>
 where
     O: 'a + MapObserver,
 {
-    type Item = &'a O::Entry;
+    type Item = O::Entry;
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
             if self.index >= self.observer.as_ref().unwrap().usable_count() {
@@ -511,7 +511,7 @@ where
             } else {
                 let i = self.index;
                 self.index += 1;
-                Some(self.observer.as_mut().unwrap().get_mut(i))
+                Some(self.observer.as_mut().unwrap().get(i))
             }
         }
     }
@@ -749,9 +749,8 @@ where
         self.as_slice()[pos]
     }
 
-    #[inline]
-    fn get_mut(&mut self, idx: usize) -> &mut T {
-        &mut self.as_slice_mut()[idx]
+    fn set(&mut self, pos: usize, val: T) {
+        self.map.as_slice_mut()[pos] = val;
     }
 
     /// Count the set bytes in the map
@@ -1283,8 +1282,8 @@ where
     }
 
     #[inline]
-    fn get_mut(&mut self, idx: usize) -> &mut T {
-        &mut self.as_slice_mut()[idx]
+    fn set(&mut self, idx: usize, val: T) {
+        self.map.as_slice_mut()[idx] = val;
     }
 
     /// Count the set bytes in the map
@@ -1646,8 +1645,8 @@ where
         self.map.as_slice()[idx]
     }
 
-    fn get_mut(&mut self, idx: usize) -> &mut T {
-        &mut self.map.as_slice_mut()[idx]
+    fn set(&mut self, idx: usize, val: T) {
+        self.map.as_slice_mut()[idx] = val;
     }
 
     /// Count the set bytes in the map
@@ -1916,8 +1915,8 @@ where
     }
 
     #[inline]
-    fn get_mut(&mut self, idx: usize) -> &mut u8 {
-        self.base.get_mut(idx)
+    fn set(&mut self, idx: usize, val: u8) {
+        self.base.set(idx, val);
     }
 
     /// Count the set bytes in the map
@@ -2188,8 +2187,8 @@ where
     }
 
     #[inline]
-    fn get_mut(&mut self, idx: usize) -> &mut u8 {
-        self.base.get_mut(idx)
+    fn set(&mut self, idx: usize, val: u8) {
+        self.base.set(idx, val);
     }
 
     /// Count the set bytes in the map
@@ -2470,11 +2469,11 @@ where
     }
 
     #[inline]
-    fn get_mut(&mut self, idx: usize) -> &mut T {
+    fn set(&mut self, idx: usize, val: Self::Entry) {
         let elem = self.intervals.query(idx..=idx).next().unwrap();
         let i = *elem.value;
         let j = idx - elem.interval.start;
-        &mut self.maps[i].as_slice_mut()[j]
+        self.maps[i].as_slice_mut()[j] = val;
     }
 
     #[inline]
@@ -2845,8 +2844,8 @@ where
     }
 
     #[inline]
-    fn get_mut(&mut self, idx: usize) -> &mut T {
-        &mut self.as_slice_mut()[idx]
+    fn set(&mut self, pos: usize, val: Self::Entry) {
+        self.as_slice_mut()[pos] = val;
     }
 
     /// Count the set bytes in the map

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -619,10 +619,10 @@ where
         + serde::de::DeserializeOwned
         + Debug,
 {
-    type Item = T;
-    type IntoIter = IterMut<'it, T>;
+    type RefMut = &'it mut T;
+    type IntoIterMut = IterMut<'it, T>;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         let cnt = self.usable_count();
         self.as_slice_mut()[..cnt].iter_mut()
     }
@@ -1148,10 +1148,10 @@ where
         + serde::de::DeserializeOwned
         + Debug,
 {
-    type Item = T;
-    type IntoIter = IterMut<'it, T>;
+    type RefMut = &'it mut T;
+    type IntoIterMut = IterMut<'it, T>;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         let cnt = self.usable_count();
         self.as_slice_mut()[..cnt].iter_mut()
     }
@@ -1498,10 +1498,10 @@ where
         + PartialEq
         + Bounded,
 {
-    type Item = T;
-    type IntoIter = IterMut<'it, T>;
+    type RefMut = &'it mut T;
+    type IntoIterMut = IterMut<'it, T>;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         let cnt = self.usable_count();
         self.as_slice_mut()[..cnt].iter_mut()
     }
@@ -2002,10 +2002,10 @@ impl<'it, M> AsIterMut<'it> for HitcountsMapObserver<M>
 where
     M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item = u8>,
 {
-    type Item = u8;
-    type IntoIter = <M as AsIterMut<'it>>::IntoIter;
+    type RefMut = <M as AsIterMut<'it>>::RefMut;
+    type IntoIterMut = <M as AsIterMut<'it>>::IntoIterMut;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         self.base.as_iter_mut()
     }
 }
@@ -2116,7 +2116,7 @@ where
         input: &S::Input,
         exit_kind: &ExitKind,
     ) -> Result<(), Error> {
-        for item in self.as_iter_mut() {
+        for mut item in self.as_iter_mut() {
             *item = unsafe { *COUNT_CLASS_LOOKUP.get_unchecked((*item) as usize) };
         }
 
@@ -2274,10 +2274,10 @@ impl<'it, M> AsIterMut<'it> for HitcountsIterableMapObserver<M>
 where
     M: Named + Serialize + serde::de::DeserializeOwned + AsIterMut<'it, Item = u8>,
 {
-    type Item = u8;
-    type IntoIter = <M as AsIterMut<'it>>::IntoIter;
+    type RefMut = <M as AsIterMut<'it>>::RefMut;
+    type IntoIterMut = <M as AsIterMut<'it>>::IntoIterMut;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         self.base.as_iter_mut()
     }
 }
@@ -2628,10 +2628,10 @@ where
     T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
     'a: 'it,
 {
-    type Item = T;
-    type IntoIter = Flatten<IterMut<'it, OwnedMutSlice<'a, T>>>;
+    type RefMut = &'it mut T;
+    type IntoIterMut = Flatten<IterMut<'it, OwnedMutSlice<'a, T>>>;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         self.maps.iter_mut().flatten()
     }
 }
@@ -2749,10 +2749,10 @@ impl<'it, T> AsIterMut<'it> for OwnedMapObserver<T>
 where
     T: 'static + Default + Copy + Serialize + serde::de::DeserializeOwned + Debug,
 {
-    type Item = T;
-    type IntoIter = IterMut<'it, T>;
+    type RefMut = &'it mut T;
+    type IntoIterMut = IterMut<'it, T>;
 
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
         self.as_slice_mut().iter_mut()
     }
 }

--- a/libafl/src/observers/map.rs
+++ b/libafl/src/observers/map.rs
@@ -414,7 +414,7 @@ pub trait MapObserver:
     type Entry: Bounded + PartialEq + Default + Copy + Debug + Hash + 'static;
 
     /// Get the value at `idx`
-    fn get(&self, idx: usize) -> &Self::Entry;
+    fn get(&self, idx: usize) -> Self::Entry;
 
     /// Get the value at `idx` (mutable)
     fn get_mut(&mut self, idx: usize) -> &mut Self::Entry;
@@ -474,7 +474,7 @@ impl<'a, O> Iterator for MapObserverSimpleIterator<'a, O>
 where
     O: 'a + MapObserver,
 {
-    type Item = &'a O::Entry;
+    type Item = O::Entry;
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
             if self.index >= self.observer.as_ref().unwrap().usable_count() {
@@ -745,8 +745,8 @@ where
     type Entry = T;
 
     #[inline]
-    fn get(&self, pos: usize) -> &T {
-        &self.as_slice()[pos]
+    fn get(&self, pos: usize) -> T {
+        self.as_slice()[pos]
     }
 
     #[inline]
@@ -1278,8 +1278,8 @@ where
     }
 
     #[inline]
-    fn get(&self, idx: usize) -> &T {
-        &self.as_slice()[idx]
+    fn get(&self, idx: usize) -> T {
+        self.as_slice()[idx]
     }
 
     #[inline]
@@ -1642,8 +1642,8 @@ where
         *self.size.as_ref()
     }
 
-    fn get(&self, idx: usize) -> &T {
-        &self.map.as_slice()[idx]
+    fn get(&self, idx: usize) -> T {
+        self.map.as_slice()[idx]
     }
 
     fn get_mut(&mut self, idx: usize) -> &mut T {
@@ -1911,7 +1911,7 @@ where
     }
 
     #[inline]
-    fn get(&self, idx: usize) -> &u8 {
+    fn get(&self, idx: usize) -> u8 {
         self.base.get(idx)
     }
 
@@ -2183,7 +2183,7 @@ where
     }
 
     #[inline]
-    fn get(&self, idx: usize) -> &u8 {
+    fn get(&self, idx: usize) -> u8 {
         self.base.get(idx)
     }
 
@@ -2462,11 +2462,11 @@ where
     type Entry = T;
 
     #[inline]
-    fn get(&self, idx: usize) -> &T {
+    fn get(&self, idx: usize) -> T {
         let elem = self.intervals.query(idx..=idx).next().unwrap();
         let i = *elem.value;
         let j = idx - elem.interval.start;
-        &self.maps[i].as_slice()[j]
+        self.maps[i].as_slice()[j]
     }
 
     #[inline]
@@ -2518,7 +2518,7 @@ where
         let cnt = self.usable_count();
         let mut res = Vec::with_capacity(cnt);
         for i in 0..cnt {
-            res.push(*self.get(i));
+            res.push(self.get(i));
         }
         res
     }
@@ -2529,7 +2529,7 @@ where
         let cnt = self.usable_count();
         let mut res = 0;
         for i in indexes {
-            if *i < cnt && *self.get(*i) != initial {
+            if *i < cnt && self.get(*i) != initial {
                 res += 1;
             }
         }
@@ -2840,8 +2840,8 @@ where
     type Entry = T;
 
     #[inline]
-    fn get(&self, pos: usize) -> &T {
-        &self.as_slice()[pos]
+    fn get(&self, pos: usize) -> T {
+        self.as_slice()[pos]
     }
 
     #[inline]

--- a/libafl/src/observers/value.rs
+++ b/libafl/src/observers/value.rs
@@ -2,7 +2,7 @@
 
 use alloc::{borrow::Cow, boxed::Box};
 use core::{
-    cell::{Ref, RefCell},
+    cell::{Ref, RefCell, RefMut},
     fmt::Debug,
     hash::Hash,
     ops::Deref,
@@ -125,12 +125,25 @@ where
     }
 
     /// Get a reference to the underlying value.
+    ///
+    /// Panics if it can't borrow.
     #[must_use]
     pub fn get_ref<'b>(&'b self) -> Ref<'a, T>
     where
         'b: 'a,
     {
         self.value.as_ref().borrow()
+    }
+
+    /// Get a mutable reference to the underlying value.
+    ///
+    /// Panics if it can't borrow.
+    #[must_use]
+    pub fn get_ref_mut<'b>(&'b self) -> RefMut<'a, T>
+    where
+        'b: 'a,
+    {
+        self.value.as_ref().borrow_mut()
     }
 
     /// Set the value.

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -2,9 +2,10 @@
 
 use alloc::vec::Vec;
 use core::fmt::Debug;
+use std::ops::{Deref, DerefMut};
 
 use hashbrown::HashMap;
-use libafl_bolts::{rands::Rand, AsSlice, AsSliceMut, HasLen, HasRefCnt};
+use libafl_bolts::{rands::Rand, HasLen, HasRefCnt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -35,19 +36,15 @@ pub struct AccountingIndexesMetadata {
 
 libafl_bolts::impl_serdeany!(AccountingIndexesMetadata);
 
-impl AsSlice for AccountingIndexesMetadata {
-    type Entry = usize;
-    /// Convert to a slice
-    fn as_slice(&self) -> &[usize] {
-        self.list.as_slice()
+impl Deref for AccountingIndexesMetadata {
+    type Target = [usize];
+    fn deref(&self) -> &[usize] {
+        &self.list
     }
 }
-impl AsSliceMut for AccountingIndexesMetadata {
-    type Entry = usize;
-
-    /// Convert to a slice
-    fn as_slice_mut(&mut self) -> &mut [usize] {
-        self.list.as_slice_mut()
+impl DerefMut for AccountingIndexesMetadata {
+    fn deref_mut(&mut self) -> &mut [usize] {
+        &mut self.list
     }
 }
 

--- a/libafl/src/schedulers/accounting.rs
+++ b/libafl/src/schedulers/accounting.rs
@@ -1,8 +1,10 @@
 //! Coverage accounting corpus scheduler, more details at <https://www.ndss-symposium.org/wp-content/uploads/2020/02/24422-paper.pdf>
 
 use alloc::vec::Vec;
-use core::fmt::Debug;
-use std::ops::{Deref, DerefMut};
+use core::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use hashbrown::HashMap;
 use libafl_bolts::{rands::Rand, HasLen, HasRefCnt};

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -675,68 +675,47 @@ pub trait IntoOwned {
 }
 
 /// Can be converted to a slice
-pub trait AsSlice {
-    /// Type of the entries in this slice
-    type Entry;
+pub trait AsSlice<'a> {
+    /// Type of the entries of this slice
+    type Entry: 'a;
+    /// Type of the reference to this slice
+    type SliceRef: Deref<Target = [Self::Entry]> + AsRef<[Self::Entry]>;
+
     /// Convert to a slice
-    fn as_slice(&self) -> &[Self::Entry];
+    fn as_slice(&'a self) -> Self::SliceRef;
+}
+
+impl<'a, T, R> AsSlice<'a> for R
+where
+    T: 'a,
+    R: Deref<Target = [T]>,
+{
+    type Entry = T;
+    type SliceRef = &'a [T];
+
+    fn as_slice(&'a self) -> Self::SliceRef {
+        &*self
+    }
 }
 
 /// Can be converted to a mutable slice
-pub trait AsSliceMut {
-    /// Type of the entries in this mut slice
-    type Entry;
+pub trait AsSliceMut<'a>: AsSlice<'a> {
+    /// Type of the mutable reference to this slice
+    type SliceRefMut: DerefMut<Target = [Self::Entry]> + AsMut<[Self::Entry]>;
+
     /// Convert to a slice
-    fn as_slice_mut(&mut self) -> &mut [Self::Entry];
+    fn as_slice_mut(&'a mut self) -> Self::SliceRefMut;
 }
 
-#[cfg(feature = "alloc")]
-impl<T> AsSlice for Vec<T> {
-    type Entry = T;
+impl<'a, T, R> AsSliceMut<'a> for R
+where
+    T: 'a,
+    R: DerefMut<Target = [T]>,
+{
+    type SliceRefMut = &'a mut [T];
 
-    fn as_slice(&self) -> &[Self::Entry] {
-        self
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T> AsSliceMut for Vec<T> {
-    type Entry = T;
-
-    fn as_slice_mut(&mut self) -> &mut [Self::Entry] {
-        self
-    }
-}
-
-impl<T> AsSlice for &[T] {
-    type Entry = T;
-
-    fn as_slice(&self) -> &[Self::Entry] {
-        self
-    }
-}
-
-impl<T> AsSlice for [T] {
-    type Entry = T;
-
-    fn as_slice(&self) -> &[Self::Entry] {
-        self
-    }
-}
-
-impl<T> AsSliceMut for &mut [T] {
-    type Entry = T;
-
-    fn as_slice_mut(&mut self) -> &mut [Self::Entry] {
-        self
-    }
-}
-
-impl<T> AsSliceMut for [T] {
-    type Entry = T;
-
-    fn as_slice_mut(&mut self) -> &mut [Self::Entry] {
-        self
+    fn as_slice_mut(&'a mut self) -> Self::SliceRefMut {
+        &mut *self
     }
 }
 
@@ -753,6 +732,20 @@ pub trait AsIter<'it> {
     fn as_iter(&'it self) -> Self::IntoIter;
 }
 
+impl<'it, S, T> AsIter<'it> for S
+where
+    S: AsSlice<'it, Entry = T, SliceRef = &'it [T]>,
+    T: 'it,
+{
+    type Item = S::Entry;
+    type Ref = &'it Self::Item;
+    type IntoIter = core::slice::Iter<'it, Self::Item>;
+
+    fn as_iter(&'it self) -> Self::IntoIter {
+        self.as_slice().iter()
+    }
+}
+
 /// Create an `Iterator` from a mutable reference
 pub trait AsIterMut<'it>: AsIter<'it> {
     /// The ref type
@@ -762,6 +755,19 @@ pub trait AsIterMut<'it>: AsIter<'it> {
 
     /// Create an iterator from &mut self
     fn as_iter_mut(&'it mut self) -> Self::IntoIterMut;
+}
+
+impl<'it, S, T> AsIterMut<'it> for S
+where
+    S: AsSliceMut<'it, Entry = T, SliceRef = &'it [T], SliceRefMut = &'it mut [T]>,
+    T: 'it,
+{
+    type RefMut = &'it mut Self::Item;
+    type IntoIterMut = core::slice::IterMut<'it, Self::Item>;
+
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
+        self.as_slice_mut().iter_mut()
+    }
 }
 
 /// Has a length field

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -213,7 +213,7 @@ use core::{
     array::TryFromSliceError,
     fmt::{self, Display},
     num::{ParseIntError, TryFromIntError},
-    ops::Deref,
+    ops::{Deref, DerefMut},
     time,
 };
 #[cfg(feature = "std")]
@@ -754,14 +754,14 @@ pub trait AsIter<'it> {
 }
 
 /// Create an `Iterator` from a mutable reference
-pub trait AsIterMut<'it> {
-    /// The item type
-    type Item: 'it;
+pub trait AsIterMut<'it>: AsIter<'it> {
+    /// The ref type
+    type RefMut: DerefMut<Target = Self::Item>;
     /// The iterator type
-    type IntoIter: Iterator<Item = &'it mut Self::Item>;
+    type IntoIterMut: Iterator<Item = Self::RefMut>;
 
     /// Create an iterator from &mut self
-    fn as_iter_mut(&'it mut self) -> Self::IntoIter;
+    fn as_iter_mut(&'it mut self) -> Self::IntoIterMut;
 }
 
 /// Has a length field

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -213,6 +213,7 @@ use core::{
     array::TryFromSliceError,
     fmt::{self, Display},
     num::{ParseIntError, TryFromIntError},
+    ops::Deref,
     time,
 };
 #[cfg(feature = "std")]
@@ -743,8 +744,10 @@ impl<T> AsSliceMut for [T] {
 pub trait AsIter<'it> {
     /// The item type
     type Item: 'it;
+    /// The ref type
+    type Ref: Deref<Target = Self::Item>;
     /// The iterator type
-    type IntoIter: Iterator<Item = &'it Self::Item>;
+    type IntoIter: Iterator<Item = Self::Ref>;
 
     /// Create an iterator from &self
     fn as_iter(&'it self) -> Self::IntoIter;

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -679,7 +679,7 @@ pub trait AsSlice<'a> {
     /// Type of the entries of this slice
     type Entry: 'a;
     /// Type of the reference to this slice
-    type SliceRef: Deref<Target = [Self::Entry]> + AsRef<[Self::Entry]>;
+    type SliceRef: Deref<Target = [Self::Entry]>;
 
     /// Convert to a slice
     fn as_slice(&'a self) -> Self::SliceRef;
@@ -701,7 +701,7 @@ where
 /// Can be converted to a mutable slice
 pub trait AsSliceMut<'a>: AsSlice<'a> {
     /// Type of the mutable reference to this slice
-    type SliceRefMut: DerefMut<Target = [Self::Entry]> + AsMut<[Self::Entry]>;
+    type SliceRefMut: DerefMut<Target = [Self::Entry]>;
 
     /// Convert to a slice
     fn as_slice_mut(&'a mut self) -> Self::SliceRefMut;

--- a/libafl_bolts/src/llmp.rs
+++ b/libafl_bolts/src/llmp.rs
@@ -394,14 +394,14 @@ impl Listener {
 #[inline]
 #[allow(clippy::cast_ptr_alignment)]
 unsafe fn shmem2page_mut<SHM: ShMem>(afl_shmem: &mut SHM) -> *mut LlmpPage {
-    afl_shmem.as_slice_mut().as_mut_ptr() as *mut LlmpPage
+    afl_shmem.as_mut_ptr() as *mut LlmpPage
 }
 
 /// Get sharedmem from a page
 #[inline]
 #[allow(clippy::cast_ptr_alignment)]
 unsafe fn shmem2page<SHM: ShMem>(afl_shmem: &SHM) -> *const LlmpPage {
-    afl_shmem.as_slice().as_ptr() as *const LlmpPage
+    afl_shmem.as_ptr() as *const LlmpPage
 }
 
 /// Return, if a msg is contained in the current page
@@ -564,7 +564,7 @@ unsafe fn llmp_next_msg_ptr_checked<SHM: ShMem>(
     alloc_size: usize,
 ) -> Result<*mut LlmpMsg, Error> {
     let page = map.page_mut();
-    let map_size = map.shmem.as_slice().len();
+    let map_size = map.shmem.len();
     let msg_begin_min = (page as *const u8).add(size_of::<LlmpPage>());
     // We still need space for this msg (alloc_size).
     let msg_begin_max = (page as *const u8).add(map_size - alloc_size);
@@ -662,7 +662,7 @@ impl LlmpMsg {
     /// Returns `true`, if the pointer is, indeed, in the page of this shared map.
     #[inline]
     pub fn in_shmem<SHM: ShMem>(&self, map: &mut LlmpSharedMap<SHM>) -> bool {
-        let map_size = map.shmem.as_slice().len();
+        let map_size = map.shmem.len();
         let buf_ptr = self.buf.as_ptr();
         let len = self.buf_len_padded as usize + size_of::<LlmpMsg>();
         unsafe {
@@ -1970,7 +1970,7 @@ where
         let offset = offset as usize;
 
         let page = unsafe { self.page_mut() };
-        let page_size = self.shmem.as_slice().len() - size_of::<LlmpPage>();
+        let page_size = self.shmem.len() - size_of::<LlmpPage>();
         if offset > page_size {
             Err(Error::illegal_argument(format!(
                 "Msg offset out of bounds (size: {page_size}, requested offset: {offset})"

--- a/libafl_bolts/src/ownedref.rs
+++ b/libafl_bolts/src/ownedref.rs
@@ -6,7 +6,12 @@ use alloc::{
     slice::{Iter, IterMut},
     vec::Vec,
 };
-use core::{clone::Clone, fmt::Debug, slice};
+use core::{
+    clone::Clone,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    slice,
+};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -455,11 +460,10 @@ impl<'a, T> From<OwnedMutSlice<'a, T>> for OwnedSlice<'a, T> {
     }
 }
 
-impl<'a, T: Sized> AsSlice for OwnedSlice<'a, T> {
-    type Entry = T;
-    /// Get the [`OwnedSlice`] as slice.
-    #[must_use]
-    fn as_slice(&self) -> &[T] {
+impl<'a, T: Sized> Deref for OwnedSlice<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
         match &self.inner {
             OwnedSliceInner::Ref(r) => r,
             OwnedSliceInner::RefRaw(rr, len, _) => unsafe { slice::from_raw_parts(*rr, *len) },
@@ -639,11 +643,10 @@ impl<'a, T: 'a + Sized> OwnedMutSlice<'a, T> {
     }
 }
 
-impl<'a, T: Sized> AsSlice for OwnedMutSlice<'a, T> {
-    type Entry = T;
-    /// Get the value as slice
-    #[must_use]
-    fn as_slice(&self) -> &[T] {
+impl<'a, T: Sized> Deref for OwnedMutSlice<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
         match &self.inner {
             OwnedMutSliceInner::RefRaw(rr, len, _) => unsafe { slice::from_raw_parts(*rr, *len) },
             OwnedMutSliceInner::Ref(r) => r,
@@ -651,11 +654,9 @@ impl<'a, T: Sized> AsSlice for OwnedMutSlice<'a, T> {
         }
     }
 }
-impl<'a, T: Sized> AsSliceMut for OwnedMutSlice<'a, T> {
-    type Entry = T;
-    /// Get the value as mut slice
-    #[must_use]
-    fn as_slice_mut(&mut self) -> &mut [T] {
+
+impl<'a, T: Sized> DerefMut for OwnedMutSlice<'a, T> {
+    fn deref_mut(&mut self) -> &mut [T] {
         match &mut self.inner {
             OwnedMutSliceInner::RefRaw(rr, len, _) => unsafe {
                 slice::from_raw_parts_mut(*rr, *len)

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -35,7 +35,7 @@ pub use win32_shmem::{Win32ShMem, Win32ShMemProvider};
 use crate::os::pipes::Pipe;
 #[cfg(all(feature = "std", unix, not(target_os = "haiku")))]
 pub use crate::os::unix_shmem_server::{ServedShMemProvider, ShMemService};
-use crate::{AsSlice, AsSliceMut, Error};
+use crate::Error;
 
 /// The standard sharedmem provider
 #[cfg(all(windows, feature = "std"))]
@@ -1374,6 +1374,7 @@ impl<T: ShMem> ShMemCursor<T> {
 
     /// Slice from the current location on this map to the end, mutable
     fn empty_slice_mut(&mut self) -> &mut [u8] {
+        use crate::AsSliceMut;
         &mut (self.inner.as_slice_mut()[self.pos..])
     }
 }
@@ -1421,6 +1422,7 @@ impl<T: ShMem> std::io::Seek for ShMemCursor<T> {
         let effective_new_pos = match pos {
             std::io::SeekFrom::Start(s) => s,
             std::io::SeekFrom::End(offset) => {
+                use crate::AsSlice;
                 let map_len = self.inner.as_slice().len();
                 let signed_pos = i64::try_from(map_len).unwrap();
                 let effective = signed_pos.checked_add(offset).unwrap();

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -1166,6 +1166,7 @@ pub mod win32_shmem {
     use core::{
         ffi::c_void,
         fmt::{self, Debug, Formatter},
+        ops::{Deref, DerefMut},
         slice,
     };
 
@@ -1183,7 +1184,7 @@ pub mod win32_shmem {
 
     use crate::{
         shmem::{ShMem, ShMemId, ShMemProvider},
-        AsSlice, AsSliceMut, Error,
+        Error,
     };
 
     const INVALID_HANDLE_VALUE: isize = -1;
@@ -1274,21 +1275,16 @@ pub mod win32_shmem {
         fn id(&self) -> ShMemId {
             self.id
         }
-
-        fn len(&self) -> usize {
-            self.map_size
-        }
     }
 
-    impl AsSlice for Win32ShMem {
-        type Entry = u8;
-        fn as_slice(&self) -> &[u8] {
+    impl Deref for Win32ShMem {
+        type Target = [u8];
+        fn deref(&self) -> &[u8] {
             unsafe { slice::from_raw_parts(self.map, self.map_size) }
         }
     }
-    impl AsSliceMut for Win32ShMem {
-        type Entry = u8;
-        fn as_slice_mut(&mut self) -> &mut [u8] {
+    impl DerefMut for Win32ShMem {
+        fn deref_mut(&mut self) -> &mut [u8] {
             unsafe { slice::from_raw_parts_mut(self.map, self.map_size) }
         }
     }

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -7,7 +7,11 @@ use alloc::{rc::Rc, string::ToString};
 use core::fmt::Display;
 #[cfg(feature = "alloc")]
 use core::{cell::RefCell, fmt, mem::ManuallyDrop};
-use core::{fmt::Debug, mem};
+use core::{
+    fmt::Debug,
+    mem,
+    ops::{Deref, DerefMut},
+};
 #[cfg(feature = "std")]
 use std::env;
 #[cfg(all(unix, feature = "std", not(target_os = "haiku")))]
@@ -168,9 +172,10 @@ impl ShMemId {
         alloc::str::from_utf8(&self.id[..self.null_pos()]).unwrap()
     }
 }
-impl AsSlice for ShMemId {
-    type Entry = u8;
-    fn as_slice(&self) -> &[u8] {
+
+impl Deref for ShMemId {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
         &self.id
     }
 }
@@ -192,23 +197,15 @@ impl Display for ShMemId {
 /// A [`ShMem`] is an interface to shared maps.
 /// They are the backbone of [`crate::llmp`] for inter-process communication.
 /// All you need for scaling on a new target is to implement this interface, as well as the respective [`ShMemProvider`].
-pub trait ShMem: Sized + Debug + Clone + AsSlice<Entry = u8> + AsSliceMut<Entry = u8> {
+pub trait ShMem: Sized + Debug + Clone + DerefMut<Target = [u8]> {
     /// Get the id of this shared memory mapping
     fn id(&self) -> ShMemId;
-
-    /// Get the size of this mapping
-    fn len(&self) -> usize;
-
-    /// Check if the mapping is empty
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
 
     /// Convert to a ptr of a given type, checking the size.
     /// If the map is too small, returns `None`
     fn as_ptr_of<T: Sized>(&self) -> Option<*const T> {
         if self.len() >= mem::size_of::<T>() {
-            Some(self.as_slice().as_ptr() as *const T)
+            Some(self.as_ptr() as *const T)
         } else {
             None
         }
@@ -218,7 +215,7 @@ pub trait ShMem: Sized + Debug + Clone + AsSlice<Entry = u8> + AsSliceMut<Entry 
     /// If the map is too small, returns `None`
     fn as_mut_ptr_of<T: Sized>(&mut self) -> Option<*mut T> {
         if self.len() >= mem::size_of::<T>() {
-            Some(self.as_slice_mut().as_mut_ptr() as *mut T)
+            Some(self.as_mut_ptr() as *mut T)
         } else {
             None
         }
@@ -339,31 +336,27 @@ where
     fn id(&self) -> ShMemId {
         self.internal.id()
     }
+}
 
-    fn len(&self) -> usize {
-        self.internal.len()
+#[cfg(feature = "alloc")]
+impl<T> Deref for RcShMem<T>
+where
+    T: ShMemProvider + Debug,
+{
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.internal
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<T> AsSlice for RcShMem<T>
+impl<T> DerefMut for RcShMem<T>
 where
     T: ShMemProvider + Debug,
 {
-    type Entry = u8;
-    fn as_slice(&self) -> &[u8] {
-        self.internal.as_slice()
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T> AsSliceMut for RcShMem<T>
-where
-    T: ShMemProvider + Debug,
-{
-    type Entry = u8;
-    fn as_slice_mut(&mut self) -> &mut [u8] {
-        self.internal.as_slice_mut()
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.internal
     }
 }
 
@@ -562,6 +555,13 @@ where
 /// Is needed on top.
 #[cfg(all(unix, feature = "std", not(target_os = "haiku")))]
 pub mod unix_shmem {
+    /// Mmap [`ShMem`] for Unix
+    #[cfg(not(target_os = "android"))]
+    pub use default::MmapShMem;
+    /// Mmap [`ShMemProvider`] for Unix
+    #[cfg(not(target_os = "android"))]
+    pub use default::MmapShMemProvider;
+
     #[cfg(doc)]
     use crate::shmem::{ShMem, ShMemProvider};
 
@@ -578,18 +578,13 @@ pub mod unix_shmem {
     #[cfg(not(target_os = "android"))]
     pub type UnixShMem = default::CommonUnixShMem;
 
-    /// Mmap [`ShMem`] for Unix
-    #[cfg(not(target_os = "android"))]
-    pub use default::MmapShMem;
-    /// Mmap [`ShMemProvider`] for Unix
-    #[cfg(not(target_os = "android"))]
-    pub use default::MmapShMemProvider;
-
     #[cfg(all(unix, feature = "std", not(target_os = "android")))]
     mod default {
-
         use alloc::string::ToString;
-        use core::{ptr, slice};
+        use core::{
+            ops::{Deref, DerefMut},
+            ptr, slice,
+        };
         use std::{io::Write, process};
 
         use libc::{
@@ -600,7 +595,7 @@ pub mod unix_shmem {
         use crate::{
             rands::{Rand, RandomSeed, StdRand},
             shmem::{ShMem, ShMemId, ShMemProvider},
-            AsSlice, AsSliceMut, Error,
+            Error,
         };
 
         // This is macOS's limit
@@ -769,22 +764,18 @@ pub mod unix_shmem {
             fn id(&self) -> ShMemId {
                 self.id
             }
-
-            fn len(&self) -> usize {
-                self.map_size
-            }
         }
 
-        impl AsSlice for MmapShMem {
-            type Entry = u8;
-            fn as_slice(&self) -> &[u8] {
+        impl Deref for MmapShMem {
+            type Target = [u8];
+
+            fn deref(&self) -> &[u8] {
                 unsafe { slice::from_raw_parts(self.map, self.map_size) }
             }
         }
 
-        impl AsSliceMut for MmapShMem {
-            type Entry = u8;
-            fn as_slice_mut(&mut self) -> &mut [u8] {
+        impl DerefMut for MmapShMem {
+            fn deref_mut(&mut self) -> &mut [u8] {
                 unsafe { slice::from_raw_parts_mut(self.map, self.map_size) }
             }
         }
@@ -881,22 +872,18 @@ pub mod unix_shmem {
             fn id(&self) -> ShMemId {
                 self.id
             }
-
-            fn len(&self) -> usize {
-                self.map_size
-            }
         }
 
-        impl AsSlice for CommonUnixShMem {
-            type Entry = u8;
-            fn as_slice(&self) -> &[u8] {
+        impl Deref for CommonUnixShMem {
+            type Target = [u8];
+
+            fn deref(&self) -> &[u8] {
                 unsafe { slice::from_raw_parts(self.map, self.map_size) }
             }
         }
 
-        impl AsSliceMut for CommonUnixShMem {
-            type Entry = u8;
-            fn as_slice_mut(&mut self) -> &mut [u8] {
+        impl DerefMut for CommonUnixShMem {
+            fn deref_mut(&mut self) -> &mut [u8] {
                 unsafe { slice::from_raw_parts_mut(self.map, self.map_size) }
             }
         }
@@ -954,7 +941,10 @@ pub mod unix_shmem {
     #[cfg(all(unix, feature = "std"))]
     pub mod ashmem {
         use alloc::string::ToString;
-        use core::{ptr, slice};
+        use core::{
+            ops::{Deref, DerefMut},
+            ptr, slice,
+        };
         use std::ffi::CString;
 
         use libc::{
@@ -964,7 +954,7 @@ pub mod unix_shmem {
 
         use crate::{
             shmem::{ShMem, ShMemId, ShMemProvider},
-            AsSlice, AsSliceMut, Error,
+            Error,
         };
 
         /// An ashmem based impl for linux/android
@@ -1091,23 +1081,18 @@ pub mod unix_shmem {
             fn id(&self) -> ShMemId {
                 self.id
             }
-
-            fn len(&self) -> usize {
-                self.map_size
-            }
         }
 
-        impl AsSlice for AshmemShMem {
-            type Entry = u8;
-            fn as_slice(&self) -> &[u8] {
+        impl Deref for AshmemShMem {
+            type Target = [u8];
+
+            fn deref(&self) -> &[u8] {
                 unsafe { slice::from_raw_parts(self.map, self.map_size) }
             }
         }
 
-        impl AsSliceMut for AshmemShMem {
-            type Entry = u8;
-
-            fn as_slice_mut(&mut self) -> &mut [u8] {
+        impl DerefMut for AshmemShMem {
+            fn deref_mut(&mut self) -> &mut [u8] {
                 unsafe { slice::from_raw_parts_mut(self.map, self.map_size) }
             }
         }
@@ -1177,7 +1162,6 @@ pub mod unix_shmem {
 /// Then `win32` implementation for shared memory.
 #[cfg(all(feature = "std", windows))]
 pub mod win32_shmem {
-
     use alloc::string::String;
     use core::{
         ffi::c_void,
@@ -1186,14 +1170,6 @@ pub mod win32_shmem {
     };
 
     use uuid::Uuid;
-
-    use crate::{
-        shmem::{ShMem, ShMemId, ShMemProvider},
-        AsSlice, AsSliceMut, Error,
-    };
-
-    const INVALID_HANDLE_VALUE: isize = -1;
-
     use windows::{
         core::PCSTR,
         Win32::{
@@ -1204,6 +1180,13 @@ pub mod win32_shmem {
             },
         },
     };
+
+    use crate::{
+        shmem::{ShMem, ShMemId, ShMemProvider},
+        AsSlice, AsSliceMut, Error,
+    };
+
+    const INVALID_HANDLE_VALUE: isize = -1;
 
     /// The default [`ShMem`] impl for Windows using `shmctl` & `shmget`
     #[derive(Clone)]

--- a/libafl_concolic/symcc_runtime/src/filter/coverage.rs
+++ b/libafl_concolic/symcc_runtime/src/filter/coverage.rs
@@ -196,7 +196,6 @@ where
             // The index is modulo by the length, therefore it is always in bounds
             let len = self.hitcounts_map.len();
             self.hitcounts_map
-                .as_slice_mut()
                 .get_unchecked_mut(hash % len)
         };
         *val = val.saturating_add(1);

--- a/libafl_concolic/symcc_runtime/src/filter/coverage.rs
+++ b/libafl_concolic/symcc_runtime/src/filter/coverage.rs
@@ -195,8 +195,7 @@ where
             // # Safety
             // The index is modulo by the length, therefore it is always in bounds
             let len = self.hitcounts_map.len();
-            self.hitcounts_map
-                .get_unchecked_mut(hash % len)
+            self.hitcounts_map.get_unchecked_mut(hash % len)
         };
         *val = val.saturating_add(1);
     }

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     hash::{Hash, Hasher},
+    ops::Deref,
 };
 
 use ahash::AHasher;
@@ -202,9 +203,10 @@ impl<'it, I, O, T> MappedEdgeMapIter<'it, I, O, T> {
     }
 }
 
-impl<'it, I, O, T> Iterator for MappedEdgeMapIter<'it, I, O, T>
+impl<'it, I, O, R, T> Iterator for MappedEdgeMapIter<'it, I, O, T>
 where
-    I: Iterator<Item = &'it T>,
+    I: Iterator<Item = R>,
+    R: Deref<Target = T>,
     T: PartialEq + 'it,
     O: ValueObserver,
 {
@@ -225,7 +227,7 @@ where
     O: ValueObserver + 'it,
 {
     type Item = O::ValueType;
-    type Ref = <M as AsIter<'it>>::Ref;
+    type Ref = &'it Self::Item;
     type IntoIter = MappedEdgeMapIter<'it, <M as AsIter<'it>>::IntoIter, O, M::Entry>;
 
     fn as_iter(&'it self) -> Self::IntoIter {

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
@@ -148,7 +148,7 @@ where
         let value = *self.value_observer.value();
         self.inner
             .as_iter()
-            .map(|&e| if e == initial { default } else { value })
+            .map(|e| if *e == initial { default } else { value })
             .collect()
     }
 
@@ -225,6 +225,7 @@ where
     O: ValueObserver + 'it,
 {
     type Item = O::ValueType;
+    type Ref = <M as AsIter<'it>>::Ref;
     type IntoIter = MappedEdgeMapIter<'it, <M as AsIter<'it>>::IntoIter, O, M::Entry>;
 
     fn as_iter(&'it self) -> Self::IntoIter {

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
@@ -116,7 +116,7 @@ where
         }
     }
 
-    fn get_mut(&mut self, _idx: usize) -> &mut Self::Entry {
+    fn set(&mut self, _idx: usize, _val: Self::Entry) {
         unimplemented!("Impossible to implement for a proxy map.")
     }
 

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/observers.rs
@@ -107,12 +107,12 @@ where
 {
     type Entry = O::ValueType;
 
-    fn get(&self, idx: usize) -> &Self::Entry {
+    fn get(&self, idx: usize) -> Self::Entry {
         let initial = self.inner.initial();
-        if *self.inner.get(idx) == initial {
-            self.value_observer.default_value()
+        if self.inner.get(idx) == initial {
+            *self.value_observer.default_value()
         } else {
-            self.value_observer.value()
+            *self.value_observer.value()
         }
     }
 

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -322,6 +322,7 @@ mod observers {
 
     impl<'it, const DIFFERENTIAL: bool> AsIter<'it> for CountersMultiMapObserver<DIFFERENTIAL> {
         type Item = u8;
+        type Ref = &'it Self::Item;
         type IntoIter = Flatten<Iter<'it, OwnedMutSlice<'static, u8>>>;
 
         fn as_iter(&'it self) -> Self::IntoIter {

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -332,9 +332,9 @@ mod observers {
 
     impl<'it, const DIFFERENTIAL: bool> AsIterMut<'it> for CountersMultiMapObserver<DIFFERENTIAL> {
         type Item = u8;
-        type IntoIter = Flatten<IterMut<'it, OwnedMutSlice<'static, u8>>>;
+        type IntoIterMut = Flatten<IterMut<'it, OwnedMutSlice<'static, u8>>>;
 
-        fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+        fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {
             unsafe { COUNTERS_MAPS.iter_mut().flatten() }
         }
     }

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -185,11 +185,11 @@ mod observers {
         type Entry = u8;
 
         #[inline]
-        fn get(&self, idx: usize) -> &u8 {
+        fn get(&self, idx: usize) -> u8 {
             let elem = self.intervals.query(idx..=idx).next().unwrap();
             let i = elem.value;
             let j = idx - elem.interval.start;
-            unsafe { &(*addr_of!(COUNTERS_MAPS[*i])).as_slice()[j] }
+            unsafe { (*addr_of!(COUNTERS_MAPS[*i])).as_slice()[j] }
         }
 
         #[inline]
@@ -241,7 +241,7 @@ mod observers {
             let cnt = self.usable_count();
             let mut res = Vec::with_capacity(cnt);
             for i in 0..cnt {
-                res.push(*self.get(i));
+                res.push(self.get(i));
             }
             res
         }
@@ -252,7 +252,7 @@ mod observers {
             let cnt = self.usable_count();
             let mut res = 0;
             for i in indexes {
-                if *i < cnt && *self.get(*i) != initial {
+                if *i < cnt && self.get(*i) != initial {
                     res += 1;
                 }
             }

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -193,11 +193,11 @@ mod observers {
         }
 
         #[inline]
-        fn get_mut(&mut self, idx: usize) -> &mut u8 {
+        fn set(&mut self, idx: usize, val: u8) {
             let elem = self.intervals.query_mut(idx..=idx).next().unwrap();
             let i = elem.value;
             let j = idx - elem.interval.start;
-            unsafe { &mut (*addr_of_mut!(COUNTERS_MAPS[*i])).as_slice_mut()[j] }
+            unsafe { (*addr_of_mut!(COUNTERS_MAPS[*i])).as_slice_mut()[j] = val };
         }
 
         #[inline]

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -331,7 +331,7 @@ mod observers {
     }
 
     impl<'it, const DIFFERENTIAL: bool> AsIterMut<'it> for CountersMultiMapObserver<DIFFERENTIAL> {
-        type Item = u8;
+        type RefMut = &'it mut Self::Item;
         type IntoIterMut = Flatten<IterMut<'it, OwnedMutSlice<'static, u8>>>;
 
         fn as_iter_mut(&'it mut self) -> Self::IntoIterMut {


### PR DESCRIPTION
Redux of #2000.

Previously, `MapFeedback` required the `Observer` to implement `AsIter`, and to give out references via `.get` and `.get_mut`. This works for all the existing in-repo `MapObserver`s, which use `unsafe` to pretend that they own the underlying map/vector/array. This lets them loan out items in the array with the same lifetime as `&self`.

This wasn't previously possible for observers using `RefCell`, as the loan of the content of a `RefCell` by definition has a shorter lifetime than the `RefCell` itself. With the changes here, we can have a `MapObserver` built in safe Rust, i.e., `RefCellValueObserver<Vec<...>>`

`MapFeedback` already requires that all the values are `Copy`, and in practice, they're generally small (in fact, they're generally primitive integers, meaning copying is free). The changes in this PR take advantage of this to remove borrowing values from the interface, thus enabling implementation of `MapObserver`s in safe Rust.

We may want to make similar changes for `AsIterMut`, although it doesn't appear to be necessary for this particular use-case.

These modifications to the LibAFL library were made under funding provided by the U.S. government. The work represented in this PR is provided under Distribution Statement “A” (Approved for Public Release, Distribution Unlimited.)