### PR TITLE
Rename some functions in fuzzer.rs

### DIFF
--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -608,7 +608,7 @@ where
                             process::id(),
                             event_name
                         );
-                        fuzzer.execute_and_process(
+                        fuzzer.evaluate_execution(
                             state,
                             self,
                             input.clone(),

--- a/libafl/src/events/llmp/mgr.rs
+++ b/libafl/src/events/llmp/mgr.rs
@@ -443,9 +443,8 @@ where
                         {
                             state.scalability_monitor_mut().testcase_with_observers += 1;
                         }
-                        fuzzer.evaluate_execution(
-                            state, self, input, &observers, &exit_kind, false,
-                        )?
+                        fuzzer
+                            .evaluate_execution(state, self, input, &observers, &exit_kind, false)?
                     } else {
                         #[cfg(feature = "scalability_introspection")]
                         {

--- a/libafl/src/events/llmp/mgr.rs
+++ b/libafl/src/events/llmp/mgr.rs
@@ -443,7 +443,7 @@ where
                         {
                             state.scalability_monitor_mut().testcase_with_observers += 1;
                         }
-                        fuzzer.execute_and_process(
+                        fuzzer.evaluate_execution(
                             state, self, input, &observers, &exit_kind, false,
                         )?
                     } else {

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -636,7 +636,7 @@ where
                     {
                         state.scalability_monitor_mut().testcase_with_observers += 1;
                     }
-                    fuzzer.execute_and_process(state, self, input, &observers, &exit_kind, false)?
+                    fuzzer.evaluate_execution(state, self, input, &observers, &exit_kind, false)?
                 } else {
                     #[cfg(feature = "scalability_introspection")]
                     {

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -70,8 +70,8 @@ pub trait HasObjective: UsesState {
 
 /// Evaluates if an input is interesting using the feedback
 pub trait ExecutionProcessor<OT>: UsesState {
-    /// Evaluate if a set of observation channels has an interesting state
-    fn execute_no_process<EM>(
+    /// Check the outcome of the execution, find if it is worth for corpus or objectives
+    fn check_results<EM>(
         &mut self,
         state: &mut Self::State,
         manager: &mut EM,
@@ -98,7 +98,7 @@ pub trait ExecutionProcessor<OT>: UsesState {
         EM: EventFirer<State = Self::State>;
 
     /// Evaluate if a set of observation channels has an interesting state
-    fn execute_and_process<EM>(
+    fn evaluate_execution<EM>(
         &mut self,
         state: &mut Self::State,
         manager: &mut EM,
@@ -356,7 +356,7 @@ where
         + HasCurrentTestcase<<Self::State as UsesInput>::Input>
         + HasCurrentCorpusId,
 {
-    fn execute_no_process<EM>(
+    fn check_results<EM>(
         &mut self,
         state: &mut Self::State,
         manager: &mut EM,
@@ -399,7 +399,7 @@ where
         Ok(res)
     }
 
-    fn execute_and_process<EM>(
+    fn evaluate_execution<EM>(
         &mut self,
         state: &mut Self::State,
         manager: &mut EM,
@@ -411,7 +411,7 @@ where
     where
         EM: EventFirer<State = Self::State>,
     {
-        let exec_res = self.execute_no_process(state, manager, &input, observers, exit_kind)?;
+        let exec_res = self.check_results(state, manager, &input, observers, exit_kind)?;
         let corpus_id = self.process_execution(
             state,
             manager,
@@ -548,7 +548,7 @@ where
 
         self.scheduler.on_evaluation(state, &input, &*observers)?;
 
-        self.execute_and_process(state, manager, input, &*observers, &exit_kind, send_events)
+        self.evaluate_execution(state, manager, input, &*observers, &exit_kind, send_events)
     }
 }
 

--- a/libafl/src/stages/push/mutational.rs
+++ b/libafl/src/stages/push/mutational.rs
@@ -169,7 +169,7 @@ where
     ) -> Result<(), Error> {
         // todo: is_interesting, etc.
 
-        fuzzer.execute_and_process(state, event_mgr, last_input, observers, &exit_kind, true)?;
+        fuzzer.evaluate_execution(state, event_mgr, last_input, observers, &exit_kind, true)?;
 
         start_timer!(state);
         self.mutator.post_exec(state, self.current_corpus_id)?;

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -139,7 +139,7 @@ where
                 // TODO replace if process_execution adds a return value for solution index
                 let solution_count = state.solutions().count();
                 let corpus_count = state.corpus().count();
-                let (_, corpus_id) = fuzzer.execute_and_process(
+                let (_, corpus_id) = fuzzer.evaluate_execution(
                     state,
                     manager,
                     input.clone(),


### PR DESCRIPTION
Some functions have really strange names.
execute_no_process doesn't execute anything.
execute_and_process doesn't execute anything either.

i just rename it to make them have proper names