### PR TITLE
Add documentation for InProcessForkExecutor

### DIFF
--- a/libafl/src/executors/inprocess_fork/mod.rs
+++ b/libafl/src/executors/inprocess_fork/mod.rs
@@ -40,7 +40,8 @@ pub mod inner;
 /// A version of `InProcessForkExecutor` with a state accessible from the harness.
 pub mod stateful;
 
-/// The `InProcessForkExecutor` with no user hooks
+/// The `InProcessForkExecutor` with no user hooks. On Linux, when fuzzing a Rust target, set `panic = "abort"` in your `Cargo.toml` (see [Cargo documentation](https://doc.rust-lang.org/cargo/reference/profiles.html#panic)).
+/// Else panics can not be caught by LibAFL.
 pub type InProcessForkExecutor<'a, H, OT, S, SP, EM, Z> =
     GenericInProcessForkExecutor<'a, H, (), OT, S, SP, EM, Z>;
 
@@ -79,7 +80,8 @@ where
     }
 }
 
-/// [`GenericInProcessForkExecutor`] is an executor that forks the current process before each execution.
+/// [`GenericInProcessForkExecutor`] is an executor that forks the current process before each execution. On Linux, when fuzzing a Rust target, set `panic = "abort"` in your `Cargo.toml` (see [Cargo documentation](https://doc.rust-lang.org/cargo/reference/profiles.html#panic)).
+/// Else panics can not be caught by LibAFL.
 pub struct GenericInProcessForkExecutor<'a, H, HT, OT, S, SP, EM, Z>
 where
     H: FnMut(&S::Input) -> ExitKind + ?Sized,


### PR DESCRIPTION
On Linux, when fuzzing a Rust target, set `panic = "abort"` in your `Cargo.toml` (see [Cargo documentation](https://doc.rust-lang.org/cargo/reference/profiles.html#panic)).

This PR adds this hint.