### PR TITLE
Improved documentation for fuzzers/cargo_fuzz and dynamic_analysis

### DIFF
--- a/fuzzers/cargo_fuzz/README.md
+++ b/fuzzers/cargo_fuzz/README.md
@@ -1,4 +1,3 @@
 # cargo-fuzz
 
-This is a minimalistic example how to use LibAFL with cargo-fuzz. It uses the `libafl_libfuzzer` compatibility layer in
-order to be libFuzzer compatible.
+This is a minimalistic example how to use LibAFL with cargo-fuzz. It uses the `libafl_libfuzzer` compatibility layer in order to be libFuzzer compatible.

--- a/fuzzers/cargo_fuzz/README.md
+++ b/fuzzers/cargo_fuzz/README.md
@@ -1,3 +1,4 @@
 # cargo-fuzz
 
-This is a minimalistic example how to use LibAFL with cargo-fuzz. It uses the `libafl_libfuzzer` comatability layer to be libFuzzer compatiable.
+This is a minimalistic example how to use LibAFL with cargo-fuzz. It uses the `libafl_libfuzzer` compatibility layer in
+order to be libFuzzer compatible.

--- a/fuzzers/dynamic_analysis/README.md
+++ b/fuzzers/dynamic_analysis/README.md
@@ -1,16 +1,12 @@
 # Dynamic Analysis Fuzzer
 
-This fuzzer is to show how you can collect runtime analysis information during fuzzing using LibAFL. We use the
-Little-CMS project for the example.
+This fuzzer is to show how you can collect runtime analysis information during fuzzing using LibAFL. We use the [Little-CMS](https://github.com/mm2/Little-CMS) project for the example.
 First, this fuzzer requires `nlohmann-json3-dev` to work.
 
 To run the fuzzer:
 
 1. Compile the fuzzer with `cargo build --release`
-2. `mkdir analysis` and run `build.sh`. This will compile Little-CMS to extract the analysis information and generate a
-   json file for each module.
-3. run `python3 concatenator.py analysis`. This will concatenate all the json into one single file. This json file maps
-   a function id to its analysis information.
-4. Compile the fuzzer with `cargo make fuzzer`. This will instrument the fuzzer at every function entry point.
-   Therefore, whenever we reach the entry of any function, we can log its id and logs what functions we executed.
+2. `mkdir analysis` and run `build.sh`. This will compile Little-CMS to extract the analysis information and generate a json file for each module.
+3. run `python3 concatenator.py analysis`. This will concatenate all the json into one single file. This json file maps a function id to its analysis information.
+4. Compile the fuzzer with `cargo make fuzzer`. This will instrument the fuzzer at every function entry point. Therefore, whenever we reach the entry of any function, we can log its id and logs what functions we executed.
 5. Run the fuzzer `RUST_LOG=info ./fuzzer --input ./corpus --output ./out`. You'll see a stream of analysis data 

--- a/fuzzers/dynamic_analysis/README.md
+++ b/fuzzers/dynamic_analysis/README.md
@@ -1,11 +1,16 @@
 # Dynamic Analysis Fuzzer
-This fuzzer is to show how you can collect runtime analysis information during fuzzing using LibAFL. We use the Little-CMS project for the example.
+
+This fuzzer is to show how you can collect runtime analysis information during fuzzing using LibAFL. We use the
+Little-CMS project for the example.
 First, this fuzzer requires `nlohmann-json3-dev` to work.
 
-To run the fuzzer,
-0. Compile the fuzzer with `cargo build --release`
-1. `mkdir analysis` and run `build.sh`. This will compile Little-CMS to extract the analysis information and generate a json file for each module.
-2. run `python3 concatenator.py analysis`. This will concatenate all the json into one single file. This json file maps a function id to its analysis information.
-3. Compile the fuzzer with `cargo make fuzzer`. This will instrument the fuzzer at every function entry point. Therefore, whenever we reach the entry of any function, we 
-can log its id and logs what functions we executed.
-4. Run the fuzzer `RUST_LOG=info ./fuzzer --input ./corpus --output ./out`. You'll see a stream of analysis data 
+To run the fuzzer:
+
+1. Compile the fuzzer with `cargo build --release`
+2. `mkdir analysis` and run `build.sh`. This will compile Little-CMS to extract the analysis information and generate a
+   json file for each module.
+3. run `python3 concatenator.py analysis`. This will concatenate all the json into one single file. This json file maps
+   a function id to its analysis information.
+4. Compile the fuzzer with `cargo make fuzzer`. This will instrument the fuzzer at every function entry point.
+   Therefore, whenever we reach the entry of any function, we can log its id and logs what functions we executed.
+5. Run the fuzzer `RUST_LOG=info ./fuzzer --input ./corpus --output ./out`. You'll see a stream of analysis data 


### PR DESCRIPTION
In light of #424 i fixed some typos in the cargo_fuzz README and also in the dynamic_analyis README. 

In the latter one the instructions lack anything about the corpus right now. Would it be possible to just commit some files into the repository and have the user extend them as needed?