### PR TITLE
Stable type_eq

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -88,11 +88,13 @@ llmp_debug = ["alloc", "std"]
 ## Reduces the initial map size for llmp
 llmp_small_maps = ["alloc"]
 
+[build-dependencies]
+rustversion = "1.0"
+
 [dependencies]
 libafl_derive = { version = "0.12.0", optional = true, path = "../libafl_derive" }
 static_assertions = "1.1.0"
 
-rustversion = "1.0"
 tuple_list = { version = "0.1.3" }
 hashbrown = { version = "0.14", features = ["serde", "ahash"], default-features = false, optional = true } # A faster hashmap, nostd compatible
 xxhash-rust = { version = "0.8.5", features = ["xxh3"], optional = true } # xxh3 hashing for rust

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -27,7 +27,7 @@ document-features = ["dep:document-features"]
 std = ["serde_json", "serde_json/std", "hostname", "nix", "serde/std", "uuid", "backtrace", "uds", "serial_test", "alloc"]
 
 ## Enables all features that allocate in `no_std`
-alloc = ["serde/alloc",  "hashbrown", "postcard", "erased-serde/alloc", "ahash"]
+alloc = ["serde/alloc", "hashbrown", "postcard", "erased-serde/alloc", "ahash"]
 
 ## Provide the `#[derive(SerdeAny)]` macro.
 derive = ["libafl_derive"]
@@ -88,32 +88,29 @@ llmp_debug = ["alloc", "std"]
 ## Reduces the initial map size for llmp
 llmp_small_maps = ["alloc"]
 
-[build-dependencies]
-rustversion = "1.0"
-
 [dependencies]
 libafl_derive = { version = "0.12.0", optional = true, path = "../libafl_derive" }
 static_assertions = "1.1.0"
 
 rustversion = "1.0"
 tuple_list = { version = "0.1.3" }
-hashbrown =  { version = "0.14", features = ["serde", "ahash"], default-features=false, optional = true } # A faster hashmap, nostd compatible
+hashbrown = { version = "0.14", features = ["serde", "ahash"], default-features = false, optional = true } # A faster hashmap, nostd compatible
 xxhash-rust = { version = "0.8.5", features = ["xxh3"], optional = true } # xxh3 hashing for rust
 serde = { version = "1.0", default-features = false, features = ["derive"] } # serialization lib
 erased-serde = { version = "0.3.21", default-features = false, optional = true } # erased serde
 postcard = { version = "1.0", features = ["alloc"], default-features = false, optional = true } # no_std compatible serde serialization format
 num_enum = { version = "0.7", default-features = false }
-ahash = { version = "0.8", default-features=false, optional = true } # The hash function already used in hashbrown
-backtrace = {version = "0.3", optional = true} # Used to get the stacktrace in StacktraceObserver
+ahash = { version = "0.8", default-features = false, optional = true } # The hash function already used in hashbrown
+backtrace = { version = "0.3", optional = true } # Used to get the stacktrace in StacktraceObserver
 
 ctor = { optional = true, version = "0.2" }
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
-miniz_oxide = { version = "0.7.1", optional = true}
+miniz_oxide = { version = "0.7.1", optional = true }
 hostname = { version = "^0.3", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.6", optional = true }
 nix = { version = "0.27", default-features = false, optional = true, features = ["signal", "socket", "poll"] }
 uuid = { version = "1.4", optional = true, features = ["serde", "v4"] }
-clap = {version = "4.5", features = ["derive", "wrap_help"], optional = true} # CLI parsing, for libafl_bolts::cli / the `cli` feature
+clap = { version = "4.5", features = ["derive", "wrap_help"], optional = true } # CLI parsing, for libafl_bolts::cli / the `cli` feature
 log = "0.4.20"
 
 pyo3 = { version = "0.18", optional = true, features = ["serde", "macros"] }

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -438,10 +438,6 @@ where
 }
 
 /// Match for a name and return the value
-///
-/// # Note
-/// This operation may not be 100% accurate with Rust stable, see the notes for [`type_eq`]
-/// (in `nightly`, it uses [specialization](https://stackoverflow.com/a/60138532/7658998)).
 #[cfg(feature = "alloc")]
 pub trait MatchName {
     /// Match for a name and return the borrowed value

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -36,6 +36,7 @@ pub fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
         }
     }
 
+    #[allow(clippy::mismatching_type_param_order)]
     impl<'a, T: ?Sized> Copy for W<'a, T, T> {}
 
     let detected = Cell::new(true);

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -34,6 +34,7 @@ pub fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
 
     // default implementation: if the types are unequal, we will use the clone implementation
     impl<'a, T: ?Sized, U: ?Sized> Clone for W<'a, T, U> {
+        #[inline]
         fn clone(&self) -> Self {
             // indicate that the types are unequal
             // unfortunately, use of interior mutability (Cell) makes this not const-compatible


### PR DESCRIPTION
This is right up there with the evilest code I've ever written.

```rs
struct A;
struct B;

fn main() {
    println!("A is A: {}", type_eq::<A, A>()); // true
    println!("A is B: {}", type_eq::<A, B>()); // false
}
```

This performs a type equality comparison using Copy/Clone specialisation imported from core. In testing, I found that it is optimized out entirely, i.e.:

```rs
fn main() {
    if type_eq::<A, A>() {
        abort();
    }
}
```

Is compiled down to:

```
> disass copy_specialization::main
Dump of assembler code for function _ZN19copy_specialization4main17h45816c84b6311796E:
   0x000055555555c260 <+0>:     push   rax
=> 0x000055555555c261 <+1>:     call   QWORD PTR [rip+0x4a8f9]        # 0x5555555a6b60 (std::process::abort)
End of assembler dump.
```
