### PR TITLE
Add null ptr to devices vector

### DIFF
--- a/libafl_qemu/src/emu/systemmode.rs
+++ b/libafl_qemu/src/emu/systemmode.rs
@@ -187,6 +187,7 @@ impl DeviceSnapshotFilter {
                 for name in l {
                     v.push(name.as_bytes().as_ptr() as *mut i8);
                 }
+                v.push(core::ptr::null_mut());
                 v.as_mut_ptr()
             }
         }


### PR DESCRIPTION
It's not guaranteed that the `devices` list will be null terminated, so the QEMU function `is_in_list` might loop out of range and cause a SIGSEGV on the `strcmp`.