### PR TITLE
libafl_qemu: Structured error types for reading/writing registers

### DIFF
--- a/libafl_qemu/src/arch/x86_64.rs
+++ b/libafl_qemu/src/arch/x86_64.rs
@@ -80,7 +80,7 @@ impl crate::ArchExtras for crate::CPU {
     where
         T: From<GuestReg>,
     {
-        let stack_ptr: GuestReg = self.read_reg(Regs::Rsp)?;
+        let stack_ptr: GuestReg = self.read_reg(Regs::Rsp).map_err(|e| e.to_string())?;
         let mut ret_addr = [0; size_of::<GuestReg>()];
         unsafe { self.read_mem(stack_ptr, &mut ret_addr) };
         Ok(GuestReg::from_le_bytes(ret_addr).into())
@@ -90,7 +90,7 @@ impl crate::ArchExtras for crate::CPU {
     where
         T: Into<GuestReg>,
     {
-        let stack_ptr: GuestReg = self.read_reg(Regs::Rsp)?;
+        let stack_ptr: GuestReg = self.read_reg(Regs::Rsp).map_err(|e| e.to_string())?;
         let val: GuestReg = val.into();
         let ret_addr = val.to_le_bytes();
         unsafe { self.write_mem(stack_ptr, &ret_addr) };
@@ -115,7 +115,7 @@ impl crate::ArchExtras for crate::CPU {
             r => return Err(format!("Unsupported argument: {r:}")),
         };
 
-        self.read_reg(reg_id)
+        self.read_reg(reg_id).map_err(|e| e.to_string())
     }
 
     fn write_function_argument<T>(
@@ -133,8 +133,8 @@ impl crate::ArchExtras for crate::CPU {
 
         let val: GuestReg = val.into();
         match idx {
-            0 => self.write_reg(Regs::Rdi, val),
-            1 => self.write_reg(Regs::Rsi, val),
+            0 => self.write_reg(Regs::Rdi, val).map_err(|e| e.to_string()),
+            1 => self.write_reg(Regs::Rsi, val).map_err(|e| e.to_string()),
             _ => Err(format!("Unsupported argument: {idx:}")),
         }
     }

--- a/libafl_qemu/src/command.rs
+++ b/libafl_qemu/src/command.rs
@@ -21,8 +21,8 @@ use crate::{
     executor::QemuExecutorState, get_exit_arch_regs, sync_exit::ExitArgs, Emulator,
     EmulatorExitHandler, EmulatorMemoryChunk, ExitHandlerError, ExitHandlerResult, GuestReg,
     HasInstrumentationFilter, InputLocation, IsFilter, IsSnapshotManager, Qemu, QemuHelperTuple,
-    QemuInstrumentationAddressRangeFilter, Regs, StdEmulatorExitHandler, StdInstrumentationFilter,
-    CPU,
+    QemuInstrumentationAddressRangeFilter, ReadRegError, Regs, StdEmulatorExitHandler,
+    StdInstrumentationFilter, WriteRegError, CPU,
 };
 
 pub const VERSION: u64 = bindings::LIBAFL_QEMU_HDR_VERSION_NUMBER as u64;
@@ -121,9 +121,15 @@ impl From<TryFromPrimitiveError<NativeCommand>> for CommandError {
     }
 }
 
-impl From<String> for CommandError {
-    fn from(error_string: String) -> Self {
-        CommandError::RegError(error_string)
+impl<R: Debug> From<ReadRegError<R>> for CommandError {
+    fn from(e: ReadRegError<R>) -> Self {
+        CommandError::RegError(e.to_string())
+    }
+}
+
+impl<R: Debug, T: Debug> From<WriteRegError<R, T>> for CommandError {
+    fn from(e: WriteRegError<R, T>) -> Self {
+        CommandError::RegError(e.to_string())
     }
 }
 

--- a/libafl_qemu/src/emu/mod.rs
+++ b/libafl_qemu/src/emu/mod.rs
@@ -32,7 +32,8 @@ use crate::{
     sys::TCGTemp,
     BackdoorHookId, BlockHookId, CmpHookId, EdgeHookId, EmulatorMemoryChunk, GuestReg, HookData,
     HookId, InstructionHookId, MemAccessInfo, Qemu, QemuExitError, QemuExitReason, QemuHelperTuple,
-    QemuInitError, QemuShutdownCause, ReadHookId, Regs, StdInstrumentationFilter, WriteHookId, CPU,
+    QemuInitError, QemuShutdownCause, ReadHookId, ReadRegError, Regs, StdInstrumentationFilter,
+    WriteHookId, WriteRegError, CPU,
 };
 
 #[cfg(emulation_mode = "usermode")]
@@ -506,10 +507,10 @@ where
     #[deprecated(
         note = "This function has been moved to the `Qemu` low-level structure. Please access it through `emu.qemu()`."
     )]
-    pub fn write_reg<R, T>(&self, reg: R, val: T) -> Result<(), String>
+    pub fn write_reg<R, T>(&self, reg: R, val: T) -> Result<(), WriteRegError<R, T>>
     where
         T: Num + PartialOrd + Copy + Into<GuestReg>,
-        R: Into<i32>,
+        R: Copy + Into<i32>,
     {
         self.qemu.write_reg(reg, val)
     }
@@ -517,10 +518,10 @@ where
     #[deprecated(
         note = "This function has been moved to the `Qemu` low-level structure. Please access it through `emu.qemu()`."
     )]
-    pub fn read_reg<R, T>(&self, reg: R) -> Result<T, String>
+    pub fn read_reg<R, T>(&self, reg: R) -> Result<T, ReadRegError<R>>
     where
         T: Num + PartialOrd + Copy + From<GuestReg>,
-        R: Into<i32>,
+        R: Copy + Into<i32>,
     {
         self.qemu.read_reg(reg)
     }


### PR DESCRIPTION
Makes the errors more programatically inspectable, and instances of `std::error::Error`. Removes the temptation to `impl From<String>` for errors that wrap these. Can be trivially converted to strings, which is demonstrated in this PR. Does introduce new `Copy` bounds, but I think this should be fine?