### PR TITLE
Implement tuple mapping

### DIFF
--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -954,6 +954,7 @@ mod test {
         let mapped = orig.map(MyMapper);
 
         // this won't compile if the mapped type is not correct
+        #[allow(clippy::no_effect_underscore_binding)]
         let _type_assert: tuple_list_type!(W<A>, W<B>, W<C>) = mapped;
     }
 }

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -732,12 +732,12 @@ where
 }
 
 /// Trait for structs which are capable of mapping a given type to another.
-pub trait Mapper<T> {
+pub trait MappingFunctor<T> {
     /// The result of the mapping operation.
     type Output;
 
     /// The actual mapping operation.
-    fn map(&mut self, from: T) -> Self::Output;
+    fn apply(&mut self, from: T) -> Self::Output;
 }
 
 /// Map all entries in a tuple to another type, dependent on the tail type.
@@ -751,13 +751,13 @@ pub trait Map<M> {
 
 impl<Head, Tail, M> Map<M> for (Head, Tail)
 where
-    M: Mapper<Head>,
+    M: MappingFunctor<Head>,
     Tail: Map<M>,
 {
     type MapResult = (M::Output, Tail::MapResult);
 
     fn map(self, mut mapper: M) -> Self::MapResult {
-        let head = mapper.map(self.0);
+        let head = mapper.apply(self.0);
         (head, self.1.map(mapper))
     }
 }
@@ -888,7 +888,7 @@ mod test {
 
     #[cfg(feature = "alloc")]
     use crate::ownedref::OwnedMutSlice;
-    use crate::tuples::{type_eq, Map, Mapper};
+    use crate::tuples::{type_eq, Map, MappingFunctor};
 
     #[test]
     #[allow(unused_qualifications)] // for type name tests
@@ -938,10 +938,10 @@ mod test {
         struct W<T>(T);
         struct MyMapper;
 
-        impl<T> Mapper<T> for MyMapper {
+        impl<T> MappingFunctor<T> for MyMapper {
             type Output = W<T>;
 
-            fn map(&mut self, from: T) -> Self::Output {
+            fn apply(&mut self, from: T) -> Self::Output {
                 W(from)
             }
         }

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -731,16 +731,21 @@ where
     }
 }
 
+/// Trait for structs which are capable of mapping a given type to another.
 pub trait Mapper<T> {
+    /// The result of the mapping operation.
     type Output;
 
+    /// The actual mapping operation.
     fn map(&mut self, from: T) -> Self::Output;
 }
 
 /// Map all entries in a tuple to another type, dependent on the tail type.
 pub trait Map<M> {
+    /// The result of the mapping operation.
     type MapResult;
 
+    /// Perform the mapping!
     fn map(self, mapper: M) -> Self::MapResult;
 }
 
@@ -760,9 +765,7 @@ where
 impl<M> Map<M> for () {
     type MapResult = ();
 
-    fn map(self, _mapper: M) -> Self::MapResult {
-        self
-    }
+    fn map(self, _mapper: M) -> Self::MapResult {}
 }
 
 /// Iterate over a tuple, executing the given `expr` for each element.

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -731,6 +731,40 @@ where
     }
 }
 
+pub trait Mapper<T> {
+    type Output;
+
+    fn map(&mut self, from: T) -> Self::Output;
+}
+
+/// Map all entries in a tuple to another type, dependent on the tail type.
+pub trait Map<M> {
+    type MapResult;
+
+    fn map(self, mapper: M) -> Self::MapResult;
+}
+
+impl<Head, Tail, M> Map<M> for (Head, Tail)
+where
+    M: Mapper<Head>,
+    Tail: Map<M>,
+{
+    type MapResult = (M::Output, Tail::MapResult);
+
+    fn map(self, mut mapper: M) -> Self::MapResult {
+        let head = mapper.map(self.0);
+        (head, self.1.map(mapper))
+    }
+}
+
+impl<M> Map<M> for () {
+    type MapResult = ();
+
+    fn map(self, _mapper: M) -> Self::MapResult {
+        self
+    }
+}
+
 /// Iterate over a tuple, executing the given `expr` for each element.
 #[macro_export]
 #[allow(clippy::items_after_statements)]
@@ -847,9 +881,11 @@ impl<Head, Tail> PlusOne for (Head, Tail) where
 
 #[cfg(test)]
 mod test {
+    use tuple_list::{tuple_list, tuple_list_type};
+
     #[cfg(feature = "alloc")]
     use crate::ownedref::OwnedMutSlice;
-    use crate::tuples::type_eq;
+    use crate::tuples::{type_eq, Map, Mapper};
 
     #[test]
     #[allow(unused_qualifications)] // for type name tests
@@ -892,5 +928,29 @@ mod test {
             OwnedMutSlice<u8>,
             crate::ownedref::OwnedMutSlice<u32>,
         >());
+    }
+
+    #[test]
+    fn test_mapper() {
+        struct W<T>(T);
+        struct MyMapper;
+
+        impl<T> Mapper<T> for MyMapper {
+            type Output = W<T>;
+
+            fn map(&mut self, from: T) -> Self::Output {
+                W(from)
+            }
+        }
+
+        struct A;
+        struct B;
+        struct C;
+
+        let orig = tuple_list!(A, B, C);
+        let mapped = orig.map(MyMapper);
+
+        // this won't compile if the mapped type is not correct
+        let _type_assert: tuple_list_type!(W<A>, W<B>, W<C>) = mapped;
     }
 }


### PR DESCRIPTION
This allows for the mapping of all tuple members to another type, potentially as a generic of the original type.

See the test for details.