### PR TITLE
libafl_qemu_build: Disable docs in user mode

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -101,7 +101,7 @@ fn configure_qemu(
 
     if is_usermode {
         // Usermode options
-        cmd.args(["--disable-fdt", "--disable-system"]);
+        cmd.args(["--disable-fdt", "--disable-system", "--disable-docs"]);
     } else {
         // Systemmode options
         cmd.arg(if cfg!(feature = "slirp") {


### PR DESCRIPTION
I observed a qemu build failure when writing unit tests for my fuzzer that was related to sphinx failing. I found disabling the docs fixed the failure. I think this is probably a good default, and it seems docs are already being disabled for system mode.