### PR TITLE
Make every Builder ::builder(), so  BobTheBuilder::new() becomes BobThe::builder()

### DIFF
--- a/fuzzers/nautilus_sync/src/lib.rs
+++ b/fuzzers/nautilus_sync/src/lib.rs
@@ -9,7 +9,7 @@ use std::{env, net::SocketAddr, path::PathBuf, time::Duration};
 use clap::Parser;
 use libafl::{
     corpus::{InMemoryCorpus, OnDiskCorpus},
-    events::{launcher::Launcher, EventConfig, LlmpEventConverterBuilder},
+    events::{launcher::Launcher, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, NautilusChunksMetadata, NautilusFeedback},
@@ -120,7 +120,7 @@ pub extern "C" fn libafl_main() {
     let context = NautilusContext::from_file(15, "grammar.json");
 
     let mut event_converter = opt.bytes_broker_port.map(|port| {
-        LlmpEventConverterBuilder::new()
+        LlmpEventConverter::builder()
             .build_on_port(
                 shmem_provider.clone(),
                 port,

--- a/fuzzers/nautilus_sync/src/lib.rs
+++ b/fuzzers/nautilus_sync/src/lib.rs
@@ -9,7 +9,7 @@ use std::{env, net::SocketAddr, path::PathBuf, time::Duration};
 use clap::Parser;
 use libafl::{
     corpus::{InMemoryCorpus, OnDiskCorpus},
-    events::{launcher::Launcher, EventConfig},
+    events::{launcher::Launcher, llmp::LlmpEventConverter, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, NautilusChunksMetadata, NautilusFeedback},

--- a/fuzzers/nyx_libxml2_parallel/src/main.rs
+++ b/fuzzers/nyx_libxml2_parallel/src/main.rs
@@ -19,7 +19,7 @@ use libafl_bolts::{
     shmem::{ShMemProvider, StdShMemProvider},
     tuples::tuple_list,
 };
-use libafl_nyx::{executor::NyxExecutorBuilder, helper::NyxHelper, settings::NyxSettings};
+use libafl_nyx::{executor::NyxExecutor, helper::NyxHelper, settings::NyxSettings};
 
 fn main() {
     let shmem_provider = StdShMemProvider::new().expect("Failed to init shared memory");

--- a/fuzzers/nyx_libxml2_parallel/src/main.rs
+++ b/fuzzers/nyx_libxml2_parallel/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         let mut feedback = MaxMapFeedback::new(&observer);
         let mut objective = CrashFeedback::new();
         let scheduler = RandScheduler::new();
-        let mut executor = NyxExecutorBuilder::new().build(helper, tuple_list!(observer));
+        let mut executor = NyxExecutor::builder().build(helper, tuple_list!(observer));
 
         // If not restarting, create a State from scratch
         let mut state = state.unwrap_or_else(|| {

--- a/fuzzers/nyx_libxml2_standalone/src/main.rs
+++ b/fuzzers/nyx_libxml2_standalone/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
     let monitor = TuiMonitor::new(ui);
 
     let mut mgr = SimpleEventManager::new(monitor);
-    let mut executor = NyxExecutorBuilder::new().build(helper, tuple_list!(observer));
+    let mut executor = NyxExecutor::builder().build(helper, tuple_list!(observer));
     let mutator = StdScheduledMutator::new(havoc_mutations());
     let mut stages = tuple_list!(StdMutationalStage::new(mutator));
 

--- a/fuzzers/nyx_libxml2_standalone/src/main.rs
+++ b/fuzzers/nyx_libxml2_standalone/src/main.rs
@@ -14,7 +14,7 @@ use libafl::{
     Fuzzer, StdFuzzer,
 };
 use libafl_bolts::{rands::StdRand, tuples::tuple_list};
-use libafl_nyx::{executor::NyxExecutorBuilder, helper::NyxHelper, settings::NyxSettings};
+use libafl_nyx::{executor::NyxExecutor, helper::NyxHelper, settings::NyxSettings};
 
 fn main() {
     // nyx stuff

--- a/fuzzers/tinyinst_simple/src/main.rs
+++ b/fuzzers/tinyinst_simple/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
 
     let mut mgr = SimpleEventManager::new(monitor);
     let mut executor = unsafe {
-        TinyInstExecutorBuilder::new()
+        TinyInstExecutor::builder()
             .tinyinst_args(tinyinst_args)
             .program_args(args)
             .use_shmem()

--- a/fuzzers/tinyinst_simple/src/main.rs
+++ b/fuzzers/tinyinst_simple/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
     let scheduler = RandScheduler::new();
     let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
-    let monitor = SimpleMonitor::new(|x| println!("{}", x));
+    let monitor = SimpleMonitor::new(|x| println!("{x}"));
 
     let mut mgr = SimpleEventManager::new(monitor);
     let mut executor = unsafe {

--- a/fuzzers/tinyinst_simple/src/main.rs
+++ b/fuzzers/tinyinst_simple/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, ptr::addr_of_mut, time::Duration};
 
 use libafl::{
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus, Testcase},
@@ -20,7 +20,7 @@ use libafl_bolts::shmem::Win32ShMemProvider;
 use libafl_bolts::{
     ownedref::OwnedMutPtr, rands::StdRand, shmem::ShMemProvider, tuples::tuple_list,
 };
-use libafl_tinyinst::executor::TinyInstExecutorBuilder;
+use libafl_tinyinst::executor::TinyInstExecutor;
 static mut COVERAGE: Vec<u64> = vec![];
 
 #[cfg(not(any(target_vendor = "apple", windows, target_os = "linux")))]
@@ -37,7 +37,7 @@ fn main() {
     // use file to pass testcases
     // let args = vec!["test.exe".to_string(), "-f".to_string(), "@@".to_string()];
 
-    let coverage = unsafe { OwnedMutPtr::Ptr(core::ptr::addr_of_mut!(COVERAGE)) };
+    let coverage = unsafe { OwnedMutPtr::Ptr(addr_of_mut!(COVERAGE)) };
     let observer = ListObserver::new("cov", coverage);
     let mut feedback = ListFeedback::new(&observer);
     #[cfg(windows)]
@@ -68,9 +68,10 @@ fn main() {
             .program_args(args)
             .use_shmem()
             .persistent("test.exe".to_string(), "fuzz".to_string(), 1, 10000)
-            .timeout(std::time::Duration::new(5, 0))
+            .timeout(Duration::new(5, 0))
             .shmem_provider(&mut shmem_provider)
-            .build(&mut COVERAGE, tuple_list!(observer))
+            .coverage_ptr(addr_of_mut!(COVERAGE))
+            .build(tuple_list!(observer))
             .unwrap()
     };
     let mutator = StdScheduledMutator::new(havoc_mutations());

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -231,7 +231,7 @@ where
     is_main: bool,
 }
 
-impl CentralizedEventManager<NopEventManager<NopState<NopInput>>, StdShMemProvider> {
+impl CentralizedEventManager<NopEventManager<NopState<NopInput>>, NopShMemProvider> {
     /// Creates a builder for [`CentralizedEventManager`]
     #[must_use]
     pub fn builder() -> CentralizedEventManagerBuilder {

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -19,11 +19,12 @@ use libafl_bolts::{
 };
 use libafl_bolts::{
     llmp::{self, LlmpBroker, LlmpClient, LlmpClientDescription, Tag},
-    shmem::ShMemProvider,
+    shmem::{ShMemProvider, StdShMemProvider},
     ClientId,
 };
 use serde::{Deserialize, Serialize};
 
+use super::NopEventManager;
 #[cfg(feature = "llmp_compression")]
 use crate::events::llmp::COMPRESS_THRESHOLD;
 #[cfg(feature = "adaptive_serialization")]
@@ -38,9 +39,9 @@ use crate::{
     },
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
-    inputs::{Input, UsesInput},
+    inputs::{Input, NopInput, UsesInput},
     observers::ObserversTuple,
-    state::{HasExecutions, HasLastReportTime, UsesState},
+    state::{HasExecutions, HasLastReportTime, NopState, UsesState},
     Error, HasMetadata,
 };
 
@@ -228,6 +229,14 @@ where
     #[cfg(feature = "adaptive_serialization")]
     time_ref: Handle<TimeObserver>,
     is_main: bool,
+}
+
+impl CentralizedEventManager<NopEventManager<NopState<NopInput>>, StdShMemProvider> {
+    /// Creates a builder for [`CentralizedEventManager`]
+    #[must_use]
+    pub fn builder() -> CentralizedEventManagerBuilder {
+        CentralizedEventManagerBuilder::new()
+    }
 }
 
 /// The builder or `CentralizedEventManager`

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -19,7 +19,7 @@ use libafl_bolts::{
 };
 use libafl_bolts::{
     llmp::{self, LlmpBroker, LlmpClient, LlmpClientDescription, Tag},
-    shmem::{ShMemProvider, StdShMemProvider},
+    shmem::{NopShMemProvider, ShMemProvider},
     ClientId,
 };
 use serde::{Deserialize, Serialize};

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -49,9 +49,9 @@ use typed_builder::TypedBuilder;
 
 use super::hooks::EventManagerHooksTuple;
 #[cfg(all(unix, feature = "std"))]
-use crate::events::centralized::CentralizedEventManagerBuilder;
+use crate::events::centralized::CentralizedEventManager;
 #[cfg(all(unix, feature = "std", feature = "fork"))]
-use crate::events::{CentralizedEventManager, CentralizedLlmpEventBroker};
+use crate::events::CentralizedLlmpEventBroker;
 #[cfg(feature = "adaptive_serialization")]
 use crate::observers::TimeObserver;
 #[cfg(feature = "std")]
@@ -698,7 +698,7 @@ where
                         let builder = builder.time_ref(self.time_obs.handle());
                         let (state, mgr) = builder.build().launch()?;
 
-                        let mut centralized_builder = CentralizedEventManagerBuilder::new();
+                        let mut centralized_builder = CentralizedEventManager::builder();
 
                         if index == 1 {
                             centralized_builder = centralized_builder.is_main(true);

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -49,7 +49,7 @@ use typed_builder::TypedBuilder;
 
 use super::hooks::EventManagerHooksTuple;
 #[cfg(all(unix, feature = "std", feature = "fork"))]
-use crate::events::centralized::{CentralizedLlmpEventBroker, CentralizedEventManager};
+use crate::events::centralized::{CentralizedEventManager, CentralizedLlmpEventBroker};
 #[cfg(feature = "adaptive_serialization")]
 use crate::observers::TimeObserver;
 #[cfg(feature = "std")]

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -48,10 +48,8 @@ use libafl_bolts::{
 use typed_builder::TypedBuilder;
 
 use super::hooks::EventManagerHooksTuple;
-#[cfg(all(unix, feature = "std"))]
-use crate::events::centralized::CentralizedEventManager;
 #[cfg(all(unix, feature = "std", feature = "fork"))]
-use crate::events::CentralizedLlmpEventBroker;
+use crate::events::centralized::{CentralizedLlmpEventBroker, CentralizedEventManager};
 #[cfg(feature = "adaptive_serialization")]
 use crate::observers::TimeObserver;
 #[cfg(feature = "std")]

--- a/libafl/src/events/llmp/mgr.rs
+++ b/libafl/src/events/llmp/mgr.rs
@@ -18,7 +18,7 @@ use libafl_bolts::{
 use libafl_bolts::{
     current_time,
     llmp::{LlmpClient, LlmpClientDescription},
-    shmem::ShMemProvider,
+    shmem::{ShMemProvider, StdShMemProvider},
     ClientId,
 };
 #[cfg(feature = "std")]
@@ -44,8 +44,9 @@ use crate::{
     },
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
-    inputs::UsesInput,
+    inputs::{NopInput, UsesInput},
     observers::ObserversTuple,
+    prelude::NopState,
     state::{HasExecutions, HasLastReportTime, State, UsesState},
     Error, HasMetadata,
 };
@@ -83,6 +84,14 @@ where
     #[cfg(feature = "adaptive_serialization")]
     pub(crate) time_ref: Handle<TimeObserver>,
     phantom: PhantomData<S>,
+}
+
+impl LlmpEventManager<(), NopState<NopInput>, StdShMemProvider> {
+    /// Creates a builder for [`LlmpEventManager`]
+    #[must_use]
+    pub fn builder() -> LlmpEventManagerBuilder<()> {
+        LlmpEventManagerBuilder::new()
+    }
 }
 
 /// Builder for `LlmpEventManager`

--- a/libafl/src/events/llmp/mgr.rs
+++ b/libafl/src/events/llmp/mgr.rs
@@ -18,7 +18,7 @@ use libafl_bolts::{
 use libafl_bolts::{
     current_time,
     llmp::{LlmpClient, LlmpClientDescription},
-    shmem::{ShMemProvider, StdShMemProvider},
+    shmem::{NopShMemProvider, ShMemProvider},
     ClientId,
 };
 #[cfg(feature = "std")]
@@ -46,8 +46,7 @@ use crate::{
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
     inputs::{NopInput, UsesInput},
     observers::ObserversTuple,
-    prelude::NopState,
-    state::{HasExecutions, HasLastReportTime, State, UsesState},
+    state::{HasExecutions, HasLastReportTime, NopState, State, UsesState},
     Error, HasMetadata,
 };
 
@@ -86,7 +85,7 @@ where
     phantom: PhantomData<S>,
 }
 
-impl LlmpEventManager<(), NopState<NopInput>, StdShMemProvider> {
+impl LlmpEventManager<(), NopState<NopInput>, NopShMemProvider> {
     /// Creates a builder for [`LlmpEventManager`]
     #[must_use]
     pub fn builder() -> LlmpEventManagerBuilder<()> {

--- a/libafl/src/events/llmp/mod.rs
+++ b/libafl/src/events/llmp/mod.rs
@@ -10,7 +10,7 @@ use libafl_bolts::{
 };
 use libafl_bolts::{
     llmp::{LlmpClient, LlmpClientDescription, Tag},
-    shmem::{ShMemProvider, StdShMemProvider},
+    shmem::{NopShMemProvider, ShMemProvider},
     ClientId,
 };
 use serde::Deserialize;
@@ -20,8 +20,7 @@ use crate::{
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
     inputs::{Input, InputConverter, NopInput, NopInputConverter, UsesInput},
-    prelude::NopState,
-    state::{HasExecutions, State, UsesState},
+    state::{HasExecutions, NopState, State, UsesState},
     Error, HasMetadata,
 };
 
@@ -115,7 +114,7 @@ impl
         NopInputConverter<NopInput>,
         NopInputConverter<NopInput>,
         NopState<NopInput>,
-        StdShMemProvider,
+        NopShMemProvider,
     >
 {
     /// Create a builder for [`LlmpEventConverter`]

--- a/libafl/src/events/llmp/mod.rs
+++ b/libafl/src/events/llmp/mod.rs
@@ -10,7 +10,7 @@ use libafl_bolts::{
 };
 use libafl_bolts::{
     llmp::{LlmpClient, LlmpClientDescription, Tag},
-    shmem::ShMemProvider,
+    shmem::{ShMemProvider, StdShMemProvider},
     ClientId,
 };
 use serde::Deserialize;
@@ -19,7 +19,8 @@ use crate::{
     events::{CustomBufEventResult, CustomBufHandlerFn, Event, EventFirer},
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
-    inputs::{Input, InputConverter, UsesInput},
+    inputs::{Input, InputConverter, NopInput, NopInputConverter, UsesInput},
+    prelude::NopState,
     state::{HasExecutions, State, UsesState},
     Error, HasMetadata,
 };
@@ -106,6 +107,22 @@ where
     converter: Option<IC>,
     converter_back: Option<ICB>,
     phantom: PhantomData<S>,
+}
+
+impl
+    LlmpEventConverter<
+        NopInput,
+        NopInputConverter<NopInput>,
+        NopInputConverter<NopInput>,
+        NopState<NopInput>,
+        StdShMemProvider,
+    >
+{
+    /// Create a builder for [`LlmpEventConverter`]
+    #[must_use]
+    pub fn builder() -> LlmpEventConverterBuilder {
+        LlmpEventConverterBuilder::new()
+    }
 }
 
 /// Build `LlmpEventConverter`

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -440,6 +440,13 @@ where
     phantom: PhantomData<S>,
 }
 
+impl<S> TcpEventManager<(), S> {
+    /// Create a builder for [`TcpEventManager`]
+    pub fn builder() -> TcpEventManagerBuilder<(), S> {
+        TcpEventManager::builder()
+    }
+}
+
 /// Builder for `TcpEventManager`
 #[derive(Debug, Copy, Clone)]
 pub struct TcpEventManagerBuilder<EMH, S> {
@@ -1168,7 +1175,7 @@ where
                         }
                         Err(Error::OsError(..)) => {
                             // port was likely already bound
-                            let mgr = TcpEventManagerBuilder::new()
+                            let mgr = TcpEventManager::builder()
                                 .hooks(self.hooks)
                                 .build_from_client(
                                     &("127.0.0.1", self.broker_port),
@@ -1193,9 +1200,11 @@ where
                 }
                 TcpManagerKind::Client { cpu_core } => {
                     // We are a client
-                    let mgr = TcpEventManagerBuilder::new()
-                        .hooks(self.hooks)
-                        .build_on_port(self.broker_port, UNDEFINED_CLIENT_ID, self.configuration)?;
+                    let mgr = TcpEventManager::builder().hooks(self.hooks).build_on_port(
+                        self.broker_port,
+                        UNDEFINED_CLIENT_ID,
+                        self.configuration,
+                    )?;
 
                     (mgr, cpu_core)
                 }
@@ -1315,9 +1324,11 @@ where
             (
                 state_opt,
                 TcpRestartingEventManager::with_save_state(
-                    TcpEventManagerBuilder::new()
-                        .hooks(self.hooks)
-                        .build_on_port(self.broker_port, this_id, self.configuration)?,
+                    TcpEventManager::builder().hooks(self.hooks).build_on_port(
+                        self.broker_port,
+                        this_id,
+                        self.configuration,
+                    )?,
                     staterestorer,
                     self.serialize_state,
                 ),
@@ -1325,7 +1336,7 @@ where
         } else {
             log::info!("First run. Let's set it all up");
             // Mgr to send and receive msgs from/to all other fuzzer instances
-            let mgr = TcpEventManagerBuilder::new()
+            let mgr = TcpEventManager::builder()
                 .hooks(self.hooks)
                 .build_existing_from_env(
                     &("127.0.0.1", self.broker_port),

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -445,6 +445,7 @@ where
     S: State,
 {
     /// Create a builder for [`TcpEventManager`]
+    #[must_use]
     pub fn builder() -> TcpEventManagerBuilder<(), S> {
         TcpEventManagerBuilder::new()
     }

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -440,10 +440,13 @@ where
     phantom: PhantomData<S>,
 }
 
-impl<S> TcpEventManager<(), S> {
+impl<S> TcpEventManager<(), S>
+where
+    S: State,
+{
     /// Create a builder for [`TcpEventManager`]
     pub fn builder() -> TcpEventManagerBuilder<(), S> {
-        TcpEventManager::builder()
+        TcpEventManagerBuilder::new()
     }
 }
 
@@ -1175,7 +1178,7 @@ where
                         }
                         Err(Error::OsError(..)) => {
                             // port was likely already bound
-                            let mgr = TcpEventManager::builder()
+                            let mgr = TcpEventManagerBuilder::new()
                                 .hooks(self.hooks)
                                 .build_from_client(
                                     &("127.0.0.1", self.broker_port),
@@ -1200,11 +1203,9 @@ where
                 }
                 TcpManagerKind::Client { cpu_core } => {
                     // We are a client
-                    let mgr = TcpEventManager::builder().hooks(self.hooks).build_on_port(
-                        self.broker_port,
-                        UNDEFINED_CLIENT_ID,
-                        self.configuration,
-                    )?;
+                    let mgr = TcpEventManagerBuilder::new()
+                        .hooks(self.hooks)
+                        .build_on_port(self.broker_port, UNDEFINED_CLIENT_ID, self.configuration)?;
 
                     (mgr, cpu_core)
                 }
@@ -1324,11 +1325,9 @@ where
             (
                 state_opt,
                 TcpRestartingEventManager::with_save_state(
-                    TcpEventManager::builder().hooks(self.hooks).build_on_port(
-                        self.broker_port,
-                        this_id,
-                        self.configuration,
-                    )?,
+                    TcpEventManagerBuilder::new()
+                        .hooks(self.hooks)
+                        .build_on_port(self.broker_port, this_id, self.configuration)?,
                     staterestorer,
                     self.serialize_state,
                 ),
@@ -1336,7 +1335,7 @@ where
         } else {
             log::info!("First run. Let's set it all up");
             // Mgr to send and receive msgs from/to all other fuzzer instances
-            let mgr = TcpEventManager::builder()
+            let mgr = TcpEventManagerBuilder::new()
                 .hooks(self.hooks)
                 .build_existing_from_env(
                     &("127.0.0.1", self.broker_port),

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -182,8 +182,7 @@ impl CommandExecutor<(), (), ()> {
     /// By default, input is read from stdin, unless you specify a different location using
     /// * `arg_input_arg` for input delivered _as_ an command line argument
     /// * `arg_input_file` for input via a file of a specific name
-    /// * `arg_input_file_std` for a file with default name
-    /// (at the right location in the arguments)
+    /// * `arg_input_file_std` for a file with default name (at the right location in the arguments)
     #[must_use]
     pub fn builder() -> CommandExecutorBuilder {
         CommandExecutorBuilder::new()

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -1324,7 +1324,7 @@ mod tests {
     use serial_test::serial;
 
     use crate::{
-        executors::forkserver::ForkserverExecutorBuilder,
+        executors::forkserver::ForkserverExecutor,
         observers::{ConstMapObserver, HitcountsMapObserver},
         Error,
     };
@@ -1348,7 +1348,7 @@ mod tests {
             shmem_buf,
         ));
 
-        let executor = ForkserverExecutorBuilder::new()
+        let executor = ForkserverExecutor::builder()
             .program(bin)
             .args(args)
             .debug_child(false)

--- a/libafl/src/executors/inprocess/inner.rs
+++ b/libafl/src/executors/inprocess/inner.rs
@@ -219,7 +219,7 @@ where
     /// * `user_hooks` - the hooks run before and after the harness's execution
     /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
-    /// 
+    ///
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout_generic<E, EM, OF, Z>(
         user_hooks: HT,

--- a/libafl/src/executors/inprocess/inner.rs
+++ b/libafl/src/executors/inprocess/inner.rs
@@ -219,6 +219,7 @@ where
     /// * `user_hooks` - the hooks run before and after the harness's execution
     /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
+    /// 
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout_generic<E, EM, OF, Z>(
         user_hooks: HT,

--- a/libafl/src/executors/inprocess/mod.rs
+++ b/libafl/src/executors/inprocess/mod.rs
@@ -232,6 +232,7 @@ where
     /// * `user_hooks` - the hooks run before and after the harness's execution
     /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
+    ///
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout<EM, OF, Z>(
         harness_fn: &'a mut H,
@@ -329,12 +330,13 @@ where
         })
     }
 
-    /// Create a new in mem executor.
+    /// Create a new [`InProcessExecutor`].
     /// Caution: crash and restart in one of them will lead to odd behavior if multiple are used,
     /// depending on different corpus or state.
     /// * `user_hooks` - the hooks run before and after the harness's execution
     /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
+    ///
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout_generic<EM, OF, Z>(
         user_hooks: HT,

--- a/libafl/src/executors/inprocess/stateful.rs
+++ b/libafl/src/executors/inprocess/stateful.rs
@@ -227,6 +227,7 @@ where
     /// * `user_hooks` - the hooks run before and after the harness's execution
     /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
+    ///
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout<EM, OF, Z>(
         harness_fn: &'a mut H,
@@ -354,6 +355,7 @@ where
     /// * `user_hooks` - the hooks run before and after the harness's execution
     /// * `harness_fn` - the harness, executing the function
     /// * `observers` - the observers observing the target during execution
+    ///
     /// This may return an error on unix, if signal handler setup fails
     #[allow(clippy::too_many_arguments)]
     pub fn with_timeout_generic<EM, OF, Z>(

--- a/libafl/src/observers/concolic/serialization_format.rs
+++ b/libafl/src/observers/concolic/serialization_format.rs
@@ -1,22 +1,23 @@
 //! # Concolic Tracing Serialization Format
+//!
 //! ## Design Goals
 //! * The serialization format for concolic tracing was developed with the goal of being space and time efficient.
 //! * Additionally, it should be easy to maintain and extend.
 //! * It does not have to be compatible with other programming languages.
 //! * It should be resilient to crashes. Since we are fuzzing, we are expecting the traced program to crash at some
-//! point.
+//!   point.
 //!
 //! The format as implemented fulfils these design goals.
 //! Specifically:
 //! * it requires only constant memory space for serialization, which allows for tracing complex and/or
-//! long-running programs.
+//!   long-running programs.
 //! * the trace itself requires little space. A typical binary operation (such as an add) typically takes just 3 bytes.
 //! * it easy to encode. There is no translation between the interface of the runtime itself and the trace it generates.
 //! * it is similarly easy to decode and can be easily translated into an in-memory AST without overhead, because
-//! expressions are decoded from leaf to root instead of root to leaf.
+//!   expressions are decoded from leaf to root instead of root to leaf.
 //! * At its core, it is just [`SymExpr`]s, which can be added to, modified and removed from with ease. The
-//! definitions are automatically shared between the runtime and the consuming program, since both depend on the same
-//! `LibAFL`.
+//!   definitions are automatically shared between the runtime and the consuming program, since both depend on the same
+//!   `LibAFL`.
 //!
 //! ## Techniques
 //! The serialization format applies multiple techniques to achieve its goals.

--- a/libafl/src/observers/concolic/serialization_format.rs
+++ b/libafl/src/observers/concolic/serialization_format.rs
@@ -21,15 +21,15 @@
 //! ## Techniques
 //! The serialization format applies multiple techniques to achieve its goals.
 //! * It uses bincode for efficient binary serialization. Crucially, bincode uses variable length integer encoding,
-//! allowing it encode small integers use fewer bytes.
+//!   allowing it encode small integers use fewer bytes.
 //! * References to previous expressions are stored relative to the current expressions id. The vast majority of
-//! expressions refer to other expressions that were defined close to their use. Therefore, encoding relative references
-//! keeps references small. Therefore, they make optimal use of bincodes variable length integer encoding.
+//!   expressions refer to other expressions that were defined close to their use. Therefore, encoding relative references
+//!   keeps references small. Therefore, they make optimal use of bincodes variable length integer encoding.
 //! * Ids of expressions ([`SymExprRef`]s) are implicitly derived by their position in the message stream. Effectively,
-//! a counter is used to identify expressions.
+//!   a counter is used to identify expressions.
 //! * The current length of the trace in bytes in serialized in a fixed format at the beginning of the trace.
-//! This length is updated regularly when the trace is in a consistent state. This allows the reader to avoid reading
-//! malformed data if the traced process crashed.
+//!   This length is updated regularly when the trace is in a consistent state. This allows the reader to avoid reading
+//!   malformed data if the traced process crashed.
 //!
 //! ## Example
 //! The expression `SymExpr::BoolAnd { a: SymExpr::True, b: SymExpr::False }` would be encoded as:

--- a/libafl_bolts/src/build_id.rs
+++ b/libafl_bolts/src/build_id.rs
@@ -22,13 +22,12 @@ static BUILD_ID: OnceLock<Uuid> = OnceLock::new();
 /// invocations of identically laid out binaries.
 ///
 /// As such:
-/// * It is guaranteed to be identical within multiple invocations of the same
-/// binary.
+/// * It is guaranteed to be identical within multiple invocations of the same binary.
 /// * It is guaranteed to be different across binaries with different code or
-/// data segments or layout.
+///   data segments or layout.
 /// * Equality is unspecified if the binaries have identical code and data
-/// segments and layout but differ immaterially (e.g. if a timestamp is included
-/// in the binary at compile time).
+///   segments and layout but differ immaterially (e.g. if a timestamp is included
+///   in the binary at compile time).
 ///
 /// # Examples
 ///

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -1,13 +1,10 @@
 //! A generic shared memory region to be used by any functions (queues or feedbacks
 //! too.)
 
-use alloc::vec::Vec;
 #[cfg(feature = "alloc")]
-use alloc::{rc::Rc, string::ToString};
+use alloc::{rc::Rc, vec::Vec, string::ToString};
 #[cfg(feature = "alloc")]
-use core::fmt::Display;
-#[cfg(feature = "alloc")]
-use core::{cell::RefCell, fmt, mem::ManuallyDrop};
+use core::{cell::RefCell, fmt, mem::ManuallyDrop, fmt::Display};
 use core::{
     fmt::Debug,
     mem,

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -2,9 +2,9 @@
 //! too.)
 
 #[cfg(feature = "alloc")]
-use alloc::{rc::Rc, vec::Vec, string::ToString};
+use alloc::{rc::Rc, string::ToString, vec::Vec};
 #[cfg(feature = "alloc")]
-use core::{cell::RefCell, fmt, mem::ManuallyDrop, fmt::Display};
+use core::{cell::RefCell, fmt, fmt::Display, mem::ManuallyDrop};
 use core::{
     fmt::Debug,
     mem,
@@ -320,7 +320,7 @@ pub trait ShMemProvider: Clone + Default + Debug {
 /// This is mainly for testing and type magic.
 /// The resulting [`NopShMem`] is backed by a simple byte buffer to do some simple non-shared things with.
 /// Calling [`NopShMemProvider::shmem_from_id_and_size`] will return new maps for the same id every time.
-/// 
+///
 /// # Note
 /// If you just want a simple shared memory implementation, use [`StdShMemProvider`] instead.
 #[cfg(feature = "alloc")]
@@ -339,15 +339,22 @@ impl ShMemProvider for NopShMemProvider {
         self.shmem_from_id_and_size(ShMemId::default(), map_size)
     }
 
-    fn shmem_from_id_and_size(&mut self, id: ShMemId, map_size: usize) -> Result<Self::ShMem, Error> {
-        Ok(NopShMem {id, buf: vec![0; map_size]})
+    fn shmem_from_id_and_size(
+        &mut self,
+        id: ShMemId,
+        map_size: usize,
+    ) -> Result<Self::ShMem, Error> {
+        Ok(NopShMem {
+            id,
+            buf: vec![0; map_size],
+        })
     }
 }
 
 /// An [`ShMem]`] that does not have any mem nor share anything.
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Default)]
-pub struct NopShMem{
+pub struct NopShMem {
     id: ShMemId,
     buf: Vec<u8>,
 }

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -318,6 +318,50 @@ pub trait ShMemProvider: Clone + Default + Debug {
     }
 }
 
+/// An ShMemProvider that does not provide any [`ShMem`].`
+#[derive(Debug, Clone, Default)]
+pub struct NopShMemProvider;
+
+impl ShMemProvider for NopShMemProvider {
+    type ShMem = NopShMem;
+
+    fn new() -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    fn new_shmem(&mut self, _map_size: usize) -> Result<Self::ShMem, Error> {
+        Ok(NopShMem::default())
+    }
+
+    fn shmem_from_id_and_size(&mut self, _id: ShMemId, _size: usize) -> Result<Self::ShMem, Error> {
+        Ok(NopShMem::default())
+    }
+}
+
+/// An ShMemProvider that does not provide any [`ShMem`].`
+#[derive(Debug, Clone, Default)]
+pub struct NopShMem;
+
+impl ShMem for NopShMem {
+    fn id(&self) -> ShMemId {
+        ShMemId::default()
+    }
+}
+
+impl DerefMut for NopShMem {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unimplemented!("NopShMem does not actually have data (DerefMut won't work)")
+    }
+}
+
+impl Deref for NopShMem {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unimplemented!("NopShMem does not actually have data (Deref won't work)")
+    }
+}
+
 /// A Handle Counted shared map,
 /// that can use internal mutability.
 /// Useful if the `ShMemProvider` needs to keep local state.

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -318,7 +318,8 @@ pub trait ShMemProvider: Clone + Default + Debug {
     }
 }
 
-/// An ShMemProvider that does not provide any [`ShMem`].`
+/// An [`ShMemProvider`] that does not provide any [`ShMem`].
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Default)]
 pub struct NopShMemProvider;
 
@@ -330,15 +331,15 @@ impl ShMemProvider for NopShMemProvider {
     }
 
     fn new_shmem(&mut self, _map_size: usize) -> Result<Self::ShMem, Error> {
-        Ok(NopShMem::default())
+        Ok(NopShMem)
     }
 
     fn shmem_from_id_and_size(&mut self, _id: ShMemId, _size: usize) -> Result<Self::ShMem, Error> {
-        Ok(NopShMem::default())
+        Ok(NopShMem)
     }
 }
 
-/// An ShMemProvider that does not provide any [`ShMem`].`
+/// An [`ShMem]`] that does not have any mem nor share anything.
 #[derive(Debug, Clone, Default)]
 pub struct NopShMem;
 
@@ -350,6 +351,7 @@ impl ShMem for NopShMem {
 
 impl DerefMut for NopShMem {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // TODO: Do we actually want to use a Vec here and have un-shared memory?
         unimplemented!("NopShMem does not actually have data (DerefMut won't work)")
     }
 }

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -319,7 +319,6 @@ pub trait ShMemProvider: Clone + Default + Debug {
 }
 
 /// An [`ShMemProvider`] that does not provide any [`ShMem`].
-#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Default)]
 pub struct NopShMemProvider;
 

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -189,7 +189,7 @@ impl FridaInstrumentationHelperBuilder {
     /// Instrument all modules in `/usr/lib` as well as `libfoo.so`:
     /// ```
     ///# use libafl_frida::helper::FridaInstrumentationHelperBuilder;
-    /// let builder = FridaInstrumentationHelperBuilder::new()
+    /// let builder = FridaInstrumentationHelper::builder()
     ///     .instrument_module_if(|module| module.name() == "libfoo.so")
     ///     .instrument_module_if(|module| module.path().starts_with("/usr/lib"));
     /// ```
@@ -218,7 +218,7 @@ impl FridaInstrumentationHelperBuilder {
     ///
     /// ```
     ///# use libafl_frida::helper::FridaInstrumentationHelperBuilder;
-    /// let builder = FridaInstrumentationHelperBuilder::new()
+    /// let builder = FridaInstrumentationHelper::builder()
     ///     .instrument_module_if(|module| module.path().starts_with("/usr/lib"))
     ///     .skip_module_if(|module| module.name() == "libfoo.so");
     /// ```
@@ -365,6 +365,13 @@ pub struct FridaInstrumentationHelper<'a, RT: 'a> {
     runtimes: Rc<RefCell<RT>>,
     stalker_enabled: bool,
     pub(crate) disable_excludes: bool,
+}
+
+impl<'a> FridaInstrumentationHelper<'a, ()> {
+    /// Creates a builder for [`FridaInstrumentationHelper`]
+    pub fn builder() -> FridaInstrumentationHelperBuilder {
+        FridaInstrumentationHelper::builder()
+    }
 }
 
 impl<RT> Debug for FridaInstrumentationHelper<'_, RT> {

--- a/libafl_frida/src/helper.rs
+++ b/libafl_frida/src/helper.rs
@@ -367,13 +367,6 @@ pub struct FridaInstrumentationHelper<'a, RT: 'a> {
     pub(crate) disable_excludes: bool,
 }
 
-impl<'a> FridaInstrumentationHelper<'a, ()> {
-    /// Creates a builder for [`FridaInstrumentationHelper`]
-    pub fn builder() -> FridaInstrumentationHelperBuilder {
-        FridaInstrumentationHelper::builder()
-    }
-}
-
 impl<RT> Debug for FridaInstrumentationHelper<'_, RT> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut dbg_me = f.debug_struct("FridaInstrumentationHelper");

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
@@ -236,7 +236,7 @@ pub fn merge(
                     .scheduler_mut()
                     .on_remove(&mut state, idx, &Some(testcase))?;
             } else {
-                rename(file_path, &new_file_path)?;
+                rename(&file_path, &new_file_path)?;
                 *file_path = new_file_path;
             }
         }

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
@@ -236,6 +236,7 @@ pub fn merge(
                     .scheduler_mut()
                     .on_remove(&mut state, idx, &Some(testcase))?;
             } else {
+                #[allow(clippy::needless_borrows_for_generic_args)] // False-positive: file_path is used just below
                 rename(&file_path, &new_file_path)?;
                 *file_path = new_file_path;
             }

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/merge.rs
@@ -236,7 +236,7 @@ pub fn merge(
                     .scheduler_mut()
                     .on_remove(&mut state, idx, &Some(testcase))?;
             } else {
-                rename(&file_path, &new_file_path)?;
+                rename(file_path, &new_file_path)?;
                 *file_path = new_file_path;
             }
         }

--- a/libafl_nyx/src/executor.rs
+++ b/libafl_nyx/src/executor.rs
@@ -30,6 +30,13 @@ pub struct NyxExecutor<S, OT> {
     phantom: PhantomData<S>,
 }
 
+impl NyxExecutor<(), ()> {
+    /// Create a builder for [`NyxExeuctor`]
+    pub fn builder() -> NyxExecutorBuilder {
+        NyxExecutor::builder()
+    }
+}
+
 impl<S, OT> UsesState for NyxExecutor<S, OT>
 where
     S: State,

--- a/libafl_nyx/src/executor.rs
+++ b/libafl_nyx/src/executor.rs
@@ -33,7 +33,7 @@ pub struct NyxExecutor<S, OT> {
 impl NyxExecutor<(), ()> {
     /// Create a builder for [`NyxExeuctor`]
     pub fn builder() -> NyxExecutorBuilder {
-        NyxExecutor::builder()
+        NyxExecutorBuilder::new()
     }
 }
 

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -5,7 +5,7 @@ use std::{fs, net::SocketAddr, path::PathBuf, time::Duration};
 use libafl::{
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig, EventRestarter, LlmpRestartingEventManager},
-    executors::forkserver::ForkserverExecutorBuilder,
+    executors::forkserver::ForkserverExecutor,
     feedback_or, feedback_or_fast,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback, TimeoutFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
@@ -175,7 +175,7 @@ impl<'a> ForkserverBytesCoverageSugar<'a> {
             let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
 
             let forkserver = if self.shmem_testcase {
-                ForkserverExecutorBuilder::new()
+                ForkserverExecutor::builder()
                     .program(self.program.clone())
                     .parse_afl_cmdline(self.arguments)
                     .is_persistent(true)
@@ -186,7 +186,7 @@ impl<'a> ForkserverBytesCoverageSugar<'a> {
                     .shmem_provider(&mut shmem_provider_client)
                     .build_dynamic_map(edges_observer, tuple_list!(time_observer))
             } else {
-                ForkserverExecutorBuilder::new()
+                ForkserverExecutor::builder()
                     .program(self.program.clone())
                     .parse_afl_cmdline(self.arguments)
                     .is_persistent(true)

--- a/libafl_targets/build.rs
+++ b/libafl_targets/build.rs
@@ -200,6 +200,7 @@ fn main() {
         }
     }
 
+    #[cfg(any(feature = "forkserver", feature = "windows_asan"))]
     let target_family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
 
     #[cfg(feature = "forkserver")]

--- a/libafl_tinyinst/src/executor.rs
+++ b/libafl_tinyinst/src/executor.rs
@@ -37,7 +37,7 @@ impl<'a> TinyInstExecutor<(), NopShMemProvider, ()> {
     }
 }
 
-impl<'a, S, SP, OT> std::fmt::Debug for TinyInstExecutor<S, SP, OT>
+impl<S, SP, OT> std::fmt::Debug for TinyInstExecutor<S, SP, OT>
 where
     SP: ShMemProvider,
 {
@@ -48,7 +48,7 @@ where
     }
 }
 
-impl<'a, EM, S, SP, OT, Z> Executor<EM, Z> for TinyInstExecutor<S, SP, OT>
+impl<EM, S, SP, OT, Z> Executor<EM, Z> for TinyInstExecutor<S, SP, OT>
 where
     EM: UsesState<State = S>,
     S: State + HasExecutions,
@@ -242,6 +242,7 @@ where
     /// # Safety
     /// The coverage vec pointer must point to a valid vec and outlive the time the [`TinyInstExecutor`] is alive.
     /// The map will be dereferenced and borrowed mutably during execution. This may not happen concurrently.
+    #[must_use]
     pub fn coverage_ptr(mut self, coverage_ptr: *mut Vec<u64>) -> Self {
         self.coverage_ptr = coverage_ptr;
         self

--- a/libafl_tinyinst/src/executor.rs
+++ b/libafl_tinyinst/src/executor.rs
@@ -10,7 +10,7 @@ use libafl::{
 };
 use libafl_bolts::{
     fs::{InputFile, INPUTFILE_STD},
-    shmem::{ShMem, ShMemProvider, StdShMemProvider},
+    shmem::{NopShMemProvider, ShMem, ShMemProvider},
     tuples::RefIndexable,
     AsSlice, AsSliceMut,
 };
@@ -30,10 +30,11 @@ where
     map: Option<<SP as ShMemProvider>::ShMem>,
 }
 
-impl<'a, SP> TinyInstExecutor<'a, (), SP, ()> {
+impl<'a> TinyInstExecutor<'a, (), NopShMemProvider, ()> {
     /// Create a builder for [`TinyInstExecutor`]
-    pub fn builder() -> TinyInstExecutorBuilder<'a, SP> {
-        TinyInstExecutor::builder()
+    #[must_use]
+    pub fn builder() -> TinyInstExecutorBuilder<'a, NopShMemProvider> {
+        TinyInstExecutorBuilder::new()
     }
 }
 
@@ -113,16 +114,16 @@ pub struct TinyInstExecutorBuilder<'a, SP> {
 const MAX_FILE: usize = 1024 * 1024;
 const SHMEM_FUZZ_HDR_SIZE: usize = 4;
 
-impl<'a> Default for TinyInstExecutorBuilder<'a, StdShMemProvider> {
+impl<'a> Default for TinyInstExecutorBuilder<'a, NopShMemProvider> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> TinyInstExecutorBuilder<'a, StdShMemProvider> {
+impl<'a> TinyInstExecutorBuilder<'a, NopShMemProvider> {
     /// Constructor
     #[must_use]
-    pub fn new() -> TinyInstExecutorBuilder<'a, StdShMemProvider> {
+    pub fn new() -> TinyInstExecutorBuilder<'a, NopShMemProvider> {
         Self {
             tinyinst_args: vec![],
             program_args: vec![],

--- a/libafl_tinyinst/src/executor.rs
+++ b/libafl_tinyinst/src/executor.rs
@@ -241,13 +241,14 @@ where
     ///
     /// # Safety
     /// The coverage vec pointer must point to a valid vec and outlive the time the [`TinyInstExecutor`] is alive.
+    /// The map will be dereferenced and borrowed mutably during execution. This may not happen concurrently.
     pub fn coverage_ptr(mut self, coverage_ptr: *mut Vec<u64>) -> Self {
         self.coverage_ptr = coverage_ptr;
         self
     }
 
     /// Build [`TinyInst`](https://github.com/googleprojectzero/TinyInst) executor
-    pub unsafe fn build<OT, S>(
+    pub fn build<OT, S>(
         &mut self,
         observers: OT,
     ) -> Result<TinyInstExecutor<S, SP, OT>, Error> {

--- a/libafl_tinyinst/src/executor.rs
+++ b/libafl_tinyinst/src/executor.rs
@@ -30,6 +30,13 @@ where
     map: Option<<SP as ShMemProvider>::ShMem>,
 }
 
+impl<'a, SP> TinyInstExecutor<'a, (), SP, ()> {
+    /// Create a builder for [`TinyInstExecutor`]
+    pub fn builder() -> TinyInstExecutorBuilder<'a, SP> {
+        TinyInstExecutor::builder()
+    }
+}
+
 impl<'a, S, SP, OT> std::fmt::Debug for TinyInstExecutor<'a, S, SP, OT>
 where
     SP: ShMemProvider,

--- a/libafl_tinyinst/src/executor.rs
+++ b/libafl_tinyinst/src/executor.rs
@@ -248,10 +248,7 @@ where
     }
 
     /// Build [`TinyInst`](https://github.com/googleprojectzero/TinyInst) executor
-    pub fn build<OT, S>(
-        &mut self,
-        observers: OT,
-    ) -> Result<TinyInstExecutor<S, SP, OT>, Error> {
+    pub fn build<OT, S>(&mut self, observers: OT) -> Result<TinyInstExecutor<S, SP, OT>, Error> {
         if self.coverage_ptr.is_null() {
             return Err(Error::illegal_argument("Coverage pointer may not be null."));
         }


### PR DESCRIPTION
Unifies all builders.  Unionize!

Also adds a NopShMemProvider and fixes a bunch of new clippy lints.