### PR TITLE
Handle name cleanup after #2142

### DIFF
--- a/fuzzers/forkserver_libafl_cc/src/main.rs
+++ b/fuzzers/forkserver_libafl_cc/src/main.rs
@@ -166,7 +166,7 @@ pub fn main() {
     // Create the executor for the forkserver
     let args = opt.arguments;
 
-    let observer_ref = edges_observer.handle();
+    let observer_handle = edges_observer.handle();
 
     let mut tokens = Tokens::new();
     let mut executor = ForkserverExecutor::builder()
@@ -182,7 +182,7 @@ pub fn main() {
         .unwrap();
 
     if let Some(dynamic_map_size) = executor.coverage_map_size() {
-        executor.observers_mut()[&observer_ref]
+        executor.observers_mut()[&observer_handle]
             .as_mut()
             .truncate(dynamic_map_size);
     }

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -51,7 +51,7 @@ where
 /// Algorithm based on WMOPT: <https://hexhive.epfl.ch/publications/files/21ISSTA2.pdf>
 #[derive(Debug)]
 pub struct MapCorpusMinimizer<C, E, O, T, TS> {
-    obs_ref: Handle<C>,
+    observer_handle: Handle<C>,
     phantom: PhantomData<(E, O, T, TS)>,
 }
 
@@ -70,7 +70,7 @@ where
     /// in the future to get observed maps from an executed input.
     pub fn new(obs: &C) -> Self {
         Self {
-            obs_ref: obs.handle(),
+            observer_handle: obs.handle(),
             phantom: PhantomData,
         }
     }
@@ -161,7 +161,7 @@ where
 
             let seed_expr = Bool::fresh_const(&ctx, "seed");
             let observers = executor.observers();
-            let obs = observers[&self.obs_ref].as_ref();
+            let obs = observers[&self.observer_handle].as_ref();
 
             // Store coverage, mapping coverage map indices to hit counts (if present) and the
             // associated seeds for the map indices with those hit counts.

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -11,7 +11,7 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{marker::PhantomData, num::NonZeroUsize, time::Duration};
 
 #[cfg(feature = "adaptive_serialization")]
-use libafl_bolts::tuples::{Handle, Handleable};
+use libafl_bolts::tuples::{CanBeHandled, Handle};
 #[cfg(feature = "llmp_compression")]
 use libafl_bolts::{
     compress::GzipCompressor,

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -11,7 +11,7 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{marker::PhantomData, num::NonZeroUsize, time::Duration};
 
 #[cfg(feature = "adaptive_serialization")]
-use libafl_bolts::tuples::{Handle, Handler};
+use libafl_bolts::tuples::{Handle, Handleable};
 #[cfg(feature = "llmp_compression")]
 use libafl_bolts::{
     compress::GzipCompressor,

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -33,7 +33,7 @@ use libafl_bolts::os::dup2;
 #[cfg(all(feature = "std", any(windows, not(feature = "fork"))))]
 use libafl_bolts::os::startable_self;
 #[cfg(feature = "adaptive_serialization")]
-use libafl_bolts::tuples::{Handle, Handler};
+use libafl_bolts::tuples::{Handle, Handleable};
 #[cfg(all(unix, feature = "std", feature = "fork"))]
 use libafl_bolts::{
     core_affinity::get_core_ids,

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -33,7 +33,7 @@ use libafl_bolts::os::dup2;
 #[cfg(all(feature = "std", any(windows, not(feature = "fork"))))]
 use libafl_bolts::os::startable_self;
 #[cfg(feature = "adaptive_serialization")]
-use libafl_bolts::tuples::{Handle, Handleable};
+use libafl_bolts::tuples::{CanBeHandled, Handle};
 #[cfg(all(unix, feature = "std", feature = "fork"))]
 use libafl_bolts::{
     core_affinity::get_core_ids,

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -33,7 +33,7 @@ use libafl_bolts::{
 #[cfg(feature = "adaptive_serialization")]
 use libafl_bolts::{
     current_time,
-    tuples::{Handle, Handler},
+    tuples::{Handle, Handleable},
 };
 #[cfg(feature = "std")]
 use libafl_bolts::{llmp::LlmpConnection, shmem::StdShMemProvider, staterestore::StateRestorer};
@@ -2058,7 +2058,7 @@ mod tests {
     use core::sync::atomic::{compiler_fence, Ordering};
 
     #[cfg(feature = "adaptive_serialization")]
-    use libafl_bolts::tuples::Handler;
+    use libafl_bolts::tuples::Handleable;
     use libafl_bolts::{
         llmp::{LlmpClient, LlmpSharedMap},
         rands::StdRand,

--- a/libafl/src/events/llmp.rs
+++ b/libafl/src/events/llmp.rs
@@ -33,7 +33,7 @@ use libafl_bolts::{
 #[cfg(feature = "adaptive_serialization")]
 use libafl_bolts::{
     current_time,
-    tuples::{Handle, Handleable},
+    tuples::{CanBeHandled, Handle},
 };
 #[cfg(feature = "std")]
 use libafl_bolts::{llmp::LlmpConnection, shmem::StdShMemProvider, staterestore::StateRestorer};
@@ -2058,7 +2058,7 @@ mod tests {
     use core::sync::atomic::{compiler_fence, Ordering};
 
     #[cfg(feature = "adaptive_serialization")]
-    use libafl_bolts::tuples::Handleable;
+    use libafl_bolts::tuples::CanBeHandled;
     use libafl_bolts::{
         llmp::{LlmpClient, LlmpSharedMap},
         rands::StdRand,

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -22,7 +22,7 @@ use libafl_bolts::{
     fs::{get_unique_std_input_file, InputFile},
     os::{dup2, pipes::Pipe},
     shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{Handle, Handleable, MatchNameRef, Prepend, RefIndexable},
+    tuples::{CanBeHandled, Handle, MatchNameRef, Prepend, RefIndexable},
     AsSlice, AsSliceMut, Truncate,
 };
 use nix::{

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -22,7 +22,7 @@ use libafl_bolts::{
     fs::{get_unique_std_input_file, InputFile},
     os::{dup2, pipes::Pipe},
     shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{Handle, Handler, MatchNameRef, Prepend, RefIndexable},
+    tuples::{Handle, Handleable, MatchNameRef, Prepend, RefIndexable},
     AsSlice, AsSliceMut, Truncate,
 };
 use nix::{

--- a/libafl/src/feedbacks/concolic.rs
+++ b/libafl/src/feedbacks/concolic.rs
@@ -7,7 +7,7 @@ use alloc::borrow::Cow;
 use core::{fmt::Debug, marker::PhantomData};
 
 use libafl_bolts::{
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     Named,
 };
 
@@ -28,7 +28,7 @@ use crate::{
 /// Requires a [`ConcolicObserver`] to observe the concolic trace.
 #[derive(Debug)]
 pub struct ConcolicFeedback<'map, S> {
-    obs_ref: Handle<ConcolicObserver<'map>>,
+    observer_handle: Handle<ConcolicObserver<'map>>,
     phantom: PhantomData<S>,
 }
 
@@ -38,7 +38,7 @@ impl<'map, S> ConcolicFeedback<'map, S> {
     #[must_use]
     pub fn from_observer(observer: &ConcolicObserver<'map>) -> Self {
         Self {
-            obs_ref: observer.handle(),
+            observer_handle: observer.handle(),
             phantom: PhantomData,
         }
     }
@@ -46,7 +46,7 @@ impl<'map, S> ConcolicFeedback<'map, S> {
 
 impl<S> Named for ConcolicFeedback<'_, S> {
     fn name(&self) -> &Cow<'static, str> {
-        self.obs_ref.name()
+        self.observer_handle.name()
     }
 }
 
@@ -82,7 +82,7 @@ where
         EM: EventFirer<State = S>,
     {
         if let Some(metadata) = observers
-            .get(&self.obs_ref)
+            .get(&self.observer_handle)
             .map(ConcolicObserver::create_metadata_from_current_map)
         {
             testcase.metadata_map_mut().insert(metadata);

--- a/libafl/src/feedbacks/concolic.rs
+++ b/libafl/src/feedbacks/concolic.rs
@@ -7,7 +7,7 @@ use alloc::borrow::Cow;
 use core::{fmt::Debug, marker::PhantomData};
 
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     Named,
 };
 

--- a/libafl/src/feedbacks/differential.rs
+++ b/libafl/src/feedbacks/differential.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchName, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchName, MatchNameRef},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/feedbacks/differential.rs
+++ b/libafl/src/feedbacks/differential.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use libafl_bolts::{
-    tuples::{Handle, Handler, MatchName, MatchNameRef},
+    tuples::{Handle, Handleable, MatchName, MatchNameRef},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/feedbacks/list.rs
+++ b/libafl/src/feedbacks/list.rs
@@ -3,7 +3,7 @@ use core::{fmt::Debug, hash::Hash};
 
 use hashbrown::HashSet;
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     Error, HasRefCnt, Named,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/libafl/src/feedbacks/list.rs
+++ b/libafl/src/feedbacks/list.rs
@@ -3,7 +3,7 @@ use core::{fmt::Debug, hash::Hash};
 
 use hashbrown::HashSet;
 use libafl_bolts::{
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     Error, HasRefCnt, Named,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -73,7 +73,7 @@ pub struct ListFeedback<T>
 where
     T: Hash + Eq,
 {
-    obs_ref: Handle<ListObserver<T>>,
+    observer_handle: Handle<ListObserver<T>>,
     novelty: HashSet<T>,
 }
 
@@ -106,7 +106,7 @@ where
         OT: ObserversTuple<S>,
     {
         // TODO Replace with match_name_type when stable
-        let observer = observers.get(&self.obs_ref).unwrap();
+        let observer = observers.get(&self.observer_handle).unwrap();
         // TODO register the list content in a testcase metadata
         self.novelty.clear();
         // can't fail
@@ -151,7 +151,7 @@ where
 {
     #[inline]
     fn name(&self) -> &Cow<'static, str> {
-        self.obs_ref.name()
+        self.observer_handle.name()
     }
 }
 
@@ -163,7 +163,7 @@ where
     #[must_use]
     pub fn new(observer: &ListObserver<T>) -> Self {
         Self {
-            obs_ref: observer.handle(),
+            observer_handle: observer.handle(),
             novelty: HashSet::<T>::new(),
         }
     }

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -12,7 +12,7 @@ use core::{
 #[rustversion::nightly]
 use libafl_bolts::AsSlice;
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     AsIter, HasRefCnt, Named,
 };
 use num_traits::PrimInt;

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -12,7 +12,7 @@ use core::{
 #[rustversion::nightly]
 use libafl_bolts::AsSlice;
 use libafl_bolts::{
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     AsIter, HasRefCnt, Named,
 };
 use num_traits::PrimInt;
@@ -22,7 +22,7 @@ use crate::{
     corpus::Testcase,
     events::{Event, EventFirer},
     executors::ExitKind,
-    feedbacks::{Feedback, HasObserverReference},
+    feedbacks::{Feedback, HasObserverHandle},
     inputs::UsesInput,
     monitors::{AggregatorOps, UserStats, UserStatsValue},
     observers::{CanTrack, MapObserver, Observer, ObserversTuple},
@@ -660,7 +660,7 @@ impl<C, N, O, R, T> Named for MapFeedback<C, N, O, R, T> {
     }
 }
 
-impl<C, N, O, R, T> HasObserverReference for MapFeedback<C, N, O, R, T>
+impl<C, N, O, R, T> HasObserverHandle for MapFeedback<C, N, O, R, T>
 where
     O: Named,
     C: AsRef<O>,
@@ -668,7 +668,7 @@ where
     type Observer = C;
 
     #[inline]
-    fn observer_ref(&self) -> &Handle<C> {
+    fn observer_handle(&self) -> &Handle<C> {
         &self.map_ref
     }
 }

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -14,7 +14,7 @@ use core::{
 pub use concolic::ConcolicFeedback;
 pub use differential::DiffFeedback;
 use libafl_bolts::{
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     Named,
 };
 pub use list::*;
@@ -138,12 +138,12 @@ where
 }
 
 /// Has an associated observer name (mostly used to retrieve the observer with `MatchName` from an `ObserverTuple`)
-pub trait HasObserverReference {
+pub trait HasObserverHandle {
     /// The observer for which we hold a reference
     type Observer: ?Sized;
 
     /// The name associated with the observer
-    fn observer_ref(&self) -> &Handle<Self::Observer>;
+    fn observer_handle(&self) -> &Handle<Self::Observer>;
 }
 
 /// A combined feedback consisting of multiple [`Feedback`]s
@@ -934,7 +934,7 @@ pub type TimeoutFeedbackFactory = DefaultFeedbackFactory<TimeoutFeedback>;
 /// It decides, if the given [`TimeObserver`] value of a run is interesting.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TimeFeedback {
-    obs_ref: Handle<TimeObserver>,
+    observer_handle: Handle<TimeObserver>,
 }
 
 impl<S> Feedback<S> for TimeFeedback
@@ -971,7 +971,7 @@ where
         OT: ObserversTuple<S>,
         EM: EventFirer<State = S>,
     {
-        let observer = observers.get(&self.obs_ref).unwrap();
+        let observer = observers.get(&self.observer_handle).unwrap();
         *testcase.exec_time_mut() = *observer.last_runtime();
         Ok(())
     }
@@ -986,7 +986,7 @@ where
 impl Named for TimeFeedback {
     #[inline]
     fn name(&self) -> &Cow<'static, str> {
-        self.obs_ref.name()
+        self.observer_handle.name()
     }
 }
 
@@ -995,7 +995,7 @@ impl TimeFeedback {
     #[must_use]
     pub fn new(observer: &TimeObserver) -> Self {
         Self {
-            obs_ref: observer.handle(),
+            observer_handle: observer.handle(),
         }
     }
 }

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -14,7 +14,7 @@ use core::{
 pub use concolic::ConcolicFeedback;
 pub use differential::DiffFeedback;
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     Named,
 };
 pub use list::*;

--- a/libafl/src/feedbacks/new_hash_feedback.rs
+++ b/libafl/src/feedbacks/new_hash_feedback.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use hashbrown::HashSet;
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/feedbacks/new_hash_feedback.rs
+++ b/libafl/src/feedbacks/new_hash_feedback.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use hashbrown::HashSet;
 use libafl_bolts::{
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     Named,
 };
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::EventFirer,
     executors::ExitKind,
-    feedbacks::{Feedback, HasObserverReference},
+    feedbacks::{Feedback, HasObserverHandle},
     inputs::UsesInput,
     observers::{ObserverWithHashField, ObserversTuple},
     state::State,
@@ -145,11 +145,11 @@ impl<O, S> Named for NewHashFeedback<O, S> {
     }
 }
 
-impl<O, S> HasObserverReference for NewHashFeedback<O, S> {
+impl<O, S> HasObserverHandle for NewHashFeedback<O, S> {
     type Observer = O;
 
     #[inline]
-    fn observer_ref(&self) -> &Handle<O> {
+    fn observer_handle(&self) -> &Handle<O> {
         &self.o_ref
     }
 }

--- a/libafl/src/feedbacks/stdio.rs
+++ b/libafl/src/feedbacks/stdio.rs
@@ -4,7 +4,7 @@ use alloc::{borrow::Cow, string::String};
 
 use libafl_bolts::{
     impl_serdeany,
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/feedbacks/stdio.rs
+++ b/libafl/src/feedbacks/stdio.rs
@@ -4,7 +4,7 @@ use alloc::{borrow::Cow, string::String};
 
 use libafl_bolts::{
     impl_serdeany,
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -82,7 +82,7 @@ where
     fn set_last_hash(&mut self, value: usize);
 
     /// Get the observer map observer name
-    fn map_observer_ref(&self) -> &Handle<C>;
+    fn map_observer_handle(&self) -> &Handle<C>;
 
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add_metadata(&self, state: &mut Self::State, idx: CorpusId) -> Result<(), Error> {
@@ -121,7 +121,7 @@ where
         OT: ObserversTuple<Self::State>,
     {
         let observer = observers
-            .get(self.map_observer_ref())
+            .get(self.map_observer_handle())
             .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
             .as_ref();
 

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::{marker::PhantomData, time::Duration};
 
 use libafl_bolts::{
-    tuples::{Handle, Handler},
+    tuples::{Handle, Handleable},
     Named,
 };
 use serde::{Deserialize, Serialize};
@@ -173,7 +173,7 @@ pub enum PowerSchedule {
 #[derive(Clone, Debug)]
 pub struct PowerQueueScheduler<C, O, S> {
     strat: PowerSchedule,
-    map_observer_ref: Handle<C>,
+    map_observer_handle: Handle<C>,
     last_hash: usize,
     phantom: PhantomData<(O, S)>,
 }
@@ -226,8 +226,8 @@ where
         self.last_hash = hash;
     }
 
-    fn map_observer_ref(&self) -> &Handle<C> {
-        &self.map_observer_ref
+    fn map_observer_handle(&self) -> &Handle<C> {
+        &self.map_observer_handle
     }
 }
 
@@ -305,7 +305,7 @@ where
         }
         PowerQueueScheduler {
             strat,
-            map_observer_ref: map_observer.handle(),
+            map_observer_handle: map_observer.handle(),
             last_hash: 0,
             phantom: PhantomData,
         }

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::{marker::PhantomData, time::Duration};
 
 use libafl_bolts::{
-    tuples::{Handle, Handleable},
+    tuples::{CanBeHandled, Handle},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use hashbrown::HashMap;
 use libafl_bolts::{
     rands::Rand,
-    tuples::{Handle, Handleable},
+    tuples::{CanBeHandled, Handle},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use hashbrown::HashMap;
 use libafl_bolts::{
     rands::Rand,
-    tuples::{Handle, Handler},
+    tuples::{Handle, Handleable},
     Named,
 };
 use serde::{Deserialize, Serialize};
@@ -98,7 +98,7 @@ libafl_bolts::impl_serdeany!(WeightedScheduleMetadata);
 pub struct WeightedScheduler<C, F, O, S> {
     table_invalidated: bool,
     strat: Option<PowerSchedule>,
-    map_observer_ref: Handle<C>,
+    map_observer_handle: Handle<C>,
     last_hash: usize,
     phantom: PhantomData<(F, O, S)>,
 }
@@ -124,7 +124,7 @@ where
 
         Self {
             strat,
-            map_observer_ref: map_observer.handle(),
+            map_observer_handle: map_observer.handle(),
             last_hash: 0,
             table_invalidated: true,
             phantom: PhantomData,
@@ -274,8 +274,8 @@ where
         self.last_hash = hash;
     }
 
-    fn map_observer_ref(&self) -> &Handle<C> {
-        &self.map_observer_ref
+    fn map_observer_handle(&self) -> &Handle<C> {
+        &self.map_observer_handle
     }
 }
 

--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -12,7 +12,7 @@ use crate::{
     corpus::{Corpus, SchedulerTestcaseMetadata},
     events::{Event, EventFirer, LogSeverity},
     executors::{Executor, ExitKind, HasObservers},
-    feedbacks::{map::MapFeedbackMetadata, HasObserverReference},
+    feedbacks::{map::MapFeedbackMetadata, HasObserverHandle},
     fuzzer::Evaluator,
     inputs::UsesInput,
     monitors::{AggregatorOps, UserStats, UserStatsValue},
@@ -63,7 +63,7 @@ impl UnstableEntriesMetadata {
 /// The calibration stage will measure the average exec time and the target's stability for this input.
 #[derive(Clone, Debug)]
 pub struct CalibrationStage<C, O, OT, S> {
-    map_observer_ref: Handle<C>,
+    map_observer_handle: Handle<C>,
     map_name: Cow<'static, str>,
     stage_max: usize,
     /// If we should track stability
@@ -144,7 +144,7 @@ where
             .observers_mut()
             .post_exec_all(state, &input, &exit_kind)?;
 
-        let map_first = &executor.observers()[&self.map_observer_ref]
+        let map_first = &executor.observers()[&self.map_observer_handle]
             .as_ref()
             .to_vec();
 
@@ -185,7 +185,7 @@ where
                 .post_exec_all(state, &input, &exit_kind)?;
 
             if self.track_stability {
-                let map = &executor.observers()[&self.map_observer_ref]
+                let map = &executor.observers()[&self.map_observer_handle]
                     .as_ref()
                     .to_vec();
 
@@ -240,7 +240,7 @@ where
         // If weighted scheduler or powerscheduler is used, update it
         if state.has_metadata::<SchedulerMetadata>() {
             let observers = executor.observers();
-            let map = observers[&self.map_observer_ref].as_ref();
+            let map = observers[&self.map_observer_handle].as_ref();
 
             let mut bitmap_size = map.count_bytes();
             assert!(bitmap_size != 0);
@@ -340,10 +340,10 @@ where
     #[must_use]
     pub fn new<F>(map_feedback: &F) -> Self
     where
-        F: HasObserverReference<Observer = C> + Named,
+        F: HasObserverHandle<Observer = C> + Named,
     {
         Self {
-            map_observer_ref: map_feedback.observer_ref().clone(),
+            map_observer_handle: map_feedback.observer_handle().clone(),
             map_name: map_feedback.name().clone(),
             stage_max: CAL_STAGE_START,
             track_stability: true,
@@ -356,10 +356,10 @@ where
     #[must_use]
     pub fn ignore_stability<F>(map_feedback: &F) -> Self
     where
-        F: HasObserverReference<Observer = C> + Named,
+        F: HasObserverHandle<Observer = C> + Named,
     {
         Self {
-            map_observer_ref: map_feedback.observer_ref().clone(),
+            map_observer_handle: map_feedback.observer_handle().clone(),
             map_name: map_feedback.name().clone(),
             stage_max: CAL_STAGE_START,
             track_stability: false,

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -4,7 +4,7 @@ use core::{cmp::Ordering, fmt::Debug, marker::PhantomData, ops::Range};
 
 use libafl_bolts::{
     rands::Rand,
-    tuples::{Handle, Handler},
+    tuples::{Handle, Handleable},
     Named,
 };
 use serde::{Deserialize, Serialize};
@@ -55,7 +55,7 @@ impl Ord for Earlier {
 /// The mutational stage using power schedules
 #[derive(Clone, Debug)]
 pub struct ColorizationStage<C, E, EM, O, Z> {
-    map_observer_ref: Handle<C>,
+    map_observer_handle: Handle<C>,
     #[allow(clippy::type_complexity)]
     phantom: PhantomData<(E, EM, O, E, Z)>,
 }
@@ -72,7 +72,7 @@ where
     E: UsesState,
 {
     fn name(&self) -> &Cow<'static, str> {
-        self.map_observer_ref.name()
+        self.map_observer_handle.name()
     }
 }
 
@@ -96,7 +96,7 @@ where
         manager: &mut EM,
     ) -> Result<(), Error> {
         // Run with the mutated input
-        Self::colorize(fuzzer, executor, state, manager, &self.map_observer_ref)?;
+        Self::colorize(fuzzer, executor, state, manager, &self.map_observer_handle)?;
 
         Ok(())
     }
@@ -168,7 +168,7 @@ where
         executor: &mut E,
         state: &mut E::State,
         manager: &mut EM,
-        obs_ref: &Handle<C>,
+        observer_handle: &Handle<C>,
     ) -> Result<E::Input, Error> {
         let mut input = state.current_input_cloned()?;
         // The backup of the input
@@ -182,8 +182,14 @@ where
         // First, run orig_input once and get the original hash
 
         // Idea: No need to do this every time
-        let orig_hash =
-            Self::get_raw_map_hash_run(fuzzer, executor, state, manager, consumed_input, obs_ref)?;
+        let orig_hash = Self::get_raw_map_hash_run(
+            fuzzer,
+            executor,
+            state,
+            manager,
+            consumed_input,
+            observer_handle,
+        )?;
         let changed_bytes = changed.bytes_mut();
         let input_len = changed_bytes.len();
 
@@ -228,7 +234,7 @@ where
                     state,
                     manager,
                     consumed_input,
-                    obs_ref,
+                    observer_handle,
                 )?;
 
                 if orig_hash == changed_hash {
@@ -301,7 +307,7 @@ where
     /// Creates a new [`ColorizationStage`]
     pub fn new(map_observer: &C) -> Self {
         Self {
-            map_observer_ref: map_observer.handle(),
+            map_observer_handle: map_observer.handle(),
             phantom: PhantomData,
         }
     }
@@ -313,14 +319,14 @@ where
         state: &mut E::State,
         manager: &mut EM,
         input: E::Input,
-        obs_ref: &Handle<C>,
+        observer_handle: &Handle<C>,
     ) -> Result<usize, Error> {
         executor.observers_mut().pre_exec_all(state, &input)?;
 
         let exit_kind = executor.run_target(fuzzer, state, manager, &input)?;
 
         let observers = executor.observers();
-        let observer = observers[obs_ref].as_ref();
+        let observer = observers[observer_handle].as_ref();
 
         let hash = observer.hash_simple() as usize;
 

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -4,7 +4,7 @@ use core::{cmp::Ordering, fmt::Debug, marker::PhantomData, ops::Range};
 
 use libafl_bolts::{
     rands::Rand,
-    tuples::{Handle, Handleable},
+    tuples::{CanBeHandled, Handle},
     Named,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/stages/concolic.rs
+++ b/libafl/src/stages/concolic.rs
@@ -39,7 +39,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct ConcolicTracingStage<'a, EM, TE, Z> {
     inner: TracingStage<EM, TE, Z>,
-    obs_ref: Handle<ConcolicObserver<'a>>,
+    observer_handle: Handle<ConcolicObserver<'a>>,
 }
 
 impl<EM, TE, Z> UsesState for ConcolicTracingStage<'_, EM, TE, Z>
@@ -73,7 +73,7 @@ where
         manager: &mut EM,
     ) -> Result<(), Error> {
         self.inner.trace(fuzzer, state, manager)?;
-        if let Some(observer) = self.inner.executor().observers().get(&self.obs_ref) {
+        if let Some(observer) = self.inner.executor().observers().get(&self.observer_handle) {
             let metadata = observer.create_metadata_from_current_map();
             state
                 .current_testcase_mut()?
@@ -95,8 +95,14 @@ where
 impl<'a, EM, TE, Z> ConcolicTracingStage<'a, EM, TE, Z> {
     /// Creates a new default tracing stage using the given [`Executor`], observing traces from a
     /// [`ConcolicObserver`] with the given name.
-    pub fn new(inner: TracingStage<EM, TE, Z>, obs_ref: Handle<ConcolicObserver<'a>>) -> Self {
-        Self { inner, obs_ref }
+    pub fn new(
+        inner: TracingStage<EM, TE, Z>,
+        observer_handle: Handle<ConcolicObserver<'a>>,
+    ) -> Self {
+        Self {
+            inner,
+            observer_handle,
+        }
     }
 }
 

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -4,7 +4,7 @@ use alloc::{borrow::Cow, vec::Vec};
 use core::{fmt::Debug, marker::PhantomData};
 
 use libafl_bolts::{
-    tuples::{Handle, Handleable},
+    tuples::{CanBeHandled, Handle},
     AsSlice, Named,
 };
 

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -4,7 +4,7 @@ use alloc::{borrow::Cow, vec::Vec};
 use core::{fmt::Debug, marker::PhantomData};
 
 use libafl_bolts::{
-    tuples::{Handle, Handler},
+    tuples::{Handle, Handleable},
     AsSlice, Named,
 };
 
@@ -43,7 +43,7 @@ fn find_next_char(list: &[Option<u8>], mut idx: usize, ch: u8) -> usize {
 /// A stage that runs a tracer executor
 #[derive(Clone, Debug)]
 pub struct GeneralizationStage<C, EM, O, OT, Z> {
-    map_observer_ref: Handle<C>,
+    map_observer_handle: Handle<C>,
     #[allow(clippy::type_complexity)]
     phantom: PhantomData<(EM, O, OT, Z)>,
 }
@@ -347,7 +347,7 @@ where
     pub fn new(map_observer: &C) -> Self {
         require_novelties_tracking!("GeneralizationStage", C);
         Self {
-            map_observer_ref: map_observer.handle(),
+            map_observer_handle: map_observer.handle(),
             phantom: PhantomData,
         }
     }
@@ -381,7 +381,7 @@ where
             .post_exec_all(state, input, &exit_kind)?;
         mark_feature_time!(state, PerfFeature::PostExecObservers);
 
-        let cnt = executor.observers()[&self.map_observer_ref]
+        let cnt = executor.observers()[&self.map_observer_handle]
             .as_ref()
             .how_many_set(novelties);
 

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -5,7 +5,7 @@ use core::{borrow::BorrowMut, fmt::Debug, hash::Hash, marker::PhantomData};
 
 use ahash::RandomState;
 use libafl_bolts::{
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     HasLen, Named,
 };
 
@@ -407,7 +407,7 @@ pub struct MapEqualityFactory<C, M, S> {
 impl<C, M, S> MapEqualityFactory<C, M, S>
 where
     M: MapObserver,
-    C: AsRef<M> + Handleable,
+    C: AsRef<M> + CanBeHandled,
 {
     /// Creates a new map equality feedback for the given observer
     pub fn new(obs: &C) -> Self {
@@ -430,7 +430,7 @@ impl<C, M, OT, S> FeedbackFactory<MapEqualityFeedback<C, M, S>, S, OT>
     for MapEqualityFactory<C, M, S>
 where
     M: MapObserver,
-    C: AsRef<M> + Handleable,
+    C: AsRef<M> + CanBeHandled,
     OT: ObserversTuple<S>,
     S: State + Debug,
 {

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -504,7 +504,7 @@ where
 /// Structs that have a [`Handle`] to reference this element by, in maps.
 /// You should use this when you want to avoid specifying types.
 #[cfg(feature = "alloc")]
-pub trait Handleable: Named {
+pub trait CanBeHandled: Named {
     /// Return the [`Handle`]
     fn handle(&self) -> Handle<Self> {
         Handle {
@@ -515,7 +515,7 @@ pub trait Handleable: Named {
 }
 
 #[cfg(feature = "alloc")]
-impl<N> Handleable for N where N: Named {}
+impl<N> CanBeHandled for N where N: Named {}
 
 /// Object with the type T and the name associated with its concrete value
 #[derive(Serialize, Deserialize)]

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -501,11 +501,11 @@ where
     }
 }
 
-/// Structs that has `Handle `
-/// You should use this when you want to avoid specifying types using `match_name_type_mut`
+/// Structs that have a [`Handle`] to reference this element by, in maps.
+/// You should use this when you want to avoid specifying types.
 #[cfg(feature = "alloc")]
-pub trait Handler: Named {
-    /// Return the `Handle `
+pub trait Handleable: Named {
+    /// Return the [`Handle`]
     fn handle(&self) -> Handle<Self> {
         Handle {
             name: Named::name(self).clone(),
@@ -515,7 +515,7 @@ pub trait Handler: Named {
 }
 
 #[cfg(feature = "alloc")]
-impl<N> Handler for N where N: Named {}
+impl<N> Handleable for N where N: Named {}
 
 /// Object with the type T and the name associated with its concrete value
 #[derive(Serialize, Deserialize)]

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -24,7 +24,7 @@ use libafl::{
 };
 use libafl_bolts::{
     ownedref::OwnedPtr,
-    tuples::{Handle, Handleable, MatchNameRef},
+    tuples::{CanBeHandled, Handle, MatchNameRef},
     Named, SerdeAny,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl_frida/src/asan/errors.rs
+++ b/libafl_frida/src/asan/errors.rs
@@ -24,7 +24,7 @@ use libafl::{
 };
 use libafl_bolts::{
     ownedref::OwnedPtr,
-    tuples::{Handle, Handler, MatchNameRef},
+    tuples::{Handle, Handleable, MatchNameRef},
     Named, SerdeAny,
 };
 use serde::{Deserialize, Serialize};
@@ -646,7 +646,7 @@ impl AsanErrorsObserver {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AsanErrorsFeedback<S> {
     errors: Option<AsanErrors>,
-    obs_ref: Handle<AsanErrorsObserver>,
+    observer_handle: Handle<AsanErrorsObserver>,
     phantom: PhantomData<S>,
 }
 
@@ -669,7 +669,7 @@ where
         OT: ObserversTuple<S>,
     {
         let observer = observers
-            .get(&self.obs_ref)
+            .get(&self.observer_handle)
             .expect("An AsanErrorsFeedback needs an AsanErrorsObserver");
         let errors = observer.errors();
         if errors.is_empty() {
@@ -706,7 +706,7 @@ where
 impl<S> Named for AsanErrorsFeedback<S> {
     #[inline]
     fn name(&self) -> &Cow<'static, str> {
-        self.obs_ref.name()
+        self.observer_handle.name()
     }
 }
 
@@ -716,7 +716,7 @@ impl<S> AsanErrorsFeedback<S> {
     pub fn new(obs: &AsanErrorsObserver) -> Self {
         Self {
             errors: None,
-            obs_ref: obs.handle(),
+            observer_handle: obs.handle(),
             phantom: PhantomData,
         }
     }

--- a/libafl_qemu/src/helpers/calls.rs
+++ b/libafl_qemu/src/helpers/calls.rs
@@ -439,7 +439,7 @@ where
 #[derive(Debug)]
 pub struct OnCrashBacktraceCollector<'a> {
     callstack_hash: u64,
-    obs_ref: Handle<BacktraceObserver<'a>>,
+    observer_handle: Handle<BacktraceObserver<'a>>,
 }
 
 impl<'a> OnCrashBacktraceCollector<'a> {
@@ -447,7 +447,7 @@ impl<'a> OnCrashBacktraceCollector<'a> {
     pub fn new(observer: &BacktraceObserver<'a>) -> Self {
         Self {
             callstack_hash: 0,
-            obs_ref: observer.handle(),
+            observer_handle: observer.handle(),
         }
     }
 
@@ -511,7 +511,7 @@ where
         S: UsesInput,
     {
         let observer = observers
-            .get_mut(&self.obs_ref)
+            .get_mut(&self.observer_handle)
             .expect("A OnCrashBacktraceCollector needs a BacktraceObserver");
         observer.fill_external(self.callstack_hash, exit_kind);
     }

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -25,7 +25,7 @@ use libafl_bolts::{
     core_affinity::Cores,
     rands::StdRand,
     shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{tuple_list, Handler, Merge},
+    tuples::{tuple_list, Handleable, Merge},
     AsSliceMut,
 };
 use typed_builder::TypedBuilder;

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -25,7 +25,7 @@ use libafl_bolts::{
     core_affinity::Cores,
     rands::StdRand,
     shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{tuple_list, Handleable, Merge},
+    tuples::{tuple_list, CanBeHandled, Merge},
     AsSliceMut,
 };
 use typed_builder::TypedBuilder;

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -29,7 +29,7 @@ use libafl_bolts::{
     ownedref::OwnedMutSlice,
     rands::StdRand,
     shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Handler, Merge},
+    tuples::{tuple_list, Handleable, Merge},
     AsSlice,
 };
 use libafl_targets::{edges_map_mut_ptr, CmpLogObserver};

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -29,7 +29,7 @@ use libafl_bolts::{
     ownedref::OwnedMutSlice,
     rands::StdRand,
     shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Handleable, Merge},
+    tuples::{tuple_list, CanBeHandled, Merge},
     AsSlice,
 };
 use libafl_targets::{edges_map_mut_ptr, CmpLogObserver};

--- a/libafl_targets/src/cmps/stages/aflpptracing.rs
+++ b/libafl_targets/src/cmps/stages/aflpptracing.rs
@@ -25,7 +25,7 @@ where
     TE: UsesState,
 {
     tracer_executor: TE,
-    cmplog_observer_ref: Option<Handle<AFLppCmpLogObserver<'a, TE::State>>>,
+    cmplog_observer_handle: Option<Handle<AFLppCmpLogObserver<'a, TE::State>>>,
     #[allow(clippy::type_complexity)]
     phantom: PhantomData<(EM, TE, Z)>,
 }
@@ -67,8 +67,12 @@ where
         // First run with the un-mutated input
         let unmutated_input = state.current_input_cloned()?;
 
-        if let Some(obs_ref) = &self.cmplog_observer_ref {
-            if let Some(ob) = self.tracer_executor.observers_mut().get_mut(obs_ref) {
+        if let Some(observer_handle) = &self.cmplog_observer_handle {
+            if let Some(ob) = self
+                .tracer_executor
+                .observers_mut()
+                .get_mut(observer_handle)
+            {
                 // This is not the original input,
                 // Set it to false
                 ob.set_original(true);
@@ -97,8 +101,12 @@ where
             None => return Err(Error::unknown("No metadata found")),
         };
 
-        if let Some(obs_ref) = &self.cmplog_observer_ref {
-            if let Some(ob) = self.tracer_executor.observers_mut().get_mut(obs_ref) {
+        if let Some(observer_handle) = &self.cmplog_observer_handle {
+            if let Some(ob) = self
+                .tracer_executor
+                .observers_mut()
+                .get_mut(observer_handle)
+            {
                 // This is not the original input,
                 // Set it to false
                 ob.set_original(false);
@@ -142,7 +150,7 @@ where
     /// Creates a new default stage
     pub fn new(tracer_executor: TE) -> Self {
         Self {
-            cmplog_observer_ref: None,
+            cmplog_observer_handle: None,
             tracer_executor,
             phantom: PhantomData,
         }
@@ -151,10 +159,10 @@ where
     /// With cmplog observer
     pub fn with_cmplog_observer(
         tracer_executor: TE,
-        obs_ref: Handle<AFLppCmpLogObserver<'a, TE::State>>,
+        observer_handle: Handle<AFLppCmpLogObserver<'a, TE::State>>,
     ) -> Self {
         Self {
-            cmplog_observer_ref: Some(obs_ref),
+            cmplog_observer_handle: Some(observer_handle),
             tracer_executor,
             phantom: PhantomData,
         }


### PR DESCRIPTION
This cleans up some forgotten parts, and renames `Handler` to `CanBeHandled` (I'm open to `Handelable`, but handler means the `handle` function should do some handling, IMHO)