### PR TITLE
Tutorial fuzzer: Switch lain fork to AFLplusplus/lain

### DIFF
--- a/fuzzers/tutorial/Cargo.toml
+++ b/fuzzers/tutorial/Cargo.toml
@@ -23,7 +23,7 @@ libafl = { path = "../../libafl/", features = ["default", "rand_trait"] }
 libafl_bolts = { path = "../../libafl_bolts/" }
 libafl_targets = { path = "../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog"] }
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib
-lain = { version = "0.5", features = ["serde_support"], git = "https://github.com/Mrmaxmeier/lain.git", rev = "6c8a786c7e27ed80c913c07177f95d475421bf69" } # We're using a lain fork with updated rand crate
+lain = { version = "0.5", features = ["serde_support"], git = "https://github.com/AFLplusplus/lain.git", rev = "208e927bcf411f62f8a1f51ac2d9f9423a1ec5d3" } # We're using a lain fork compatible with libafl's rand version
 # TODO Include it only when building cc
 libafl_cc = { path = "../../libafl_cc/" }
 


### PR DESCRIPTION
https://github.com/AFLplusplus/LibAFL/pull/2254#discussion_r1617344909

I can't reproduce this serde error https://github.com/AFLplusplus/LibAFL/pull/2254#discussion_r1617377032. Let's see if CI likes it.