### PR TITLE
Faster fmt_all.sh

### DIFF
--- a/scripts/fmt_all.sh
+++ b/scripts/fmt_all.sh
@@ -5,13 +5,13 @@ LIBAFL_DIR=$(realpath "$SCRIPT_DIR/..")
 
 # TODO: This should be rewritten in rust, a Makefile, or some platform-independent language
 
-if ! command -v parallel /dev/null; then
+if ! command -v parallel > /dev/null; then
     echo "Parallel could not be found. Please install parallel (often found in the 'moreutils' package)."
     exit 1
 fi
 
 # Find main rust crates
-CRATES_TO_FMT=$(find $LIBAFL_DIR -type d \( -path "*/fuzzers/*" -o -path "*/target/*" -o -path "*/utils/noaslr" -o -path "*/utils/gdb_qemu" \-o -path "*/docs/listings/baby_fuzzer/listing-*" \) -prune \
+CRATES_TO_FMT=$(find "$LIBAFL_DIR" -type d \( -path "*/fuzzers/*" -o -path "*/target/*" -o -path "*/utils/noaslr" -o -path "*/utils/gdb_qemu" \-o -path "*/docs/listings/baby_fuzzer/listing-*" \) -prune \
   -o -name "Cargo.toml" -print \
   | grep -v "$LIBAFL_DIR/Cargo.toml")$'\n'
 

--- a/scripts/fmt_all.sh
+++ b/scripts/fmt_all.sh
@@ -19,11 +19,17 @@ CRATES_TO_FMT=$(find "$LIBAFL_DIR" -type d \( -path "*/fuzzers/*" -o -path "*/ta
 CRATES_TO_FMT+=$(find "$LIBAFL_DIR/fuzzers" "$LIBAFL_DIR/fuzzers/backtrace_baby_fuzzers" "$LIBAFL_DIR/libafl_libfuzzer/libafl_libfuzzer_runtime" -maxdepth 2 -name "Cargo.toml" -print)
 
 echo "Welcome to the happy fmt script. :)"
+
+if [ "$CHECK" ]; then
+  CARGO_FLAGS="--check"
+  CLANG_FLAGS="--dry-run"
+fi
+
 echo "[*] Formatting Rust crates..."
-echo "$CRATES_TO_FMT" | parallel "echo '[*] Running fmt for {}'; cargo +nightly fmt --manifest-path {}"
+echo "$CRATES_TO_FMT" | parallel "echo '[*] Running fmt for {}'; cargo +nightly fmt $CARGO_FLAGS --manifest-path {}"
 
 echo "[*] Formatting C(pp) files"
 # shellcheck disable=SC2046
-clang-format-18 -i --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.c' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
+clang-format-18 "$CLANG_FLAGS" -i --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.c' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
 
 echo "[*] Done :)"

--- a/scripts/fmt_all.sh
+++ b/scripts/fmt_all.sh
@@ -1,33 +1,29 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/.." || exit 1
+LIBAFL_DIR=$(realpath "$SCRIPT_DIR/..")
 
 # TODO: This should be rewritten in rust, a Makefile, or some platform-independent language
 
+if ! command -v parallel /dev/null; then
+    echo "Parallel could not be found. Please install parallel (often found in the 'moreutils' package)."
+    exit 1
+fi
+
+# Find main rust crates
+CRATES_TO_FMT=$(find $LIBAFL_DIR -type d \( -path "*/fuzzers/*" -o -path "*/target/*" -o -path "*/utils/noaslr" -o -path "*/utils/gdb_qemu" \-o -path "*/docs/listings/baby_fuzzer/listing-*" \) -prune \
+  -o -name "Cargo.toml" -print \
+  | grep -v "$LIBAFL_DIR/Cargo.toml")$'\n'
+
+# Find fuzzer crates
+CRATES_TO_FMT+=$(find "$LIBAFL_DIR/fuzzers" "$LIBAFL_DIR/fuzzers/backtrace_baby_fuzzers" "$LIBAFL_DIR/libafl_libfuzzer/libafl_libfuzzer_runtime" -maxdepth 2 -name "Cargo.toml" -print)
+
 echo "Welcome to the happy fmt script. :)"
-echo "[*] Running fmt for the main crates"
-cargo +nightly fmt
+echo "[*] Formatting Rust crates..."
+echo "$CRATES_TO_FMT" | parallel "echo '[*] Running fmt for {}'; cargo +nightly fmt --manifest-path {}"
 
 echo "[*] Formatting C(pp) files"
 # shellcheck disable=SC2046
 clang-format-18 -i --style=file $(find . -type f \( -name '*.cpp' -o -iname '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.cc' -o -name '*.c' -o -name '*.h' \) | grep -v '/target/' | grep -v 'libpng-1\.6\.37' | grep -v 'stb_image\.h' | grep -v 'dlmalloc\.c' | grep -v 'QEMU-Nyx')
-
-fuzzers=$(find ./fuzzers -maxdepth 1 -type d)
-backtrace_fuzzers=$(find ./fuzzers/backtrace_baby_fuzzers -maxdepth 1 -type d)
-
-# shellcheck disable=SC2116
-for fuzzer in $(echo "$fuzzers" "$backtrace_fuzzers");
-do
-    pushd "$fuzzer" || exit 1
-    echo "[*] Running fmt for $fuzzer"
-    cargo +nightly fmt --all
-    popd || exit 1
-done
-
-echo "[*] Formatting libafl_libfuzzer_runtime"
-pushd "libafl_libfuzzer/libafl_libfuzzer_runtime" || exit 1
-cargo +nightly fmt --all
-popd || exit 1
 
 echo "[*] Done :)"

--- a/scripts/fmt_all.sh
+++ b/scripts/fmt_all.sh
@@ -11,7 +11,7 @@ if ! command -v parallel > /dev/null; then
 fi
 
 # Find main rust crates
-CRATES_TO_FMT=$(find "$LIBAFL_DIR" -type d \( -path "*/fuzzers/*" -o -path "*/target/*" -o -path "*/utils/noaslr" -o -path "*/utils/gdb_qemu" \-o -path "*/docs/listings/baby_fuzzer/listing-*" \) -prune \
+CRATES_TO_FMT=$(find "$LIBAFL_DIR" -type d \( -path "*/fuzzers/*" -o -path "*/target/*" -o -path "*/utils/noaslr" -o -path "*/utils/gdb_qemu" -o -path "*/docs/listings/baby_fuzzer/listing-*" \) -prune \
   -o -name "Cargo.toml" -print \
   | grep -v "$LIBAFL_DIR/Cargo.toml")$'\n'
 


### PR DESCRIPTION
Makes `fmt_all.sh` 30 times faster on my local machine.
Requires `parallel` to work, but I think it's not a problematic dependency.