### PR TITLE
Allow setting stdout_file in non-fork launcher

### DIFF
--- a/fuzzers/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida_gdiplus/src/fuzzer.rs
@@ -473,15 +473,22 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
         }
     };
 
-    Launcher::builder()
+    let builder = Launcher::builder()
         .configuration(EventConfig::AlwaysUnique)
         .shmem_provider(shmem_provider)
         .monitor(monitor)
         .run_client(&mut run_client)
         .cores(&options.cores)
         .broker_port(options.broker_port)
-        .stdout_file(Some(&options.stdout))
-        .remote_broker_addr(options.remote_broker_addr)
-        .build()
-        .launch()
+        .remote_broker_addr(options.remote_broker_addr);
+
+    #[cfg(all(unix, feature = "std"))]
+    {
+        return builder.stdout_file(Some(&options.stdout)).build().launch();
+    }
+
+    #[cfg(not(all(unix, feature = "std")))]
+    {
+        return builder.build().launch();
+    }
 }

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -102,6 +102,7 @@ where
     /// The list of cores to run on
     cores: &'a Cores,
     /// A file name to write all client output to
+    #[cfg(all(unix, feature = "std", feature = "fork"))]
     #[builder(default = None)]
     stdout_file: Option<&'a str>,
     /// The actual, opened, `stdout_file` - so that we keep it open until the end
@@ -110,6 +111,7 @@ where
     opened_stdout_file: Option<File>,
     /// A file name to write all client stderr output to. If not specified, output is sent to
     /// `stdout_file`.
+    #[cfg(all(unix, feature = "std", feature = "fork"))]
     #[builder(default = None)]
     stderr_file: Option<&'a str>,
     /// The actual, opened, `stdout_file` - so that we keep it open until the end


### PR DESCRIPTION
Previously setting the stdout_file in the launcher, while not forking would only result in the stdout being forwarded from the child processes to the parent process, but not written into the specified location.

This PR changes this behaviour to make the parent and all children write into the log file. It also hides the file in non-unix builds. This means, unless debug output is set, on non-unix platforms the stdio from child processes is hidden.

Discovered while debugging https://github.com/AFLplusplus/LibAFL/issues/2111