### PR TITLE
Non-shrinking BytesInput

### DIFF
--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -1,4 +1,4 @@
-//! Inputs are the actual contents sent to a target for each exeuction.
+//! Inputs are the actual contents sent to a target for each execution.
 
 pub mod bytes;
 pub use bytes::BytesInput;


### PR DESCRIPTION
This may benefit LLVM custom mutators as it will have less allocs. On the other hand, it may introduce more checks for other use cases. Should we merge it?