### PR TITLE
Make adaptive serialization into default

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -53,9 +53,6 @@ gzip = ["libafl_bolts/gzip"]
 ## If set, will use the `fork()` syscall to spawn children, instead of launching a new command, if supported by the OS (has no effect on `Windows`).
 fork = ["libafl_bolts/derive"]
 
-## Collected stats to decide if observers must be serialized or not (which should reduce mem use and increase speed)
-adaptive_serialization = []
-
 ## If this feature is set, `LibAFL` targets (and the fuzzer) will crash on `SIGPIPE` on unix systems.
 handle_sigpipe = []
 

--- a/libafl/src/events/llmp/restarting.rs
+++ b/libafl/src/events/llmp/restarting.rs
@@ -22,9 +22,11 @@ use libafl_bolts::os::startable_self;
 use libafl_bolts::os::unix_signals::setup_signal_handler;
 #[cfg(all(feature = "std", feature = "fork", unix))]
 use libafl_bolts::os::{fork, ForkResult};
-#[cfg(feature = "adaptive_serialization")]
-use libafl_bolts::tuples::{Handle, Handled};
-use libafl_bolts::{llmp::LlmpBroker, shmem::ShMemProvider, tuples::tuple_list};
+use libafl_bolts::{
+    llmp::LlmpBroker,
+    shmem::ShMemProvider,
+    tuples::{tuple_list, Handle},
+};
 #[cfg(feature = "std")]
 use libafl_bolts::{
     llmp::LlmpConnection, os::CTRL_C_EXIT, shmem::StdShMemProvider, staterestore::StateRestorer,
@@ -33,14 +35,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use typed_builder::TypedBuilder;
 
-#[cfg(all(feature = "std", not(feature = "adaptive_serialization")))]
-use crate::events::AdaptiveSerializer;
-#[cfg(all(feature = "std", feature = "adaptive_serialization"))]
+#[cfg(feature = "std")]
 use crate::events::AdaptiveSerializer;
 #[cfg(all(unix, feature = "std", not(miri)))]
 use crate::events::EVENTMGR_SIGHANDLER_STATE;
-#[cfg(feature = "adaptive_serialization")]
-use crate::observers::TimeObserver;
 use crate::{
     events::{
         hooks::EventManagerHooksTuple, Event, EventConfig, EventFirer, EventManager,
@@ -51,7 +49,7 @@ use crate::{
     fuzzer::{Evaluator, EvaluatorObservers, ExecutionProcessor},
     inputs::UsesInput,
     monitors::Monitor,
-    observers::ObserversTuple,
+    observers::{ObserversTuple, TimeObserver},
     state::{HasExecutions, HasLastReportTime, State, UsesState},
     Error, HasMetadata,
 };
@@ -73,7 +71,7 @@ where
     save_state: LlmpShouldSaveState,
 }
 
-#[cfg(all(feature = "std", feature = "adaptive_serialization"))]
+#[cfg(feature = "std")]
 impl<EMH, S, SP> AdaptiveSerializer for LlmpRestartingEventManager<EMH, S, SP>
 where
     SP: ShMemProvider,
@@ -105,17 +103,9 @@ where
         self.llmp_mgr.should_serialize_cnt_mut()
     }
 
-    fn time_ref(&self) -> &Handle<TimeObserver> {
+    fn time_ref(&self) -> &Option<Handle<TimeObserver>> {
         &self.llmp_mgr.time_ref
     }
-}
-
-#[cfg(all(feature = "std", not(feature = "adaptive_serialization")))]
-impl<EMH, S, SP> AdaptiveSerializer for LlmpRestartingEventManager<EMH, S, SP>
-where
-    SP: ShMemProvider,
-    S: State,
-{
 }
 
 #[cfg(feature = "std")]
@@ -330,12 +320,13 @@ pub enum ManagerKind {
 /// Sets up a restarting fuzzer, using the [`StdShMemProvider`], and standard features.
 /// The restarting mgr is a combination of restarter and runner, that can be used on systems with and without `fork` support.
 /// The restarter will spawn a new process each time the child crashes or timeouts.
-#[cfg(all(feature = "std", not(feature = "adaptive_serialization")))]
+#[cfg(feature = "std")]
 #[allow(clippy::type_complexity)]
 pub fn setup_restarting_mgr_std<MT, S>(
     monitor: MT,
     broker_port: u16,
     configuration: EventConfig,
+    time_obs: Option<Handle<TimeObserver>>,
 ) -> Result<
     (
         Option<S>,
@@ -353,38 +344,7 @@ where
         .broker_port(broker_port)
         .configuration(configuration)
         .hooks(tuple_list!())
-        .build()
-        .launch()
-}
-
-/// Sets up a restarting fuzzer, using the [`StdShMemProvider`], and standard features.
-/// The restarting mgr is a combination of restarter and runner, that can be used on systems with and without `fork` support.
-/// The restarter will spawn a new process each time the child crashes or timeouts.
-#[cfg(all(feature = "std", feature = "adaptive_serialization"))]
-#[allow(clippy::type_complexity)]
-pub fn setup_restarting_mgr_std<MT, S>(
-    monitor: MT,
-    broker_port: u16,
-    configuration: EventConfig,
-    time_obs: &TimeObserver,
-) -> Result<
-    (
-        Option<S>,
-        LlmpRestartingEventManager<(), S, StdShMemProvider>,
-    ),
-    Error,
->
-where
-    MT: Monitor + Clone,
-    S: State + HasExecutions,
-{
-    RestartingMgr::builder()
-        .shmem_provider(StdShMemProvider::new()?)
-        .monitor(Some(monitor))
-        .broker_port(broker_port)
-        .configuration(configuration)
-        .hooks(tuple_list!())
-        .time_ref(time_obs.handle())
+        .time_ref(time_obs)
         .build()
         .launch()
 }
@@ -436,8 +396,7 @@ where
     serialize_state: LlmpShouldSaveState,
     /// The hooks passed to event manager:
     hooks: EMH,
-    #[cfg(feature = "adaptive_serialization")]
-    time_ref: Handle<TimeObserver>,
+    time_ref: Option<Handle<TimeObserver>>,
     #[builder(setter(skip), default = PhantomData)]
     phantom_data: PhantomData<(EMH, S)>,
 }
@@ -500,12 +459,6 @@ where
                             return Err(Error::shutting_down());
                         }
                         LlmpConnection::IsClient { client } => {
-                            #[cfg(not(feature = "adaptive_serialization"))]
-                            let mgr: LlmpEventManager<EMH, S, SP> = LlmpEventManager::builder()
-                                .always_interesting(self.always_interesting)
-                                .hooks(self.hooks)
-                                .build_from_client(client, self.configuration)?;
-                            #[cfg(feature = "adaptive_serialization")]
                             let mgr: LlmpEventManager<EMH, S, SP> = LlmpEventManager::builder()
                                 .always_interesting(self.always_interesting)
                                 .hooks(self.hooks)
@@ -532,16 +485,6 @@ where
                 }
                 ManagerKind::Client { cpu_core } => {
                     // We are a client
-                    #[cfg(not(feature = "adaptive_serialization"))]
-                    let mgr = LlmpEventManager::builder()
-                        .always_interesting(self.always_interesting)
-                        .hooks(self.hooks)
-                        .build_on_port(
-                            self.shmem_provider.clone(),
-                            self.broker_port,
-                            self.configuration,
-                        )?;
-                    #[cfg(feature = "adaptive_serialization")]
                     let mgr = LlmpEventManager::builder()
                         .always_interesting(self.always_interesting)
                         .hooks(self.hooks)
@@ -671,15 +614,6 @@ where
         // If we're restarting, deserialize the old state.
         let (state, mut mgr) =
             if let Some((state_opt, mgr_description)) = staterestorer.restore()? {
-                #[cfg(not(feature = "adaptive_serialization"))]
-                let llmp_mgr = LlmpEventManager::builder()
-                    .hooks(self.hooks)
-                    .build_existing_client_from_description(
-                        new_shmem_provider,
-                        &mgr_description,
-                        self.configuration,
-                    )?;
-                #[cfg(feature = "adaptive_serialization")]
                 let llmp_mgr = LlmpEventManager::builder()
                     .hooks(self.hooks)
                     .build_existing_client_from_description(
@@ -699,15 +633,6 @@ where
             } else {
                 log::info!("First run. Let's set it all up");
                 // Mgr to send and receive msgs from/to all other fuzzer instances
-                #[cfg(not(feature = "adaptive_serialization"))]
-                let mgr = LlmpEventManager::builder()
-                    .hooks(self.hooks)
-                    .build_existing_client_from_env(
-                        new_shmem_provider,
-                        _ENV_FUZZER_BROKER_CLIENT_INITIAL,
-                        self.configuration,
-                    )?;
-                #[cfg(feature = "adaptive_serialization")]
                 let mgr = LlmpEventManager::builder()
                     .hooks(self.hooks)
                     .build_existing_client_from_env(
@@ -748,14 +673,12 @@ where
 mod tests {
     use core::sync::atomic::{compiler_fence, Ordering};
 
-    #[cfg(feature = "adaptive_serialization")]
-    use libafl_bolts::tuples::Handled;
     use libafl_bolts::{
         llmp::{LlmpClient, LlmpSharedMap},
         rands::StdRand,
         shmem::{ShMemProvider, StdShMemProvider},
         staterestore::StateRestorer,
-        tuples::tuple_list,
+        tuples::{tuple_list, Handled},
         ClientId,
     };
     use serial_test::serial;
@@ -782,7 +705,6 @@ mod tests {
         let rand = StdRand::with_seed(0);
 
         let time = TimeObserver::new("time");
-        #[cfg(feature = "adaptive_serialization")]
         let time_ref = time.handle();
 
         let mut corpus = InMemoryCorpus::<BytesInput>::new();
@@ -811,13 +733,8 @@ mod tests {
             llmp_client.mark_safe_to_unmap();
         }
 
-        #[cfg(not(feature = "adaptive_serialization"))]
         let mut llmp_mgr = LlmpEventManager::builder()
-            .build_from_client(llmp_client, "fuzzer".into())
-            .unwrap();
-        #[cfg(feature = "adaptive_serialization")]
-        let mut llmp_mgr = LlmpEventManager::builder()
-            .build_from_client(llmp_client, "fuzzer".into(), time_ref.clone())
+            .build_from_client(llmp_client, "fuzzer".into(), Some(time_ref.clone()))
             .unwrap();
 
         let scheduler = RandScheduler::new();
@@ -860,21 +777,12 @@ mod tests {
         assert!(sc_cpy.has_content());
 
         let (mut state_clone, mgr_description) = staterestorer.restore().unwrap().unwrap();
-        #[cfg(not(feature = "adaptive_serialization"))]
         let mut llmp_clone = LlmpEventManager::builder()
             .build_existing_client_from_description(
                 shmem_provider,
                 &mgr_description,
                 "fuzzer".into(),
-            )
-            .unwrap();
-        #[cfg(feature = "adaptive_serialization")]
-        let mut llmp_clone = LlmpEventManager::builder()
-            .build_existing_client_from_description(
-                shmem_provider,
-                &mgr_description,
-                "fuzzer".into(),
-                time_ref,
+                Some(time_ref),
             )
             .unwrap();
 

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -32,9 +32,11 @@ use ahash::RandomState;
 pub use launcher::*;
 #[cfg(all(unix, feature = "std"))]
 use libafl_bolts::os::unix_signals::{siginfo_t, ucontext_t, Handler, Signal, CTRL_C_EXIT};
-#[cfg(feature = "adaptive_serialization")]
-use libafl_bolts::tuples::{Handle, MatchNameRef};
-use libafl_bolts::{current_time, ClientId};
+use libafl_bolts::{
+    current_time,
+    tuples::{Handle, MatchNameRef},
+    ClientId,
+};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use uuid::Uuid;
@@ -104,9 +106,9 @@ pub struct EventManagerId(
 
 #[cfg(feature = "introspection")]
 use crate::monitors::ClientPerfMonitor;
-#[cfg(feature = "adaptive_serialization")]
-use crate::observers::TimeObserver;
-use crate::{inputs::UsesInput, stages::HasCurrentStage, state::UsesState};
+use crate::{
+    inputs::UsesInput, observers::TimeObserver, stages::HasCurrentStage, state::UsesState,
+};
 
 /// The log event severity
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -839,11 +841,6 @@ where
 }
 
 /// Collected stats to decide if observers must be serialized or not
-#[cfg(not(feature = "adaptive_serialization"))]
-pub trait AdaptiveSerializer {}
-
-/// Collected stats to decide if observers must be serialized or not
-#[cfg(feature = "adaptive_serialization")]
 pub trait AdaptiveSerializer {
     /// Expose the collected observers serialization time
     fn serialization_time(&self) -> Duration;
@@ -864,7 +861,7 @@ pub trait AdaptiveSerializer {
     fn should_serialize_cnt_mut(&mut self) -> &mut usize;
 
     /// A [`Handle`] to the time observer to determine the `time_factor`
-    fn time_ref(&self) -> &Handle<TimeObserver>;
+    fn time_ref(&self) -> &Option<Handle<TimeObserver>>;
 
     /// Serialize the observer using the `time_factor` and `percentage_threshold`.
     /// These parameters are unique to each of the different types of `EventManager`
@@ -878,35 +875,41 @@ pub trait AdaptiveSerializer {
         OT: ObserversTuple<S> + Serialize,
         S: UsesInput,
     {
-        let exec_time = observers
-            .get(self.time_ref())
-            .map(|o| o.last_runtime().unwrap_or(Duration::ZERO))
-            .unwrap();
+        match self.time_ref() {
+            Some(t) => {
+                let exec_time = observers
+                    .get(t)
+                    .map(|o| o.last_runtime().unwrap_or(Duration::ZERO))
+                    .unwrap();
 
-        let mut must_ser =
-            (self.serialization_time() + self.deserialization_time()) * time_factor < exec_time;
-        if must_ser {
-            *self.should_serialize_cnt_mut() += 1;
-        }
+                let mut must_ser = (self.serialization_time() + self.deserialization_time())
+                    * time_factor
+                    < exec_time;
+                if must_ser {
+                    *self.should_serialize_cnt_mut() += 1;
+                }
 
-        if self.serializations_cnt() > 32 {
-            must_ser = (self.should_serialize_cnt() * 100 / self.serializations_cnt())
-                > percentage_threshold;
-        }
+                if self.serializations_cnt() > 32 {
+                    must_ser = (self.should_serialize_cnt() * 100 / self.serializations_cnt())
+                        > percentage_threshold;
+                }
 
-        if self.serialization_time() == Duration::ZERO
-            || must_ser
-            || self.serializations_cnt().trailing_zeros() >= 8
-        {
-            let start = current_time();
-            let ser = postcard::to_allocvec(observers)?;
-            *self.serialization_time_mut() = current_time() - start;
+                if self.serialization_time() == Duration::ZERO
+                    || must_ser
+                    || self.serializations_cnt().trailing_zeros() >= 8
+                {
+                    let start = current_time();
+                    let ser = postcard::to_allocvec(observers)?;
+                    *self.serialization_time_mut() = current_time() - start;
 
-            *self.serializations_cnt_mut() += 1;
-            Ok(Some(ser))
-        } else {
-            *self.serializations_cnt_mut() += 1;
-            Ok(None)
+                    *self.serializations_cnt_mut() += 1;
+                    Ok(Some(ser))
+                } else {
+                    *self.serializations_cnt_mut() += 1;
+                    Ok(None)
+                }
+            }
+            None => Ok(None),
         }
     }
 }

--- a/libafl_frida/src/asan/hook_funcs.rs
+++ b/libafl_frida/src/asan/hook_funcs.rs
@@ -11,9 +11,12 @@ use crate::{
         errors::{AsanError, AsanErrors},
     },
 };
+
+#[cfg(windows)]
 extern "system" {
     fn memcpy(dst: *mut c_void, src: *const c_void, size: usize) -> *mut c_void;
 }
+#[cfg(windows)]
 extern "system" {
     fn memset(s: *mut c_void, c: i32, n: usize) -> *mut c_void;
 }

--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -48,7 +48,7 @@ hexagon = ["libafl_qemu/hexagon"]
 pyo3-build-config = { version = "0.21", optional = true }
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.12.0", features = ["adaptive_serialization"] }
+libafl = { path = "../libafl", version = "0.12.0" }
 libafl_bolts = { path = "../libafl_bolts", version = "0.12.0" }
 libafl_targets = { path = "../libafl_targets", version = "0.12.0" }
 

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -295,7 +295,7 @@ impl<'a> ForkserverBytesCoverageSugar<'a> {
             .cores(self.cores)
             .broker_port(self.broker_port)
             .remote_broker_addr(self.remote_broker_addr)
-            .time_ref(time_ref);
+            .time_ref(Some(time_ref));
         #[cfg(unix)]
         let launcher = launcher.stdout_file(Some("/dev/null"));
         match launcher.build().launch() {

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -351,7 +351,7 @@ where
             .cores(self.cores)
             .broker_port(self.broker_port)
             .remote_broker_addr(self.remote_broker_addr)
-            .time_ref(time_ref);
+            .time_ref(Some(time_ref));
         #[cfg(unix)]
         let launcher = launcher.stdout_file(Some("/dev/null"));
         match launcher.build().launch() {

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -440,7 +440,7 @@ where
             .cores(self.cores)
             .broker_port(self.broker_port)
             .remote_broker_addr(self.remote_broker_addr)
-            .time_ref(time_ref);
+            .time_ref(Some(time_ref));
         #[cfg(unix)]
         let launcher = launcher.stdout_file(Some("/dev/null"));
 

--- a/libafl_targets/src/sancov_pcguard.rs
+++ b/libafl_targets/src/sancov_pcguard.rs
@@ -17,7 +17,9 @@ use libafl::executors::{hooks::ExecutorHook, HasObservers};
 ))]
 use crate::coverage::EDGES_MAP;
 use crate::coverage::MAX_EDGES_FOUND;
+
 #[cfg(feature = "sancov_ngram4")]
+#[allow(unused)]
 use crate::EDGES_MAP_SIZE_IN_USE;
 #[cfg(feature = "pointer_maps")]
 use crate::{coverage::EDGES_MAP_PTR, EDGES_MAP_SIZE_MAX};
@@ -29,6 +31,7 @@ compile_error!(
 );
 
 #[cfg(any(feature = "sancov_ngram4", feature = "sancov_ngram8"))]
+#[allow(unused)]
 use core::ops::ShlAssign;
 
 #[cfg(feature = "sancov_ngram4")]


### PR DESCRIPTION
why not?
i'm tired of seeing repeated code in event manager. these cfgs are totally not needed

also clean up the API a bit.
because now we should always pass the Handle<Something> to the interface