### PR TITLE
Fix LlmpEventManager not calling hooks pre_exec

### DIFF
--- a/libafl/src/events/llmp/mgr.rs
+++ b/libafl/src/events/llmp/mgr.rs
@@ -409,8 +409,10 @@ where
             + EvaluatorObservers<E::Observers>
             + Evaluator<E, Self>,
     {
+        if !self.hooks.pre_exec_all(state, client_id, &event)? {
+            return Ok(());
+        }
         let evt_name = event.name_detailed();
-
         match event {
             Event::NewTestcase {
                 input,


### PR DESCRIPTION
This applies the same behavior as ``TcpEventManager::handle_in_client``
https://github.com/AFLplusplus/LibAFL/blob/main/libafl/src/events/tcp.rs#L616-L618