### PR TITLE
Replace uses std HashMap with hashbrown for consistency

### DIFF
--- a/libafl/src/common/nautilus/grammartec/mutator.rs
+++ b/libafl/src/common/nautilus/grammartec/mutator.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
-use std::{collections::HashSet, mem};
+use core::mem;
 
+use hashbrown::HashSet;
 use libafl_bolts::{rands::Rand, Error};
 
 use crate::common::nautilus::grammartec::{

--- a/libafl/src/common/nautilus/grammartec/mutator.rs
+++ b/libafl/src/common/nautilus/grammartec/mutator.rs
@@ -308,9 +308,10 @@ impl Mutator {
 #[cfg(test)]
 mod tests {
     use alloc::{
-        string::{str, String, ToString},
+        string::{String, ToString},
         vec::Vec,
     };
+    use core::str;
 
     use hashbrown::HashSet;
     use libafl_bolts::rands::StdRand;

--- a/libafl/src/common/nautilus/grammartec/mutator.rs
+++ b/libafl/src/common/nautilus/grammartec/mutator.rs
@@ -308,11 +308,11 @@ impl Mutator {
 #[cfg(test)]
 mod tests {
     use alloc::{
-        string::{String, ToString},
+        string::{str, String, ToString},
         vec::Vec,
     };
-    use std::{collections::HashSet, str};
 
+    use hashbrown::HashSet;
     use libafl_bolts::rands::StdRand;
 
     use crate::{

--- a/libafl/src/common/nautilus/grammartec/tree.rs
+++ b/libafl/src/common/nautilus/grammartec/tree.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
-use std::{cmp, collections::HashSet, io, io::Write, marker::Sized};
+use std::{cmp, io, io::Write, marker::Sized};
 
+use hashbrown::HashSet;
 use libafl_bolts::rands::Rand;
 use pyo3::{
     prelude::{PyObject, PyResult, Python},

--- a/libafl_frida/src/cmplog_rt.rs
+++ b/libafl_frida/src/cmplog_rt.rs
@@ -6,8 +6,6 @@
 
 #[cfg(target_arch = "aarch64")]
 use core::ffi::c_void;
-#[cfg(all(feature = "cmplog", target_arch = "x86_64"))]
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use dynasmrt::dynasm;
@@ -22,6 +20,8 @@ use frida_gum::{
     stalker::StalkerOutput,
 };
 use frida_gum_sys::Insn;
+#[cfg(all(feature = "cmplog", target_arch = "x86_64"))]
+use hashbrown::HashMap;
 #[cfg(all(feature = "cmplog", target_arch = "x86_64"))]
 use iced_x86::{
     BlockEncoder, Code, DecoderOptions, Instruction, InstructionBlock, MemoryOperand, MemorySize,

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/Cargo.toml
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/Cargo.toml
@@ -42,6 +42,7 @@ mimalloc = { version = "0.1.34", default-features = false }
 num-traits = "0.2.15"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] } # serialization lib
+hashbrown = "0.14"
 
 # for identifying if we can grimoire-ify
 utf8-chars = "3.0.1"

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/rustfmt.toml
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/corpus.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/corpus.rs
@@ -1,11 +1,12 @@
 use std::{
     cell::RefCell,
-    collections::{hash_map::Entry, BTreeMap, HashMap},
+    collections::BTreeMap,
     io::ErrorKind,
     path::PathBuf,
     sync::atomic::{AtomicU64, Ordering},
 };
 
+use hashbrown::{hash_map::Entry, HashMap};
 use libafl::{
     corpus::{
         inmemory::{TestcaseStorage, TestcaseStorageMap},

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/misc.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/misc.rs
@@ -1,9 +1,6 @@
-use std::{
-    collections::VecDeque,
-    path::PathBuf,
-};
-use hashbrown::HashSet;
+use std::{collections::VecDeque, path::PathBuf};
 
+use hashbrown::HashSet;
 use libafl::{Error, HasMetadata};
 use libafl_bolts::impl_serdeany;
 use serde::{Deserialize, Serialize};

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/misc.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/misc.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::VecDeque,
     path::PathBuf,
 };
+use hashbrown::HashSet;
 
 use libafl::{Error, HasMetadata};
 use libafl_bolts::impl_serdeany;

--- a/libafl_libfuzzer/libafl_libfuzzer_runtime/src/schedulers.rs
+++ b/libafl_libfuzzer/libafl_libfuzzer_runtime/src/schedulers.rs
@@ -1,8 +1,6 @@
-use std::{
-    collections::{BTreeSet, HashMap},
-    marker::PhantomData,
-};
+use std::{collections::BTreeSet, marker::PhantomData};
 
+use hashbrown::HashMap;
 use libafl::{
     corpus::{Corpus, CorpusId, Testcase},
     feedbacks::MapNoveltiesMetadata,

--- a/libafl_qemu/src/command/mod.rs
+++ b/libafl_qemu/src/command/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(emulation_mode = "systemmode")]
-use std::collections::HashSet;
 use std::{
     fmt::{Debug, Display, Error, Formatter},
     rc::Rc,
@@ -7,6 +5,8 @@ use std::{
 
 use enum_map::{Enum, EnumMap};
 use hashbrown::HashMap;
+#[cfg(emulation_mode = "systemmode")]
+use hashbrown::HashSet;
 use libafl::{
     executors::ExitKind,
     inputs::HasTargetBytes,

--- a/libafl_qemu/src/helpers/asan.rs
+++ b/libafl_qemu/src/helpers/asan.rs
@@ -1,13 +1,8 @@
 #![allow(clippy::cast_possible_wrap)]
 
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-    env, fs,
-    path::PathBuf,
-    sync::Mutex,
-};
+use std::{borrow::Cow, env, fs, path::PathBuf, sync::Mutex};
 
+use hashbrown::{HashMap, HashSet};
 use libafl::{executors::ExitKind, inputs::UsesInput, observers::ObserversTuple, HasMetadata};
 use libc::{
     c_void, MAP_ANON, MAP_FAILED, MAP_FIXED, MAP_NORESERVE, MAP_PRIVATE, PROT_READ, PROT_WRITE,

--- a/libafl_qemu/src/helpers/mod.rs
+++ b/libafl_qemu/src/helpers/mod.rs
@@ -1,6 +1,7 @@
 use core::{fmt::Debug, ops::Range};
-use std::{cell::UnsafeCell, collections::HashSet, hash::BuildHasher};
+use std::{cell::UnsafeCell, hash::BuildHasher};
 
+use hashbrown::HashSet;
 use libafl::{executors::ExitKind, inputs::UsesInput, observers::ObserversTuple};
 use libafl_bolts::tuples::{MatchFirstType, SplitBorrowExtractFirstType};
 use libafl_qemu_sys::{GuestAddr, GuestPhysAddr};

--- a/libafl_qemu/src/helpers/snapshot.rs
+++ b/libafl_qemu/src/helpers/snapshot.rs
@@ -1,10 +1,6 @@
-use std::{
-    cell::UnsafeCell,
-    collections::{HashMap, HashSet},
-    mem::MaybeUninit,
-    sync::Mutex,
-};
+use std::{cell::UnsafeCell, mem::MaybeUninit, sync::Mutex};
 
+use hashbrown::{HashMap, HashSet};
 use libafl::{inputs::UsesInput, HasMetadata};
 use libafl_qemu_sys::{GuestAddr, MmapPerms};
 use meminterval::{Interval, IntervalTree};


### PR DESCRIPTION
We use it everywhere so we should continue doing so. We should especially not mix and match both.