### PR TITLE
Add client_stats to OnDiskJSONMonitor

### DIFF
--- a/libafl/src/monitors/disk.rs
+++ b/libafl/src/monitors/disk.rs
@@ -223,6 +223,7 @@ where
                 "objectives": self.base.objective_size(),
                 "executions": self.base.total_execs(),
                 "exec_sec": self.base.execs_per_sec(),
+                "client_stats": self.client_stats(),
             });
             writeln!(&file, "{line}").expect("Unable to write JSON to file");
         }


### PR DESCRIPTION
This adds all client_stats to the continuous JSON logging file. This is nice for visualization, e.g., here: https://github.com/eknoes/libafl-dashboard

If you think that its too much, saving all client stats, I could also make it configurable, however you guys prefer.