### PR TITLE
Improve `OnDiskTOMLMonitor`

### DIFF
--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -81,7 +81,7 @@ exec_sec = {}
             )
             .expect("Failed to write to the TOML file");
 
-            for (i, client) in self.client_stats_mut().iter_mut().skip(1).enumerate() {
+            for (i, client) in self.client_stats_mut().iter_mut().enumerate() {
                 let exec_sec = client.execs_per_sec(cur_time);
 
                 write!(

--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -129,12 +129,11 @@ where
     where
         P: Into<PathBuf>,
     {
-        Self {
+        Self::with_update_interval(
+            filename,
             base,
-            filename: filename.into(),
-            last_update: current_time(),
-            update_interval: Duration::from_secs(60),
-        }
+            Duration::from_secs(60)
+        )
     }
 
     /// Create new [`OnDiskTOMLMonitor`] with custom update interval

--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -22,6 +22,7 @@ where
     base: M,
     filename: PathBuf,
     last_update: Duration,
+    update_interval: Duration,
 }
 
 impl<M> Monitor for OnDiskTOMLMonitor<M>
@@ -55,7 +56,7 @@ where
     fn display(&mut self, event_msg: &str, sender_id: ClientId) {
         let cur_time = current_time();
 
-        if (cur_time - self.last_update).as_secs() >= 60 {
+        if cur_time - self.last_update >= self.update_interval {
             self.last_update = cur_time;
 
             let mut file = File::create(&self.filename).expect("Failed to open the TOML file");
@@ -132,6 +133,21 @@ where
             base,
             filename: filename.into(),
             last_update: current_time(),
+            update_interval: Duration::from_secs(60),
+        }
+    }
+
+    /// Create new [`OnDiskTOMLMonitor`] with custom update interval
+    #[must_use]
+    pub fn with_update_interval<P>(filename: P, base: M, update_interval: Duration) -> Self
+    where
+        P: Into<PathBuf>,
+    {
+        Self {
+            base,
+            filename: filename.into(),
+            last_update: current_time(),
+            update_interval,
         }
     }
 }

--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -145,7 +145,7 @@ where
         Self {
             base,
             filename: filename.into(),
-            last_update: current_time(),
+            last_update: current_time() - update_interval,
             update_interval,
         }
     }


### PR DESCRIPTION
What this PR does:
 - Fix `OnDiskTOMLMonitor` to record the stats from all clients
 - Add possibility to configure update interval
 - Starts writing the first TOML file to disk as soon as it gets the first message