### PR TITLE
Fix libafl_libfuzzer's compatibility with LLVM 14

### DIFF
--- a/libafl_libfuzzer/build.rs
+++ b/libafl_libfuzzer/build.rs
@@ -94,13 +94,8 @@ fn main() {
         let target_libdir = Path::new(target_libdir.trim());
 
         let rust_objcopy = target_libdir.join("../bin/llvm-objcopy"); // NOTE: depends on llvm-tools
-        let nm = if cfg!(target_os = "macos") {
-            // NOTE: depends on llvm-tools
-            target_libdir.join("../bin/llvm-nm")
-        } else {
-            // NOTE: we use system nm on linux because llvm-nm doesn't respect the encoding?
-            PathBuf::from("nm")
-        };
+        // NOTE: depends on llvm-tools
+        let nm = target_libdir.join("../bin/llvm-nm");
 
         let redefined_archive_path = custom_lib_dir.join("libFuzzer.a");
         let redefined_symbols = custom_lib_dir.join("redefs.txt");

--- a/libafl_libfuzzer/build.rs
+++ b/libafl_libfuzzer/build.rs
@@ -94,7 +94,7 @@ fn main() {
         let target_libdir = Path::new(target_libdir.trim());
 
         // NOTE: depends on llvm-tools
-        let rust_objcopy = target_libdir.join("../bin/llvm-objcopy"); 
+        let rust_objcopy = target_libdir.join("../bin/llvm-objcopy");
         let nm = target_libdir.join("../bin/llvm-nm");
 
         let redefined_archive_path = custom_lib_dir.join("libFuzzer.a");

--- a/libafl_libfuzzer/build.rs
+++ b/libafl_libfuzzer/build.rs
@@ -93,8 +93,8 @@ fn main() {
         let target_libdir = String::from_utf8(target_libdir.stdout).unwrap();
         let target_libdir = Path::new(target_libdir.trim());
 
-        let rust_objcopy = target_libdir.join("../bin/llvm-objcopy"); // NOTE: depends on llvm-tools
         // NOTE: depends on llvm-tools
+        let rust_objcopy = target_libdir.join("../bin/llvm-objcopy"); 
         let nm = target_libdir.join("../bin/llvm-nm");
 
         let redefined_archive_path = custom_lib_dir.join("libFuzzer.a");


### PR DESCRIPTION
TL;DR: The LLVM 14 bfd gold linker plugin, which is used by `nm` is not compatible with libraries compiled with LLVM 18 (default since a few days in Rust)

I was confused by [this issue](https://github.com/AFLplusplus/LibAFL/issues/2039) and wanted to dig deeper why with LLVM 14 installed, compilation fails.

It turned out that the package `llvm-14-linker-tools` installs a bfd plugin at `/usr/lib/bfd-plugins/LLVMgold-14.so` which is used by the system `nm` tool.

The `nm` tool is used to relocate the symbols under a namespace. If the LLVM 14 bfd plugin is installed then the relocations miss the following relocations:

```
_ZN101_$LT$std..os..unix..net..addr..SocketAddr$u20$as$u20$std..os..net..linux_ext..addr..SocketAddrExt$GT$16as_abstract_name17hc452dbc34e1bfe57E _ZN8__libafl101_$LT$std..os..unix..net..addr..SocketAddr$u20$as$u20$std..os..net..linux_ext..addr..SocketAddrExt$GT$16as_abstract_name17hc452dbc34e1bfe57E
_ZN101_$LT$std..sys..pal..unix..args..Args$u20$as$u20$core..iter..traits..exact_size..ExactSizeIterator$GT$3len17h9ca930e01064494dE 
_ZN102_$LT$std..panicking..begin_panic_handler..FormatStringPayload$u20$as$u20$core..panic..PanicPayload$GT$8take_box17h53fb99eebdacb271E _ZN8__libafl102_$LT$std..panicking..begin_panic_handler..FormatStringPayload$u20$as$u20$core..panic..PanicPayload$GT$8take_box17h53fb99eebdacb271E
_ZN104_$LT$std..io..error..Error$u20$as$u20$core..convert..From$LT$alloc..collections..TryRes...
_ZN8__libafl3std5panic12always_abort17h4cc7dd61c889ce9dE
_ZN3std5panic13resume_unwind17he12c900ad05f6f99E _ZN8__libafl3std5panic13resume_unwind17he12c900ad05f6f99E
_ZN3std5panic14SHOULD_CAPTURE17h2c119f305541c440E.0 
...
...
_ZN8__libafl94_$LT$object..xcoff..SectionHeader32$u20$as$u20$object..read..xcoff..section..SectionHeader$GT$7s_paddr17h23cb1d58e67ebc72E
_ZN94_$LT$object..xcoff..SectionHeader32$u20$as$u20$object..read..xcoff..section..SectionHeader$GT$7s_vaddr17hb4d7110b54122240E _ZN8__libafl94_$LT$object..xcoff..SectionHeader32$u20$as$u20$object..read..xcoff..section..SectionHeader$GT$7s_vaddr17hb4d7110b54122240E
...
_ZN17compiler_builtins3int19specialized_div_rem11u32_div_rem17h62b27ed2b12fda33E _ZN8__libafl17compiler_builtins3int19specialized_div_rem11u32_div_rem17h62b27ed2b12fda33E
_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h2b7242287a3771ebE _ZN8__libafl17compiler_builtins3int19specialized_div_rem12u128_div_rem17h2b7242287a3771ebE
```

I also noticed now this output of nm:

```
bfd plugin: LLVM gold plugin has failed to create LTO module: Opaque pointers are only supported in -opaque-pointers mode (Producer: 'LLVM18.1.4-rust-1.80.0-nightly' Reader: 'LLVM 14.0.0')
```


Is there a reason why we are not using the Rust supplied `nm` version?