### PR TITLE
`NopScheduler`, for use in generative fuzzers

### DIFF
--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -14,6 +14,9 @@ pub use minimizer::{
     IndexesLenTimeMinimizerScheduler, LenTimeMinimizerScheduler, MinimizerScheduler,
 };
 
+pub mod nop;
+pub use nop::NopScheduler;
+
 pub mod powersched;
 pub use powersched::{PowerQueueScheduler, SchedulerMetadata};
 

--- a/libafl/src/schedulers/nop.rs
+++ b/libafl/src/schedulers/nop.rs
@@ -1,0 +1,49 @@
+use core::marker::PhantomData;
+
+use libafl_bolts::Error;
+
+use crate::corpus::CorpusId;
+use crate::state::{HasCorpus, State, UsesState};
+
+use super::Scheduler;
+
+/// Never return any testcases.
+///
+/// Useful with [`crate::corpus::nop::NopCorpus`] and
+/// [`crate::feedbacks::ConstFeedback::False`].
+#[derive(Debug, Clone)]
+pub struct NopScheduler<S>(PhantomData<S>);
+
+impl<S> UsesState for NopScheduler<S>
+where
+    S: State,
+{
+    type State = S;
+}
+
+impl<S> Scheduler for NopScheduler<S>
+where
+    S: HasCorpus + State,
+{
+    fn on_add(&mut self, _state: &mut Self::State, _idx: CorpusId) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn next(&mut self, _state: &mut Self::State) -> Result<CorpusId, Error> {
+        Err(Error::empty("`NopScheduler` is always empty"))
+    }
+}
+
+impl<S> NopScheduler<S> {
+    /// Create a new [`NopScheduler`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<S> Default for NopScheduler<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This commit introduces the `NopScheduler`, which never picks a testcase. This is useful for generative fuzzers, which don't maintain a corpus.

Previously, `StdFuzzer::fuzz_one` would panic if the scheduler didn't return a `CorpusId`, but now it handles that case by ignoring `Error::Empty` and returning an `Option<CorpusId>` itself.

Fixes #2161.