### PR TITLE
Revert "Update zip requirement from 0.6 to 1.2"

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -138,7 +138,7 @@ nautilus = ["grammartec", "std", "serde_json/std"]
 [build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"], optional = true }
 rustversion = "1.0"
-zip = { version = "1.2", optional = true }
+zip = { version = "0.6", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Reverts AFLplusplus/LibAFL#2169

```rust
 error: failed to run custom build command for `libz-ng-sys v1.1.15`

  Caused by:
    process didn't exit successfully: `/home/runner/work/LibAFL/LibAFL/target/x86_64-unknown-linux-gnu/release/build/libafl_libfuzzer-fe1e0e503aac7e96/out/libafl_libfuzzer/release/build/libz-ng-sys-a9d11f6fafc12dfd/build-script-build_zng` (exit status: 101)
    --- stdout
```