### PR TITLE
feat: generic cleanup

### DIFF
--- a/libafl/src/corpus/cached.rs
+++ b/libafl/src/corpus/cached.rs
@@ -11,7 +11,7 @@ use crate::{
         inmemory_ondisk::InMemoryOnDiskCorpus, ondisk::OnDiskMetadataFormat, Corpus, CorpusId,
         HasTestcase, Testcase,
     },
-    inputs::{Input, UsesInput},
+    inputs::Input,
     Error,
 };
 
@@ -20,27 +20,13 @@ use crate::{
 /// The eviction policy is FIFO.
 #[cfg(feature = "std")]
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct CachedOnDiskCorpus<I>
-where
-    I: Input,
-{
+pub struct CachedOnDiskCorpus<I> {
     inner: InMemoryOnDiskCorpus<I>,
     cached_indexes: RefCell<VecDeque<CorpusId>>,
     cache_max_len: usize,
 }
 
-impl<I> UsesInput for CachedOnDiskCorpus<I>
-where
-    I: Input,
-{
-    type Input = I;
-}
-
-impl<I> CachedOnDiskCorpus<I>
-where
-    I: Input,
-{
+impl<I> CachedOnDiskCorpus<I> {
     fn cache_testcase<'a>(
         &'a self,
         testcase: &'a RefCell<Testcase<I>>,
@@ -67,10 +53,13 @@ where
         Ok(())
     }
 }
+
 impl<I> Corpus for CachedOnDiskCorpus<I>
 where
     I: Input,
 {
+    type Input = I;
+
     /// Returns the number of all enabled entries
     #[inline]
     fn count(&self) -> usize {
@@ -189,26 +178,7 @@ where
     }
 }
 
-impl<I> HasTestcase for CachedOnDiskCorpus<I>
-where
-    I: Input,
-{
-    fn testcase(&self, id: CorpusId) -> Result<core::cell::Ref<Testcase<Self::Input>>, Error> {
-        Ok(self.get(id)?.borrow())
-    }
-
-    fn testcase_mut(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::RefMut<Testcase<Self::Input>>, Error> {
-        Ok(self.get(id)?.borrow_mut())
-    }
-}
-
-impl<I> CachedOnDiskCorpus<I>
-where
-    I: Input,
-{
+impl<I> CachedOnDiskCorpus<I> {
     /// Creates the [`CachedOnDiskCorpus`].
     ///
     /// This corpus stores (and reads) all testcases to/from disk

--- a/libafl/src/corpus/inmemory.rs
+++ b/libafl/src/corpus/inmemory.rs
@@ -8,18 +8,14 @@ use serde::{Deserialize, Serialize};
 use super::HasTestcase;
 use crate::{
     corpus::{Corpus, CorpusId, Testcase},
-    inputs::{Input, UsesInput},
+    inputs::Input,
     Error,
 };
 
 /// Keep track of the stored `Testcase` and the siblings ids (insertion order)
 #[cfg(not(feature = "corpus_btreemap"))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct TestcaseStorageItem<I>
-where
-    I: Input,
-{
+pub struct TestcaseStorageItem<I> {
     /// The stored testcase
     pub testcase: RefCell<Testcase<I>>,
     /// Previously inserted id
@@ -30,11 +26,7 @@ where
 
 /// The map type in which testcases are stored (disable the feature `corpus_btreemap` to use a `HashMap` instead of `BTreeMap`)
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct TestcaseStorageMap<I>
-where
-    I: Input,
-{
+pub struct TestcaseStorageMap<I> {
     #[cfg(not(feature = "corpus_btreemap"))]
     /// A map of `CorpusId` to `TestcaseStorageItem`
     pub map: hashbrown::HashMap<CorpusId, TestcaseStorageItem<I>>,
@@ -51,10 +43,7 @@ where
     last_idx: Option<CorpusId>,
 }
 
-impl<I> TestcaseStorageMap<I>
-where
-    I: Input,
-{
+impl<I> TestcaseStorageMap<I> {
     /// Insert a key in the keys set
     fn insert_key(&mut self, id: CorpusId) {
         if let Err(idx) = self.keys.binary_search(&id) {
@@ -235,11 +224,7 @@ where
 }
 /// Storage map for the testcases (used in `Corpus` implementations) with an incremental index
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct TestcaseStorage<I>
-where
-    I: Input,
-{
+pub struct TestcaseStorage<I> {
     /// The map in which enabled testcases are stored
     pub enabled: TestcaseStorageMap<I>,
     /// The map in which disabled testcases are stored
@@ -248,17 +233,7 @@ where
     progressive_idx: usize,
 }
 
-impl<I> UsesInput for TestcaseStorage<I>
-where
-    I: Input,
-{
-    type Input = I;
-}
-
-impl<I> TestcaseStorage<I>
-where
-    I: Input,
-{
+impl<I> TestcaseStorage<I> {
     /// Insert a testcase assigning a `CorpusId` to it
     pub fn insert(&mut self, testcase: RefCell<Testcase<I>>) -> CorpusId {
         self._insert(testcase, false)
@@ -334,26 +309,17 @@ where
 
 /// A corpus handling all in memory.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct InMemoryCorpus<I>
-where
-    I: Input,
-{
+pub struct InMemoryCorpus<I> {
     storage: TestcaseStorage<I>,
     current: Option<CorpusId>,
-}
-
-impl<I> UsesInput for InMemoryCorpus<I>
-where
-    I: Input,
-{
-    type Input = I;
 }
 
 impl<I> Corpus for InMemoryCorpus<I>
 where
     I: Input,
 {
+    type Input = I;
+
     /// Returns the number of all enabled entries
     #[inline]
     fn count(&self) -> usize {
@@ -438,15 +404,15 @@ where
         &mut self.current
     }
 
+    #[inline]
+    fn next(&self, idx: CorpusId) -> Option<CorpusId> {
+        self.storage.enabled.next(idx)
+    }
+
     /// Peek the next free corpus id
     #[inline]
     fn peek_free_id(&self) -> CorpusId {
         self.storage.peek_free_id()
-    }
-
-    #[inline]
-    fn next(&self, idx: CorpusId) -> Option<CorpusId> {
-        self.storage.enabled.next(idx)
     }
 
     #[inline]
@@ -492,29 +458,7 @@ where
     }
 }
 
-impl<I> HasTestcase for InMemoryCorpus<I>
-where
-    I: Input,
-{
-    fn testcase(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::Ref<Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.get(id)?.borrow())
-    }
-
-    fn testcase_mut(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::RefMut<Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.get(id)?.borrow_mut())
-    }
-}
-
-impl<I> InMemoryCorpus<I>
-where
-    I: Input,
-{
+impl<I> InMemoryCorpus<I> {
     /// Creates a new [`InMemoryCorpus`], keeping all [`Testcase`]`s` in memory.
     /// This is the simplest and fastest option, however test progress will be lost on exit or on OOM.
     #[must_use]

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -22,7 +22,7 @@ use super::{
 };
 use crate::{
     corpus::{Corpus, CorpusId, InMemoryCorpus, Testcase},
-    inputs::{Input, UsesInput},
+    inputs::Input,
     Error, HasMetadata,
 };
 
@@ -31,11 +31,7 @@ use crate::{
 /// Metadata is written to a `.<filename>.metadata` file in the same folder by default.
 #[cfg(feature = "std")]
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct InMemoryOnDiskCorpus<I>
-where
-    I: Input,
-{
+pub struct InMemoryOnDiskCorpus<I> {
     inner: InMemoryCorpus<I>,
     dir_path: PathBuf,
     meta_format: Option<OnDiskMetadataFormat>,
@@ -43,17 +39,12 @@ where
     locking: bool,
 }
 
-impl<I> UsesInput for InMemoryOnDiskCorpus<I>
-where
-    I: Input,
-{
-    type Input = I;
-}
-
 impl<I> Corpus for InMemoryOnDiskCorpus<I>
 where
     I: Input,
 {
+    type Input = I;
+
     /// Returns the number of all enabled entries
     #[inline]
     fn count(&self) -> usize {
@@ -200,29 +191,7 @@ where
     }
 }
 
-impl<I> HasTestcase for InMemoryOnDiskCorpus<I>
-where
-    I: Input,
-{
-    fn testcase(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::Ref<Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.get(id)?.borrow())
-    }
-
-    fn testcase_mut(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::RefMut<Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.get(id)?.borrow_mut())
-    }
-}
-
-impl<I> InMemoryOnDiskCorpus<I>
-where
-    I: Input,
-{
+impl<I> InMemoryOnDiskCorpus<I> {
     /// Creates an [`InMemoryOnDiskCorpus`].
     ///
     /// This corpus stores all testcases to disk, and keeps all of them in memory, as well.

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -14,13 +14,13 @@ use num_traits::ToPrimitive;
 use z3::{ast::Bool, Config, Context, Optimize};
 
 use crate::{
-    corpus::Corpus,
+    corpus::{Corpus, HasCorpus},
     events::{Event, EventFirer, LogSeverity},
     executors::{Executor, HasObservers},
     monitors::{AggregatorOps, UserStats, UserStatsValue},
     observers::{MapObserver, ObserversTuple},
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
-    state::{HasCorpus, HasExecutions, UsesState},
+    state::{HasExecutions, UsesState},
     Error, HasMetadata, HasScheduler,
 };
 

--- a/libafl/src/corpus/mod.rs
+++ b/libafl/src/corpus/mod.rs
@@ -1,7 +1,7 @@
 //! Corpuses contain the testcases, either in memory, on disk, or somewhere else.
 
 pub mod testcase;
-pub use testcase::{HasTestcase, SchedulerTestcaseMetadata, Testcase};
+pub use testcase::{HasTestcase, Testcase};
 
 pub mod inmemory;
 pub use inmemory::InMemoryCorpus;

--- a/libafl/src/corpus/nop.rs
+++ b/libafl/src/corpus/nop.rs
@@ -5,29 +5,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     corpus::{Corpus, CorpusId, Testcase},
-    inputs::{Input, UsesInput},
     Error,
 };
 
 /// A corpus which does not store any [`Testcase`]s.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
 pub struct NopCorpus<I> {
     empty: Option<CorpusId>,
     phantom: PhantomData<I>,
 }
 
-impl<I> UsesInput for NopCorpus<I>
-where
-    I: Input,
-{
+impl<I> Corpus for NopCorpus<I> {
     type Input = I;
-}
 
-impl<I> Corpus for NopCorpus<I>
-where
-    I: Input,
-{
     /// Returns the number of all enabled entries
     #[inline]
     fn count(&self) -> usize {
@@ -87,12 +77,6 @@ where
         &self.empty
     }
 
-    /// Peek the next free corpus id
-    #[inline]
-    fn peek_free_id(&self) -> CorpusId {
-        CorpusId::from(0_usize)
-    }
-
     /// Current testcase scheduled (mutable)
     #[inline]
     fn current_mut(&mut self) -> &mut Option<CorpusId> {
@@ -102,6 +86,12 @@ where
     #[inline]
     fn next(&self, _idx: CorpusId) -> Option<CorpusId> {
         None
+    }
+
+    /// Peek the next free corpus id
+    #[inline]
+    fn peek_free_id(&self) -> CorpusId {
+        CorpusId::from(0_usize)
     }
 
     #[inline]
@@ -142,10 +132,7 @@ where
     }
 }
 
-impl<I> NopCorpus<I>
-where
-    I: Input,
-{
+impl<I> NopCorpus<I> {
     /// Creates a new [`NopCorpus`].
     #[must_use]
     pub fn new() -> Self {

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use super::{CachedOnDiskCorpus, HasTestcase};
 use crate::{
     corpus::{Corpus, CorpusId, Testcase},
-    inputs::{Input, UsesInput},
+    inputs::Input,
     Error,
 };
 
@@ -49,22 +49,11 @@ pub struct OnDiskMetadata<'a> {
 ///
 /// Metadata is written to a `.<filename>.metadata` file in the same folder by default.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct OnDiskCorpus<I>
-where
-    I: Input,
-{
+pub struct OnDiskCorpus<I> {
     /// The root directory backing this corpus
     dir_path: PathBuf,
     /// We wrapp a cached corpus and set its size to 1.
     inner: CachedOnDiskCorpus<I>,
-}
-
-impl<I> UsesInput for OnDiskCorpus<I>
-where
-    I: Input,
-{
-    type Input = I;
 }
 
 impl<I> Corpus for OnDiskCorpus<I>
@@ -184,29 +173,7 @@ where
     }
 }
 
-impl<I> HasTestcase for OnDiskCorpus<I>
-where
-    I: Input,
-{
-    fn testcase(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::Ref<Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.get(id)?.borrow())
-    }
-
-    fn testcase_mut(
-        &self,
-        id: CorpusId,
-    ) -> Result<core::cell::RefMut<Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.get(id)?.borrow_mut())
-    }
-}
-
-impl<I> OnDiskCorpus<I>
-where
-    I: Input,
-{
+impl<I> OnDiskCorpus<I> {
     /// Creates an [`OnDiskCorpus`].
     ///
     /// This corpus stores all testcases to disk.

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     monitors::UserStats,
     observers::ObserversTuple,
     state::{HasExecutions, HasLastReportTime, State},
-    Error, HasMetadata,
+    Error,
 };
 #[cfg(feature = "scalability_introspection")]
 use crate::{
@@ -404,7 +404,7 @@ where
 /// [`ProgressReporter`] report progress to the broker.
 pub trait ProgressReporter<S>: EventFirer<S>
 where
-    S: HasCorpus + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasExecutions + HasLastReportTime,
 {
     /// Given the last time, if `monitor_timeout` seconds passed, send off an info/monitor/heartbeat message to the broker.
     /// Returns the new `last` time (so the old one, unless `monitor_timeout` time has passed and monitor have been sent)
@@ -542,7 +542,7 @@ pub trait EventManager<E, S, Z>:
     + HasEventManagerId
     + ProgressReporter<S>
 where
-    S: HasCorpus + HasCurrentStage + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasCurrentStage + HasExecutions + HasLastReportTime,
 {
 }
 
@@ -650,12 +650,12 @@ impl<E, S, Z> EventProcessor<E, S, Z> for NopEventManager<S> {
 }
 
 impl<E, S, Z> EventManager<E, S, Z> for NopEventManager<S> where
-    S: HasCorpus + HasCurrentStage + HasMetadata + HasExecutions + HasLastReportTime
+    S: HasCorpus + HasCurrentStage + HasExecutions + HasLastReportTime
 {
 }
 
 impl<S> ProgressReporter<S> for NopEventManager<S> where
-    S: HasCorpus + HasMetadata + HasExecutions + HasLastReportTime
+    S: HasCorpus + HasExecutions + HasLastReportTime
 {
 }
 
@@ -765,14 +765,14 @@ where
 impl<E, EM, M, S, Z> EventManager<E, S, Z> for MonitorTypedEventManager<EM, M>
 where
     EM: EventManager<E, S, Z>,
-    S: HasCorpus + HasCurrentStage + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasCurrentStage + HasExecutions + HasLastReportTime,
 {
 }
 
 impl<EM, M, S> ProgressReporter<S> for MonitorTypedEventManager<EM, M>
 where
     EM: ProgressReporter<S>,
-    S: HasCorpus + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasExecutions + HasLastReportTime,
 {
     #[inline]
     fn maybe_report_progress(

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -36,7 +36,7 @@ use crate::{
     monitors::Monitor,
     stages::HasCurrentStage,
     state::{HasExecutions, HasLastReportTime},
-    Error, HasMetadata,
+    Error,
 };
 #[cfg(feature = "std")]
 use crate::{
@@ -97,8 +97,6 @@ impl<H, I, MT, S> EventRestarter<S> for SimpleEventManager<H, I, MT> where S: Ha
 
 impl<E, H, I, MT, S, Z> EventProcessor<E, S, Z> for SimpleEventManager<H, I, MT>
 where
-    S: HasCorpus,
-    S::Corpus: Corpus<Input = I>,
     H: CustomBufHandlerTuple<S>,
 {
     fn process(
@@ -118,7 +116,7 @@ where
 impl<H, I, MT, S> ProgressReporter<S> for SimpleEventManager<H, I, MT>
 where
     MT: Monitor,
-    S: HasCorpus + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasExecutions + HasLastReportTime,
     S::Corpus: Corpus<Input = I>,
 {
 }
@@ -132,7 +130,7 @@ impl<H, I, MT> HasEventManagerId for SimpleEventManager<H, I, MT> {
 impl<E, H, I, MT, S, Z> EventManager<E, S, Z> for SimpleEventManager<H, I, MT>
 where
     MT: Monitor,
-    S: HasCorpus + HasCurrentStage + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasCurrentStage + HasExecutions + HasLastReportTime,
     S::Corpus: Corpus<Input = I>,
     H: CustomBufHandlerTuple<S>,
 {
@@ -385,7 +383,7 @@ where
 impl<E, H, I, MT, S, SP, Z> EventManager<E, S, Z> for SimpleRestartingEventManager<H, I, MT, SP>
 where
     MT: Monitor,
-    S: HasCorpus + HasCurrentStage + HasMetadata + HasExecutions + HasLastReportTime,
+    S: HasCorpus + HasCurrentStage + HasExecutions + HasLastReportTime,
     S::Corpus: Corpus<Input = I>,
     SP: ShMemProvider,
     H: CustomBufHandlerTuple<S>,

--- a/libafl/src/executors/combined.rs
+++ b/libafl/src/executors/combined.rs
@@ -8,7 +8,7 @@ use libafl_bolts::tuples::RefIndexable;
 use crate::{
     executors::{Executor, ExitKind, HasObservers},
     observers::UsesObservers,
-    state::{HasExecutions, UsesState},
+    state::HasExecutions,
     Error,
 };
 
@@ -21,13 +21,7 @@ pub struct CombinedExecutor<A, B> {
 
 impl<A, B> CombinedExecutor<A, B> {
     /// Create a new `CombinedExecutor`, wrapping the given `executor`s.
-    pub fn new<EM, Z>(primary: A, secondary: B) -> Self
-    where
-        A: Executor<EM, Z>,
-        B: Executor<EM, Z, State = <Self as UsesState>::State>,
-        EM: UsesState<State = <Self as UsesState>::State>,
-        Z: UsesState<State = <Self as UsesState>::State>,
-    {
+    pub fn new(primary: A, secondary: B) -> Self {
         Self { primary, secondary }
     }
 
@@ -42,13 +36,11 @@ impl<A, B> CombinedExecutor<A, B> {
     }
 }
 
-impl<A, B, EM, Z> Executor<EM, Z> for CombinedExecutor<A, B>
+impl<A, B, EM, I, S, Z> Executor<EM, I, S, Z> for CombinedExecutor<A, B>
 where
-    A: Executor<EM, Z>,
-    B: Executor<EM, Z, State = <Self as UsesState>::State>,
-    Self::State: HasExecutions,
-    EM: UsesState<State = <Self as UsesState>::State>,
-    Z: UsesState<State = <Self as UsesState>::State>,
+    A: Executor<EM, I, S, Z>,
+    B: Executor<EM, I, S, Z>,
+    S: HasExecutions,
 {
     fn run_target(
         &mut self,
@@ -61,13 +53,6 @@ where
 
         self.primary.run_target(fuzzer, state, mgr, input)
     }
-}
-
-impl<A, B> UsesState for CombinedExecutor<A, B>
-where
-    A: UsesState,
-{
-    type State = A::State;
 }
 
 impl<A, B> UsesObservers for CombinedExecutor<A, B>

--- a/libafl/src/executors/combined.rs
+++ b/libafl/src/executors/combined.rs
@@ -7,7 +7,6 @@ use libafl_bolts::tuples::RefIndexable;
 
 use crate::{
     executors::{Executor, ExitKind, HasObservers},
-    observers::UsesObservers,
     state::HasExecutions,
     Error,
 };
@@ -55,24 +54,21 @@ where
     }
 }
 
-impl<A, B> UsesObservers for CombinedExecutor<A, B>
+impl<'a, A, B> HasObservers<'a> for CombinedExecutor<A, B>
 where
-    A: UsesObservers,
+    A: HasObservers<'a>,
 {
     type Observers = A::Observers;
-}
+    type ObserversRef = A::ObserversRef;
+    type ObserversRefMut = A::ObserversRefMut;
 
-impl<A, B> HasObservers for CombinedExecutor<A, B>
-where
-    A: HasObservers,
-{
     #[inline]
-    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
+    fn observers(&self) -> RefIndexable<Self::ObserversRef, Self::Observers> {
         self.primary.observers()
     }
 
     #[inline]
-    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
+    fn observers_mut(&mut self) -> RefIndexable<Self::ObserversRefMut, Self::Observers> {
         self.primary.observers_mut()
     }
 }

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -23,7 +23,7 @@ use crate::executors::{Executor, ExitKind};
 use crate::{
     executors::HasObservers,
     inputs::{BytesInput, HasTargetBytes},
-    observers::{ObserversTuple, StdErrObserver, StdOutObserver, UsesObservers},
+    observers::{ObserversTuple, StdErrObserver, StdOutObserver},
     state::{HasExecutions, State},
     std::borrow::ToOwned,
 };
@@ -262,19 +262,19 @@ where
     }
 }
 
-impl<OT, T> UsesObservers for CommandExecutor<OT, T> {
-    type Observers = OT;
-}
-
-impl<OT, T> HasObservers for CommandExecutor<OT, T>
+impl<'a, OT, T> HasObservers<'a> for CommandExecutor<OT, T>
 where
     OT: MatchName,
 {
-    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
+    type Observers = OT;
+    type ObserversRef = &'a Self::Observers;
+    type ObserversRefMut = &'a mut Self::Observers;
+
+    fn observers(&'a self) -> RefIndexable<&'a Self::Observers, Self::Observers> {
         RefIndexable::from(&self.observers)
     }
 
-    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
+    fn observers_mut(&'a mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
         RefIndexable::from(&mut self.observers)
     }
 }

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -3,7 +3,6 @@
 use alloc::{borrow::ToOwned, string::ToString, vec::Vec};
 use core::{
     fmt::{self, Debug, Formatter},
-    marker::PhantomData,
     time::Duration,
 };
 use std::{
@@ -23,7 +22,7 @@ use libafl_bolts::{
     os::{dup2, pipes::Pipe},
     ownedref::OwnedSlice,
     shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{Handle, Handled, MatchNameRef, Prepend, RefIndexable},
+    tuples::{Handle, Handled, MatchNameRef, RefIndexable},
     AsSlice, AsSliceMut, Truncate,
 };
 use nix::{
@@ -39,11 +38,12 @@ use nix::{
 #[cfg(feature = "regex")]
 use crate::observers::{get_asan_runtime_flags_with_log_path, AsanBacktraceObserver};
 use crate::{
+    corpus::{Corpus, HasCorpus},
     executors::{Executor, ExitKind, HasObservers},
-    inputs::{HasTargetBytes, Input, UsesInput},
+    inputs::HasTargetBytes,
     mutators::Tokens,
-    observers::{MapObserver, Observer, ObserversTuple, UsesObservers},
-    state::{HasExecutions, State, UsesState},
+    observers::{MapObserver, Observer, ObserversTuple},
+    state::HasExecutions,
     Error,
 };
 
@@ -518,7 +518,7 @@ impl Forkserver {
 /// This [`Executor`] can run binaries compiled for AFL/AFL++ that make use of a forkserver.
 /// Shared memory feature is also available, but you have to set things up in your code.
 /// Please refer to AFL++'s docs. <https://github.com/AFLplusplus/AFLplusplus/blob/stable/instrumentation/README.persistent_mode.md>
-pub struct ForkserverExecutor<OT, S, SP>
+pub struct ForkserverExecutor<OT, SP>
 where
     SP: ShMemProvider,
 {
@@ -529,7 +529,6 @@ where
     forkserver: Forkserver,
     observers: OT,
     map: Option<SP::ShMem>,
-    phantom: PhantomData<S>,
     map_size: Option<usize>,
     min_input_size: usize,
     max_input_size: usize,
@@ -539,7 +538,7 @@ where
     crash_exitcode: Option<i8>,
 }
 
-impl<OT, S, SP> Debug for ForkserverExecutor<OT, S, SP>
+impl<OT, SP> Debug for ForkserverExecutor<OT, SP>
 where
     OT: Debug,
     SP: ShMemProvider,
@@ -557,7 +556,7 @@ where
     }
 }
 
-impl ForkserverExecutor<(), (), UnixShMemProvider> {
+impl ForkserverExecutor<(), UnixShMemProvider> {
     /// Builder for `ForkserverExecutor`
     #[must_use]
     pub fn builder() -> ForkserverExecutorBuilder<'static, UnixShMemProvider> {
@@ -565,10 +564,8 @@ impl ForkserverExecutor<(), (), UnixShMemProvider> {
     }
 }
 
-impl<OT, S, SP> ForkserverExecutor<OT, S, SP>
+impl<OT, SP> ForkserverExecutor<OT, SP>
 where
-    OT: ObserversTuple<S>,
-    S: UsesInput,
     SP: ShMemProvider,
 {
     /// The `target` binary that's going to run.
@@ -634,11 +631,8 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
     /// in case no input file is specified.
     /// If `debug_child` is set, the child will print to `stdout`/`stderr`.
     #[allow(clippy::pedantic)]
-    pub fn build<OT, S>(&mut self, observers: OT) -> Result<ForkserverExecutor<OT, S, SP>, Error>
+    pub fn build<OT>(&mut self, observers: OT) -> Result<ForkserverExecutor<OT, SP>, Error>
     where
-        OT: ObserversTuple<S>,
-        S: UsesInput,
-        S::Input: Input + HasTargetBytes,
         SP: ShMemProvider,
     {
         let (forkserver, input_file, map) = self.build_helper()?;
@@ -679,7 +673,6 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
             forkserver,
             observers,
             map,
-            phantom: PhantomData,
             map_size: self.map_size,
             min_input_size: self.min_input_size,
             max_input_size: self.max_input_size,
@@ -694,17 +687,14 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
 
     /// Builds `ForkserverExecutor` downsizing the coverage map to fit exaclty the AFL++ map size.
     #[allow(clippy::pedantic)]
-    pub fn build_dynamic_map<A, MO, OT, S>(
+    pub fn build_dynamic_map<A, MO, OT>(
         &mut self,
         mut map_observer: A,
         other_observers: OT,
-    ) -> Result<ForkserverExecutor<(A, OT), S, SP>, Error>
+    ) -> Result<ForkserverExecutor<(A, OT), SP>, Error>
     where
-        MO: MapObserver + Truncate, // TODO maybe enforce Entry = u8 for the cov map
-        A: Observer<S> + AsRef<MO> + AsMut<MO>,
-        OT: ObserversTuple<S> + Prepend<MO, PreprendResult = OT>,
-        S: UsesInput,
-        S::Input: Input + HasTargetBytes,
+        MO: MapObserver<Entry = u8> + Truncate,
+        A: AsMut<MO>,
         SP: ShMemProvider,
     {
         let (forkserver, input_file, map) = self.build_helper()?;
@@ -743,7 +733,6 @@ impl<'a, SP> ForkserverExecutorBuilder<'a, SP> {
             forkserver,
             observers,
             map,
-            phantom: PhantomData,
             map_size: self.map_size,
             min_input_size: self.min_input_size,
             max_input_size: self.max_input_size,
@@ -1205,14 +1194,12 @@ impl<'a> Default for ForkserverExecutorBuilder<'a, UnixShMemProvider> {
     }
 }
 
-impl<EM, OT, S, SP, Z> Executor<EM, Z> for ForkserverExecutor<OT, S, SP>
+impl<EM, I, OT, S, SP, Z> Executor<EM, I, S, Z> for ForkserverExecutor<OT, SP>
 where
-    OT: ObserversTuple<S>,
+    OT: ObserversTuple<I, S>,
     SP: ShMemProvider,
-    S: State + HasExecutions,
-    S::Input: HasTargetBytes,
-    EM: UsesState<State = S>,
-    Z: UsesState<State = S>,
+    S: HasCorpus + HasExecutions,
+    <<S as HasCorpus>::Corpus as Corpus>::Input: HasTargetBytes,
 {
     #[inline]
     fn run_target(
@@ -1320,36 +1307,21 @@ where
     }
 }
 
-impl<OT, S, SP> UsesState for ForkserverExecutor<OT, S, SP>
+impl<'a, OT, SP> HasObservers<'a> for ForkserverExecutor<OT, SP>
 where
-    S: State,
-    SP: ShMemProvider,
-{
-    type State = S;
-}
-
-impl<OT, S, SP> UsesObservers for ForkserverExecutor<OT, S, SP>
-where
-    OT: ObserversTuple<S>,
-    S: State,
     SP: ShMemProvider,
 {
     type Observers = OT;
-}
+    type ObserversRef = &'a Self::Observers;
+    type ObserversRefMut = &'a mut Self::Observers;
 
-impl<OT, S, SP> HasObservers for ForkserverExecutor<OT, S, SP>
-where
-    OT: ObserversTuple<S>,
-    S: State,
-    SP: ShMemProvider,
-{
     #[inline]
-    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
+    fn observers(&'a self) -> RefIndexable<&'a Self::Observers, Self::Observers> {
         RefIndexable::from(&self.observers)
     }
 
     #[inline]
-    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
+    fn observers_mut(&'a mut self) -> RefIndexable<&'a mut Self::Observers, Self::Observers> {
         RefIndexable::from(&mut self.observers)
     }
 }
@@ -1395,7 +1367,7 @@ mod tests {
             .args(args)
             .debug_child(false)
             .shmem_provider(&mut shmem_provider)
-            .build::<_, ()>(tuple_list!(edges_observer));
+            .build::<_>(tuple_list!(edges_observer));
 
         // Since /usr/bin/echo is not a instrumented binary file, the test will just check if the forkserver has failed at the initial handshake
         let result = match executor {

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -16,15 +16,12 @@ pub use inprocess::InProcessExecutor;
 pub use inprocess_fork::InProcessForkExecutor;
 #[cfg(unix)]
 use libafl_bolts::os::unix_signals::Signal;
-use libafl_bolts::tuples::RefIndexable;
+use libafl_bolts::{bolts_prelude::MatchName, tuples::RefIndexable};
 use serde::{Deserialize, Serialize};
 pub use shadow::ShadowExecutor;
 pub use with_observers::WithObservers;
 
-use crate::{
-    observers::{ObserversTuple, UsesObservers},
-    Error,
-};
+use crate::{observers::ObserversTuple, Error};
 
 pub mod combined;
 #[cfg(all(feature = "std", any(unix, doc)))]
@@ -109,15 +106,17 @@ impl From<ExitKind> for DiffExitKind {
 libafl_bolts::impl_serdeany!(DiffExitKind);
 
 /// Holds a tuple of Observers
-pub trait HasObservers: UsesObservers {
+pub trait HasObservers<'a> {
+    /// The observers type
+    type Observers: MatchName;
     type ObserversRef: Deref<Target = Self::Observers>;
     type ObserversRefMut: DerefMut<Target = Self::Observers>;
 
     /// Get the linked observers
-    fn observers(&self) -> RefIndexable<Self::ObserversRef, Self::Observers>;
+    fn observers(&'a self) -> RefIndexable<Self::ObserversRef, Self::Observers>;
 
     /// Get the linked observers (mutable)
-    fn observers_mut(&mut self) -> RefIndexable<Self::ObserversRefMut, Self::Observers>;
+    fn observers_mut(&'a mut self) -> RefIndexable<Self::ObserversRefMut, Self::Observers>;
 }
 
 /// An executor takes the given inputs, and runs the harness/target.

--- a/libafl/src/generators/mod.rs
+++ b/libafl/src/generators/mod.rs
@@ -20,12 +20,11 @@ pub mod nautilus;
 pub use nautilus::*;
 
 /// Generators can generate ranges of bytes.
-pub trait Generator<I, S>
-where
-    I: Input,
-{
+pub trait Generator<S> {
+    type Input;
+
     /// Generate a new input
-    fn generate(&mut self, state: &mut S) -> Result<I, Error>;
+    fn generate(&mut self, state: &mut S) -> Result<Self::Input, Error>;
 }
 
 /// Iterators may be used as generators.

--- a/libafl/src/inputs/generalized.rs
+++ b/libafl/src/inputs/generalized.rs
@@ -6,10 +6,9 @@ use libafl_bolts::impl_serdeany;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    corpus::Testcase,
+    corpus::{HasCorpus, Testcase},
     inputs::BytesInput,
     stages::mutational::{MutatedTransform, MutatedTransformPost},
-    state::HasCorpus,
     Error, HasMetadata,
 };
 

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -61,7 +61,7 @@ pub trait Input: Clone + Serialize + serde::de::DeserializeOwned + Debug {
 
 /// An input for the target
 #[cfg(feature = "std")]
-pub trait Input: Clone + Serialize + serde::de::DeserializeOwned + Debug {
+pub trait Input: Clone {
     /// Write this input to the file
     fn to_file<P>(&self, path: P) -> Result<(), Error>
     where
@@ -89,7 +89,7 @@ pub trait Input: Clone + Serialize + serde::de::DeserializeOwned + Debug {
 }
 
 /// Convert between two input types with a state
-pub trait InputConverter: Debug {
+pub trait InputConverter {
     /// Source type
     type From: Input;
     /// Destination type
@@ -213,13 +213,6 @@ impl<'a> HasMutatorBytes for MutVecInput<'a> {
     {
         self.0.drain(range)
     }
-}
-
-/// Defines the input type shared across traits of the type.
-/// Needed for consistency across HasCorpus/HasSolutions and friends.
-pub trait UsesInput {
-    /// Type which will be used throughout this state.
-    type Input: Input;
 }
 
 #[derive(Debug)]

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -39,7 +39,13 @@ pub use list::*;
 use serde::{Deserialize, Serialize};
 pub use value::*;
 
-use crate::{executors::ExitKind, inputs::UsesInput, state::UsesState, Error};
+use crate::{
+    corpus::{Corpus, HasCorpus},
+    executors::ExitKind,
+    inputs::UsesInput,
+    state::UsesState,
+    Error,
+};
 
 /// Observers observe different information about the target.
 /// They can then be used by various sorts of feedback.
@@ -99,27 +105,35 @@ pub trait UsesObservers: UsesState {
 /// A haskell-style tuple of observers
 pub trait ObserversTuple<S>: MatchName
 where
-    S: UsesInput,
+    S: HasCorpus,
 {
     /// This is called right before the next execution.
-    fn pre_exec_all(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error>;
+    fn pre_exec_all(
+        &mut self,
+        state: &mut S,
+        input: &<S::Corpus as Corpus>::Input,
+    ) -> Result<(), Error>;
 
     /// This is called right after the last execution
     fn post_exec_all(
         &mut self,
         state: &mut S,
-        input: &S::Input,
+        input: &<S::Corpus as Corpus>::Input,
         exit_kind: &ExitKind,
     ) -> Result<(), Error>;
 
     /// This is called right before the next execution in the child process, if any.
-    fn pre_exec_child_all(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error>;
+    fn pre_exec_child_all(
+        &mut self,
+        state: &mut S,
+        input: &<S::Corpus as Corpus>::Input,
+    ) -> Result<(), Error>;
 
     /// This is called right after the last execution in the child process, if any.
     fn post_exec_child_all(
         &mut self,
         state: &mut S,
-        input: &S::Input,
+        input: &<S::Corpus as Corpus>::Input,
         exit_kind: &ExitKind,
     ) -> Result<(), Error>;
 }

--- a/libafl/src/observers/mod.rs
+++ b/libafl/src/observers/mod.rs
@@ -86,13 +86,6 @@ pub trait Observer<I, S>: Named {
     }
 }
 
-/// Defines the observer type shared across traits of the type.
-/// Needed for consistency across HasCorpus/HasSolutions and friends.
-pub trait UsesObservers {
-    /// The observers type
-    type Observers: MatchName;
-}
-
 /// A haskell-style tuple of observers
 pub trait ObserversTuple<I, S>: MatchName {
     /// This is called right before the next execution.

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     feedbacks::Feedback,
     fuzzer::{Evaluator, ExecuteInputResult},
     generators::Generator,
-    inputs::{Input, UsesInput},
+    inputs::Input,
     stages::{HasCurrentStage, HasNestedStageStatus, StageId},
     Error, HasMetadata, HasNamedMetadata,
 };
@@ -48,13 +48,7 @@ pub const DEFAULT_MAX_SIZE: usize = 1_048_576;
 /// Contains all important information about the current run.
 /// Will be used to restart the fuzzing process at any time.
 pub trait State:
-    UsesInput
-    + Serialize
-    + DeserializeOwned
-    + MaybeHasClientPerfMonitor
-    + MaybeHasScalabilityMonitor
-    + HasCurrentCorpusId
-    + HasCurrentStage
+    MaybeHasClientPerfMonitor + MaybeHasScalabilityMonitor + HasCurrentCorpusId + HasCurrentStage
 {
 }
 
@@ -447,33 +441,6 @@ impl<I, C, R, SC> HasCurrentCorpusId for StdState<I, C, R, SC> {
     fn current_corpus_id(&self) -> Result<Option<CorpusId>, Error> {
         Ok(self.corpus_idx)
     }
-}
-
-/// Has information about the current [`Testcase`] we are fuzzing
-pub trait HasCurrentTestcase<I>
-where
-    I: Input,
-{
-    /// Gets the current [`Testcase`] we are fuzzing
-    ///
-    /// Will return [`Error::key_not_found`] if no `corpus_idx` is currently set.
-    fn current_testcase(&self) -> Result<Ref<'_, Testcase<I>>, Error>;
-    //fn current_testcase(&self) -> Result<&Testcase<I>, Error>;
-
-    /// Gets the current [`Testcase`] we are fuzzing (mut)
-    ///
-    /// Will return [`Error::key_not_found`] if no `corpus_idx` is currently set.
-    fn current_testcase_mut(&self) -> Result<RefMut<'_, Testcase<I>>, Error>;
-    //fn current_testcase_mut(&self) -> Result<&mut Testcase<I>, Error>;
-
-    /// Gets a cloned representation of the current [`Testcase`].
-    ///
-    /// Will return [`Error::key_not_found`] if no `corpus_idx` is currently set.
-    ///
-    /// # Note
-    /// This allocates memory and copies the contents!
-    /// For performance reasons, if you just need to access the testcase, use [`Self::current_testcase`] instead.
-    fn current_input_cloned(&self) -> Result<I, Error>;
 }
 
 impl<I, T> HasCurrentTestcase<I> for T

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -31,7 +31,7 @@ use crate::monitors::ClientPerfMonitor;
 #[cfg(feature = "scalability_introspection")]
 use crate::monitors::ScalabilityMonitor;
 use crate::{
-    corpus::{Corpus, CorpusId, HasCurrentCorpusId, HasTestcase, Testcase},
+    corpus::{Corpus, CorpusId, HasCorpus, HasCurrentCorpusId, HasTestcase, Testcase},
     events::{Event, EventFirer, LogSeverity},
     feedbacks::Feedback,
     fuzzer::{Evaluator, ExecuteInputResult},
@@ -56,31 +56,6 @@ pub trait State:
     + HasCurrentCorpusId
     + HasCurrentStage
 {
-}
-
-/// Structs which implement this trait are aware of the state. This is used for type enforcement.
-pub trait UsesState: UsesInput<Input = <Self::State as UsesInput>::Input> {
-    /// The state known by this type.
-    type State: State;
-}
-
-// blanket impl which automatically defines UsesInput for anything that implements UsesState
-impl<KS> UsesInput for KS
-where
-    KS: UsesState,
-{
-    type Input = <KS::State as UsesInput>::Input;
-}
-
-/// Trait for elements offering a corpus
-pub trait HasCorpus: UsesInput {
-    /// The associated type implementing [`Corpus`].
-    type Corpus: Corpus<Input = <Self as UsesInput>::Input>;
-
-    /// The testcase corpus
-    fn corpus(&self) -> &Self::Corpus;
-    /// The testcase corpus (mutable)
-    fn corpus_mut(&mut self) -> &mut Self::Corpus;
 }
 
 /// Interact with the maximum size

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -2,13 +2,7 @@
 
 #[cfg(feature = "std")]
 use alloc::vec::Vec;
-use core::{
-    borrow::BorrowMut,
-    cell::{Ref, RefMut},
-    fmt::Debug,
-    marker::PhantomData,
-    time::Duration,
-};
+use core::{borrow::BorrowMut, fmt::Debug, marker::PhantomData, time::Duration};
 #[cfg(feature = "std")]
 use std::{
     fs,
@@ -20,6 +14,7 @@ use libafl_bolts::core_affinity::{CoreId, Cores};
 use libafl_bolts::{
     rands::{Rand, StdRand},
     serdeany::{NamedSerdeAnyMap, SerdeAnyMap},
+    HasLen,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -31,7 +26,7 @@ use crate::monitors::ClientPerfMonitor;
 #[cfg(feature = "scalability_introspection")]
 use crate::monitors::ScalabilityMonitor;
 use crate::{
-    corpus::{Corpus, CorpusId, HasCorpus, HasCurrentCorpusId, HasTestcase, Testcase},
+    corpus::{Corpus, CorpusId, HasCorpus, HasCurrentCorpusId},
     events::{Event, EventFirer, LogSeverity},
     feedbacks::Feedback,
     fuzzer::{Evaluator, ExecuteInputResult},
@@ -61,9 +56,9 @@ pub trait HasMaxSize {
 }
 
 /// Trait for elements offering a corpus of solutions
-pub trait HasSolutions: UsesInput {
+pub trait HasSolutions {
     /// The associated type implementing [`Corpus`] for solutions
-    type Solutions: Corpus<Input = <Self as UsesInput>::Input>;
+    type Solutions: Corpus;
 
     /// The solutions corpus
     fn solutions(&self) -> &Self::Solutions;
@@ -75,6 +70,7 @@ pub trait HasSolutions: UsesInput {
 pub trait HasRand {
     /// The associated type implementing [`Rand`]
     type Rand: Rand;
+
     /// The rand instance
     fn rand(&self) -> &Self::Rand;
     /// The rand instance (mutable)
@@ -91,10 +87,6 @@ pub trait HasClientPerfMonitor {
     fn introspection_monitor_mut(&mut self) -> &mut ClientPerfMonitor;
 }
 
-/// Intermediate trait for `HasClientPerfMonitor`
-#[cfg(feature = "introspection")]
-pub trait MaybeHasClientPerfMonitor: HasClientPerfMonitor {}
-
 /// Intermediate trait for `HasClientPerfmonitor`
 #[cfg(not(feature = "introspection"))]
 pub trait MaybeHasClientPerfMonitor {}
@@ -102,21 +94,12 @@ pub trait MaybeHasClientPerfMonitor {}
 #[cfg(not(feature = "introspection"))]
 impl<T> MaybeHasClientPerfMonitor for T {}
 
+/// Intermediate trait for `HasClientPerfMonitor`
+#[cfg(feature = "introspection")]
+pub trait MaybeHasClientPerfMonitor: HasClientPerfMonitor {}
+
 #[cfg(feature = "introspection")]
 impl<T> MaybeHasClientPerfMonitor for T where T: HasClientPerfMonitor {}
-
-/// Intermediate trait for `HasScalabilityMonitor`
-#[cfg(feature = "scalability_introspection")]
-pub trait MaybeHasScalabilityMonitor: HasScalabilityMonitor {}
-/// Intermediate trait for `HasScalabilityMonitor`
-#[cfg(not(feature = "scalability_introspection"))]
-pub trait MaybeHasScalabilityMonitor {}
-
-#[cfg(not(feature = "scalability_introspection"))]
-impl<T> MaybeHasScalabilityMonitor for T {}
-
-#[cfg(feature = "scalability_introspection")]
-impl<T> MaybeHasScalabilityMonitor for T where T: HasScalabilityMonitor {}
 
 /// Trait for offering a [`ScalabilityMonitor`]
 #[cfg(feature = "scalability_introspection")]
@@ -127,6 +110,20 @@ pub trait HasScalabilityMonitor {
     /// Mutable ref to [`ScalabilityMonitor`]
     fn scalability_monitor_mut(&mut self) -> &mut ScalabilityMonitor;
 }
+
+/// Intermediate trait for `HasScalabilityMonitor`
+#[cfg(not(feature = "scalability_introspection"))]
+pub trait MaybeHasScalabilityMonitor {}
+
+#[cfg(not(feature = "scalability_introspection"))]
+impl<T> MaybeHasScalabilityMonitor for T {}
+
+/// Intermediate trait for `HasScalabilityMonitor`
+#[cfg(feature = "scalability_introspection")]
+pub trait MaybeHasScalabilityMonitor: HasScalabilityMonitor {}
+
+#[cfg(feature = "scalability_introspection")]
+impl<T> MaybeHasScalabilityMonitor for T where T: HasScalabilityMonitor {}
 
 /// Trait for the execution counter
 pub trait HasExecutions {
@@ -186,12 +183,7 @@ impl<'a, I, S, Z> Debug for LoadConfig<'a, I, S, Z> {
 
 /// The state a fuzz run.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "
-        C: serde::Serialize + for<'a> serde::Deserialize<'a>,
-        SC: serde::Serialize + for<'a> serde::Deserialize<'a>,
-        R: serde::Serialize + for<'a> serde::Deserialize<'a>
-    ")]
-pub struct StdState<I, C, R, SC> {
+pub struct StdState<C, R, SC> {
     /// RNG instance
     rand: R,
     /// How many times the executor ran the harness/target
@@ -231,26 +223,16 @@ pub struct StdState<I, C, R, SC> {
     /// The current index of the corpus; used to record for resumable fuzzing.
     corpus_idx: Option<CorpusId>,
     stage_stack: StageStack,
-    phantom: PhantomData<I>,
 }
 
-impl<I, C, R, SC> UsesInput for StdState<I, C, R, SC>
+impl<C, R, SC> State for StdState<C, R, SC>
 where
-    I: Input,
-{
-    type Input = I;
-}
-
-impl<I, C, R, SC> State for StdState<I, C, R, SC>
-where
-    C: Corpus<Input = Self::Input>,
-    R: Rand,
-    SC: Corpus<Input = Self::Input>,
-    Self: UsesInput,
+    C: Corpus,
+    SC: Corpus<Input = C::Input>,
 {
 }
 
-impl<I, C, R, SC> HasRand for StdState<I, C, R, SC>
+impl<C, R, SC> HasRand for StdState<C, R, SC>
 where
     R: Rand,
 {
@@ -269,11 +251,9 @@ where
     }
 }
 
-impl<I, C, R, SC> HasCorpus for StdState<I, C, R, SC>
+impl<C, R, SC> HasCorpus for StdState<C, R, SC>
 where
-    I: Input,
-    C: Corpus<Input = <Self as UsesInput>::Input>,
-    R: Rand,
+    C: Corpus,
 {
     type Corpus = C;
 
@@ -290,33 +270,9 @@ where
     }
 }
 
-impl<I, C, R, SC> HasTestcase for StdState<I, C, R, SC>
+impl<C, R, SC> HasSolutions for StdState<C, R, SC>
 where
-    I: Input,
-    C: Corpus<Input = <Self as UsesInput>::Input>,
-    R: Rand,
-{
-    /// To get the testcase
-    fn testcase(
-        &self,
-        id: CorpusId,
-    ) -> Result<Ref<'_, Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.corpus().get(id)?.borrow())
-    }
-
-    /// To get mutable testcase
-    fn testcase_mut(
-        &self,
-        id: CorpusId,
-    ) -> Result<RefMut<'_, Testcase<<Self as UsesInput>::Input>>, Error> {
-        Ok(self.corpus().get(id)?.borrow_mut())
-    }
-}
-
-impl<I, C, R, SC> HasSolutions for StdState<I, C, R, SC>
-where
-    I: Input,
-    SC: Corpus<Input = <Self as UsesInput>::Input>,
+    SC: Corpus,
 {
     type Solutions = SC;
 
@@ -333,7 +289,7 @@ where
     }
 }
 
-impl<I, C, R, SC> HasMetadata for StdState<I, C, R, SC> {
+impl<C, R, SC> HasMetadata for StdState<C, R, SC> {
     /// Get all the metadata into an [`hashbrown::HashMap`]
     #[inline]
     fn metadata_map(&self) -> &SerdeAnyMap {
@@ -347,7 +303,7 @@ impl<I, C, R, SC> HasMetadata for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasNamedMetadata for StdState<I, C, R, SC> {
+impl<C, R, SC> HasNamedMetadata for StdState<C, R, SC> {
     /// Get all the metadata into an [`hashbrown::HashMap`]
     #[inline]
     fn named_metadata_map(&self) -> &NamedSerdeAnyMap {
@@ -361,7 +317,7 @@ impl<I, C, R, SC> HasNamedMetadata for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasExecutions for StdState<I, C, R, SC> {
+impl<C, R, SC> HasExecutions for StdState<C, R, SC> {
     /// The executions counter
     #[inline]
     fn executions(&self) -> &u64 {
@@ -375,7 +331,7 @@ impl<I, C, R, SC> HasExecutions for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasImported for StdState<I, C, R, SC> {
+impl<C, R, SC> HasImported for StdState<C, R, SC> {
     /// Return the number of new paths that imported from other fuzzers
     #[inline]
     fn imported(&self) -> &usize {
@@ -389,7 +345,7 @@ impl<I, C, R, SC> HasImported for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasLastReportTime for StdState<I, C, R, SC> {
+impl<C, R, SC> HasLastReportTime for StdState<C, R, SC> {
     /// The last time we reported progress,if available/used.
     /// This information is used by fuzzer `maybe_report_progress`.
     fn last_report_time(&self) -> &Option<Duration> {
@@ -403,7 +359,11 @@ impl<I, C, R, SC> HasLastReportTime for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasMaxSize for StdState<I, C, R, SC> {
+impl<C, R, SC> HasMaxSize for StdState<C, R, SC>
+where
+    C: Corpus,
+    C::Input: HasLen,
+{
     fn max_size(&self) -> usize {
         self.max_size
     }
@@ -413,7 +373,7 @@ impl<I, C, R, SC> HasMaxSize for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasStartTime for StdState<I, C, R, SC> {
+impl<C, R, SC> HasStartTime for StdState<C, R, SC> {
     /// The starting time
     #[inline]
     fn start_time(&self) -> &Duration {
@@ -427,7 +387,7 @@ impl<I, C, R, SC> HasStartTime for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasCurrentCorpusId for StdState<I, C, R, SC> {
+impl<C, R, SC> HasCurrentCorpusId for StdState<C, R, SC> {
     fn set_corpus_idx(&mut self, idx: CorpusId) -> Result<(), Error> {
         self.corpus_idx = Some(idx);
         Ok(())
@@ -443,38 +403,7 @@ impl<I, C, R, SC> HasCurrentCorpusId for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, T> HasCurrentTestcase<I> for T
-where
-    I: Input,
-    T: HasCorpus + HasCurrentCorpusId + UsesInput<Input = I>,
-{
-    fn current_testcase(&self) -> Result<Ref<'_, Testcase<I>>, Error> {
-        let Some(corpus_id) = self.current_corpus_id()? else {
-            return Err(Error::key_not_found(
-                "We are not currently processing a testcase",
-            ));
-        };
-
-        Ok(self.corpus().get(corpus_id)?.borrow())
-    }
-
-    fn current_testcase_mut(&self) -> Result<RefMut<'_, Testcase<I>>, Error> {
-        let Some(corpus_id) = self.current_corpus_id()? else {
-            return Err(Error::illegal_state(
-                "We are not currently processing a testcase",
-            ));
-        };
-
-        Ok(self.corpus().get(corpus_id)?.borrow_mut())
-    }
-
-    fn current_input_cloned(&self) -> Result<I, Error> {
-        let mut testcase = self.current_testcase_mut()?;
-        Ok(testcase.borrow_mut().load_input(self.corpus())?.clone())
-    }
-}
-
-impl<I, C, R, SC> HasCurrentStage for StdState<I, C, R, SC> {
+impl<C, R, SC> HasCurrentStage for StdState<C, R, SC> {
     fn set_current_stage_idx(&mut self, idx: StageId) -> Result<(), Error> {
         self.stage_stack.set_current_stage_idx(idx)
     }
@@ -492,7 +421,7 @@ impl<I, C, R, SC> HasCurrentStage for StdState<I, C, R, SC> {
     }
 }
 
-impl<I, C, R, SC> HasNestedStageStatus for StdState<I, C, R, SC> {
+impl<C, R, SC> HasNestedStageStatus for StdState<C, R, SC> {
     fn enter_inner_stage(&mut self) -> Result<(), Error> {
         self.stage_stack.enter_inner_stage()
     }
@@ -503,12 +432,11 @@ impl<I, C, R, SC> HasNestedStageStatus for StdState<I, C, R, SC> {
 }
 
 #[cfg(feature = "std")]
-impl<C, I, R, SC> StdState<I, C, R, SC>
+impl<C, R, SC> StdState<C, R, SC>
 where
-    I: Input,
-    C: Corpus<Input = <Self as UsesInput>::Input>,
-    R: Rand,
-    SC: Corpus<Input = <Self as UsesInput>::Input>,
+    C: Corpus,
+    C::Input: Input,
+    SC: Corpus<Input = C::Input>,
 {
     /// Decide if the state nust load the inputs
     pub fn must_load_initial_inputs(&self) -> bool {
@@ -522,11 +450,7 @@ where
         loop {
             if let Some(path) = self.remaining_initial_files.as_mut().and_then(Vec::pop) {
                 let filename = path.file_name().unwrap().to_string_lossy();
-                if filename.starts_with('.')
-                // || filename
-                //     .rsplit_once('-')
-                //     .map_or(false, |(_, s)| u64::from_str(s).is_ok())
-                {
+                if filename.starts_with('.') {
                     continue;
                 }
 
@@ -597,12 +521,11 @@ where
         executor: &mut E,
         manager: &mut EM,
         file_list: &[PathBuf],
-        load_config: LoadConfig<I, Self, Z>,
+        load_config: LoadConfig<C::Input, Self, Z>,
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         if let Some(remaining) = self.remaining_initial_files.as_ref() {
             // everything was loaded
@@ -622,12 +545,11 @@ where
         manager: &mut EM,
         fuzzer: &mut Z,
         executor: &mut E,
-        config: &mut LoadConfig<I, Self, Z>,
+        config: &mut LoadConfig<C::Input, Self, Z>,
     ) -> Result<ExecuteInputResult, Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         log::info!("Loading file {:?} ...", &path);
         let input = (config.loader)(fuzzer, self, path)?;
@@ -651,12 +573,11 @@ where
         fuzzer: &mut Z,
         executor: &mut E,
         manager: &mut EM,
-        mut config: LoadConfig<I, Self, Z>,
+        mut config: LoadConfig<C::Input, Self, Z>,
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         loop {
             match self.next_file() {
@@ -679,7 +600,7 @@ where
             Event::Log {
                 severity_level: LogSeverity::Debug,
                 message: format!("Loaded {} initial testcases.", self.corpus().count()), // get corpus count
-                phantom: PhantomData::<I>,
+                phantom: PhantomData::<C::Input>,
             },
         )?;
         Ok(())
@@ -697,9 +618,8 @@ where
         file_list: &[PathBuf],
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         self.load_initial_inputs_custom_by_filenames(
             fuzzer,
@@ -707,7 +627,7 @@ where
             manager,
             file_list,
             LoadConfig {
-                loader: &mut |_, _, path| I::from_file(path),
+                loader: &mut |_, _, path| <C::Input as Input>::from_file(path),
                 forced: false,
                 exit_on_solution: false,
             },
@@ -725,9 +645,8 @@ where
         in_dirs: &[PathBuf],
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         self.canonicalize_input_dirs(in_dirs)?;
         self.continue_loading_initial_inputs_custom(
@@ -735,7 +654,7 @@ where
             executor,
             manager,
             LoadConfig {
-                loader: &mut |_, _, path| I::from_file(path),
+                loader: &mut |_, _, path| <C::Input as Input>::from_file(path),
                 forced: true,
                 exit_on_solution: false,
             },
@@ -752,9 +671,8 @@ where
         file_list: &[PathBuf],
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         self.load_initial_inputs_custom_by_filenames(
             fuzzer,
@@ -762,7 +680,7 @@ where
             manager,
             file_list,
             LoadConfig {
-                loader: &mut |_, _, path| I::from_file(path),
+                loader: &mut |_, _, path| <C::Input as Input>::from_file(path),
                 forced: true,
                 exit_on_solution: false,
             },
@@ -778,9 +696,8 @@ where
         in_dirs: &[PathBuf],
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         self.canonicalize_input_dirs(in_dirs)?;
         self.continue_loading_initial_inputs_custom(
@@ -788,7 +705,7 @@ where
             executor,
             manager,
             LoadConfig {
-                loader: &mut |_, _, path| I::from_file(path),
+                loader: &mut |_, _, path| <C::Input as Input>::from_file(path),
                 forced: false,
                 exit_on_solution: false,
             },
@@ -805,9 +722,8 @@ where
         in_dirs: &[PathBuf],
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         self.canonicalize_input_dirs(in_dirs)?;
         self.continue_loading_initial_inputs_custom(
@@ -815,7 +731,7 @@ where
             executor,
             manager,
             LoadConfig {
-                loader: &mut |_, _, path| I::from_file(path),
+                loader: &mut |_, _, path| <C::Input as Input>::from_file(path),
                 forced: false,
                 exit_on_solution: true,
             },
@@ -835,6 +751,7 @@ where
         }
         Ok(count)
     }
+
     /// Loads initial inputs by dividing the from the passed-in `in_dirs`
     /// in a multicore fashion. Divides the corpus in chunks spread across cores.
     pub fn load_initial_inputs_multicore<E, EM, Z>(
@@ -847,9 +764,8 @@ where
         cores: &Cores,
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
     {
         if self.multicore_inputs_processed.unwrap_or(false) {
             self.continue_loading_initial_inputs_custom(
@@ -857,7 +773,7 @@ where
                 executor,
                 manager,
                 LoadConfig {
-                    loader: &mut |_, _, path| I::from_file(path),
+                    loader: &mut |_, _, path| <C::Input as Input>::from_file(path),
                     forced: false,
                     exit_on_solution: false,
                 },
@@ -925,12 +841,10 @@ where
     }
 }
 
-impl<C, I, R, SC> StdState<I, C, R, SC>
+impl<C, R, SC> StdState<C, R, SC>
 where
-    I: Input,
-    C: Corpus<Input = <Self as UsesInput>::Input>,
-    R: Rand,
-    SC: Corpus<Input = <Self as UsesInput>::Input>,
+    C: Corpus,
+    SC: Corpus<Input = C::Input>,
 {
     fn generate_initial_internal<G, E, EM, Z>(
         &mut self,
@@ -942,10 +856,9 @@ where
         forced: bool,
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        G: Generator<<Self as UsesInput>::Input, Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
+        G: Generator<Self, Input = C::Input>,
     {
         let mut added = 0;
         for _ in 0..num {
@@ -981,10 +894,9 @@ where
         num: usize,
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        G: Generator<<Self as UsesInput>::Input, Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
+        G: Generator<Self, Input = C::Input>,
     {
         self.generate_initial_internal(fuzzer, executor, generator, manager, num, true)
     }
@@ -999,10 +911,9 @@ where
         num: usize,
     ) -> Result<(), Error>
     where
-        E: UsesState<State = Self>,
-        EM: EventFirer<State = Self>,
-        G: Generator<<Self as UsesInput>::Input, Self>,
-        Z: Evaluator<E, EM, State = Self>,
+        EM: EventFirer,
+        Z: Evaluator<E, EM>,
+        G: Generator<Self, Input = C::Input>,
     {
         self.generate_initial_internal(fuzzer, executor, generator, manager, num, false)
     }
@@ -1040,7 +951,6 @@ where
             last_report_time: None,
             corpus_idx: None,
             stage_stack: StageStack::default(),
-            phantom: PhantomData,
             #[cfg(feature = "std")]
             multicore_inputs_processed: None,
         };
@@ -1102,13 +1012,6 @@ impl<I> HasMaxSize for NopState<I> {
     fn set_max_size(&mut self, _max_size: usize) {
         unimplemented!("NopState doesn't allow setting a max size")
     }
-}
-
-impl<I> UsesInput for NopState<I>
-where
-    I: Input,
-{
-    type Input = I;
 }
 
 impl<I> HasExecutions for NopState<I> {

--- a/libafl_bolts/src/ownedref.rs
+++ b/libafl_bolts/src/ownedref.rs
@@ -827,14 +827,14 @@ where
 
 /// Wrap a C-style mutable pointer and convert to a Box on serialize
 #[derive(Clone, Debug)]
-pub enum OwnedMutPtr<T: Sized> {
+pub enum OwnedMutPtr<T> {
     /// A mut ptr to the content
     Ptr(*mut T),
     /// An owned [`Box`] to the content
     Owned(Box<T>),
 }
 
-impl<T: Sized> OwnedMutPtr<T> {
+impl<T> OwnedMutPtr<T> {
     /// Creates a new [`OwnedMutPtr`] from a raw pointer
     ///
     /// # Safety
@@ -845,7 +845,10 @@ impl<T: Sized> OwnedMutPtr<T> {
     }
 }
 
-impl<T: Sized + Serialize> Serialize for OwnedMutPtr<T> {
+impl<T> Serialize for OwnedMutPtr<T>
+where
+    T: Serialize,
+{
     fn serialize<S>(&self, se: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -854,9 +857,9 @@ impl<T: Sized + Serialize> Serialize for OwnedMutPtr<T> {
     }
 }
 
-impl<'de, T: Sized + serde::de::DeserializeOwned> Deserialize<'de> for OwnedMutPtr<T>
+impl<'de, T> Deserialize<'de> for OwnedMutPtr<T>
 where
-    Vec<T>: Deserialize<'de>,
+    T: Sized + Deserialize<'de>,
 {
     fn deserialize<D>(de: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
This PR attempts to massively simplify usage of generics throughout the code base, as well as reducing constraints on how one may use generic types.

Most critically so far, this PR:
- partially reverts #767, #836, #881 (these were misguided based on overconstrained design goals)
- rework of Differential{Observer{,sTuple},Executor} to be safe (#868)