### PR TITLE
LibAFL QEMU fix failing Doc-tests

### DIFF
--- a/libafl_qemu/README.md
+++ b/libafl_qemu/README.md
@@ -8,7 +8,7 @@ It comes in two variants, usermode to fuzz Linux ELFs userspace binaries and sys
 
 If you use LibAFL QEMU for your academic work, consider citing the follwing paper:
 
-```
+```bibtex
 @InProceedings{libaflqemu:bar24,
   title        = {{LibAFL QEMU: A Library for Fuzzing-oriented Emulation}},
   author       = {Romain Malmain and Andrea Fioraldi and Aurélien Francillon},


### PR DESCRIPTION
Explicitly mark the README snippet as bibtex to avoid cargo trying to run it as Rust code