### PR TITLE
launcher: add launch_delay option

### DIFF
--- a/fuzzers/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida_gdiplus/src/fuzzer.rs
@@ -461,6 +461,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
         .configuration(EventConfig::AlwaysUnique)
         .shmem_provider(shmem_provider)
         .monitor(monitor)
+        .launch_delay(100)
         .run_client(&mut run_client)
         .cores(&options.cores)
         .broker_port(options.broker_port)

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -402,7 +402,7 @@ where
                                 stderr = Stdio::inherit();
                             };
                         }
-                        
+
                         #[cfg(feature = "std")]
                         std::thread::sleep(Duration::from_millis(id as u64 * self.launch_delay));
 

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -727,6 +727,7 @@ where
                 .broker_port(self.broker_port)
                 .kind(ManagerKind::Broker)
                 .remote_broker_addr(self.remote_broker_addr)
+                .launch_delay(100)
                 .exit_cleanly_after(Some(NonZeroUsize::try_from(self.cores.ids.len()).unwrap()))
                 .configuration(self.configuration)
                 .serialize_state(self.serialize_state)

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -511,6 +511,9 @@ where
     /// A file name to write all client output to
     #[builder(default = None)]
     stdout_file: Option<&'a str>,
+    /// The time in milliseconds to delay between child launches
+    #[builder(default = 10)]
+    launch_delay: u64,
     /// The actual, opened, `stdout_file` - so that we keep it open until the end
     #[cfg(all(unix, feature = "std", feature = "fork"))]
     #[builder(setter(skip), default = None)]

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -15,7 +15,7 @@
 use alloc::string::ToString;
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
-#[cfg(all(feature = "std", feature = "fork"))]
+#[cfg(feature = "std")]
 use core::time::Duration;
 use core::{
     fmt::{self, Debug, Formatter},

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -107,6 +107,9 @@ where
     #[cfg(all(unix, feature = "std"))]
     #[builder(default = None)]
     stdout_file: Option<&'a str>,
+    /// The time in milliseconds to delay between child launches
+    #[builder(default = 10)]
+    launch_delay: u64,
     /// The actual, opened, `stdout_file` - so that we keep it open until the end
     #[cfg(all(unix, feature = "std", feature = "fork"))]
     #[builder(setter(skip), default = None)]
@@ -251,7 +254,7 @@ where
                         self.shmem_provider.post_fork(true)?;
 
                         #[cfg(feature = "std")]
-                        std::thread::sleep(Duration::from_millis(index * 10));
+                        std::thread::sleep(Duration::from_millis(index * self.launch_delay));
 
                         #[cfg(feature = "std")]
                         if !debug_output {
@@ -659,7 +662,7 @@ where
                         log::info!("{:?} PostFork", unsafe { libc::getpid() });
                         self.shmem_provider.post_fork(true)?;
 
-                        std::thread::sleep(Duration::from_millis(index * 10));
+                        std::thread::sleep(Duration::from_millis(index * self.launch_delay));
 
                         if !debug_output {
                             if let Some(file) = &self.opened_stdout_file {

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -15,7 +15,7 @@
 use alloc::string::ToString;
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
-#[cfg(all(unix, feature = "std", feature = "fork"))]
+#[cfg(all(feature = "std", feature = "fork"))]
 use core::time::Duration;
 use core::{
     fmt::{self, Debug, Formatter},
@@ -402,6 +402,10 @@ where
                                 stderr = Stdio::inherit();
                             };
                         }
+                        
+                        #[cfg(feature = "std")]
+                        std::thread::sleep(Duration::from_millis(id as u64 * self.launch_delay));
+
                         std::env::set_var(_AFL_LAUNCHER_CLIENT, id.to_string());
                         let mut child = startable_self()?;
                         let child = (if debug_output {

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -727,7 +727,6 @@ where
                 .broker_port(self.broker_port)
                 .kind(ManagerKind::Broker)
                 .remote_broker_addr(self.remote_broker_addr)
-                .launch_delay(100)
                 .exit_cleanly_after(Some(NonZeroUsize::try_from(self.cores.ids.len()).unwrap()))
                 .configuration(self.configuration)
                 .serialize_state(self.serialize_state)


### PR DESCRIPTION
This adds a `launch_delay` option, which specifies a delay in milliseconds to wait between launches of fuzzers.