### PR TITLE
Fix duplicate package warning

### DIFF
--- a/fuzzers/dynamic_analysis/Cargo.toml
+++ b/fuzzers/dynamic_analysis/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fuzzbench"
+name = "dynamic_analysis"
 version = "0.12.0"
 authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
```
warning: skipping duplicate package `fuzzbench` found at `~/.cargo/git/checkouts/libafl-c33dc6f5ec2f7a70/058e15f/fuzzers/fuzzbench`
```