### PR TITLE
Fix hook_func and implement deinit

### DIFF
--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -557,12 +557,12 @@ impl Allocator {
                 let start = range.memory_range().base_address().0 as usize;
                 let end = start + range.memory_range().size();
                 //the poisoned region should be the highest valid userspace region
-                if !self.is_managed(start as *mut c_void) {
+                if self.is_managed(start as *mut c_void) {
+                    false
+                } else {
                     log::trace!("Unpoisoning: {:#x}-{:#x}", start, end);
                     self.map_shadow_for_region(start, end, true);
                     true
-                } else {
-                    false
                 }
             },
         );
@@ -634,7 +634,7 @@ impl Allocator {
         log::trace!("max bit: {}", maxbit);
 
         {
-            for try_shadow_bit in 44..maxbit + 1 {
+            for try_shadow_bit in 44..=maxbit {
                 let addr: usize = 1 << try_shadow_bit;
                 let shadow_start = addr;
                 let shadow_end = addr + addr + addr;

--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -551,7 +551,6 @@ impl Allocator {
 
     /// Unpoison all the memory that is currently mapped with read/write permissions.
     pub fn unpoison_all_existing_memory(&mut self) {
-
         RangeDetails::enumerate_with_prot(
             PageProtection::Read,
             &mut |range: &RangeDetails| -> bool {
@@ -559,14 +558,12 @@ impl Allocator {
                 let end = start + range.memory_range().size();
                 //the poisoned region should be the highest valid userspace region
                 if !self.is_managed(start as *mut c_void) {
-                    log::trace!("Unpoisoning: {:#x}-{:#x}", start,end);
+                    log::trace!("Unpoisoning: {:#x}-{:#x}", start, end);
                     self.map_shadow_for_region(start, end, true);
                     true
                 } else {
                     false
                 }
-
-                
             },
         );
     }
@@ -592,10 +589,11 @@ impl Allocator {
             &mut |range: &RangeDetails| -> bool {
                 let start = range.memory_range().base_address().0 as usize;
                 let end = start + range.memory_range().size();
-                log::trace!("New range: {:#x}-{:#x}", start,end);
+                log::trace!("New range: {:#x}-{:#x}", start, end);
 
                 #[cfg(target_vendor = "apple")]
-                if start >= 0x600000000000 { //this is the MALLOC_NANO region. There is no point in poisoning this as we replace malloc.
+                if start >= 0x600000000000 {
+                    //this is the MALLOC_NANO region. There is no point in poisoning this as we replace malloc.
                     return false;
                 }
 
@@ -610,7 +608,6 @@ impl Allocator {
                 // if end <= 2_usize.pow(64) && end > userspace_max {
                 //     userspace_max = end;
                 // }
-
 
                 // On aarch64, if end > 2**52, then range is not in userspace
                 #[cfg(target_arch = "aarch64")]
@@ -639,7 +636,7 @@ impl Allocator {
         log::trace!("max bit: {}", maxbit);
 
         {
-            for try_shadow_bit in 44..maxbit+1 {
+            for try_shadow_bit in 44..maxbit + 1 {
                 let addr: usize = 1 << try_shadow_bit;
                 let shadow_start = addr;
                 let shadow_end = addr + addr + addr;

--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -619,8 +619,6 @@ impl Allocator {
             },
         );
 
-        log::trace!("userspace max: {:#x}", userspace_max);
-
         #[cfg(unix)]
         let mut maxbit = 63;
         #[cfg(windows)]

--- a/libafl_frida/src/alloc.rs
+++ b/libafl_frida/src/alloc.rs
@@ -556,7 +556,7 @@ impl Allocator {
             &mut |range: &RangeDetails| -> bool {
                 let start = range.memory_range().base_address().0 as usize;
                 let end = start + range.memory_range().size();
-                //the poisoned region should be the highest valid userspace region
+                //the shadow region should be the highest valid userspace region, so don't continue after
                 if self.is_managed(start as *mut c_void) {
                     false
                 } else {
@@ -593,7 +593,7 @@ impl Allocator {
 
                 #[cfg(target_vendor = "apple")]
                 if start >= 0x600000000000 {
-                    //this is the MALLOC_NANO region. There is no point in poisoning this as we replace malloc.
+                    //this is the MALLOC_NANO region. There is no point in spending time tracking this region as we hook malloc
                     return false;
                 }
 

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -161,7 +161,6 @@ impl FridaRuntime for AsanRuntime {
 
         AsanErrors::get_mut_blocking().set_continue_on_error(self.continue_on_error);
 
-
         self.module_map = Some(module_map.clone());
         self.suppressed_addresses
             .extend(self.skip_ranges.iter().map(|skip| match skip {
@@ -172,7 +171,6 @@ impl FridaRuntime for AsanRuntime {
                     lib_start + range.start
                 }
             }));
-        
 
         self.register_hooks(gum);
         self.generate_instrumentation_blobs();
@@ -471,8 +469,6 @@ impl AsanRuntime {
         self.pc = None;
     }
 
-
-
     /// Register the required hooks
     #[allow(clippy::too_many_lines)]
     pub fn register_hooks(&mut self, gum: &Gum) {
@@ -483,7 +479,7 @@ impl AsanRuntime {
                     log::trace!("Hooking {}", stringify!($name));
 
                     let target_function = frida_gum::Module::find_export_by_name($lib, stringify!($name)).expect("Failed to find function");
-                    
+
                     extern "system" { fn $name($($param: $param_type),*) -> $return_type; }
 
                     #[allow(non_snake_case)]
@@ -1148,16 +1144,15 @@ impl AsanRuntime {
             (s: *mut c_void, c: *const c_void, n: usize),
             ()
         );
-
     }
 
     /// Deregister all the hooks
     fn deregister_hooks(&mut self, gum: &Gum) {
-        /*This is terrible code and should be replaced as soon as possible. 
-        
-        This is basically a bandaid solution that happens to work because 2 different Interceptor::obtains will return the same interceptor. 
-        
-        Ideally the interceptor should be stored in AsanRuntime, but because FridaRuntime has a 'sttaic bound it becomes difficult to introduce that. 
+        /*This is terrible code and should be replaced as soon as possible.
+
+        This is basically a bandaid solution that happens to work because 2 different Interceptor::obtains will return the same interceptor.
+
+        Ideally the interceptor should be stored in AsanRuntime, but because FridaRuntime has a 'sttaic bound it becomes difficult to introduce that.
         */
         let mut interceptor = Interceptor::obtain(gum);
         for hook in &self.hooks {

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -557,7 +557,6 @@ impl AsanRuntime {
                             this.hooks_enabled = previous_hook_state;
                             ret
                         } else {
-
                             let previous_hook_state = this.hooks_enabled;
                             this.hooks_enabled = false;
                             let ret = (original)($($param),*);

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -37,7 +37,10 @@ use yaxpeax_arch::Arch;
 #[cfg(target_arch = "aarch64")]
 use yaxpeax_arm::armv8::a64::{ARMv8, InstDecoder, Opcode, Operand, ShiftStyle, SizeCode};
 #[cfg(target_arch = "x86_64")]
-use yaxpeax_x86::{amd64::{InstDecoder, Instruction, Opcode}, long_mode::DisplayStyle};
+use yaxpeax_x86::{
+    amd64::{InstDecoder, Instruction, Opcode},
+    long_mode::DisplayStyle,
+};
 
 #[cfg(target_arch = "x86_64")]
 use crate::utils::frida_to_cs;
@@ -596,7 +599,7 @@ impl AsanRuntime {
                             this.hooks_enabled = previous_hook_state;
                             ret
                         } else {
-                            
+
                             let previous_hook_state = this.hooks_enabled;
                             this.hooks_enabled = false;
                             let ret = (original)($($param),*);
@@ -1259,7 +1262,10 @@ impl AsanRuntime {
         );
 
         let insn = instructions[0]; // This is the very instruction that has triggered fault
-        log::info!("Fault Instruction: {}", insn.display_with(DisplayStyle::Intel).to_string());
+        log::info!(
+            "Fault Instruction: {}",
+            insn.display_with(DisplayStyle::Intel).to_string()
+        );
         let operand_count = insn.operand_count();
 
         let mut access_type: Option<AccessType> = None;

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -26,6 +26,14 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_CreateThread(
         &mut self,
+        original: extern "C" fn(
+            thread_attributes: *const c_void,
+            stack_size: usize,
+            start_address: *const c_void,
+            parameter: *const c_void,
+            creation_flags: i32,
+            thread_id: *mut i32,
+        ) -> usize,
         thread_attributes: *const c_void,
         stack_size: usize,
         start_address: *const c_void,
@@ -33,32 +41,28 @@ impl AsanRuntime {
         creation_flags: i32,
         thread_id: *mut i32,
     ) -> usize {
-        extern "system" {
-            fn CreateThread(
-                thread_attributes: *const c_void,
-                stack_size: usize,
-                start_address: *const c_void,
-                parameter: *const c_void,
-                creation_flags: i32,
-                thread_id: *mut i32,
-            ) -> usize;
-        }
-        unsafe {
-            CreateThread(
-                thread_attributes,
-                stack_size,
-                start_address,
-                parameter,
-                creation_flags,
-                thread_id,
-            )
-        }
+        original(
+            thread_attributes,
+            stack_size,
+            start_address,
+            parameter,
+            creation_flags,
+            thread_id,
+        )
     }
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
     pub fn hook_CreateFileMappingW(
         &mut self,
+        original: extern "C" fn(
+            file: usize,
+            file_mapping_attributes: *const c_void,
+            protect: i32,
+            maximum_size_high: u32,
+            maximum_size_low: u32,
+            name: *const c_void,
+        ) -> usize,
         file: usize,
         file_mapping_attributes: *const c_void,
         protect: i32,
@@ -66,49 +70,36 @@ impl AsanRuntime {
         maximum_size_low: u32,
         name: *const c_void,
     ) -> usize {
-        extern "system" {
-            fn CreateFileMappingW(
-                file: usize,
-                file_mapping_attributes: *const c_void,
-                protect: i32,
-                maximum_size_high: u32,
-                maximum_size_low: u32,
-                name: *const c_void,
-            ) -> usize;
-        }
-        winsafe::OutputDebugString("In CreateFileMapping\n");
-        unsafe {
-            CreateFileMappingW(
-                file,
-                file_mapping_attributes,
-                protect,
-                maximum_size_high,
-                maximum_size_low,
-                name,
-            )
-        }
+//        winsafe::OutputDebugString("In CreateFileMapping\n");
+        original(
+            file,
+            file_mapping_attributes,
+            protect,
+            maximum_size_high,
+            maximum_size_low,
+            name,
+        )
     }
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
     pub fn hook_LdrLoadDll(
         &mut self,
+        original: extern "C" fn(
+            search_path: *const c_void,
+            charecteristics: *const u32,
+            dll_name: *const c_void,
+            base_address: *mut *const c_void,
+        ) -> usize,
         search_path: *const c_void,
         charecteristics: *const u32,
         dll_name: *const c_void,
         base_address: *mut *const c_void,
     ) -> usize {
-        extern "system" {
-            fn LdrLoadDll(
-                search_path: *const c_void,
-                charecteristics: *const u32,
-                dll_name: *const c_void,
-                base_address: *mut *const c_void,
-            ) -> usize;
-        }
-        winsafe::OutputDebugString("LdrLoadDll");
+//        winsafe::OutputDebugString("LdrLoadDll");
         log::trace!("LdrLoadDll");
-        let result = unsafe { LdrLoadDll(search_path, charecteristics, dll_name, base_address) };
+        let result = original(search_path, charecteristics, dll_name, base_address);
+
         self.allocator_mut().unpoison_all_existing_memory();
         result
     }
@@ -117,12 +108,18 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_LdrpCallInitRoutine(
         &mut self,
+        _original: extern "C" fn(
+            _base_address: *const c_void,
+            _reason: usize,
+            _base_address: *const c_void,
+            _entry_point: usize,
+        ) -> usize,
         _base_address: *const c_void,
         _reason: usize,
         _context: usize,
         _entry_point: usize,
     ) -> usize {
-        winsafe::OutputDebugString("LdrpCallInitRoutine");
+//        winsafe::OutputDebugString("LdrpCallInitRoutine");
         // let result = unsafe { LdrLoadDll(path, file, flags,x )};
         // self.allocator_mut().unpoison_all_existing_memory();
         // result
@@ -131,12 +128,16 @@ impl AsanRuntime {
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LoadLibraryExW(&mut self, path: *const c_void, file: usize, flags: i32) -> usize {
+    pub fn hook_LoadLibraryExW(
+        &mut self,
+        original: extern "C" fn(path: *const c_void, file: usize, flags: i32) -> usize,
+        path: *const c_void,
+        file: usize,
+        flags: i32,
+    ) -> usize {
         log::trace!("Loaded library!");
-        extern "system" {
-            fn LoadLibraryExW(path: *const c_void, file: usize, flags: i32) -> usize;
-        }
-        let result = unsafe { LoadLibraryExW(path, file, flags) };
+
+        let result = original(path, file, flags);
         self.allocator_mut().unpoison_all_existing_memory();
         result
     }
@@ -146,6 +147,14 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_RtlCreateHeap(
         &mut self,
+        _original: extern "C" fn(
+            _flags: u32,
+            _heap_base: *const c_void,
+            _reserve_size: usize,
+            _commit_size: usize,
+            _lock: *const c_void,
+            _parameters: *const c_void,
+        ) -> *mut c_void,
         _flags: u32,
         _heap_base: *const c_void,
         _reserve_size: usize,
@@ -158,14 +167,24 @@ impl AsanRuntime {
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_RtlDestroyHeap(&mut self, _handle: *const c_void) -> *mut c_void {
+    pub fn hook_RtlDestroyHeap(
+        &mut self,
+        _original: extern "C" fn(_handle: *const c_void) -> *mut c_void,
+        _handle: *const c_void,
+    ) -> *mut c_void {
         std::ptr::null_mut()
     }
 
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_HeapAlloc(&mut self, _handle: *mut c_void, flags: u32, size: usize) -> *mut c_void {
+    pub fn hook_HeapAlloc(
+        &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, flags: u32, size: usize) -> *mut c_void,
+        _handle: *mut c_void,
+        flags: u32,
+        size: usize,
+    ) -> *mut c_void {
         let allocator = self.allocator_mut();
         let ret = unsafe { allocator.alloc(size, 8) };
 
@@ -187,6 +206,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_RtlAllocateHeap(
         &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, flags: u32, size: usize) -> *mut c_void,
         _handle: *mut c_void,
         flags: u32,
         size: usize,
@@ -212,6 +232,12 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_HeapReAlloc(
         &mut self,
+        original: extern "C" fn(
+            handle: *mut c_void,
+            flags: u32,
+            ptr: *mut c_void,
+            size: usize,
+        ) -> *mut c_void,
         handle: *mut c_void,
         flags: u32,
         ptr: *mut c_void,
@@ -219,15 +245,7 @@ impl AsanRuntime {
     ) -> *mut c_void {
         let allocator = self.allocator_mut();
         if !allocator.is_managed(ptr) {
-            extern "system" {
-                fn HeapReAlloc(
-                    handle: *mut c_void,
-                    flags: u32,
-                    ptr: *mut c_void,
-                    size: usize,
-                ) -> *mut c_void;
-            }
-            return unsafe { HeapReAlloc(handle, flags, ptr, size) };
+            return original(handle, flags, ptr, size);
         }
         let ret = unsafe {
             let ret = allocator.alloc(size, 8);
@@ -260,6 +278,12 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_RtlReAllocateHeap(
         &mut self,
+        original: extern "C" fn(
+            handle: *mut c_void,
+            flags: u32,
+            ptr: *mut c_void,
+            size: usize,
+        ) -> *mut c_void,
         handle: *mut c_void,
         flags: u32,
         ptr: *mut c_void,
@@ -268,15 +292,7 @@ impl AsanRuntime {
         let allocator = self.allocator_mut();
         log::trace!("RtlReAllocateHeap({ptr:?}, {size:x})");
         if !allocator.is_managed(ptr) {
-            extern "system" {
-                fn HeapReAlloc(
-                    handle: *mut c_void,
-                    flags: u32,
-                    ptr: *mut c_void,
-                    size: usize,
-                ) -> *mut c_void;
-            }
-            return unsafe { HeapReAlloc(handle, flags, ptr, size) };
+            return original(handle, flags, ptr, size);
         }
         let ret = unsafe {
             let ret = allocator.alloc(size, 8);
@@ -320,6 +336,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_RtlFreeHeap(
         &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, _flags: u32, ptr: *mut c_void) -> usize,
         _handle: *mut c_void,
         _flags: u32,
         ptr: *mut c_void,
@@ -341,7 +358,13 @@ impl AsanRuntime {
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_HeapFree(&mut self, _handle: *mut c_void, _flags: u32, ptr: *mut c_void) -> bool {
+    pub fn hook_HeapFree(
+        &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, _flags: u32, ptr: *mut c_void) -> bool,
+        _handle: *mut c_void,
+        _flags: u32,
+        ptr: *mut c_void,
+    ) -> bool {
         unsafe { self.allocator_mut().release(ptr) };
         true
     }
@@ -359,7 +382,13 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_HeapSize(&mut self, _handle: *mut c_void, _flags: u32, ptr: *mut c_void) -> usize {
+    pub fn hook_HeapSize(
+        &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, _flags: u32, ptr: *mut c_void) -> usize,
+        _handle: *mut c_void,
+        _flags: u32,
+        ptr: *mut c_void,
+    ) -> usize {
         self.allocator().get_usable_size(ptr)
     }
     #[inline]
@@ -378,6 +407,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_RtlSizeHeap(
         &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, _flags: u32, ptr: *mut c_void) -> usize,
         _handle: *mut c_void,
         _flags: u32,
         ptr: *mut c_void,
@@ -400,6 +430,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_RtlValidateHeap(
         &mut self,
+        _original: extern "C" fn(_handle: *mut c_void, _flags: u32, _ptr: *mut c_void) -> bool,
         _handle: *mut c_void,
         _flags: u32,
         _ptr: *mut c_void,
@@ -409,7 +440,12 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalAlloc(&mut self, flags: u32, size: usize) -> *mut c_void {
+    pub fn hook_LocalAlloc(
+        &mut self,
+        _original: extern "C" fn(flags: u32, size: usize) -> *mut c_void,
+        flags: u32,
+        size: usize,
+    ) -> *mut c_void {
         let ret = unsafe { self.allocator_mut().alloc(size, 8) };
 
         if flags & 0x40 == 0x40 {
@@ -424,7 +460,13 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalReAlloc(&mut self, mem: *mut c_void, size: usize, _flags: u32) -> *mut c_void {
+    pub fn hook_LocalReAlloc(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void, size: usize, _flags: u32) -> *mut c_void,
+        mem: *mut c_void,
+        size: usize,
+        _flags: u32,
+    ) -> *mut c_void {
         unsafe {
             let ret = self.allocator_mut().alloc(size, 0x8);
             if mem != std::ptr::null_mut() && ret != std::ptr::null_mut() {
@@ -445,7 +487,11 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalFree(&mut self, mem: *mut c_void) -> *mut c_void {
+    pub fn hook_LocalFree(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> *mut c_void,
+        mem: *mut c_void,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().release(mem) };
         mem
     }
@@ -457,7 +503,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalHandle(&mut self, mem: *mut c_void) -> *mut c_void {
+    pub fn hook_LocalHandle(
+        &mut self,
+        _soriginal: extern "C" fn(mem: *mut c_void) -> *mut c_void,
+        mem: *mut c_void,
+    ) -> *mut c_void {
         mem
     }
     #[allow(non_snake_case)]
@@ -468,7 +518,11 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalLock(&mut self, mem: *mut c_void) -> *mut c_void {
+    pub fn hook_LocalLock(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> *mut c_void,
+        mem: *mut c_void,
+    ) -> *mut c_void {
         mem
     }
     #[allow(non_snake_case)]
@@ -478,7 +532,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalUnlock(&mut self, _mem: *mut c_void) -> bool {
+    pub fn hook_LocalUnlock(
+        &mut self,
+        _original: extern "C" fn(_mem: *mut c_void) -> bool,
+        _mem: *mut c_void,
+    ) -> bool {
         false
     }
     #[allow(non_snake_case)]
@@ -488,7 +546,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalSize(&mut self, mem: *mut c_void) -> usize {
+    pub fn hook_LocalSize(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> bool,
+        mem: *mut c_void,
+    ) -> usize {
         self.allocator_mut().get_usable_size(mem)
     }
     #[allow(non_snake_case)]
@@ -498,13 +560,22 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_LocalFlags(&mut self, _mem: *mut c_void) -> u32 {
+    pub fn hook_LocalFlags(
+        &mut self,
+        _original: extern "C" fn(_mem: *mut c_void) -> u32,
+        _mem: *mut c_void,
+    ) -> u32 {
         0
     }
 
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalAlloc(&mut self, flags: u32, size: usize) -> *mut c_void {
+    pub fn hook_GlobalAlloc(
+        &mut self,
+        _original: extern "C" fn(flags: u32, size: usize) -> *mut c_void,
+        flags: u32,
+        size: usize,
+    ) -> *mut c_void {
         let ret = unsafe { self.allocator_mut().alloc(size, 8) };
 
         if flags & 0x40 == 0x40 {
@@ -521,6 +592,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_GlobalReAlloc(
         &mut self,
+        _original: extern "C" fn(mem: *mut c_void, _flags: u32, size: usize) -> *mut c_void,
         mem: *mut c_void,
         _flags: u32,
         size: usize,
@@ -543,7 +615,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalFree(&mut self, mem: *mut c_void) -> *mut c_void {
+    pub fn hook_GlobalFree(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> *mut c_void,
+        mem: *mut c_void,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().release(mem) };
         mem
     }
@@ -555,7 +631,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalHandle(&mut self, mem: *mut c_void) -> *mut c_void {
+    pub fn hook_GlobalHandle(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> *mut c_void,
+        mem: *mut c_void,
+    ) -> *mut c_void {
         mem
     }
     #[allow(non_snake_case)]
@@ -566,7 +646,11 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalLock(&mut self, mem: *mut c_void) -> *mut c_void {
+    pub fn hook_GlobalLock(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> *mut c_void,
+        mem: *mut c_void,
+    ) -> *mut c_void {
         mem
     }
     #[allow(non_snake_case)]
@@ -576,7 +660,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalUnlock(&mut self, _mem: *mut c_void) -> bool {
+    pub fn hook_GlobalUnlock(
+        &mut self,
+        _original: extern "C" fn(_mem: *mut c_void) -> bool,
+        _mem: *mut c_void,
+    ) -> bool {
         false
     }
     #[allow(non_snake_case)]
@@ -586,7 +674,11 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalSize(&mut self, mem: *mut c_void) -> usize {
+    pub fn hook_GlobalSize(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> usize,
+        mem: *mut c_void,
+    ) -> usize {
         self.allocator_mut().get_usable_size(mem)
     }
     #[allow(non_snake_case)]
@@ -596,23 +688,39 @@ impl AsanRuntime {
     }
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_GlobalFlags(&mut self, _mem: *mut c_void) -> u32 {
+    pub fn hook_GlobalFlags(
+        &mut self,
+        _original: extern "C" fn(mem: *mut c_void) -> u32,
+        _mem: *mut c_void,
+    ) -> u32 {
         0
     }
 
     #[inline]
-    pub fn hook_malloc(&mut self, size: usize) -> *mut c_void {
+    pub fn hook_malloc(
+        &mut self,
+        _original: extern "C" fn(size: usize) -> *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(size, 8) }
     }
 
     #[inline]
-    pub fn hook_o_malloc(&mut self, size: usize) -> *mut c_void {
+    pub fn hook_o_malloc(
+        &mut self,
+        _original: extern "C" fn(size: usize) -> *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(size, 8) }
     }
 
     #[allow(non_snake_case)]
     #[inline]
-    pub fn hook__Znam(&mut self, size: usize) -> *mut c_void {
+    pub fn hook__Znam(
+        &mut self,
+        _original: extern "C" fn(size: usize) -> *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(size, 8) }
     }
 
@@ -620,6 +728,7 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZnamRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(size: usize, _nothrow: *const c_void) -> *mut c_void,
         size: usize,
         _nothrow: *const c_void,
     ) -> *mut c_void {
@@ -628,7 +737,12 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[inline]
-    pub fn hook__ZnamSt11align_val_t(&mut self, size: usize, alignment: usize) -> *mut c_void {
+    pub fn hook__ZnamSt11align_val_t(
+        &mut self,
+        _original: extern "C" fn(size: usize, alignment: usize) -> *mut c_void,
+        size: usize,
+        alignment: usize,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(size, alignment) }
     }
 
@@ -636,6 +750,11 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZnamSt11align_val_tRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(
+            size: usize,
+            alignment: usize,
+            _nothrow: *const c_void,
+        ) -> *mut c_void,
         size: usize,
         alignment: usize,
         _nothrow: *const c_void,
@@ -645,7 +764,11 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[inline]
-    pub fn hook__Znwm(&mut self, size: usize) -> *mut c_void {
+    pub fn hook__Znwm(
+        &mut self,
+        _original: extern "C" fn(size: usize) -> *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         let result = unsafe { self.allocator_mut().alloc(size, 8) };
         if result.is_null() {
             extern "system" {
@@ -665,6 +788,7 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZnwmRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(size: usize, _nothrow: *const c_void) -> *mut c_void,
         size: usize,
         _nothrow: *const c_void,
     ) -> *mut c_void {
@@ -673,7 +797,12 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[inline]
-    pub fn hook__ZnwmSt11align_val_t(&mut self, size: usize, alignment: usize) -> *mut c_void {
+    pub fn hook__ZnwmSt11align_val_t(
+        &mut self,
+        _original: extern "C" fn(size: usize, alignment: usize) -> *mut c_void,
+        size: usize,
+        alignment: usize,
+    ) -> *mut c_void {
         let result = unsafe { self.allocator_mut().alloc(size, alignment) };
         if result.is_null() {
             extern "system" {
@@ -691,6 +820,11 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZnwmSt11align_val_tRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(
+            size: usize,
+            alignment: usize,
+            _nothrow: *const c_void,
+        ) -> *mut c_void,
         size: usize,
         alignment: usize,
         _nothrow: *const c_void,
@@ -700,11 +834,20 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[inline]
-    pub fn hook__o_malloc(&mut self, size: usize) -> *mut c_void {
+    pub fn hook__o_malloc(
+        &mut self,
+        _original: extern "C" fn(size: usize) -> *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(size, 8) }
     }
     #[inline]
-    pub fn hook_calloc(&mut self, nmemb: usize, size: usize) -> *mut c_void {
+    pub fn hook_calloc(
+        &mut self,
+        _original: extern "C" fn(nmemb: usize, size: usize) -> *mut c_void,
+        nmemb: usize,
+        size: usize,
+    ) -> *mut c_void {
         extern "system" {
             fn memset(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
         }
@@ -717,7 +860,12 @@ impl AsanRuntime {
 
     #[allow(non_snake_case)]
     #[inline]
-    pub fn hook__o_calloc(&mut self, nmemb: usize, size: usize) -> *mut c_void {
+    pub fn hook__o_calloc(
+        &mut self,
+        _original: extern "C" fn(nmemb: usize, size: usize) -> *mut c_void,
+        nmemb: usize,
+        size: usize,
+    ) -> *mut c_void {
         extern "system" {
             fn memset(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
         }
@@ -731,7 +879,12 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[inline]
     #[allow(clippy::cmp_null)]
-    pub fn hook_realloc(&mut self, ptr: *mut c_void, size: usize) -> *mut c_void {
+    pub fn hook_realloc(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, size: usize) -> *mut c_void,
+        ptr: *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         unsafe {
             let ret = self.allocator_mut().alloc(size, 0x8);
             if ptr != std::ptr::null_mut() && ret != std::ptr::null_mut() {
@@ -747,7 +900,12 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[inline]
     #[allow(clippy::cmp_null)]
-    pub fn hook__o_realloc(&mut self, ptr: *mut c_void, size: usize) -> *mut c_void {
+    pub fn hook__o_realloc(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, size: usize) -> *mut c_void,
+        ptr: *mut c_void,
+        size: usize,
+    ) -> *mut c_void {
         unsafe {
             let ret = self.allocator_mut().alloc(size, 0x8);
             if ptr != std::ptr::null_mut() && ret != std::ptr::null_mut() {
@@ -769,7 +927,11 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[inline]
     #[allow(clippy::cmp_null)]
-    pub fn hook__o_free(&mut self, ptr: *mut c_void) -> usize {
+    pub fn hook__o_free(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void) -> usize,
+        ptr: *mut c_void,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -782,7 +944,11 @@ impl AsanRuntime {
 
     #[inline]
     #[allow(clippy::cmp_null)]
-    pub fn hook_free(&mut self, ptr: *mut c_void) -> usize {
+    pub fn hook_free(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void) -> usize,
+        ptr: *mut c_void,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -791,13 +957,19 @@ impl AsanRuntime {
 
     #[cfg(not(target_vendor = "apple"))]
     #[inline]
-    pub fn hook_memalign(&mut self, alignment: usize, size: usize) -> *mut c_void {
+    pub fn hook_memalign(
+        &mut self,
+        _original: extern "C" fn(alignment: usize, size: usize) -> *mut c_void,
+        alignment: usize,
+        size: usize,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(size, alignment) }
     }
 
     #[inline]
     pub fn hook_posix_memalign(
         &mut self,
+        _original: extern "C" fn(pptr: *mut *mut c_void, alignment: usize, size: usize) -> i32,
         pptr: *mut *mut c_void,
         alignment: usize,
         size: usize,
@@ -810,7 +982,11 @@ impl AsanRuntime {
 
     #[inline]
     #[cfg(not(target_vendor = "apple"))]
-    pub fn hook_malloc_usable_size(&mut self, ptr: *mut c_void) -> usize {
+    pub fn hook_malloc_usable_size(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void) -> usize,
+        ptr: *mut c_void,
+    ) -> usize {
         self.allocator_mut().get_usable_size(ptr)
     }
 
@@ -819,11 +995,6 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_MapViewOfFile(
         &mut self,
-        _handle: *const c_void,
-        _desired_access: u32,
-        _file_offset_high: u32,
-        _file_offset_low: u32,
-        size: usize,
         original: extern "C" fn(
             handle: *const c_void,
             desired_access: u32,
@@ -831,6 +1002,11 @@ impl AsanRuntime {
             file_offset_low: u32,
             size: usize,
         ) -> *const c_void,
+        _handle: *const c_void,
+        _desired_access: u32,
+        _file_offset_high: u32,
+        _file_offset_low: u32,
+        size: usize,
     ) -> *const c_void {
         let ret = original(
             _handle,
@@ -846,7 +1022,11 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[allow(clippy::cmp_null)]
     #[inline]
-    pub fn hook__ZdaPv(&mut self, ptr: *mut c_void) -> usize {
+    pub fn hook__ZdaPv(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void) -> usize,
+        ptr: *mut c_void,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -856,7 +1036,12 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[allow(clippy::cmp_null)]
     #[inline]
-    pub fn hook__ZdaPvm(&mut self, ptr: *mut c_void, _ulong: u64) -> usize {
+    pub fn hook__ZdaPvm(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _ulong: u64) -> usize,
+        ptr: *mut c_void,
+        _ulong: u64,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -868,6 +1053,7 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZdaPvmSt11align_val_t(
         &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _ulong: u64, _alignment: usize) -> usize,
         ptr: *mut c_void,
         _ulong: u64,
         _alignment: usize,
@@ -883,6 +1069,7 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZdaPvRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _nothrow: *const c_void) -> usize,
         ptr: *mut c_void,
         _nothrow: *const c_void,
     ) -> usize {
@@ -897,6 +1084,11 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZdaPvSt11align_val_tRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(
+            ptr: *mut c_void,
+            _alignment: usize,
+            _nothrow: *const c_void,
+        ) -> usize,
         ptr: *mut c_void,
         _alignment: usize,
         _nothrow: *const c_void,
@@ -910,7 +1102,12 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[allow(clippy::cmp_null)]
     #[inline]
-    pub fn hook__ZdaPvSt11align_val_t(&mut self, ptr: *mut c_void, _alignment: usize) -> usize {
+    pub fn hook__ZdaPvSt11align_val_t(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _alignment: usize) -> usize,
+        ptr: *mut c_void,
+        _alignment: usize,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -920,7 +1117,11 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[allow(clippy::cmp_null)]
     #[inline]
-    pub fn hook__ZdlPv(&mut self, ptr: *mut c_void) -> usize {
+    pub fn hook__ZdlPv(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void) -> usize,
+        ptr: *mut c_void,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -930,7 +1131,12 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[allow(clippy::cmp_null)]
     #[inline]
-    pub fn hook__ZdlPvm(&mut self, ptr: *mut c_void, _ulong: u64) -> usize {
+    pub fn hook__ZdlPvm(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _ulong: u64) -> usize,
+        ptr: *mut c_void,
+        _ulong: u64,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -942,6 +1148,7 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZdlPvmSt11align_val_t(
         &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _ulong: u64, _alignment: usize) -> usize,
         ptr: *mut c_void,
         _ulong: u64,
         _alignment: usize,
@@ -957,6 +1164,7 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZdlPvRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _nothrow: *const c_void) -> usize,
         ptr: *mut c_void,
         _nothrow: *const c_void,
     ) -> usize {
@@ -971,6 +1179,11 @@ impl AsanRuntime {
     #[inline]
     pub fn hook__ZdlPvSt11align_val_tRKSt9nothrow_t(
         &mut self,
+        _original: extern "C" fn(
+            ptr: *mut c_void,
+            _alignment: usize,
+            _nothrow: *const c_void,
+        ) -> usize,
         ptr: *mut c_void,
         _alignment: usize,
         _nothrow: *const c_void,
@@ -984,7 +1197,12 @@ impl AsanRuntime {
     #[allow(non_snake_case)]
     #[allow(clippy::cmp_null)]
     #[inline]
-    pub fn hook__ZdlPvSt11align_val_t(&mut self, ptr: *mut c_void, _alignment: usize) -> usize {
+    pub fn hook__ZdlPvSt11align_val_t(
+        &mut self,
+        _original: extern "C" fn(ptr: *mut c_void, _alignment: usize) -> usize,
+        ptr: *mut c_void,
+        _alignment: usize,
+    ) -> usize {
         if ptr != std::ptr::null_mut() {
             unsafe { self.allocator_mut().release(ptr) }
         }
@@ -994,6 +1212,14 @@ impl AsanRuntime {
     #[inline]
     pub fn hook_mmap(
         &mut self,
+        original: extern "C" fn(
+            addr: *const c_void,
+            length: usize,
+            prot: i32,
+            flags: i32,
+            fd: i32,
+            offset: usize,
+        ) -> *mut c_void,
         addr: *const c_void,
         length: usize,
         prot: i32,
@@ -1001,17 +1227,7 @@ impl AsanRuntime {
         fd: i32,
         offset: usize,
     ) -> *mut c_void {
-        extern "system" {
-            fn mmap(
-                addr: *const c_void,
-                length: usize,
-                prot: i32,
-                flags: i32,
-                fd: i32,
-                offset: usize,
-            ) -> *mut c_void;
-        }
-        let res = unsafe { mmap(addr, length, prot, flags, fd, offset) };
+        let res = original(addr, length, prot, flags, fd, offset);
         if res != (-1_isize as *mut c_void) {
             self.allocator_mut()
                 .map_shadow_for_region(res as usize, res as usize + length, true);
@@ -1020,11 +1236,13 @@ impl AsanRuntime {
     }
 
     #[inline]
-    pub fn hook_munmap(&mut self, addr: *const c_void, length: usize) -> i32 {
-        extern "system" {
-            fn munmap(addr: *const c_void, length: usize) -> i32;
-        }
-        let res = unsafe { munmap(addr, length) };
+    pub fn hook_munmap(
+        &mut self,
+        original: extern "C" fn(addr: *const c_void, length: usize) -> i32,
+        addr: *const c_void,
+        length: usize,
+    ) -> i32 {
+        let res = original(addr, length);
         if res != -1 {
             Allocator::poison(self.allocator_mut().map_to_shadow(addr as usize), length);
         }
@@ -1033,14 +1251,24 @@ impl AsanRuntime {
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn hook__write(&mut self, fd: i32, buf: *const c_void, count: usize) -> usize {
-        self.hook_write(fd, buf, count)
+    pub fn hook__write(
+        &mut self,
+        original: extern "C" fn(fd: i32, buf: *const c_void, count: usize) -> usize,
+        fd: i32,
+        buf: *const c_void,
+        count: usize,
+    ) -> usize {
+        self.hook_write(original, fd, buf, count)
     }
     #[inline]
-    pub fn hook_write(&mut self, fd: i32, buf: *const c_void, count: usize) -> usize {
-        extern "system" {
-            fn write(fd: i32, buf: *const c_void, count: usize) -> usize;
-        }
+    pub fn hook_write(
+        &mut self,
+        original: extern "C" fn(fd: i32, buf: *const c_void, count: usize) -> usize,
+        fd: i32,
+        buf: *const c_void,
+        count: usize,
+    ) -> usize {
+
         if !self.allocator_mut().check_shadow(buf, count) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "write".to_string(),
@@ -1050,19 +1278,28 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { write(fd, buf, count) }
+        original(fd, buf, count) 
     }
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn hook__read(&mut self, fd: i32, buf: *mut c_void, count: usize) -> usize {
-        self.hook_read(fd, buf, count)
+    pub fn hook__read(
+        &mut self,
+        original: extern "C" fn(fd: i32, buf: *mut c_void, count: usize) -> usize,
+        fd: i32,
+        buf: *mut c_void,
+        count: usize,
+    ) -> usize {
+        self.hook_read(original, fd, buf, count)
     }
     #[inline]
-    pub fn hook_read(&mut self, fd: i32, buf: *mut c_void, count: usize) -> usize {
-        extern "system" {
-            fn read(fd: i32, buf: *mut c_void, count: usize) -> usize;
-        }
+    pub fn hook_read(
+        &mut self,
+        original: extern "C" fn(fd: i32, buf: *mut c_void, count: usize) -> usize,
+        fd: i32,
+        buf: *mut c_void,
+        count: usize,
+    ) -> usize {
         if !self.allocator_mut().check_shadow(buf, count) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "read".to_string(),
@@ -1072,14 +1309,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { read(fd, buf, count) }
+        original(fd, buf, count)
     }
 
     #[inline]
-    pub fn hook_fgets(&mut self, s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void {
-        extern "system" {
-            fn fgets(s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void;
-        }
+    pub fn hook_fgets(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, size: u32, stream: *mut c_void) -> *mut c_void,
+        s: *mut c_void,
+        size: u32,
+        stream: *mut c_void,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(s, size as usize) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "fgets".to_string(),
@@ -1089,14 +1329,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { fgets(s, size, stream) }
+        original(s, size, stream)
     }
 
     #[inline]
-    pub fn hook_memcmp(&mut self, s1: *const c_void, s2: *const c_void, n: usize) -> i32 {
-        extern "system" {
-            fn memcmp(s1: *const c_void, s2: *const c_void, n: usize) -> i32;
-        }
+    pub fn hook_memcmp(
+        &mut self,
+        original: extern "C" fn(s1: *const c_void, s2: *const c_void, n: usize) -> i32,
+        s1: *const c_void,
+        s2: *const c_void,
+        n: usize,
+    ) -> i32 {
         if !self.allocator_mut().check_shadow(s1, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "memcmp".to_string(),
@@ -1115,14 +1358,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memcmp(s1, s2, n) }
+        original(s1, s2, n)
     }
 
     #[inline]
-    pub fn hook_memcpy(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
-        extern "system" {
-            fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
-        }
+    pub fn hook_memcpy(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void,
+        dest: *mut c_void,
+        src: *const c_void,
+        n: usize,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(dest, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "memcpy".to_string(),
@@ -1141,15 +1387,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memcpy(dest, src, n) }
+        original(dest, src, n)
     }
 
     #[inline]
     #[cfg(not(target_vendor = "apple"))]
-    pub fn hook_mempcpy(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
-        extern "system" {
-            fn mempcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
-        }
+    pub fn hook_mempcpy(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void,
+        dest: *mut c_void,
+        src: *const c_void,
+        n: usize,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(dest, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "mempcpy".to_string(),
@@ -1168,14 +1417,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { mempcpy(dest, src, n) }
+        original(dest, src, n)
     }
 
     #[inline]
-    pub fn hook_memmove(&mut self, dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
-        extern "system" {
-            fn memmove(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void;
-        }
+    pub fn hook_memmove(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void,
+        dest: *mut c_void,
+        src: *const c_void,
+        n: usize,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(dest, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "memmove".to_string(),
@@ -1195,14 +1447,17 @@ impl AsanRuntime {
             )));
         }
 
-        unsafe { memmove(dest, src, n) }
+        original(dest, src, n)
     }
 
     #[inline]
-    pub fn hook_memset(&mut self, dest: *mut c_void, c: i32, n: usize) -> *mut c_void {
-        extern "system" {
-            fn memset(dest: *mut c_void, c: i32, n: usize) -> *mut c_void;
-        }
+    pub fn hook_memset(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_void, c: i32, n: usize) -> *mut c_void,
+        dest: *mut c_void,
+        c: i32,
+        n: usize,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(dest, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "memset".to_string(),
@@ -1212,14 +1467,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memset(dest, c, n) }
+        original(dest, c, n)
     }
 
     #[inline]
-    pub fn hook_memchr(&mut self, s: *mut c_void, c: i32, n: usize) -> *mut c_void {
-        extern "system" {
-            fn memchr(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
-        }
+    pub fn hook_memchr(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, c: i32, n: usize) -> *mut c_void,
+        s: *mut c_void,
+        c: i32,
+        n: usize,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "memchr".to_string(),
@@ -1229,15 +1487,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memchr(s, c, n) }
+        original(s, c, n)
     }
 
     #[inline]
     #[cfg(not(target_vendor = "apple"))]
-    pub fn hook_memrchr(&mut self, s: *mut c_void, c: i32, n: usize) -> *mut c_void {
-        extern "system" {
-            fn memrchr(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
-        }
+    pub fn hook_memrchr(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, c: i32, n: usize) -> *mut c_void,
+        s: *mut c_void,
+        c: i32,
+        n: usize,
+    ) -> *mut c_void {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "memrchr".to_string(),
@@ -1247,25 +1508,23 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memrchr(s, c, n) }
+        original(s, c, n)
     }
 
     #[inline]
     pub fn hook_memmem(
         &mut self,
+        original: extern "C" fn(
+            haystack: *const c_void,
+            haystacklen: usize,
+            needle: *const c_void,
+            needlelen: usize,
+        ) -> *mut c_void,
         haystack: *const c_void,
         haystacklen: usize,
         needle: *const c_void,
         needlelen: usize,
     ) -> *mut c_void {
-        extern "system" {
-            fn memmem(
-                haystack: *const c_void,
-                haystacklen: usize,
-                needle: *const c_void,
-                needlelen: usize,
-            ) -> *mut c_void;
-        }
         if !self.allocator_mut().check_shadow(haystack, haystacklen) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "memmem".to_string(),
@@ -1284,15 +1543,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memmem(haystack, haystacklen, needle, needlelen) }
+        original(haystack, haystacklen, needle, needlelen)
     }
 
     #[cfg(not(target_os = "android"))]
     #[inline]
-    pub fn hook_bzero(&mut self, s: *mut c_void, n: usize) -> usize {
-        extern "system" {
-            fn bzero(s: *mut c_void, n: usize) -> usize;
-        }
+    pub fn hook_bzero(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, n: usize) -> usize,
+        s: *mut c_void,
+        n: usize,
+    ) -> usize {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "bzero".to_string(),
@@ -1302,15 +1563,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { bzero(s, n) }
+        original(s, n)
     }
 
     #[cfg(all(not(target_os = "android"), not(target_vendor = "apple")))]
     #[inline]
-    pub fn hook_explicit_bzero(&mut self, s: *mut c_void, n: usize) -> usize {
-        extern "system" {
-            fn explicit_bzero(s: *mut c_void, n: usize) -> usize;
-        }
+    pub fn hook_explicit_bzero(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, n: usize) -> usize,
+        s: *mut c_void,
+        n: usize,
+    ) -> usize {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "explicit_bzero".to_string(),
@@ -1320,15 +1583,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { explicit_bzero(s, n) }
+        original(s, n)
     }
 
     #[cfg(not(target_os = "android"))]
     #[inline]
-    pub fn hook_bcmp(&mut self, s1: *const c_void, s2: *const c_void, n: usize) -> i32 {
-        extern "system" {
-            fn bcmp(s1: *const c_void, s2: *const c_void, n: usize) -> i32;
-        }
+    pub fn hook_bcmp(
+        &mut self,
+        original: extern "C" fn(s1: *const c_void, s2: *const c_void, n: usize) -> i32,
+        s1: *const c_void,
+        s2: *const c_void,
+        n: usize,
+    ) -> i32 {
         if !self.allocator_mut().check_shadow(s1, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "bcmp".to_string(),
@@ -1347,13 +1613,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { bcmp(s1, s2, n) }
+        original(s1, s2, n)
     }
 
     #[inline]
-    pub fn hook_strchr(&mut self, s: *mut c_char, c: i32) -> *mut c_char {
+    pub fn hook_strchr(
+        &mut self,
+        original: extern "C" fn(s: *mut c_char, c: i32) -> *mut c_char,
+        s: *mut c_char,
+        c: i32,
+    ) -> *mut c_char {
         extern "system" {
-            fn strchr(s: *mut c_char, c: i32) -> *mut c_char;
+
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1368,13 +1639,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strchr(s, c) }
+        original(s, c)
     }
 
     #[inline]
-    pub fn hook_strrchr(&mut self, s: *mut c_char, c: i32) -> *mut c_char {
+    pub fn hook_strrchr(
+        &mut self,
+        original: extern "C" fn(s: *mut c_char, c: i32) -> *mut c_char,
+        s: *mut c_char,
+        c: i32,
+    ) -> *mut c_char {
         extern "system" {
-            fn strrchr(s: *mut c_char, c: i32) -> *mut c_char;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1389,13 +1664,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strrchr(s, c) }
+        original(s, c)
     }
 
     #[inline]
-    pub fn hook_strcasecmp(&mut self, s1: *const c_char, s2: *const c_char) -> i32 {
+    pub fn hook_strcasecmp(
+        &mut self,
+        original: extern "C" fn(s1: *const c_char, s2: *const c_char) -> i32,
+        s1: *const c_char,
+        s2: *const c_char,
+    ) -> i32 {
         extern "system" {
-            fn strcasecmp(s1: *const c_char, s2: *const c_char) -> i32;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1422,14 +1701,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strcasecmp(s1, s2) }
+        original(s1, s2)
     }
 
     #[inline]
-    pub fn hook_strncasecmp(&mut self, s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
-        extern "system" {
-            fn strncasecmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32;
-        }
+    pub fn hook_strncasecmp(
+        &mut self,
+        original: extern "C" fn(s1: *const c_char, s2: *const c_char, n: usize) -> i32,
+        s1: *const c_char,
+        s2: *const c_char,
+        n: usize,
+    ) -> i32 {
         if !self.allocator_mut().check_shadow(s1 as *const c_void, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "strncasecmp".to_string(),
@@ -1448,13 +1730,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strncasecmp(s1, s2, n) }
+        original(s1, s2, n)
     }
 
     #[inline]
-    pub fn hook_strcat(&mut self, s1: *mut c_char, s2: *const c_char) -> *mut c_char {
+    pub fn hook_strcat(
+        &mut self,
+        original: extern "C" fn(s1: *mut c_char, s2: *const c_char) -> *mut c_char,
+        s1: *mut c_char,
+        s2: *const c_char,
+    ) -> *mut c_char {
         extern "system" {
-            fn strcat(s1: *mut c_char, s2: *const c_char) -> *mut c_char;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1481,13 +1767,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strcat(s1, s2) }
+        original(s1, s2)
     }
 
     #[inline]
-    pub fn hook_strcmp(&mut self, s1: *const c_char, s2: *const c_char) -> i32 {
+    pub fn hook_strcmp(
+        &mut self,
+        original: extern "C" fn(s1: *const c_char, s2: *const c_char) -> i32,
+        s1: *const c_char,
+        s2: *const c_char,
+    ) -> i32 {
         extern "system" {
-            fn strcmp(s1: *const c_char, s2: *const c_char) -> i32;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1514,13 +1804,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strcmp(s1, s2) }
+        original(s1, s2)
     }
 
     #[inline]
-    pub fn hook_strncmp(&mut self, s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
+    pub fn hook_strncmp(
+        &mut self,
+        original: extern "C" fn(s1: *const c_char, s2: *const c_char, n: usize) -> i32,
+        s1: *const c_char,
+        s2: *const c_char,
+        n: usize,
+    ) -> i32 {
         extern "system" {
-            fn strncmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32;
             fn strnlen(s: *const c_char, n: usize) -> usize;
         }
         if !self
@@ -1547,13 +1842,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strncmp(s1, s2, n) }
+        original(s1, s2, n)
     }
 
     #[inline]
-    pub fn hook_strcpy(&mut self, dest: *mut c_char, src: *const c_char) -> *mut c_char {
+    pub fn hook_strcpy(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_char, src: *const c_char) -> *mut c_char,
+        dest: *mut c_char,
+        src: *const c_char,
+    ) -> *mut c_char {
         extern "system" {
-            fn strcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1580,14 +1879,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strcpy(dest, src) }
+        original(dest, src)
     }
 
     #[inline]
-    pub fn hook_strncpy(&mut self, dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char {
-        extern "system" {
-            fn strncpy(dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char;
-        }
+    pub fn hook_strncpy(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_char, src: *const c_char, n: usize) -> *mut c_char,
+        dest: *mut c_char,
+        src: *const c_char,
+        n: usize,
+    ) -> *mut c_char {
         if !self.allocator_mut().check_shadow(dest as *const c_void, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "strncpy".to_string(),
@@ -1606,13 +1908,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strncpy(dest, src, n) }
+        original(dest, src, n)
     }
 
     #[inline]
-    pub fn hook_stpcpy(&mut self, dest: *mut c_char, src: *const c_char) -> *mut c_char {
+    pub fn hook_stpcpy(
+        &mut self,
+        original: extern "C" fn(dest: *mut c_char, src: *const c_char) -> *mut c_char,
+        dest: *mut c_char,
+        src: *const c_char,
+    ) -> *mut c_char {
         extern "system" {
-            fn stpcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1639,16 +1945,24 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { stpcpy(dest, src) }
+        original(dest, src)
     }
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn hook__strdup(&mut self, s: *const c_char) -> *mut c_char {
-        self.hook_strdup(s)
+    pub fn hook__strdup(
+        &mut self,
+        original: extern "C" fn(s: *const c_char) -> *mut c_char,
+        s: *const c_char,
+    ) -> *mut c_char {
+        self.hook_strdup(original, s)
     }
     #[inline]
-    pub fn hook_strdup(&mut self, s: *const c_char) -> *mut c_char {
+    pub fn hook_strdup(
+        &mut self,
+        _original: extern "C" fn(s: *const c_char) -> *mut c_char,
+        s: *const c_char,
+    ) -> *mut c_char {
         extern "system" {
             fn strlen(s: *const c_char) -> usize;
             fn strcpy(dest: *mut c_char, src: *const c_char) -> *mut c_char;
@@ -1672,11 +1986,12 @@ impl AsanRuntime {
     }
 
     #[inline]
-    pub fn hook_strlen(&mut self, s: *const c_char) -> usize {
-        extern "system" {
-            fn strlen(s: *const c_char) -> usize;
-        }
-        let size = unsafe { strlen(s) };
+    pub fn hook_strlen(
+        &mut self,
+        original: extern "C" fn(s: *const c_char) -> usize,
+        s: *const c_char,
+    ) -> usize {
+        let size = original(s);
         if !self.allocator_mut().check_shadow(s as *const c_void, size) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "strlen".to_string(),
@@ -1690,11 +2005,13 @@ impl AsanRuntime {
     }
 
     #[inline]
-    pub fn hook_strnlen(&mut self, s: *const c_char, n: usize) -> usize {
-        extern "system" {
-            fn strnlen(s: *const c_char, n: usize) -> usize;
-        }
-        let size = unsafe { strnlen(s, n) };
+    pub fn hook_strnlen(
+        &mut self,
+        original: extern "C" fn(s: *const c_char, n: usize) -> usize,
+        s: *const c_char,
+        n: usize,
+    ) -> usize {
+        let size = original(s, n);
         if !self.allocator_mut().check_shadow(s as *const c_void, size) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgRead((
                 "strnlen".to_string(),
@@ -1708,9 +2025,13 @@ impl AsanRuntime {
     }
 
     #[inline]
-    pub fn hook_strstr(&mut self, haystack: *const c_char, needle: *const c_char) -> *mut c_char {
+    pub fn hook_strstr(
+        &mut self,
+        original: extern "C" fn(haystack: *const c_char, needle: *const c_char) -> *mut c_char,
+        haystack: *const c_char,
+        needle: *const c_char,
+    ) -> *mut c_char {
         extern "system" {
-            fn strstr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1737,17 +2058,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strstr(haystack, needle) }
+        original(haystack, needle)
     }
 
     #[inline]
     pub fn hook_strcasestr(
         &mut self,
+        original: extern "C" fn(haystack: *const c_char, needle: *const c_char) -> *mut c_char,
         haystack: *const c_char,
         needle: *const c_char,
     ) -> *mut c_char {
         extern "system" {
-            fn strcasestr(haystack: *const c_char, needle: *const c_char) -> *mut c_char;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1774,13 +2095,16 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { strcasestr(haystack, needle) }
+        original(haystack, needle)
     }
 
     #[inline]
-    pub fn hook_atoi(&mut self, s: *const c_char) -> i32 {
+    pub fn hook_atoi(
+        &mut self,
+        original: extern "C" fn(s: *const c_char) -> i32,
+        s: *const c_char,
+    ) -> i32 {
         extern "system" {
-            fn atoi(s: *const c_char) -> i32;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1795,14 +2119,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { atoi(s) }
+        original(s)
     }
 
     /// Hooks `atol`
     #[inline]
-    pub fn hook_atol(&mut self, s: *const c_char) -> i32 {
+    pub fn hook_atol(
+        &mut self,
+        original: extern "C" fn(s: *const c_char) -> i32,
+        s: *const c_char,
+    ) -> i32 {
         extern "system" {
-            fn atol(s: *const c_char) -> i32;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1817,14 +2144,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { atol(s) }
+        original(s)
     }
 
     /// Hooks `atoll`
     #[inline]
-    pub fn hook_atoll(&mut self, s: *const c_char) -> i64 {
+    pub fn hook_atoll(
+        &mut self,
+        original: extern "C" fn(s: *const c_char) -> i64,
+        s: *const c_char,
+    ) -> i64 {
         extern "system" {
-            fn atoll(s: *const c_char) -> i64;
             fn strlen(s: *const c_char) -> usize;
         }
         if !self
@@ -1839,16 +2169,17 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { atoll(s) }
+        original(s)
     }
 
     /// Hooks `wcslen`
     #[inline]
-    pub fn hook_wcslen(&mut self, s: *const wchar_t) -> usize {
-        extern "system" {
-            fn wcslen(s: *const wchar_t) -> usize;
-        }
-        let size = unsafe { wcslen(s) };
+    pub fn hook_wcslen(
+        &mut self,
+        original: extern "C" fn(s: *const wchar_t) -> usize,
+        s: *const wchar_t,
+    ) -> usize {
+        let size = original(s);
         if !self
             .allocator_mut()
             .check_shadow(s as *const c_void, (size + 1) * 2)
@@ -1866,9 +2197,13 @@ impl AsanRuntime {
 
     /// Hooks `wcscpy`
     #[inline]
-    pub fn hook_wcscpy(&mut self, dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t {
+    pub fn hook_wcscpy(
+        &mut self,
+        original: extern "C" fn(dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t,
+        dest: *mut wchar_t,
+        src: *const wchar_t,
+    ) -> *mut wchar_t {
         extern "system" {
-            fn wcscpy(dest: *mut wchar_t, src: *const wchar_t) -> *mut wchar_t;
             fn wcslen(s: *const wchar_t) -> usize;
         }
         if !self
@@ -1895,14 +2230,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { wcscpy(dest, src) }
+        original(dest, src)
     }
 
     /// Hooks `wcscmp`
     #[inline]
-    pub fn hook_wcscmp(&mut self, s1: *const wchar_t, s2: *const wchar_t) -> i32 {
+    pub fn hook_wcscmp(
+        &mut self,
+        original: extern "C" fn(s1: *const wchar_t, s2: *const wchar_t) -> i32,
+        s1: *const wchar_t,
+        s2: *const wchar_t,
+    ) -> i32 {
         extern "system" {
-            fn wcscmp(s1: *const wchar_t, s2: *const wchar_t) -> i32;
             fn wcslen(s: *const wchar_t) -> usize;
         }
         if !self
@@ -1929,15 +2268,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { wcscmp(s1, s2) }
+        original(s1, s2)
     }
 
     #[cfg(target_vendor = "apple")]
     #[inline]
-    pub fn hook_memset_pattern4(&mut self, s: *mut c_void, p4: *const c_void, n: usize) {
-        extern "system" {
-            fn memset_pattern4(s: *mut c_void, p4: *const c_void, n: usize);
-        }
+    pub fn hook_memset_pattern4(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, p4: *const c_void, n: usize),
+        s: *mut c_void,
+        p4: *const c_void,
+        n: usize,
+    ) {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "memset_pattern4".to_string(),
@@ -1956,15 +2298,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memset_pattern4(s, p4, n) }
+        original(s, p4, n)
     }
 
     #[cfg(target_vendor = "apple")]
     #[inline]
-    pub fn hook_memset_pattern8(&mut self, s: *mut c_void, p8: *const c_void, n: usize) {
-        extern "system" {
-            fn memset_pattern8(s: *mut c_void, p8: *const c_void, n: usize);
-        }
+    pub fn hook_memset_pattern8(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, p8: *const c_void, n: usize),
+        s: *mut c_void,
+        p8: *const c_void,
+        n: usize,
+    ) {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "memset_pattern8".to_string(),
@@ -1983,15 +2328,18 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memset_pattern8(s, p8, n) }
+        original(s, p8, n)
     }
 
     #[cfg(target_vendor = "apple")]
     #[inline]
-    pub fn hook_memset_pattern16(&mut self, s: *mut c_void, p16: *const c_void, n: usize) {
-        extern "system" {
-            fn memset_pattern16(s: *mut c_void, p16: *const c_void, n: usize);
-        }
+    pub fn hook_memset_pattern16(
+        &mut self,
+        original: extern "C" fn(s: *mut c_void, p16: *const c_void, n: usize),
+        s: *mut c_void,
+        p16: *const c_void,
+        n: usize,
+    ) {
         if !self.allocator_mut().check_shadow(s, n) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "memset_pattern16".to_string(),
@@ -2010,6 +2358,6 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        unsafe { memset_pattern16(s, p16, n) }
+        original(s, p16, n)
     }
 }

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -17,7 +17,11 @@ impl AsanRuntime {
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_NtGdiCreateCompatibleDC(&mut self, original: extern "C" fn(_hdc: *const c_void) -> *mut c_void, _hdc: *const c_void) -> *mut c_void {
+    pub fn hook_NtGdiCreateCompatibleDC(
+        &mut self,
+        original: extern "C" fn(_hdc: *const c_void) -> *mut c_void,
+        _hdc: *const c_void,
+    ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(8, 8) }
     }
 

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -826,16 +826,24 @@ impl AsanRuntime {
         size: usize,
     ) -> *const c_void {
         extern "system" {
-            fn MapViewOfFile(handle: *const c_void, _desired_access: u32, _file_offset_high: u32, _file_offset_low: u32, size: usize) -> *const c_void;
+            fn MapViewOfFile(
+                handle: *const c_void,
+                _desired_access: u32,
+                _file_offset_high: u32,
+                _file_offset_low: u32,
+                size: usize,
+            ) -> *const c_void;
         }
-        
-        let ret = MapViewOfFile(
-            _handle,
-            _desired_access,
-            _file_offset_high,
-            _file_offset_low,
-            size,
-        );
+
+        let ret = unsafe {
+            MapViewOfFile(
+                _handle,
+                _desired_access,
+                _file_offset_high,
+                _file_offset_low,
+                size,
+            )
+        };
         self.unpoison(ret as usize, size);
         ret
     }

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -824,26 +824,16 @@ impl AsanRuntime {
         _file_offset_high: u32,
         _file_offset_low: u32,
         size: usize,
+        original: extern "C" fn(handle: *const c_void, desired_access: u32, file_offset_high: u32, file_offset_low: u32, size: usize) -> *const c_void,
     ) -> *const c_void {
-        extern "system" {
-            fn MapViewOfFile(
-                handle: *const c_void,
-                _desired_access: u32,
-                _file_offset_high: u32,
-                _file_offset_low: u32,
-                size: usize,
-            ) -> *const c_void;
-        }
 
-        let ret = unsafe {
-            MapViewOfFile(
+        let ret = original(
                 _handle,
                 _desired_access,
                 _file_offset_high,
                 _file_offset_low,
                 size,
-            )
-        };
+            );
         self.unpoison(ret as usize, size);
         ret
     }

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -1210,6 +1210,7 @@ impl AsanRuntime {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn hook_mmap(
         &mut self,
         original: extern "C" fn(

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -825,9 +825,11 @@ impl AsanRuntime {
         _file_offset_low: u32,
         size: usize,
     ) -> *const c_void {
-        let original: extern "C" fn(*const c_void, u32, u32, u32, usize) -> *const c_void =
-            unsafe { std::mem::transmute(self.hooks.get(&"MapViewOfFile".to_string()).unwrap().0) };
-        let ret = (original)(
+        extern "system" {
+            fn MapViewOfFile(handle: *const c_void, _desired_access: u32, _file_offset_high: u32, _file_offset_low: u32, size: usize) -> *const c_void;
+        }
+        
+        let ret = MapViewOfFile(
             _handle,
             _desired_access,
             _file_offset_high,

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -19,7 +19,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_NtGdiCreateCompatibleDC(
         &mut self,
-        original: extern "C" fn(_hdc: *const c_void) -> *mut c_void,
+        _original: extern "C" fn(_hdc: *const c_void) -> *mut c_void,
         _hdc: *const c_void,
     ) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(8, 8) }

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -17,7 +17,7 @@ impl AsanRuntime {
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(windows)]
-    pub fn hook_NtGdiCreateCompatibleDC(&mut self, _hdc: *const c_void) -> *mut c_void {
+    pub fn hook_NtGdiCreateCompatibleDC(&mut self, original: extern "C" fn(_hdc: *const c_void) -> *mut c_void, _hdc: *const c_void) -> *mut c_void {
         unsafe { self.allocator_mut().alloc(8, 8) }
     }
 
@@ -548,7 +548,7 @@ impl AsanRuntime {
     #[cfg(windows)]
     pub fn hook_LocalSize(
         &mut self,
-        _original: extern "C" fn(mem: *mut c_void) -> bool,
+        _original: extern "C" fn(mem: *mut c_void) -> usize,
         mem: *mut c_void,
     ) -> usize {
         self.allocator_mut().get_usable_size(mem)

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -70,7 +70,7 @@ impl AsanRuntime {
         maximum_size_low: u32,
         name: *const c_void,
     ) -> usize {
-//        winsafe::OutputDebugString("In CreateFileMapping\n");
+        //        winsafe::OutputDebugString("In CreateFileMapping\n");
         original(
             file,
             file_mapping_attributes,
@@ -96,7 +96,7 @@ impl AsanRuntime {
         dll_name: *const c_void,
         base_address: *mut *const c_void,
     ) -> usize {
-//        winsafe::OutputDebugString("LdrLoadDll");
+        //        winsafe::OutputDebugString("LdrLoadDll");
         log::trace!("LdrLoadDll");
         let result = original(search_path, charecteristics, dll_name, base_address);
 
@@ -119,7 +119,7 @@ impl AsanRuntime {
         _context: usize,
         _entry_point: usize,
     ) -> usize {
-//        winsafe::OutputDebugString("LdrpCallInitRoutine");
+        //        winsafe::OutputDebugString("LdrpCallInitRoutine");
         // let result = unsafe { LdrLoadDll(path, file, flags,x )};
         // self.allocator_mut().unpoison_all_existing_memory();
         // result
@@ -1268,7 +1268,6 @@ impl AsanRuntime {
         buf: *const c_void,
         count: usize,
     ) -> usize {
-
         if !self.allocator_mut().check_shadow(buf, count) {
             AsanErrors::get_mut_blocking().report_error(AsanError::BadFuncArgWrite((
                 "write".to_string(),
@@ -1278,7 +1277,7 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        original(fd, buf, count) 
+        original(fd, buf, count)
     }
 
     #[inline]

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -824,16 +824,21 @@ impl AsanRuntime {
         _file_offset_high: u32,
         _file_offset_low: u32,
         size: usize,
-        original: extern "C" fn(handle: *const c_void, desired_access: u32, file_offset_high: u32, file_offset_low: u32, size: usize) -> *const c_void,
+        original: extern "C" fn(
+            handle: *const c_void,
+            desired_access: u32,
+            file_offset_high: u32,
+            file_offset_low: u32,
+            size: usize,
+        ) -> *const c_void,
     ) -> *const c_void {
-
         let ret = original(
-                _handle,
-                _desired_access,
-                _file_offset_high,
-                _file_offset_low,
-                size,
-            );
+            _handle,
+            _desired_access,
+            _file_offset_high,
+            _file_offset_low,
+            size,
+        );
         self.unpoison(ret as usize, size);
         ret
     }

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -128,6 +128,8 @@ impl FridaRuntime for CmpLogRuntime {
         self.generate_instrumentation_blobs();
     }
 
+    fn deinit(&mut self, _gum: &Gum){}
+
     fn pre_exec<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {
         Ok(())
     }

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -128,7 +128,7 @@ impl FridaRuntime for CmpLogRuntime {
         self.generate_instrumentation_blobs();
     }
 
-    fn deinit(&mut self, _gum: &Gum) {}
+    fn deinit(&mut self, _gum: &frida_gum::Gum) {}
 
     fn pre_exec<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {
         Ok(())

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -128,7 +128,7 @@ impl FridaRuntime for CmpLogRuntime {
         self.generate_instrumentation_blobs();
     }
 
-    fn deinit(&mut self, _gum: &Gum){}
+    fn deinit(&mut self, _gum: &Gum) {}
 
     fn pre_exec<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {
         Ok(())

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -42,6 +42,8 @@ impl FridaRuntime for CoverageRuntime {
     ) {
     }
 
+    fn deinit(&mut self, _gum: &frida_gum::Gum){}
+
     fn pre_exec<I: libafl::inputs::Input + libafl::inputs::HasTargetBytes>(
         &mut self,
         _input: &I,

--- a/libafl_frida/src/coverage_rt.rs
+++ b/libafl_frida/src/coverage_rt.rs
@@ -42,7 +42,7 @@ impl FridaRuntime for CoverageRuntime {
     ) {
     }
 
-    fn deinit(&mut self, _gum: &frida_gum::Gum){}
+    fn deinit(&mut self, _gum: &frida_gum::Gum) {}
 
     fn pre_exec<I: libafl::inputs::Input + libafl::inputs::HasTargetBytes>(
         &mut self,

--- a/libafl_frida/src/drcov_rt.rs
+++ b/libafl_frida/src/drcov_rt.rs
@@ -40,7 +40,7 @@ impl FridaRuntime for DrCovRuntime {
             .expect("failed to create directory for coverage files");
     }
 
-    fn deinit(&mut self, _gum: &frida_gum::Gum){}
+    fn deinit(&mut self, _gum: &frida_gum::Gum) {}
 
     /// Called before execution, does nothing
     fn pre_exec<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {

--- a/libafl_frida/src/drcov_rt.rs
+++ b/libafl_frida/src/drcov_rt.rs
@@ -40,6 +40,8 @@ impl FridaRuntime for DrCovRuntime {
             .expect("failed to create directory for coverage files");
     }
 
+    fn deinit(&mut self, _gum: &frida_gum::Gum){}
+
     /// Called before execution, does nothing
     fn pre_exec<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {
         Ok(())

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -64,7 +64,7 @@ pub trait FridaRuntimeTuple: MatchFirstType + Debug {
         ranges: &RangeMap<usize, (u16, String)>,
         module_map: &Rc<ModuleMap>,
     );
-    
+
     /// Deinitialization
     fn deinit_all(&mut self, gum: &Gum);
 
@@ -83,7 +83,7 @@ impl FridaRuntimeTuple for () {
         _module_map: &Rc<ModuleMap>,
     ) {
     }
-    fn deinit_all(&mut self, _gum: &Gum){}
+    fn deinit_all(&mut self, _gum: &Gum) {}
 
     fn pre_exec_all<I: Input + HasTargetBytes>(&mut self, _input: &I) -> Result<(), Error> {
         Ok(())
@@ -325,7 +325,6 @@ impl FridaInstrumentationHelperBuilder {
             disable_excludes,
         }
     }
-
 }
 
 impl Debug for FridaInstrumentationHelperBuilder {

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -574,7 +574,5 @@ mod tests {
         ];
         let options: FuzzerOptions = FuzzerOptions::try_parse_from(simulated_args).unwrap();
         unsafe { test_asan(&options) }
-
-
     }
 }

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -529,6 +529,8 @@ mod tests {
                 }
             }
         }
+
+        frida_helper.deinit(GUM.get().expect("Gum uninitialized"));
     }
 
     #[test]
@@ -572,5 +574,7 @@ mod tests {
         ];
         let options: FuzzerOptions = FuzzerOptions::try_parse_from(simulated_args).unwrap();
         unsafe { test_asan(&options) }
+
+
     }
 }

--- a/libafl_frida/src/utils.rs
+++ b/libafl_frida/src/utils.rs
@@ -2,6 +2,7 @@
 use frida_gum::instruction_writer::Aarch64Register;
 #[cfg(target_arch = "x86_64")]
 use frida_gum::{instruction_writer::X86Register, CpuContext};
+#[cfg(target_arch = "x86_64")]
 use libafl::Error;
 #[cfg(target_arch = "aarch64")]
 use num_traits::cast::FromPrimitive;


### PR DESCRIPTION
This patch fixes hook_func and implements deinit. The issue with hook_func was that hooked implementations would run in non-harness code as well (Resulting in odd errors from stalked portions of frida). This has been fixed.

Startup should also be much faster on macos as it was earlier attempting to poison the MALLOC_NANO region which is unusually high in memory resulting in 1 min+ startup. 

Should pass all tests now on unix and macos. 