### PR TITLE
Generic QEMU snapshot checking

### DIFF
--- a/fuzzers/qemu_systemmode/src/fuzzer_breakpoint.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer_breakpoint.rs
@@ -90,7 +90,7 @@ pub fn fuzz() {
 
         // Choose Snapshot Builder
         // let emu_snapshot_manager = QemuSnapshotBuilder::new(true);
-        let emu_snapshot_manager = FastSnapshotManager::new(false);
+        let emu_snapshot_manager = FastSnapshotManager::new();
 
         // Choose Exit Handler
         let emu_exit_handler = StdEmulatorExitHandler::new(emu_snapshot_manager);

--- a/fuzzers/qemu_systemmode/src/fuzzer_sync_exit.rs
+++ b/fuzzers/qemu_systemmode/src/fuzzer_sync_exit.rs
@@ -55,7 +55,7 @@ pub fn fuzz() {
         let env: Vec<(String, String)> = env::vars().collect();
 
         // let emu_snapshot_manager = QemuSnapshotBuilder::new(true);
-        let emu_snapshot_manager = FastSnapshotManager::new(false); // Create a snapshot manager (normal or fast for now).
+        let emu_snapshot_manager = FastSnapshotManager::new(); // Create a snapshot manager (normal or fast for now).
         let emu_exit_handler: StdEmulatorExitHandler<FastSnapshotManager> =
             StdEmulatorExitHandler::new(emu_snapshot_manager); // Create an exit handler: it is the entity taking the decision of what should be done when QEMU returns.
 

--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -11,7 +11,7 @@ use crate::cargo_add_rpath;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "cc5ff3b87e80b91dc89db587ee0f94e4207ae50e";
+const QEMU_REVISION: &str = "bb98cb5d607039d424b58e1ea43859cf4af838fe";
 
 #[allow(clippy::module_name_repetitions)]
 pub struct BuildResult {

--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -11,7 +11,7 @@ use crate::cargo_add_rpath;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "bb98cb5d607039d424b58e1ea43859cf4af838fe";
+const QEMU_REVISION: &str = "9d2197b73bf5e66e709f9f1669467d5c84062da0";
 
 #[allow(clippy::module_name_repetitions)]
 pub struct BuildResult {

--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -11,7 +11,7 @@ use crate::cargo_add_rpath;
 
 const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-const QEMU_REVISION: &str = "9f3e2399ee9b106dfbb8c3afcdfdf30e235fc88f";
+const QEMU_REVISION: &str = "cc5ff3b87e80b91dc89db587ee0f94e4207ae50e";
 
 #[allow(clippy::module_name_repetitions)]
 pub struct BuildResult {

--- a/libafl_qemu/src/command/mod.rs
+++ b/libafl_qemu/src/command/mod.rs
@@ -317,6 +317,11 @@ where
             .snapshot_manager_borrow_mut()
             .restore(&snapshot_id, qemu)?;
 
+        #[cfg(feature = "paranoid_debug")]
+        emu_exit_handler
+            .snapshot_manager_borrow()
+            .check(&snapshot_id, emu.qemu())?;
+
         Ok(None)
     }
 }
@@ -444,6 +449,11 @@ where
         emu_exit_handler
             .snapshot_manager_borrow_mut()
             .restore(&snapshot_id, emu.qemu())?;
+
+        #[cfg(feature = "paranoid_debug")]
+        emu_exit_handler
+            .snapshot_manager_borrow()
+            .check(&snapshot_id, emu.qemu())?;
 
         Ok(Some(ExitHandlerResult::EndOfRun(self.0.unwrap())))
     }

--- a/libafl_qemu/src/qemu/mod.rs
+++ b/libafl_qemu/src/qemu/mod.rs
@@ -106,6 +106,20 @@ pub enum QemuExitError {
     UnexpectedExit, // Qemu exited without going through an expected exit point. Can be caused by a crash for example.
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QemuSnapshotCheckResult {
+    nb_page_inconsistencies: u64,
+}
+
+/// Represents a QEMU snapshot check result for which no error was detected
+impl Default for QemuSnapshotCheckResult {
+    fn default() -> Self {
+        Self {
+            nb_page_inconsistencies: 0,
+        }
+    }
+}
+
 /// The thin wrapper around QEMU.
 /// It is considered unsafe to use it directly.
 /// Prefer using `Emulator` instead in case of doubt.

--- a/libafl_qemu/src/qemu/systemmode.rs
+++ b/libafl_qemu/src/qemu/systemmode.rs
@@ -16,7 +16,7 @@ use num_traits::Zero;
 
 use crate::{
     EmulatorMemoryChunk, FastSnapshotPtr, GuestAddrKind, MemAccessInfo, Qemu, QemuExitError,
-    QemuExitReason, CPU,
+    QemuExitReason, QemuSnapshotCheckResult, CPU,
 };
 
 pub(super) extern "C" fn qemu_cleanup_atexit() {
@@ -256,8 +256,15 @@ impl Qemu {
         libafl_qemu_sys::syx_snapshot_root_restore(snapshot)
     }
 
-    pub unsafe fn check_fast_snapshot_memory_consistency(&self, snapshot: FastSnapshotPtr) -> u64 {
-        libafl_qemu_sys::syx_snapshot_check_memory_consistency(snapshot)
+    pub unsafe fn check_fast_snapshot(
+        &self,
+        ref_snapshot: FastSnapshotPtr,
+    ) -> QemuSnapshotCheckResult {
+        let check_result = libafl_qemu_sys::syx_snapshot_check(ref_snapshot);
+
+        QemuSnapshotCheckResult {
+            nb_page_inconsistencies: check_result.nb_inconsistencies,
+        }
     }
 
     pub fn list_devices(&self) -> Vec<String> {


### PR DESCRIPTION
check qemu snapshot correctness generically, with better typing.
for now, it mostly concerns systemmode since usermode snapshot does not implement the `SnapshotManager` trait yet.