### PR TITLE
Add RISCV support in `libafl_qemu.h`

### DIFF
--- a/libafl_qemu/runtime/libafl_qemu.h
+++ b/libafl_qemu/runtime/libafl_qemu.h
@@ -30,12 +30,12 @@ typedef UINT64 libafl_word;
 #else
   #include <stdint.h>
 
-  #if defined(__x86_64__) || defined(__aarch64__)
+  #if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
     typedef uint64_t libafl_word;
     #define LIBAFL_CALLING_CONVENTION __attribute__(())
   #endif
 
-  #ifdef __arm__
+  #if defined(__arm__) || (defined(__riscv) && __riscv_xlen == 32)
     typedef uint32_t libafl_word;
     #define LIBAFL_CALLING_CONVENTION __attribute__(())
   #endif
@@ -220,6 +220,54 @@ typedef enum LibaflQemuEndStatus {
     );   \
         return ret;                                                                                 \
       }
+
+  #elif defined(__riscv)
+    #define LIBAFL_DEFINE_FUNCTIONS(name, opcode)                                                   \
+      libafl_word LIBAFL_CALLING_CONVENTION _libafl_##name##_call0(                                 \
+          libafl_word action) {                                                                     \
+        libafl_word ret;                                                                            \
+        __asm__ volatile (                                                                        \
+        "mv a0, %1\n"                                                                            \
+        ".word " XSTRINGIFY(opcode) "\n"                                              \
+        "mv a0, a0\n"                                                                            \
+        : "=r"(ret)                                                                               \
+        : "r"(action)                                                                             \
+        : "a0"                                                                                    \
+    ); \
+        return ret;                                                                               \
+      }                                                                                             \
+                                                                                                    \
+      libafl_word LIBAFL_CALLING_CONVENTION _libafl_##name##_call1(                                 \
+          libafl_word action, libafl_word arg1) {                                                   \
+        libafl_word ret;                                                                            \
+        __asm__ volatile (                                                                      \
+        "mv a0, %1\n"                                                                      \
+        "mv a1, %2\n"                                                                      \
+        ".word " XSTRINGIFY(opcode) "\n"                                        \
+        "mv %0, a0\n"                                                                      \
+        : "=r"(ret)                                                                         \
+        : "r"(action), "r"(arg1)                                                            \
+        : "a0", "a1"                                                                        \
+    );   \
+        return ret;                                                                                 \
+      }                                                                                             \
+                                                                                                    \
+      libafl_word LIBAFL_CALLING_CONVENTION _libafl_##name##_call2(                                 \
+          libafl_word action, libafl_word arg1, libafl_word arg2) {                                 \
+        libafl_word ret;                                                                            \
+        __asm__ volatile (                                                                      \
+        "mv a0, %1\n"                                                                      \
+        "mv a1, %2\n"                                                                      \
+        "mv a2, %3\n"                                                                      \
+        ".word " XSTRINGIFY(opcode) "\n"                                        \
+        "mv %0, a0\n"                                                                      \
+        : "=r"(ret)                                                                         \
+        : "r"(action), "r"(arg1), "r"(arg2)                                                 \
+        : "a0", "a1", "a2"                                                                  \
+    );   \
+        return ret;                                                                                 \
+      }
+
   #else
     #warning "LibAFL QEMU Runtime does not support your architecture yet, please leave an issue."
   #endif


### PR DESCRIPTION
Add corresponding APIs for both riscv32 and riscv64. It can be used together with #2367.