### PR TITLE
Fix regex fixing generated bindings for QEMU

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/bindings.rs
+++ b/libafl_qemu/libafl_qemu_build/src/bindings.rs
@@ -155,7 +155,7 @@ pub fn generate(
         bindings
             .allowlist_type("CPUX86State")
             .allowlist_type("X86CPU")
-    } else if cpu_target == "arssssm" {
+    } else if cpu_target == "arm" {
         bindings
             .allowlist_type("ARMCPU")
             .allowlist_type("ARMv7MState")

--- a/libafl_qemu/libafl_qemu_build/src/lib.rs
+++ b/libafl_qemu/libafl_qemu_build/src/lib.rs
@@ -83,7 +83,8 @@ pub fn build_with_bindings(
     let bind_str = std::str::from_utf8(&bind_buf).expect("Could not convert bindings to UTF-8");
 
     // """Fix""" the bindings here
-    let re = Regex::new(r#"(Option\s*<\s*)unsafe(\s+extern\s+"C"\s+fn\s*\(\s*data\s*:\s*u64)"#).unwrap();
+    let re =
+        Regex::new(r#"(Option\s*<\s*)unsafe(\s+extern\s+"C"\s+fn\s*\(\s*data\s*:\s*u64)"#).unwrap();
     let replaced = re.replace_all(bind_str, "$1$2");
 
     // Write the final bindings

--- a/libafl_qemu/libafl_qemu_build/src/lib.rs
+++ b/libafl_qemu/libafl_qemu_build/src/lib.rs
@@ -84,7 +84,7 @@ pub fn build_with_bindings(
 
     // """Fix""" the bindings here
     let re = Regex::new(r#"(Option\s*<\s*)unsafe(\s+extern\s+"C"\s+fn\s*\(\s*data\s*:\s*u64)"#).unwrap();
-    let replaced = re.replace_all(&bind_str, "$1$2");
+    let replaced = re.replace_all(bind_str, "$1$2");
 
     // Write the final bindings
     fs::write(bindings_file, replaced.as_bytes()).expect("Unable to write file");

--- a/libafl_qemu/libafl_qemu_build/src/lib.rs
+++ b/libafl_qemu/libafl_qemu_build/src/lib.rs
@@ -12,7 +12,6 @@ use std::{
     ptr::addr_of_mut,
 };
 
-use regex::Regex;
 use which::which;
 
 mod bindings;
@@ -77,18 +76,9 @@ pub fn build_with_bindings(
 
     let bind = bindings::generate(&build_result.build_dir, cpu_target, clang_args)
         .expect("Failed to generate the bindings");
-    let mut bind_buf: Vec<u8> = Vec::new();
-    bind.write(Box::new(&mut bind_buf))
-        .expect("Failed to write to the bindings buffer");
-    let bind_str = std::str::from_utf8(&bind_buf).expect("Could not convert bindings to UTF-8");
-
-    // """Fix""" the bindings here
-    let re =
-        Regex::new(r#"(Option\s*<\s*)unsafe(\s+extern\s+"C"\s+fn\s*\(\s*data\s*:\s*u64)"#).unwrap();
-    let replaced = re.replace_all(bind_str, "$1$2");
 
     // Write the final bindings
-    fs::write(bindings_file, replaced.as_bytes()).expect("Unable to write file");
+    fs::write(bindings_file, bind.to_string()).expect("Unable to write file");
 
     cargo_propagate_rpath();
 }

--- a/libafl_qemu/libafl_qemu_sys/src/x86_64_stub_bindings.rs
+++ b/libafl_qemu/libafl_qemu_sys/src/x86_64_stub_bindings.rs
@@ -2340,7 +2340,6 @@ pub type DeviceReset = ::std::option::Option<unsafe extern "C" fn(dev: *mut Devi
 #[derive(Debug, Copy, Clone)]
 pub struct DeviceClass {
     pub parent_class: ObjectClass,
-    #[doc = " @categories: device categories device belongs to"]
     pub categories: [::std::os::raw::c_ulong; 1usize],
     #[doc = " @fw_name: name used to identify device to firmware interfaces"]
     pub fw_name: *const ::std::os::raw::c_char,
@@ -13703,7 +13702,7 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_read_hook(
         gen: ::std::option::Option<
-            unsafe extern "C" fn(
+             extern "C" fn(
                 data: u64,
                 pc: target_ulong,
                 addr: *mut TCGTemp,
@@ -13723,7 +13722,7 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_write_hook(
         gen: ::std::option::Option<
-            unsafe extern "C" fn(
+             extern "C" fn(
                 data: u64,
                 pc: target_ulong,
                 addr: *mut TCGTemp,
@@ -13820,7 +13819,7 @@ fn bindgen_test_layout_syshook_ret() {
 extern "C" {
     pub fn libafl_add_pre_syscall_hook(
         callback: ::std::option::Option<
-            unsafe extern "C" fn(
+             extern "C" fn(
                 data: u64,
                 sys_num: ::std::os::raw::c_int,
                 arg0: target_ulong,
@@ -13839,7 +13838,7 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_post_syscall_hook(
         callback: ::std::option::Option<
-            unsafe extern "C" fn(
+             extern "C" fn(
                 data: u64,
                 ret: target_ulong,
                 sys_num: ::std::os::raw::c_int,

--- a/libafl_qemu/libafl_qemu_sys/src/x86_64_stub_bindings.rs
+++ b/libafl_qemu/libafl_qemu_sys/src/x86_64_stub_bindings.rs
@@ -13622,7 +13622,7 @@ impl Default for libafl_hook {
 extern "C" {
     pub fn libafl_qemu_set_hook(
         pc: target_ulong,
-        callback: ::std::option::Option< extern "C" fn(data: u64, pc: target_ulong)>,
+        callback: ::std::option::Option<unsafe extern "C" fn(data: u64, pc: target_ulong)>,
         data: u64,
         invalidate: ::std::os::raw::c_int,
     ) -> usize;
@@ -13645,7 +13645,7 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_backdoor_hook(
         exec: ::std::option::Option<
-             extern "C" fn(data: u64, cpu: *mut CPUArchState, pc: target_ulong),
+            unsafe extern "C" fn(data: u64, cpu: *mut CPUArchState, pc: target_ulong),
         >,
         data: u64,
     ) -> usize;
@@ -13659,9 +13659,9 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_edge_hook(
         gen: ::std::option::Option<
-             extern "C" fn(data: u64, src: target_ulong, dst: target_ulong) -> u64,
+            unsafe extern "C" fn(data: u64, src: target_ulong, dst: target_ulong) -> u64,
         >,
-        exec: ::std::option::Option< extern "C" fn(data: u64, id: u64)>,
+        exec: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64)>,
         data: u64,
     ) -> usize;
 }
@@ -13679,11 +13679,11 @@ extern "C" {
 }
 extern "C" {
     pub fn libafl_add_block_hook(
-        gen: ::std::option::Option< extern "C" fn(data: u64, pc: target_ulong) -> u64>,
+        gen: ::std::option::Option<unsafe extern "C" fn(data: u64, pc: target_ulong) -> u64>,
         post_gen: ::std::option::Option<
-             extern "C" fn(data: u64, pc: target_ulong, block_length: target_ulong),
+            unsafe extern "C" fn(data: u64, pc: target_ulong, block_length: target_ulong),
         >,
-        exec: ::std::option::Option< extern "C" fn(data: u64, id: u64)>,
+        exec: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64)>,
         data: u64,
     ) -> usize;
 }
@@ -13702,19 +13702,19 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_read_hook(
         gen: ::std::option::Option<
-             extern "C" fn(
+            unsafe extern "C" fn(
                 data: u64,
                 pc: target_ulong,
                 addr: *mut TCGTemp,
                 oi: MemOpIdx,
             ) -> u64,
         >,
-        exec1: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
-        exec2: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
-        exec4: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
-        exec8: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec1: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec2: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec4: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec8: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
         execN: ::std::option::Option<
-             extern "C" fn(data: u64, id: u64, addr: target_ulong, size: usize),
+            unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong, size: usize),
         >,
         data: u64,
     ) -> usize;
@@ -13722,19 +13722,19 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_write_hook(
         gen: ::std::option::Option<
-             extern "C" fn(
+            unsafe extern "C" fn(
                 data: u64,
                 pc: target_ulong,
                 addr: *mut TCGTemp,
                 oi: MemOpIdx,
             ) -> u64,
         >,
-        exec1: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
-        exec2: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
-        exec4: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
-        exec8: ::std::option::Option< extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec1: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec2: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec4: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
+        exec8: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong)>,
         execN: ::std::option::Option<
-             extern "C" fn(data: u64, id: u64, addr: target_ulong, size: usize),
+            unsafe extern "C" fn(data: u64, id: u64, addr: target_ulong, size: usize),
         >,
         data: u64,
     ) -> usize;
@@ -13760,12 +13760,12 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_cmp_hook(
         gen: ::std::option::Option<
-             extern "C" fn(data: u64, pc: target_ulong, size: usize) -> u64,
+            unsafe extern "C" fn(data: u64, pc: target_ulong, size: usize) -> u64,
         >,
-        exec1: ::std::option::Option< extern "C" fn(data: u64, id: u64, v0: u8, v1: u8)>,
-        exec2: ::std::option::Option< extern "C" fn(data: u64, id: u64, v0: u16, v1: u16)>,
-        exec4: ::std::option::Option< extern "C" fn(data: u64, id: u64, v0: u32, v1: u32)>,
-        exec8: ::std::option::Option< extern "C" fn(data: u64, id: u64, v0: u64, v1: u64)>,
+        exec1: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, v0: u8, v1: u8)>,
+        exec2: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, v0: u16, v1: u16)>,
+        exec4: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, v0: u32, v1: u32)>,
+        exec8: ::std::option::Option<unsafe extern "C" fn(data: u64, id: u64, v0: u64, v1: u64)>,
         data: u64,
     ) -> usize;
 }
@@ -13819,7 +13819,7 @@ fn bindgen_test_layout_syshook_ret() {
 extern "C" {
     pub fn libafl_add_pre_syscall_hook(
         callback: ::std::option::Option<
-             extern "C" fn(
+            unsafe extern "C" fn(
                 data: u64,
                 sys_num: ::std::os::raw::c_int,
                 arg0: target_ulong,
@@ -13838,7 +13838,7 @@ extern "C" {
 extern "C" {
     pub fn libafl_add_post_syscall_hook(
         callback: ::std::option::Option<
-             extern "C" fn(
+            unsafe extern "C" fn(
                 data: u64,
                 ret: target_ulong,
                 sys_num: ::std::os::raw::c_int,
@@ -13863,7 +13863,7 @@ extern "C" {
 }
 extern "C" {
     pub fn libafl_add_new_thread_hook(
-        callback: ::std::option::Option< extern "C" fn(data: u64, tid: u32) -> bool>,
+        callback: ::std::option::Option<unsafe extern "C" fn(data: u64, tid: u32) -> bool>,
         data: u64,
     ) -> usize;
 }

--- a/libafl_qemu/src/emu/mod.rs
+++ b/libafl_qemu/src/emu/mod.rs
@@ -650,8 +650,8 @@ where
     pub fn add_edge_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, GuestAddr) -> u64>,
-        exec: Option<extern "C" fn(T, u64)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, GuestAddr) -> u64>,
+        exec: Option<unsafe extern "C" fn(T, u64)>,
     ) -> EdgeHookId {
         self.qemu.add_edge_hooks(data, gen, exec)
     }
@@ -662,9 +662,9 @@ where
     pub fn add_block_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr) -> u64>,
-        post_gen: Option<extern "C" fn(T, GuestAddr, GuestUsize)>,
-        exec: Option<extern "C" fn(T, u64)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr) -> u64>,
+        post_gen: Option<unsafe extern "C" fn(T, GuestAddr, GuestUsize)>,
+        exec: Option<unsafe extern "C" fn(T, u64)>,
     ) -> BlockHookId {
         self.qemu.add_block_hooks(data, gen, post_gen, exec)
     }
@@ -675,12 +675,12 @@ where
     pub fn add_read_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
-        exec1: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec2: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec4: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec8: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec_n: Option<extern "C" fn(T, u64, GuestAddr, usize)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
+        exec1: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec2: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec4: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec8: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec_n: Option<unsafe extern "C" fn(T, u64, GuestAddr, usize)>,
     ) -> ReadHookId {
         self.qemu
             .add_read_hooks(data, gen, exec1, exec2, exec4, exec8, exec_n)
@@ -693,12 +693,12 @@ where
     pub fn add_write_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
-        exec1: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec2: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec4: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec8: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec_n: Option<extern "C" fn(T, u64, GuestAddr, usize)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
+        exec1: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec2: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec4: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec8: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec_n: Option<unsafe extern "C" fn(T, u64, GuestAddr, usize)>,
     ) -> WriteHookId {
         self.qemu
             .add_write_hooks(data, gen, exec1, exec2, exec4, exec8, exec_n)
@@ -710,11 +710,11 @@ where
     pub fn add_cmp_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, usize) -> u64>,
-        exec1: Option<extern "C" fn(T, u64, u8, u8)>,
-        exec2: Option<extern "C" fn(T, u64, u16, u16)>,
-        exec4: Option<extern "C" fn(T, u64, u32, u32)>,
-        exec8: Option<extern "C" fn(T, u64, u64, u64)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, usize) -> u64>,
+        exec1: Option<unsafe extern "C" fn(T, u64, u8, u8)>,
+        exec2: Option<unsafe extern "C" fn(T, u64, u16, u16)>,
+        exec4: Option<unsafe extern "C" fn(T, u64, u32, u32)>,
+        exec8: Option<unsafe extern "C" fn(T, u64, u64, u64)>,
     ) -> CmpHookId {
         self.qemu
             .add_cmp_hooks(data, gen, exec1, exec2, exec4, exec8)

--- a/libafl_qemu/src/hooks.rs
+++ b/libafl_qemu/src/hooks.rs
@@ -572,7 +572,7 @@ where
             let gen = get_raw_hook!(
                 generation_hook,
                 edge_gen_hook_wrapper::<QT, S>,
-                extern "C" fn(
+                unsafe extern "C" fn(
                     &mut HookState<1, EdgeHookId>,
                     src: GuestAddr,
                     dest: GuestAddr,
@@ -581,7 +581,7 @@ where
             let exec = get_raw_hook!(
                 execution_hook,
                 edge_0_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<1, EdgeHookId>, id: u64)
+                unsafe extern "C" fn(&mut HookState<1, EdgeHookId>, id: u64)
             );
             EDGE_HOOKS.push(Box::pin(HookState {
                 id: EdgeHookId(0),
@@ -609,29 +609,29 @@ where
         generation_hook: Hook<
             fn(&mut Self, Option<&mut S>, pc: GuestAddr) -> Option<u64>,
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr) -> Option<u64>>,
-            extern "C" fn(*const (), pc: GuestAddr) -> u64,
+            unsafe extern "C" fn(*const (), pc: GuestAddr) -> u64,
         >,
         post_generation_hook: Hook<
             fn(&mut Self, Option<&mut S>, pc: GuestAddr, block_length: GuestUsize),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&mut S>, GuestAddr, GuestUsize)>,
-            extern "C" fn(*const (), pc: GuestAddr, block_length: GuestUsize),
+            unsafe extern "C" fn(*const (), pc: GuestAddr, block_length: GuestUsize),
         >,
         execution_hook: Hook<
             fn(&mut Self, Option<&mut S>, id: u64),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64)>,
-            extern "C" fn(*const (), id: u64),
+            unsafe extern "C" fn(*const (), id: u64),
         >,
     ) -> BlockHookId {
         unsafe {
             let gen = get_raw_hook!(
                 generation_hook,
                 block_gen_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<1, BlockHookId>, pc: GuestAddr) -> u64
+                unsafe extern "C" fn(&mut HookState<1, BlockHookId>, pc: GuestAddr) -> u64
             );
             let postgen = get_raw_hook!(
                 post_generation_hook,
                 block_post_gen_hook_wrapper::<QT, S>,
-                extern "C" fn(
+                unsafe extern "C" fn(
                     &mut HookState<1, BlockHookId>,
                     pc: GuestAddr,
                     block_length: GuestUsize,
@@ -640,7 +640,7 @@ where
             let exec = get_raw_hook!(
                 execution_hook,
                 block_0_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<1, BlockHookId>, id: u64)
+                unsafe extern "C" fn(&mut HookState<1, BlockHookId>, id: u64)
             );
             BLOCK_HOOKS.push(Box::pin(HookState {
                 id: BlockHookId(0),
@@ -684,39 +684,44 @@ where
                     MemAccessInfo,
                 ) -> Option<u64>,
             >,
-            extern "C" fn(*const (), pc: GuestAddr, addr: *mut TCGTemp, info: MemAccessInfo) -> u64,
+            unsafe extern "C" fn(
+                *const (),
+                pc: GuestAddr,
+                addr: *mut TCGTemp,
+                info: MemAccessInfo,
+            ) -> u64,
         >,
         execution_hook_1: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_2: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_4: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_8: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_n: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr, size: usize),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr, usize)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr, size: usize),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr, size: usize),
         >,
     ) -> ReadHookId {
         unsafe {
             let gen = get_raw_hook!(
                 generation_hook,
                 read_gen_hook_wrapper::<QT, S>,
-                extern "C" fn(
+                unsafe extern "C" fn(
                     &mut HookState<5, ReadHookId>,
                     pc: GuestAddr,
                     addr: *mut TCGTemp,
@@ -726,27 +731,32 @@ where
             let exec1 = get_raw_hook!(
                 execution_hook_1,
                 read_0_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
             );
             let exec2 = get_raw_hook!(
                 execution_hook_2,
                 read_1_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
             );
             let exec4 = get_raw_hook!(
                 execution_hook_4,
                 read_2_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
             );
             let exec8 = get_raw_hook!(
                 execution_hook_8,
                 read_3_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr)
             );
             let execn = get_raw_hook!(
                 execution_hook_n,
                 read_4_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, ReadHookId>, id: u64, addr: GuestAddr, size: usize)
+                unsafe extern "C" fn(
+                    &mut HookState<5, ReadHookId>,
+                    id: u64,
+                    addr: GuestAddr,
+                    size: usize,
+                )
             );
             READ_HOOKS.push(Box::pin(HookState {
                 id: ReadHookId(0),
@@ -799,39 +809,44 @@ where
                     MemAccessInfo,
                 ) -> Option<u64>,
             >,
-            extern "C" fn(*const (), pc: GuestAddr, addr: *mut TCGTemp, info: MemAccessInfo) -> u64,
+            unsafe extern "C" fn(
+                *const (),
+                pc: GuestAddr,
+                addr: *mut TCGTemp,
+                info: MemAccessInfo,
+            ) -> u64,
         >,
         execution_hook_1: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_2: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_4: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_8: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr),
         >,
         execution_hook_n: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, addr: GuestAddr, size: usize),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, GuestAddr, usize)>,
-            extern "C" fn(*const (), id: u64, addr: GuestAddr, size: usize),
+            unsafe extern "C" fn(*const (), id: u64, addr: GuestAddr, size: usize),
         >,
     ) -> WriteHookId {
         unsafe {
             let gen = get_raw_hook!(
                 generation_hook,
                 write_gen_hook_wrapper::<QT, S>,
-                extern "C" fn(
+                unsafe extern "C" fn(
                     &mut HookState<5, WriteHookId>,
                     pc: GuestAddr,
                     addr: *mut TCGTemp,
@@ -841,27 +856,27 @@ where
             let exec1 = get_raw_hook!(
                 execution_hook_1,
                 write_0_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
             );
             let exec2 = get_raw_hook!(
                 execution_hook_2,
                 write_1_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
             );
             let exec4 = get_raw_hook!(
                 execution_hook_4,
                 write_2_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
             );
             let exec8 = get_raw_hook!(
                 execution_hook_8,
                 write_3_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
+                unsafe extern "C" fn(&mut HookState<5, WriteHookId>, id: u64, addr: GuestAddr)
             );
             let execn = get_raw_hook!(
                 execution_hook_n,
                 write_4_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(
+                unsafe extern "C" fn(
                     &mut HookState<5, WriteHookId>,
                     id: u64,
                     addr: GuestAddr,
@@ -906,54 +921,58 @@ where
             Box<
                 dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, GuestAddr, usize) -> Option<u64>,
             >,
-            extern "C" fn(*const (), pc: GuestAddr, size: usize) -> u64,
+            unsafe extern "C" fn(*const (), pc: GuestAddr, size: usize) -> u64,
         >,
         execution_hook_1: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, v0: u8, v1: u8),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, u8, u8)>,
-            extern "C" fn(*const (), id: u64, v0: u8, v1: u8),
+            unsafe extern "C" fn(*const (), id: u64, v0: u8, v1: u8),
         >,
         execution_hook_2: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, v0: u16, v1: u16),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, u16, u16)>,
-            extern "C" fn(*const (), id: u64, v0: u16, v1: u16),
+            unsafe extern "C" fn(*const (), id: u64, v0: u16, v1: u16),
         >,
         execution_hook_4: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, v0: u32, v1: u32),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, u32, u32)>,
-            extern "C" fn(*const (), id: u64, v0: u32, v1: u32),
+            unsafe extern "C" fn(*const (), id: u64, v0: u32, v1: u32),
         >,
         execution_hook_8: Hook<
             fn(&mut Self, Option<&mut S>, id: u64, v0: u64, v1: u64),
             Box<dyn for<'a> FnMut(&'a mut Self, Option<&'a mut S>, u64, u64, u64)>,
-            extern "C" fn(*const (), id: u64, v0: u64, v1: u64),
+            unsafe extern "C" fn(*const (), id: u64, v0: u64, v1: u64),
         >,
     ) -> CmpHookId {
         unsafe {
             let gen = get_raw_hook!(
                 generation_hook,
                 cmp_gen_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<4, CmpHookId>, pc: GuestAddr, size: usize) -> u64
+                unsafe extern "C" fn(
+                    &mut HookState<4, CmpHookId>,
+                    pc: GuestAddr,
+                    size: usize,
+                ) -> u64
             );
             let exec1 = get_raw_hook!(
                 execution_hook_1,
                 cmp_0_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u8, v1: u8)
+                unsafe extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u8, v1: u8)
             );
             let exec2 = get_raw_hook!(
                 execution_hook_2,
                 cmp_1_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u16, v1: u16)
+                unsafe extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u16, v1: u16)
             );
             let exec4 = get_raw_hook!(
                 execution_hook_4,
                 cmp_2_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u32, v1: u32)
+                unsafe extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u32, v1: u32)
             );
             let exec8 = get_raw_hook!(
                 execution_hook_8,
                 cmp_3_exec_hook_wrapper::<QT, S>,
-                extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u64, v1: u64)
+                unsafe extern "C" fn(&mut HookState<4, CmpHookId>, id: u64, v0: u64, v1: u64)
             );
             CMP_HOOKS.push(Box::pin(HookState {
                 id: CmpHookId(0),

--- a/libafl_qemu/src/qemu/mod.rs
+++ b/libafl_qemu/src/qemu/mod.rs
@@ -817,7 +817,7 @@ impl Qemu {
         unsafe {
             let data: u64 = data.into().0;
             let gen: Option<
-                unsafe extern "C" fn(
+                extern "C" fn(
                     u64,
                     GuestAddr,
                     *mut TCGTemp,
@@ -851,7 +851,7 @@ impl Qemu {
         unsafe {
             let data: u64 = data.into().0;
             let gen: Option<
-                unsafe extern "C" fn(
+                extern "C" fn(
                     u64,
                     GuestAddr,
                     *mut TCGTemp,

--- a/libafl_qemu/src/qemu/mod.rs
+++ b/libafl_qemu/src/qemu/mod.rs
@@ -761,13 +761,14 @@ impl Qemu {
     pub fn add_edge_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, GuestAddr) -> u64>,
-        exec: Option<extern "C" fn(T, u64)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, GuestAddr) -> u64>,
+        exec: Option<unsafe extern "C" fn(T, u64)>,
     ) -> EdgeHookId {
         unsafe {
             let data: u64 = data.into().0;
-            let gen: Option<extern "C" fn(u64, GuestAddr, GuestAddr) -> u64> = transmute(gen);
-            let exec: Option<extern "C" fn(u64, u64)> = transmute(exec);
+            let gen: Option<unsafe extern "C" fn(u64, GuestAddr, GuestAddr) -> u64> =
+                transmute(gen);
+            let exec: Option<unsafe extern "C" fn(u64, u64)> = transmute(exec);
             let num = libafl_qemu_sys::libafl_add_edge_hook(gen, exec, data);
             EdgeHookId(num)
         }
@@ -777,15 +778,16 @@ impl Qemu {
     pub fn add_block_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr) -> u64>,
-        post_gen: Option<extern "C" fn(T, GuestAddr, GuestUsize)>,
-        exec: Option<extern "C" fn(T, u64)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr) -> u64>,
+        post_gen: Option<unsafe extern "C" fn(T, GuestAddr, GuestUsize)>,
+        exec: Option<unsafe extern "C" fn(T, u64)>,
     ) -> BlockHookId {
         unsafe {
             let data: u64 = data.into().0;
-            let gen: Option<extern "C" fn(u64, GuestAddr) -> u64> = transmute(gen);
-            let post_gen: Option<extern "C" fn(u64, GuestAddr, GuestUsize)> = transmute(post_gen);
-            let exec: Option<extern "C" fn(u64, u64)> = transmute(exec);
+            let gen: Option<unsafe extern "C" fn(u64, GuestAddr) -> u64> = transmute(gen);
+            let post_gen: Option<unsafe extern "C" fn(u64, GuestAddr, GuestUsize)> =
+                transmute(post_gen);
+            let exec: Option<unsafe extern "C" fn(u64, u64)> = transmute(exec);
             let num = libafl_qemu_sys::libafl_add_block_hook(gen, post_gen, exec, data);
             BlockHookId(num)
         }
@@ -807,23 +809,29 @@ impl Qemu {
     pub fn add_read_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
-        exec1: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec2: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec4: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec8: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec_n: Option<extern "C" fn(T, u64, GuestAddr, usize)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
+        exec1: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec2: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec4: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec8: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec_n: Option<unsafe extern "C" fn(T, u64, GuestAddr, usize)>,
     ) -> ReadHookId {
         unsafe {
             let data: u64 = data.into().0;
             let gen: Option<
-                extern "C" fn(u64, GuestAddr, *mut TCGTemp, libafl_qemu_sys::MemOpIdx) -> u64,
+                unsafe extern "C" fn(
+                    u64,
+                    GuestAddr,
+                    *mut TCGTemp,
+                    libafl_qemu_sys::MemOpIdx,
+                ) -> u64,
             > = transmute(gen);
-            let exec1: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec1);
-            let exec2: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec2);
-            let exec4: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec4);
-            let exec8: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec8);
-            let exec_n: Option<extern "C" fn(u64, u64, GuestAddr, usize)> = transmute(exec_n);
+            let exec1: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec1);
+            let exec2: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec2);
+            let exec4: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec4);
+            let exec8: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec8);
+            let exec_n: Option<unsafe extern "C" fn(u64, u64, GuestAddr, usize)> =
+                transmute(exec_n);
             let num = libafl_qemu_sys::libafl_add_read_hook(
                 gen, exec1, exec2, exec4, exec8, exec_n, data,
             );
@@ -836,23 +844,29 @@ impl Qemu {
     pub fn add_write_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
-        exec1: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec2: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec4: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec8: Option<extern "C" fn(T, u64, GuestAddr)>,
-        exec_n: Option<extern "C" fn(T, u64, GuestAddr, usize)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, *mut TCGTemp, MemAccessInfo) -> u64>,
+        exec1: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec2: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec4: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec8: Option<unsafe extern "C" fn(T, u64, GuestAddr)>,
+        exec_n: Option<unsafe extern "C" fn(T, u64, GuestAddr, usize)>,
     ) -> WriteHookId {
         unsafe {
             let data: u64 = data.into().0;
             let gen: Option<
-                extern "C" fn(u64, GuestAddr, *mut TCGTemp, libafl_qemu_sys::MemOpIdx) -> u64,
+                unsafe extern "C" fn(
+                    u64,
+                    GuestAddr,
+                    *mut TCGTemp,
+                    libafl_qemu_sys::MemOpIdx,
+                ) -> u64,
             > = transmute(gen);
-            let exec1: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec1);
-            let exec2: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec2);
-            let exec4: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec4);
-            let exec8: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec8);
-            let exec_n: Option<extern "C" fn(u64, u64, GuestAddr, usize)> = transmute(exec_n);
+            let exec1: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec1);
+            let exec2: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec2);
+            let exec4: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec4);
+            let exec8: Option<unsafe extern "C" fn(u64, u64, GuestAddr)> = transmute(exec8);
+            let exec_n: Option<unsafe extern "C" fn(u64, u64, GuestAddr, usize)> =
+                transmute(exec_n);
             let num = libafl_qemu_sys::libafl_add_write_hook(
                 gen, exec1, exec2, exec4, exec8, exec_n, data,
             );
@@ -864,19 +878,19 @@ impl Qemu {
     pub fn add_cmp_hooks<T: Into<HookData>>(
         &self,
         data: T,
-        gen: Option<extern "C" fn(T, GuestAddr, usize) -> u64>,
-        exec1: Option<extern "C" fn(T, u64, u8, u8)>,
-        exec2: Option<extern "C" fn(T, u64, u16, u16)>,
-        exec4: Option<extern "C" fn(T, u64, u32, u32)>,
-        exec8: Option<extern "C" fn(T, u64, u64, u64)>,
+        gen: Option<unsafe extern "C" fn(T, GuestAddr, usize) -> u64>,
+        exec1: Option<unsafe extern "C" fn(T, u64, u8, u8)>,
+        exec2: Option<unsafe extern "C" fn(T, u64, u16, u16)>,
+        exec4: Option<unsafe extern "C" fn(T, u64, u32, u32)>,
+        exec8: Option<unsafe extern "C" fn(T, u64, u64, u64)>,
     ) -> CmpHookId {
         unsafe {
             let data: u64 = data.into().0;
-            let gen: Option<extern "C" fn(u64, GuestAddr, usize) -> u64> = transmute(gen);
-            let exec1: Option<extern "C" fn(u64, u64, u8, u8)> = transmute(exec1);
-            let exec2: Option<extern "C" fn(u64, u64, u16, u16)> = transmute(exec2);
-            let exec4: Option<extern "C" fn(u64, u64, u32, u32)> = transmute(exec4);
-            let exec8: Option<extern "C" fn(u64, u64, u64, u64)> = transmute(exec8);
+            let gen: Option<unsafe extern "C" fn(u64, GuestAddr, usize) -> u64> = transmute(gen);
+            let exec1: Option<unsafe extern "C" fn(u64, u64, u8, u8)> = transmute(exec1);
+            let exec2: Option<unsafe extern "C" fn(u64, u64, u16, u16)> = transmute(exec2);
+            let exec4: Option<unsafe extern "C" fn(u64, u64, u32, u32)> = transmute(exec4);
+            let exec8: Option<unsafe extern "C" fn(u64, u64, u64, u64)> = transmute(exec8);
             let num = libafl_qemu_sys::libafl_add_cmp_hook(gen, exec1, exec2, exec4, exec8, data);
             CmpHookId(num)
         }

--- a/libafl_qemu/src/qemu/mod.rs
+++ b/libafl_qemu/src/qemu/mod.rs
@@ -817,12 +817,7 @@ impl Qemu {
         unsafe {
             let data: u64 = data.into().0;
             let gen: Option<
-                extern "C" fn(
-                    u64,
-                    GuestAddr,
-                    *mut TCGTemp,
-                    libafl_qemu_sys::MemOpIdx,
-                ) -> u64,
+                extern "C" fn(u64, GuestAddr, *mut TCGTemp, libafl_qemu_sys::MemOpIdx) -> u64,
             > = transmute(gen);
             let exec1: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec1);
             let exec2: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec2);
@@ -851,12 +846,7 @@ impl Qemu {
         unsafe {
             let data: u64 = data.into().0;
             let gen: Option<
-                extern "C" fn(
-                    u64,
-                    GuestAddr,
-                    *mut TCGTemp,
-                    libafl_qemu_sys::MemOpIdx,
-                ) -> u64,
+                extern "C" fn(u64, GuestAddr, *mut TCGTemp, libafl_qemu_sys::MemOpIdx) -> u64,
             > = transmute(gen);
             let exec1: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec1);
             let exec2: Option<extern "C" fn(u64, u64, GuestAddr)> = transmute(exec2);


### PR DESCRIPTION
Fix #2128
Also, avoid writing 2 times bindings to filesystem.