### PR TITLE
Add testcase sampling rate

### DIFF
--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -474,7 +474,7 @@ where
 
                 self.num_testcases += 1;
                 let send_events = if let Some(sampling_rate) = self.testcase_sampling_rate {
-                        send_events && self.num_testcases % sampling_rate == 0
+                    send_events && self.num_testcases % sampling_rate == 0
                 } else {
                     send_events
                 };
@@ -780,19 +780,24 @@ where
             feedback,
             objective,
             num_testcases: 0,
-            testcase_sampling_rate: None, 
+            testcase_sampling_rate: None,
             phantom: PhantomData,
         }
     }
 
     /// Create a new `StdFuzzer` with a specified `TestCase` sampling rate
-    pub fn with_sampling_rate(scheduler: CS, feedback: F, objective: OF, sampling_rate: u64) -> Self {
+    pub fn with_sampling_rate(
+        scheduler: CS,
+        feedback: F,
+        objective: OF,
+        sampling_rate: u64,
+    ) -> Self {
         Self {
             scheduler,
             feedback,
             objective,
             num_testcases: 0,
-            testcase_sampling_rate: Some(sampling_rate), 
+            testcase_sampling_rate: Some(sampling_rate),
             phantom: PhantomData,
         }
     }

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -290,6 +290,8 @@ where
     scheduler: CS,
     feedback: F,
     objective: OF,
+    num_testcases: u64,
+    testcase_sampling_rate: Option<u64>,
     phantom: PhantomData<OT>,
 }
 
@@ -469,6 +471,13 @@ where
                     .append_metadata(state, manager, observers, &mut testcase)?;
                 let idx = state.corpus_mut().add(testcase)?;
                 self.scheduler_mut().on_add(state, idx)?;
+
+                self.num_testcases += 1;
+                let send_events = if let Some(sampling_rate) = self.testcase_sampling_rate {
+                        send_events && self.num_testcases % sampling_rate == 0
+                } else {
+                    send_events
+                };
 
                 if send_events {
                     // TODO set None for fast targets
@@ -770,6 +779,20 @@ where
             scheduler,
             feedback,
             objective,
+            num_testcases: 0,
+            testcase_sampling_rate: None, 
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create a new `StdFuzzer` with a specified `TestCase` sampling rate
+    pub fn with_sampling_rate(scheduler: CS, feedback: F, objective: OF, sampling_rate: u64) -> Self {
+        Self {
+            scheduler,
+            feedback,
+            objective,
+            num_testcases: 0,
+            testcase_sampling_rate: Some(sampling_rate), 
             phantom: PhantomData,
         }
     }

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -2302,7 +2302,7 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        original(s, p4, n)
+        original(s, p4, n);
     }
 
     #[cfg(target_vendor = "apple")]
@@ -2332,7 +2332,7 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        original(s, p8, n)
+        original(s, p8, n);
     }
 
     #[cfg(target_vendor = "apple")]
@@ -2362,6 +2362,6 @@ impl AsanRuntime {
                 Backtrace::new(),
             )));
         }
-        original(s, p16, n)
+        original(s, p16, n);
     }
 }


### PR DESCRIPTION
This PR adds the ability to 'sample' testcases. In other words it allows for a user-specified 'sampling rate', which is used to decide which TestCases to send to the broker.

A sampling rate of 10 means that only every tenth TestCase is sent to the broker.

This can be useful in very large scale fuzzing where the broker is overwhelmed by the volume of TestCases, and to cause the fuzz nodes to diverge somewhat more from each other.