### PR TITLE
libqasan: Add missing return to qasan_swap

### DIFF
--- a/libafl_qemu/libqasan/libqasan.c
+++ b/libafl_qemu/libqasan/libqasan.c
@@ -361,6 +361,7 @@ void qasan_dealloc(const char *start) {
 int qasan_swap(int state) {
   QASAN_DEBUG("SWAP: %d\n", state);
   /* Do Nothing */
+  return 0;
 }
 #endif
 


### PR DESCRIPTION
Noticed the missing return statement while building `libafl_qemu`:

```
  libqasan.c:364:1: warning: non-void function does not return a value [-Wreturn-type]
    364 | }
        | ^
  1 warning generated.
```