### PR TITLE
Add support for cycling PowerSchedule on completion of a queue cycle in WeightedScheduler

### DIFF
--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -71,6 +71,11 @@ impl SchedulerMetadata {
         self.strat
     }
 
+    /// The powerschedule strategy
+    pub fn set_strat(&mut self, strat: Option<PowerSchedule>) {
+        self.strat = strat;
+    }
+
     /// The measured exec time during calibration
     #[must_use]
     pub fn exec_time(&self) -> Duration {

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -65,13 +65,13 @@ impl SchedulerMetadata {
         }
     }
 
-    /// The powerschedule strategy
+    /// The `PowerSchedule`
     #[must_use]
     pub fn strat(&self) -> Option<PowerSchedule> {
         self.strat
     }
 
-    /// The powerschedule strategy
+    /// Set the `PowerSchedule`
     pub fn set_strat(&mut self, strat: Option<PowerSchedule>) {
         self.strat = strat;
     }

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -136,7 +136,7 @@ where
 
     /// Cycle the `PowerSchedule` on completion of a queue cycle
     #[must_use]
-    pub fn cycle_schedules(mut self) -> Self {
+    pub fn cycling_scheduler(mut self) -> Self {
         self.cycle_schedules = true;
         self
     }

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -101,7 +101,7 @@ pub struct WeightedScheduler<C, F, O, S> {
     map_observer_handle: Handle<C>,
     last_hash: usize,
     phantom: PhantomData<(F, O, S)>,
-    /// Change strategy on completion of every queue cycle.
+    /// Cycle `PowerSchedule` on completion of every queue cycle.
     cycle_schedules: bool,
 }
 
@@ -134,7 +134,7 @@ where
         }
     }
 
-    /// Cycles the `PowerSchedule` on completion of a queue cycle
+    /// Cycle the `PowerSchedule` on completion of a queue cycle
     #[must_use]
     pub fn cycle_schedules(mut self) -> Self {
         self.cycle_schedules = true;

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -101,6 +101,8 @@ pub struct WeightedScheduler<C, F, O, S> {
     map_observer_handle: Handle<C>,
     last_hash: usize,
     phantom: PhantomData<(F, O, S)>,
+    /// Change strategy on completion of every queue cycle.
+    cycle_schedules: bool,
 }
 
 impl<C, F, O, S> WeightedScheduler<C, F, O, S>
@@ -127,8 +129,16 @@ where
             map_observer_handle: map_observer.handle(),
             last_hash: 0,
             table_invalidated: true,
+            cycle_schedules: false,
             phantom: PhantomData,
         }
+    }
+
+    /// Cycles the `PowerSchedule` on completion of a queue cycle
+    #[must_use]
+    pub fn cycle_schedules(mut self) -> Self {
+        self.cycle_schedules = true;
+        self
     }
 
     #[must_use]
@@ -219,6 +229,27 @@ where
         wsmeta.set_alias_probability(alias_probability);
         wsmeta.set_alias_table(alias_table);
         Ok(())
+    }
+
+    /// Cycles the strategy of the scheduler; tries to mimic AFL++'s cycling formula
+    pub fn cycle_schedule(
+        &mut self,
+        metadata: &mut SchedulerMetadata,
+    ) -> Result<PowerSchedule, Error> {
+        let next_strat = match metadata.strat().ok_or(Error::illegal_argument(
+            "No strategy specified when initializing scheduler; cannot cycle!",
+        ))? {
+            PowerSchedule::EXPLORE => PowerSchedule::EXPLOIT,
+            PowerSchedule::COE => PowerSchedule::LIN,
+            PowerSchedule::LIN => PowerSchedule::QUAD,
+            PowerSchedule::FAST => PowerSchedule::COE,
+            PowerSchedule::QUAD => PowerSchedule::FAST,
+            PowerSchedule::EXPLOIT => PowerSchedule::EXPLORE,
+        };
+        metadata.set_strat(Some(next_strat));
+        // We need to recalculate the scores of testcases.
+        self.table_invalidated = true;
+        Ok(next_strat)
     }
 }
 
@@ -343,6 +374,9 @@ where
             if runs_in_current_cycle >= corpus_counts {
                 let psmeta = state.metadata_mut::<SchedulerMetadata>()?;
                 psmeta.set_queue_cycles(psmeta.queue_cycles() + 1);
+                if self.cycle_schedules {
+                    self.cycle_schedule(psmeta)?;
+                }
             }
 
             self.set_current_scheduled(state, Some(idx))?;

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -232,7 +232,7 @@ where
     }
 
     /// Cycles the strategy of the scheduler; tries to mimic AFL++'s cycling formula
-    pub fn cycle_schedule(
+    fn cycle_schedule(
         &mut self,
         metadata: &mut SchedulerMetadata,
     ) -> Result<PowerSchedule, Error> {


### PR DESCRIPTION
Based on:
https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-fuzz.c#L2764-L2798

There are a few schedules which need to be implemented