### PR TITLE
Fix typos

### DIFF
--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -47,7 +47,7 @@ pub type AlwaysInterestingMapFeedback<C, O, T> = MapFeedback<C, AllIsNovel, O, N
 /// but only, if a value is larger than `pow2` of the previous.
 pub type MaxMapPow2Feedback<C, O, T> = MapFeedback<C, NextPow2IsNovel, O, MaxReducer, T>;
 /// A [`MapFeedback`] that strives to maximize the map contents,
-/// but only, if a value is larger than `pow2` of the previous.
+/// but only, if a value is either `T::one()` or `T::max_value()`.
 pub type MaxMapOneOrFilledFeedback<C, O, T> = MapFeedback<C, OneOrFilledIsNovel, O, MaxReducer, T>;
 
 /// A `Reducer` function is used to aggregate values for the novelty search

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -568,7 +568,7 @@ where
     R: Rand,
     SC: Corpus<Input = <Self as UsesInput>::Input>,
 {
-    /// Decide if the state nust load the inputs
+    /// Decide if the state must load the inputs
     pub fn must_load_initial_inputs(&self) -> bool {
         self.corpus().count() == 0
             || (self.remaining_initial_files.is_some()


### PR DESCRIPTION
Fix a little typo and the wrong description of the trait `MaxMapOneOrFilledFeedback` .