### PR TITLE
bolts: fix warning about `error_in_core` now stable

### DIFF
--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -11,8 +11,6 @@
 #![cfg_attr(nightly, feature(specialization))]
 // For `std::simd`
 #![cfg_attr(nightly, feature(portable_simd))]
-// For `core::error`
-#![cfg_attr(nightly, feature(error_in_core))]
 #![warn(clippy::cargo)]
 #![allow(ambiguous_glob_reexports)]
 #![deny(clippy::cargo_common_metadata)]


### PR DESCRIPTION
the feature `error_in_core` has been stable since 1.81.0-nightly and no longer requires an attribute to enable