### PR TITLE
Rename peek_next_free_id to peek_free_id (that it's the next is obvious)

### DIFF
--- a/libafl/src/corpus/cached.rs
+++ b/libafl/src/corpus/cached.rs
@@ -149,8 +149,8 @@ where
 
     /// Peek the next free corpus id
     #[inline]
-    fn peek_next_free_id(&self) -> CorpusId {
-        self.inner.peek_next_free_id()
+    fn peek_free_id(&self) -> CorpusId {
+        self.inner.peek_free_id()
     }
 
     #[inline]

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -266,7 +266,7 @@ where
 
     #[must_use]
     /// Peek the next free corpus id
-    pub fn peek_next_free_id(&self) -> CorpusId {
+    pub fn peek_free_id(&self) -> CorpusId {
         CorpusId::from(self.progressive_idx)
     }
 
@@ -438,8 +438,8 @@ where
 
     /// Peek the next free corpus id
     #[inline]
-    fn peek_next_free_id(&self) -> CorpusId {
-        self.storage.peek_next_free_id()
+    fn peek_free_id(&self) -> CorpusId {
+        self.storage.peek_free_id()
     }
 
     #[inline]

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -151,8 +151,8 @@ where
 
     /// Peek the next free corpus id
     #[inline]
-    fn peek_next_free_id(&self) -> CorpusId {
-        self.inner.peek_next_free_id()
+    fn peek_free_id(&self) -> CorpusId {
+        self.inner.peek_free_id()
     }
 
     #[inline]

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -132,7 +132,7 @@ pub trait Corpus: UsesInput + Serialize + for<'de> Deserialize<'de> {
     fn next(&self, id: CorpusId) -> Option<CorpusId>;
 
     /// Peek the next free corpus id
-    fn peek_next_free_id(&self) -> CorpusId;
+    fn peek_free_id(&self) -> CorpusId;
 
     /// Get the prev corpus id
     fn prev(&self, id: CorpusId) -> Option<CorpusId>;

--- a/libafl/src/corpus/nop.rs
+++ b/libafl/src/corpus/nop.rs
@@ -89,7 +89,7 @@ where
 
     /// Peek the next free corpus id
     #[inline]
-    fn peek_next_free_id(&self) -> CorpusId {
+    fn peek_free_id(&self) -> CorpusId {
         CorpusId::from(0_usize)
     }
 

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -108,8 +108,8 @@ where
 
     /// Peek the next free corpus id
     #[inline]
-    fn peek_next_free_id(&self) -> CorpusId {
-        self.inner.peek_next_free_id()
+    fn peek_free_id(&self) -> CorpusId {
+        self.inner.peek_free_id()
     }
 
     /// Removes an entry from the corpus, returning it if it was present.

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/corpus.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/corpus.rs
@@ -203,8 +203,8 @@ where
     fn next(&self, id: CorpusId) -> Option<CorpusId> {
         self.mapping.enabled.next(id)
     }
-    fn peek_next_free_id(&self) -> CorpusId {
-        self.mapping.peek_next_free_id()
+    fn peek_free_id(&self) -> CorpusId {
+        self.mapping.peek_free_id()
     }
 
     fn prev(&self, id: CorpusId) -> Option<CorpusId> {
@@ -359,7 +359,7 @@ where
         maybe_last.ok_or_else(|| Error::illegal_argument("Can only get the last corpus ID."))
     }
 
-    fn peek_next_free_id(&self) -> CorpusId {
+    fn peek_free_id(&self) -> CorpusId {
         CorpusId::from(self.count)
     }
 


### PR DESCRIPTION
@R9295 What do you think?