### PR TITLE
Added a tolower implementation in libqasan

### DIFF
--- a/libafl_qemu/libqasan/string.c
+++ b/libafl_qemu/libqasan/string.c
@@ -128,9 +128,14 @@ int __libqasan_strncmp(const char *str1, const char *str2, size_t len) {
   return 0;
 }
 
+unsigned char __libqasan_tolower(unsigned char c) {
+  if (c >= 'A' && c <= 'Z') return c | 0x20;
+  return c;
+}
+
 int __libqasan_strcasecmp(const char *str1, const char *str2) {
   while (1) {
-    const unsigned char c1 = tolower(*str1), c2 = tolower(*str2);
+    const unsigned char c1 = __libqasan_tolower(*str1), c2 = __libqasan_tolower(*str2);
 
     if (c1 != c2) { return c1 - c2; }
     if (!c1) { return 0; }
@@ -143,7 +148,7 @@ int __libqasan_strcasecmp(const char *str1, const char *str2) {
 
 int __libqasan_strncasecmp(const char *str1, const char *str2, size_t len) {
   while (len--) {
-    const unsigned char c1 = tolower(*str1), c2 = tolower(*str2);
+    const unsigned char c1 = __libqasan_tolower(*str1), c2 = __libqasan_tolower(*str2);
 
     if (c1 != c2) { return c1 - c2; }
     if (!c1) { return 0; }
@@ -204,7 +209,7 @@ char *__libqasan_strcasestr(const char *haystack, const char *needle) {
     const char *n = needle;
     const char *h = haystack;
 
-    while (*n && *h && tolower(*n) == tolower(*h)) {
+    while (*n && *h && __libqasan_tolower(*n) == __libqasan_tolower(*h)) {
       n++;
       h++;
     }


### PR DESCRIPTION
Some firmware has named tolower differently in it's libraries. Ideally, one would use the correct cross-compiler for libqasan, but this can be tricky to figure out. Since tolower is a trivial function, adding it in libqasan helps make the library more compiler agnostic and easier to use.