### PR TITLE
Run Qemu CI more

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -358,6 +358,9 @@ jobs:
         with:
           filters: |
             qemu:
+              - 'libafl/**'
+              - 'libafl_bolts/**'
+              - 'libafl_targets/**'
               - 'libafl_qemu/**'
               - 'fuzzers/*qemu*/**'
 


### PR DESCRIPTION
Qemu CI was running iif `libafl_qemu` or qemu-related fuzzers changed.
Recently (#2373) it caused an issue where a `libafl` change impacted negatively `libafl_qemu` but was not detected by the CI (since it was not being run).
now qemu CI will run also when its dependencies change.