### PR TITLE
Rename CurrentCorpusIdx -> CurrentCorpusId

### DIFF
--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -175,7 +175,7 @@ pub trait Corpus: UsesInput + Serialize + for<'de> Deserialize<'de> {
 }
 
 /// Trait for types which track the current corpus index
-pub trait HasCurrentCorpusIdx {
+pub trait HasCurrentCorpusId {
     /// Set the current corpus index; we have started processing this corpus entry
     fn set_corpus_idx(&mut self, idx: CorpusId) -> Result<(), Error>;
 
@@ -183,7 +183,7 @@ pub trait HasCurrentCorpusIdx {
     fn clear_corpus_idx(&mut self) -> Result<(), Error>;
 
     /// Fetch the current corpus index -- typically used after a state recovery or transfer
-    fn current_corpus_idx(&self) -> Result<Option<CorpusId>, Error>;
+    fn current_corpus_id(&self) -> Result<Option<CorpusId>, Error>;
 }
 
 /// [`Iterator`] over the ids of a [`Corpus`]

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -713,7 +713,7 @@ where
         state.introspection_monitor_mut().start_timer();
 
         // Get the next index from the scheduler
-        let idx = if let Some(idx) = state.current_corpus_idx()? {
+        let idx = if let Some(idx) = state.current_corpus_id()? {
             idx // we are resuming
         } else {
             let idx = self.scheduler.next(state)?;

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -7,7 +7,7 @@ use libafl_bolts::current_time;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    corpus::{Corpus, CorpusId, HasCurrentCorpusIdx, HasTestcase, Testcase},
+    corpus::{Corpus, CorpusId, HasCurrentCorpusId, HasTestcase, Testcase},
     events::{Event, EventConfig, EventFirer, EventProcessor, ProgressReporter},
     executors::{Executor, ExitKind, HasObservers},
     feedbacks::Feedback,
@@ -369,7 +369,7 @@ where
         + HasCorpus
         + HasImported
         + HasCurrentTestcase<<Self::State as UsesInput>::Input>
-        + HasCurrentCorpusIdx,
+        + HasCurrentCorpusId,
 {
     fn execute_no_process<EM>(
         &mut self,
@@ -697,7 +697,7 @@ where
         + HasTestcase
         + HasImported
         + HasLastReportTime
-        + HasCurrentCorpusIdx
+        + HasCurrentCorpusId
         + HasCurrentStage,
     ST: StagesTuple<E, EM, CS::State, Self>,
 {

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use crate::mutators::str_decode;
 use crate::{
-    corpus::{CorpusId, HasCurrentCorpusIdx},
+    corpus::{CorpusId, HasCurrentCorpusId},
     inputs::{HasBytesVec, UsesInput},
     mutators::{
         buffer_self_copy, mutations::buffer_copy, MultiMutator, MutationResult, Mutator, Named,
@@ -1087,7 +1087,7 @@ impl AFLppRedQueen {
 
 impl<I, S> MultiMutator<I, S> for AFLppRedQueen
 where
-    S: UsesInput + HasMetadata + HasRand + HasMaxSize + HasCorpus + HasCurrentCorpusIdx,
+    S: UsesInput + HasMetadata + HasRand + HasMaxSize + HasCorpus + HasCurrentCorpusId,
     I: HasBytesVec + From<Vec<u8>>,
 {
     #[allow(clippy::needless_range_loop)]
@@ -1135,10 +1135,10 @@ where
         // println!("orig: {:#?} new: {:#?}", orig_cmpvals, new_cmpvals);
 
         // Compute when mutating it for the 1st time.
-        let current_corpus_idx = state.current_corpus_idx()?.ok_or_else(|| Error::key_not_found("No corpus-idx is currently being fuzzed, but called AFLppRedQueen::multi_mutated()."))?;
-        if self.last_corpus_idx.is_none() || self.last_corpus_idx.unwrap() != current_corpus_idx {
+        let current_corpus_id = state.current_corpus_id()?.ok_or_else(|| Error::key_not_found("No corpus-idx is currently being fuzzed, but called AFLppRedQueen::multi_mutated()."))?;
+        if self.last_corpus_idx.is_none() || self.last_corpus_idx.unwrap() != current_corpus_id {
             self.text_type = check_if_text(orig_bytes, orig_bytes.len());
-            self.last_corpus_idx = Some(current_corpus_idx);
+            self.last_corpus_idx = Some(current_corpus_id);
         }
         // println!("approximate size: {cmp_len} x {input_len}");
         for cmp_idx in 0..cmp_len {

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -9,7 +9,7 @@ use libafl_bolts::{
 };
 
 use crate::{
-    corpus::{Corpus, HasCurrentCorpusIdx},
+    corpus::{Corpus, HasCurrentCorpusId},
     executors::{Executor, HasObservers},
     feedbacks::map::MapNoveltiesMetadata,
     inputs::{BytesInput, GeneralizedInputMetadata, GeneralizedItem, HasBytesVec, UsesInput},
@@ -83,7 +83,7 @@ where
         state: &mut E::State,
         manager: &mut EM,
     ) -> Result<(), Error> {
-        let Some(corpus_idx) = state.current_corpus_idx()? else {
+        let Some(corpus_idx) = state.current_corpus_id()? else {
             return Err(Error::illegal_state(
                 "state is not currently processing a corpus index",
             ));

--- a/libafl/src/stages/push/mod.rs
+++ b/libafl/src/stages/push/mod.rs
@@ -98,7 +98,7 @@ where
     pub errored: bool,
 
     /// The corpus index we're currently working on
-    pub current_corpus_idx: Option<CorpusId>,
+    pub current_corpus_id: Option<CorpusId>,
 
     /// The input we just ran
     pub current_input: Option<<CS::State as UsesInput>::Input>, // Todo: Get rid of copy
@@ -132,7 +132,7 @@ where
             exit_kind: exit_kind_ref,
             errored: false,
             current_input: None,
-            current_corpus_idx: None,
+            current_corpus_id: None,
         }
     }
 
@@ -167,7 +167,7 @@ where
     fn end_of_iter(&mut self, shared_state: PushStageSharedState<CS, EM, OT, Z>, errored: bool) {
         self.set_shared_state(shared_state);
         self.errored = errored;
-        self.current_corpus_idx = None;
+        self.current_corpus_id = None;
         if errored {
             self.initialized = false;
         }
@@ -193,8 +193,8 @@ where
     fn push_stage_helper_mut(&mut self) -> &mut PushStageHelper<CS, EM, OT, Z>;
 
     /// Set the current corpus index this stage works on
-    fn set_current_corpus_idx(&mut self, corpus_idx: CorpusId) {
-        self.push_stage_helper_mut().current_corpus_idx = Some(corpus_idx);
+    fn set_current_corpus_id(&mut self, corpus_idx: CorpusId) {
+        self.push_stage_helper_mut().current_corpus_id = Some(corpus_idx);
     }
 
     /// Called by `next_std` when this stage is being initialized.

--- a/libafl/src/stages/push/mutational.rs
+++ b/libafl/src/stages/push/mutational.rs
@@ -49,7 +49,7 @@ where
         + EvaluatorObservers<OT>
         + HasScheduler<Scheduler = CS>,
 {
-    current_corpus_idx: Option<CorpusId>,
+    current_corpus_id: Option<CorpusId>,
     testcases_to_do: usize,
     testcases_done: usize,
 
@@ -76,8 +76,8 @@ where
     }
 
     /// Sets the current corpus index
-    pub fn set_current_corpus_idx(&mut self, current_corpus_idx: CorpusId) {
-        self.current_corpus_idx = Some(current_corpus_idx);
+    pub fn set_current_corpus_id(&mut self, current_corpus_id: CorpusId) {
+        self.current_corpus_id = Some(current_corpus_id);
     }
 }
 
@@ -112,13 +112,13 @@ where
         _observers: &mut OT,
     ) -> Result<(), Error> {
         // Find a testcase to work on, unless someone already set it
-        self.current_corpus_idx = Some(if let Some(corpus_idx) = self.current_corpus_idx {
+        self.current_corpus_id = Some(if let Some(corpus_idx) = self.current_corpus_id {
             corpus_idx
         } else {
             fuzzer.scheduler_mut().next(state)?
         });
 
-        self.testcases_to_do = self.iterations(state, self.current_corpus_idx.unwrap())?;
+        self.testcases_to_do = self.iterations(state, self.current_corpus_id.unwrap())?;
         self.testcases_done = 0;
         Ok(())
     }
@@ -139,7 +139,7 @@ where
 
         let input = state
             .corpus_mut()
-            .cloned_input_for_id(self.current_corpus_idx.unwrap());
+            .cloned_input_for_id(self.current_corpus_id.unwrap());
         let mut input = match input {
             Err(e) => return Some(Err(e)),
             Ok(input) => input,
@@ -172,7 +172,7 @@ where
         fuzzer.execute_and_process(state, event_mgr, last_input, observers, &exit_kind, true)?;
 
         start_timer!(state);
-        self.mutator.post_exec(state, self.current_corpus_idx)?;
+        self.mutator.post_exec(state, self.current_corpus_id)?;
         mark_feature_time!(state, PerfFeature::MutatePostExec);
         self.testcases_done += 1;
 
@@ -187,7 +187,7 @@ where
         _event_mgr: &mut EM,
         _observers: &mut OT,
     ) -> Result<(), Error> {
-        self.current_corpus_idx = None;
+        self.current_corpus_id = None;
         Ok(())
     }
 }
@@ -233,7 +233,7 @@ where
         Self {
             mutator,
             psh: PushStageHelper::new(shared_state, exit_kind),
-            current_corpus_idx: None, // todo
+            current_corpus_id: None, // todo
             testcases_to_do: 0,
             testcases_done: 0,
         }

--- a/libafl/src/stages/stats.rs
+++ b/libafl/src/stages/stats.rs
@@ -9,7 +9,7 @@ use libafl_bolts::current_time;
 use serde_json::json;
 
 use crate::{
-    corpus::{Corpus, HasCurrentCorpusIdx},
+    corpus::{Corpus, HasCurrentCorpusId},
     events::EventFirer,
     schedulers::minimizer::IsFavoredMetadata,
     stages::Stage,
@@ -69,7 +69,7 @@ where
         state: &mut E::State,
         _manager: &mut EM,
     ) -> Result<(), Error> {
-        let Some(corpus_idx) = state.current_corpus_idx()? else {
+        let Some(corpus_idx) = state.current_corpus_id()? else {
             return Err(Error::illegal_state(
                 "state is not currently processing a corpus index",
             ));

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -10,7 +10,7 @@ use libafl_bolts::{
 };
 
 use crate::{
-    corpus::{Corpus, HasCurrentCorpusIdx, Testcase},
+    corpus::{Corpus, HasCurrentCorpusId, Testcase},
     events::EventFirer,
     executors::{Executor, ExitKind, HasObservers},
     feedbacks::{Feedback, FeedbackFactory, HasObserverHandle},
@@ -72,7 +72,7 @@ where
         state: &mut CS::State,
         manager: &mut EM,
     ) -> Result<(), Error> {
-        let Some(base_corpus_idx) = state.current_corpus_idx()? else {
+        let Some(base_corpus_idx) = state.current_corpus_id()? else {
             return Err(Error::illegal_state(
                 "state is not currently processing a corpus index",
             ));

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -27,7 +27,7 @@ use crate::monitors::ClientPerfMonitor;
 #[cfg(feature = "scalability_introspection")]
 use crate::monitors::ScalabilityMonitor;
 use crate::{
-    corpus::{Corpus, CorpusId, HasCurrentCorpusIdx, HasTestcase, Testcase},
+    corpus::{Corpus, CorpusId, HasCurrentCorpusId, HasTestcase, Testcase},
     events::{Event, EventFirer, LogSeverity},
     feedbacks::Feedback,
     fuzzer::{Evaluator, ExecuteInputResult},
@@ -49,7 +49,7 @@ pub trait State:
     + DeserializeOwned
     + MaybeHasClientPerfMonitor
     + MaybeHasScalabilityMonitor
-    + HasCurrentCorpusIdx
+    + HasCurrentCorpusId
     + HasCurrentStage
 {
 }
@@ -457,7 +457,7 @@ impl<I, C, R, SC> HasStartTime for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasCurrentCorpusIdx for StdState<I, C, R, SC> {
+impl<I, C, R, SC> HasCurrentCorpusId for StdState<I, C, R, SC> {
     fn set_corpus_idx(&mut self, idx: CorpusId) -> Result<(), Error> {
         self.corpus_idx = Some(idx);
         Ok(())
@@ -468,7 +468,7 @@ impl<I, C, R, SC> HasCurrentCorpusIdx for StdState<I, C, R, SC> {
         Ok(())
     }
 
-    fn current_corpus_idx(&self) -> Result<Option<CorpusId>, Error> {
+    fn current_corpus_id(&self) -> Result<Option<CorpusId>, Error> {
         Ok(self.corpus_idx)
     }
 }
@@ -503,10 +503,10 @@ where
 impl<I, T> HasCurrentTestcase<I> for T
 where
     I: Input,
-    T: HasCorpus + HasCurrentCorpusIdx + UsesInput<Input = I>,
+    T: HasCorpus + HasCurrentCorpusId + UsesInput<Input = I>,
 {
     fn current_testcase(&self) -> Result<Ref<'_, Testcase<I>>, Error> {
-        let Some(corpus_id) = self.current_corpus_idx()? else {
+        let Some(corpus_id) = self.current_corpus_id()? else {
             return Err(Error::key_not_found(
                 "We are not currently processing a testcase",
             ));
@@ -516,7 +516,7 @@ where
     }
 
     fn current_testcase_mut(&self) -> Result<RefMut<'_, Testcase<I>>, Error> {
-        let Some(corpus_id) = self.current_corpus_idx()? else {
+        let Some(corpus_id) = self.current_corpus_id()? else {
             return Err(Error::illegal_state(
                 "We are not currently processing a testcase",
             ));
@@ -1214,7 +1214,7 @@ impl<I> HasRand for NopState<I> {
 
 impl<I> State for NopState<I> where I: Input {}
 
-impl<I> HasCurrentCorpusIdx for NopState<I> {
+impl<I> HasCurrentCorpusId for NopState<I> {
     fn set_corpus_idx(&mut self, _idx: CorpusId) -> Result<(), Error> {
         Ok(())
     }
@@ -1223,7 +1223,7 @@ impl<I> HasCurrentCorpusIdx for NopState<I> {
         Ok(())
     }
 
-    fn current_corpus_idx(&self) -> Result<Option<CorpusId>, Error> {
+    fn current_corpus_id(&self) -> Result<Option<CorpusId>, Error> {
         Ok(None)
     }
 }


### PR DESCRIPTION
See discussion in #2201 -> https://github.com/AFLplusplus/LibAFL/pull/2201#issuecomment-2118940872

We currently use `CorpusId` but `current_corpus_idx`, technically confusing index and identifier...
Now that stages get a true index, we'll have to rename the corpus case