### PR TITLE
Re-export `libafl_bolts` as `libafl::bolts`

### DIFF
--- a/docs/listings/baby_fuzzer/listing-02/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-02/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 libafl = { path = "path/to/libafl/" }
-libafl_bolts = { path = "path/to/libafl_bolts/" }
 
 [profile.dev]
 panic = "abort"

--- a/docs/listings/baby_fuzzer/listing-03/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-03/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 libafl = { path = "path/to/libafl/" }
-libafl_bolts = { path = "path/to/libafl_bolts/" }
 
 [profile.dev]
 panic = "abort"

--- a/docs/listings/baby_fuzzer/listing-03/src/main.rs
+++ b/docs/listings/baby_fuzzer/listing-03/src/main.rs
@@ -1,10 +1,9 @@
 extern crate libafl;
-extern crate libafl_bolts;
 use libafl::{
+    bolts::AsSlice,
     executors::ExitKind,
     inputs::{BytesInput, HasTargetBytes},
 };
-use libafl_bolts::AsSlice;
 
 fn main() {
     let mut harness = |input: &BytesInput| {

--- a/docs/listings/baby_fuzzer/listing-04/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-04/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 libafl = { path = "path/to/libafl/" }
-libafl_bolts = { path = "path/to/libafl_bolts/" }
 
 [profile.dev]
 panic = "abort"

--- a/docs/listings/baby_fuzzer/listing-04/src/main.rs
+++ b/docs/listings/baby_fuzzer/listing-04/src/main.rs
@@ -1,10 +1,10 @@
 /* ANCHOR: use */
 extern crate libafl;
-extern crate libafl_bolts;
 
 use std::path::PathBuf;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -15,7 +15,6 @@ use libafl::{
     schedulers::QueueScheduler,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 /* ANCHOR_END: use */
 
 fn main() {

--- a/docs/listings/baby_fuzzer/listing-05/src/main.rs
+++ b/docs/listings/baby_fuzzer/listing-05/src/main.rs
@@ -1,8 +1,10 @@
 /* ANCHOR: use */
 extern crate libafl;
-extern crate libafl_bolts;
+
+use std::path::PathBuf;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -15,8 +17,6 @@ use libafl::{
     schedulers::QueueScheduler,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
-use std::path::PathBuf;
 /* ANCHOR_END: use */
 
 /* ANCHOR: signals */

--- a/docs/listings/baby_fuzzer/listing-06/Cargo.toml
+++ b/docs/listings/baby_fuzzer/listing-06/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 libafl = { path = "path/to/libafl/" }
-libafl_bolts = { path = "path/to/libafl_bolts/" }
 
 [profile.dev]
 panic = "abort"

--- a/docs/listings/baby_fuzzer/listing-06/src/main.rs
+++ b/docs/listings/baby_fuzzer/listing-06/src/main.rs
@@ -1,8 +1,10 @@
 /* ANCHOR: use */
 extern crate libafl;
-extern crate libafl_bolts;
+
+use std::path::PathBuf;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -17,8 +19,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
-use std::path::PathBuf;
 /* ANCHOR_END: use */
 
 // Coverage map with explicit assignments due to the lack of instrumentation

--- a/docs/src/design/metadata.md
+++ b/docs/src/design/metadata.md
@@ -5,10 +5,10 @@ A metadata in LibAFL is a self-contained structure that holds associated data to
 In terms of code, a metadata can be defined as a Rust struct registered in the SerdeAny register.
 
 ```rust
-# extern crate libafl_bolts;
 # extern crate serde;
+# extern crate libafl;
 
-use libafl_bolts::SerdeAny;
+use libafl::bolts::SerdeAny;
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Serialize, Deserialize, SerdeAny)]

--- a/fuzzers/baby/baby_fuzzer_gramatron/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_gramatron/Cargo.toml
@@ -20,5 +20,4 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 postcard = { version = "1.0", features = ["alloc"], default-features = false } # no_std compatible serde serialization format

--- a/fuzzers/baby/baby_fuzzer_gramatron/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_gramatron/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -24,7 +25,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];
@@ -123,7 +123,7 @@ pub fn main() {
     }
 
     let mut set = HashSet::new();
-    let st = libafl_bolts::current_milliseconds();
+    let st = libafl::bolts::current_milliseconds();
     let mut b = vec![];
     let mut c = 0;
     for _ in 0..100000 {
@@ -132,7 +132,7 @@ pub fn main() {
         set.insert(calculate_hash(&b));
         c += b.len();
     }
-    println!("{} / {}", c, libafl_bolts::current_milliseconds() - st);
+    println!("{} / {}", c, libafl::bolts::current_milliseconds() - st);
     println!("{} / 100000", set.len());
 
     return;

--- a/fuzzers/baby/baby_fuzzer_grimoire/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_grimoire/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "baby_fuzzer_grimoire"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -20,4 +23,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }

--- a/fuzzers/baby/baby_fuzzer_grimoire/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_grimoire/src/main.rs
@@ -3,6 +3,7 @@ use std::ptr::write_volatile;
 use std::{fs, io::Read, path::PathBuf, ptr::write};
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -21,7 +22,6 @@ use libafl::{
     state::StdState,
     HasMetadata,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];

--- a/fuzzers/baby/baby_fuzzer_minimizing/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_minimizing/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "baby_fuzzer_minimizing"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>", "Addison Crump <research@addisoncrump.info>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+    "Addison Crump <research@addisoncrump.info>",
+]
 edition = "2021"
 
 [features]
@@ -21,4 +25,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["prelude"] }
-libafl_bolts = { path = "../../../libafl_bolts/", features = ["prelude"] }

--- a/fuzzers/baby/baby_fuzzer_minimizing/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_minimizing/src/main.rs
@@ -2,8 +2,7 @@
 use std::ptr::write_volatile;
 use std::{path::PathBuf, ptr::write};
 
-use libafl::prelude::*;
-use libafl_bolts::prelude::*;
+use libafl::{bolts::prelude::*, prelude::*};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];

--- a/fuzzers/baby/baby_fuzzer_multi/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_multi/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "baby_fuzzer_multi"
 version = "0.10.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>", "Addison Crump <me@addisoncrump.info>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+    "Addison Crump <me@addisoncrump.info>",
+]
 edition = "2021"
 
 [features]
@@ -21,4 +25,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["multipart_inputs"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }

--- a/fuzzers/baby/baby_fuzzer_multi/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_multi/src/main.rs
@@ -7,6 +7,7 @@ use libafl::monitors::tui::TuiMonitor;
 #[cfg(not(feature = "tui"))]
 use libafl::monitors::SimpleMonitor;
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -21,7 +22,6 @@ use libafl::{
     state::StdState,
     Evaluator,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 128] = [0; 128];

--- a/fuzzers/baby/baby_fuzzer_nautilus/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_nautilus/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "baby_fuzzer_nautilus"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -20,4 +23,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["default", "nautilus"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }

--- a/fuzzers/baby/baby_fuzzer_nautilus/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_nautilus/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::ptr::write_volatile;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -21,7 +22,6 @@ use libafl::{
     state::StdState,
     HasMetadata,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];
@@ -123,7 +123,7 @@ pub fn main() {
     }
 
     let mut set = HashSet::new();
-    let st = libafl_bolts::current_milliseconds();
+    let st = libafl::bolts::current_milliseconds();
     let mut b = vec![];
     let mut c = 0;
     for _ in 0..100000 {
@@ -132,7 +132,7 @@ pub fn main() {
         set.insert(calculate_hash(&b));
         c += b.len();
     }
-    println!("{} / {}", c, libafl_bolts::current_milliseconds() - st);
+    println!("{} / {}", c, libafl::bolts::current_milliseconds() - st);
     println!("{} / 100000", set.len());
 
     return;

--- a/fuzzers/baby/baby_fuzzer_swap_differential/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_swap_differential/Cargo.toml
@@ -26,8 +26,12 @@ cc = "1.0"
 
 [dependencies]
 libafl = { path = "../../../libafl" }
-libafl_bolts = { path = "../../../libafl_bolts" }
-libafl_targets = { path = "../../../libafl_targets", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog", "pointer_maps"] }
+libafl_targets = { path = "../../../libafl_targets", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+    "sancov_cmplog",
+    "pointer_maps",
+] }
 mimalloc = { version = "*", default-features = false }
 
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/baby/baby_fuzzer_swap_differential/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_swap_differential/src/main.rs
@@ -10,6 +10,7 @@ use libafl::monitors::tui::TuiMonitor;
 #[cfg(not(feature = "tui"))]
 use libafl::monitors::SimpleMonitor;
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{Corpus, InMemoryCorpus, InMemoryOnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, DiffExecutor, ExitKind},
@@ -23,7 +24,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasSolutions, StdState},
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 use libafl_targets::{edges_max_num, DifferentialAFLMapSwapObserver};
 #[cfg(not(miri))]
 use mimalloc::MiMalloc;
@@ -46,8 +46,10 @@ use bindings::{inspect_first, inspect_second};
 
 #[cfg(feature = "multimap")]
 mod multimap {
-    pub use libafl::observers::{HitcountsIterableMapObserver, MultiMapObserver};
-    pub use libafl_bolts::ownedref::OwnedMutSlice;
+    pub use libafl::{
+        bolts::ownedref::OwnedMutSlice,
+        observers::{HitcountsIterableMapObserver, MultiMapObserver},
+    };
 }
 #[cfg(feature = "multimap")]
 use multimap::{HitcountsIterableMapObserver, MultiMapObserver, OwnedMutSlice};

--- a/fuzzers/baby/baby_fuzzer_tokens/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_tokens/Cargo.toml
@@ -20,4 +20,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }

--- a/fuzzers/baby/baby_fuzzer_tokens/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_tokens/src/main.rs
@@ -3,6 +3,7 @@ use std::ptr::write_volatile;
 use std::{fs, io::Read, path::PathBuf};
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -16,7 +17,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];

--- a/fuzzers/baby/baby_fuzzer_unicode/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_unicode/Cargo.toml
@@ -21,4 +21,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["unicode"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }

--- a/fuzzers/baby/baby_fuzzer_unicode/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_unicode/src/main.rs
@@ -7,6 +7,7 @@ use libafl::monitors::tui::TuiMonitor;
 #[cfg(not(feature = "tui"))]
 use libafl::monitors::SimpleMonitor;
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -20,7 +21,6 @@ use libafl::{
     state::StdState,
     Evaluator,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 64] = [0; 64];

--- a/fuzzers/baby/baby_fuzzer_wasm/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_wasm/Cargo.toml
@@ -15,7 +15,6 @@ js-sys = "0.3"
 wasm-bindgen = "0.2.63"
 
 libafl = { path = "../../../libafl", default-features = false }
-libafl_bolts = { path = "../../../libafl_bolts", default-features = false }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/fuzzers/baby/baby_fuzzer_wasm/src/lib.rs
+++ b/fuzzers/baby/baby_fuzzer_wasm/src/lib.rs
@@ -1,6 +1,7 @@
 mod utils;
 
 use libafl::{
+    bolts::{rands::StdRand, serdeany::RegistryBuilder, tuples::tuple_list, AsSlice},
     corpus::{Corpus, InMemoryCorpus},
     events::SimpleEventManager,
     executors::{ExitKind, InProcessExecutor},
@@ -15,7 +16,6 @@ use libafl::{
     state::{HasSolutions, StdState},
     Fuzzer, StdFuzzer,
 };
-use libafl_bolts::{rands::StdRand, serdeany::RegistryBuilder, tuples::tuple_list, AsSlice};
 use wasm_bindgen::prelude::*;
 use web_sys::{Performance, Window};
 

--- a/fuzzers/baby/baby_fuzzer_with_forkexecutor/Cargo.toml
+++ b/fuzzers/baby/baby_fuzzer_with_forkexecutor/Cargo.toml
@@ -20,4 +20,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }

--- a/fuzzers/baby/baby_fuzzer_with_forkexecutor/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_with_forkexecutor/src/main.rs
@@ -3,6 +3,12 @@ use std::ptr::write_volatile;
 use std::{path::PathBuf, ptr::write};
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        shmem::{unix_shmem, ShMemProvider},
+        tuples::tuple_list,
+        AsSlice, AsSliceMut,
+    },
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{ExitKind, InProcessForkExecutor},
@@ -16,12 +22,6 @@ use libafl::{
     schedulers::QueueScheduler,
     stages::mutational::StdMutationalStage,
     state::StdState,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    shmem::{unix_shmem, ShMemProvider},
-    tuples::tuple_list,
-    AsSlice, AsSliceMut,
 };
 
 #[allow(clippy::similar_names)]

--- a/fuzzers/baby/baby_no_std/Cargo.toml
+++ b/fuzzers/baby/baby_no_std/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "baby_no_std"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [profile.dev]
@@ -16,9 +19,7 @@ debug = true
 
 [dependencies]
 libafl = { default-features = false, path = "../../../libafl/" }
-libafl_bolts = { default-features = false, path = "../../../libafl_bolts/" }
 static-alloc = "0.2.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-

--- a/fuzzers/baby/baby_no_std/src/main.rs
+++ b/fuzzers/baby/baby_no_std/src/main.rs
@@ -11,6 +11,7 @@ use core::panic::PanicInfo;
 use core::ptr::write;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::InMemoryCorpus,
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -25,7 +26,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 #[cfg(any(windows, unix))]
 use libc::{abort, printf};
 use static_alloc::Bump;

--- a/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_fork_executor/Cargo.toml
+++ b/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_fork_executor/Cargo.toml
@@ -16,7 +16,6 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../../libafl/" }
-libafl_bolts = { path = "../../../../libafl_bolts/" }
 libc = "0.2"
 
 [build-dependencies]

--- a/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_fork_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_fork_executor/src/main.rs
@@ -1,6 +1,13 @@
 use std::{path::PathBuf, time::Duration};
 
 use libafl::{
+    bolts::{
+        ownedref::OwnedRefMut,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+        AsSlice,
+    },
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::InProcessForkExecutor,
@@ -15,13 +22,6 @@ use libafl::{
     schedulers::QueueScheduler,
     stages::mutational::StdMutationalStage,
     state::StdState,
-};
-use libafl_bolts::{
-    ownedref::OwnedRefMut,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
-    AsSlice,
 };
 use libc::{c_int, c_uchar};
 extern crate libc;

--- a/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_inprocess_executor/Cargo.toml
+++ b/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_inprocess_executor/Cargo.toml
@@ -16,7 +16,6 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../../libafl/" }
-libafl_bolts = { path = "../../../../libafl_bolts/" }
 libc = "0.2"
 
 [build-dependencies]

--- a/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_inprocess_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_inprocess_executor/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::InProcessExecutor,
@@ -16,7 +17,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 use libc::c_uchar;
 extern crate libc;
 

--- a/fuzzers/baby/backtrace_baby_fuzzers/command_executor/Cargo.toml
+++ b/fuzzers/baby/backtrace_baby_fuzzers/command_executor/Cargo.toml
@@ -18,4 +18,3 @@ cc = "*"
 
 [dependencies]
 libafl = { path = "../../../../libafl/" }
-libafl_bolts = { path = "../../../../libafl_bolts/" }

--- a/fuzzers/baby/backtrace_baby_fuzzers/command_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/command_executor/src/main.rs
@@ -8,6 +8,12 @@ use std::{
 };
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        shmem::{unix_shmem, ShMem, ShMemId, ShMemProvider},
+        tuples::tuple_list,
+        AsSlice, AsSliceMut,
+    },
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::command::CommandConfigurator,
@@ -23,12 +29,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
     Error,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    shmem::{unix_shmem, ShMem, ShMemId, ShMemProvider},
-    tuples::tuple_list,
-    AsSlice, AsSliceMut,
 };
 
 #[allow(clippy::similar_names)]

--- a/fuzzers/baby/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml
+++ b/fuzzers/baby/backtrace_baby_fuzzers/forkserver_executor/Cargo.toml
@@ -15,4 +15,3 @@ opt-level = 3
 
 [dependencies]
 libafl = { path = "../../../../libafl/" }
-libafl_bolts = { path = "../../../../libafl_bolts/" }

--- a/fuzzers/baby/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/forkserver_executor/src/main.rs
@@ -1,6 +1,16 @@
 use std::path::PathBuf;
 
+#[cfg(not(target_vendor = "apple"))]
+use libafl::bolts::shmem::StdShMemProvider;
+#[cfg(target_vendor = "apple")]
+use libafl::bolts::shmem::UnixShMemProvider;
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        shmem::{ShMem, ShMemProvider},
+        tuples::tuple_list,
+        AsSliceMut,
+    },
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::forkserver::ForkserverExecutor,
@@ -15,16 +25,6 @@ use libafl::{
     schedulers::QueueScheduler,
     stages::mutational::StdMutationalStage,
     state::StdState,
-};
-#[cfg(not(target_vendor = "apple"))]
-use libafl_bolts::shmem::StdShMemProvider;
-#[cfg(target_vendor = "apple")]
-use libafl_bolts::shmem::UnixShMemProvider;
-use libafl_bolts::{
-    rands::StdRand,
-    shmem::{ShMem, ShMemProvider},
-    tuples::tuple_list,
-    AsSliceMut,
 };
 
 #[allow(clippy::similar_names)]

--- a/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_fork_executor/Cargo.toml
+++ b/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_fork_executor/Cargo.toml
@@ -19,4 +19,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../../libafl/" }
-libafl_bolts = { path = "../../../../libafl_bolts/" }

--- a/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_fork_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_fork_executor/src/main.rs
@@ -3,6 +3,13 @@ use std::ptr::write_volatile;
 use std::{path::PathBuf, ptr::write};
 
 use libafl::{
+    bolts::{
+        ownedref::OwnedRefMut,
+        rands::StdRand,
+        shmem::{unix_shmem, ShMem, ShMemProvider},
+        tuples::tuple_list,
+        AsSlice, AsSliceMut,
+    },
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{ExitKind, InProcessForkExecutor},
@@ -17,13 +24,6 @@ use libafl::{
     schedulers::QueueScheduler,
     stages::mutational::StdMutationalStage,
     state::StdState,
-};
-use libafl_bolts::{
-    ownedref::OwnedRefMut,
-    rands::StdRand,
-    shmem::{unix_shmem, ShMem, ShMemProvider},
-    tuples::tuple_list,
-    AsSlice, AsSliceMut,
 };
 
 #[allow(clippy::similar_names)]

--- a/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_inprocess_executor/Cargo.toml
+++ b/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_inprocess_executor/Cargo.toml
@@ -19,4 +19,3 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../../libafl/" }
-libafl_bolts = { path = "../../../../libafl_bolts/" }

--- a/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_inprocess_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/rust_code_with_inprocess_executor/src/main.rs
@@ -3,6 +3,7 @@ use std::ptr::write_volatile;
 use std::{path::PathBuf, ptr::write};
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -18,7 +19,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::StdState,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 16] = [0; 16];

--- a/fuzzers/forkserver/forkserver_libafl_cc/Cargo.toml
+++ b/fuzzers/forkserver/forkserver_libafl_cc/Cargo.toml
@@ -24,7 +24,6 @@ which = { version = "6.0" }
 clap = { version = "4.5", features = ["derive"] }
 nix = { version = "0.29", features = ["signal"] }
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_cc = { path = "../../../libafl_cc/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "pointer_maps"] }
 env_logger = "0.11"

--- a/fuzzers/forkserver/forkserver_libafl_cc/src/main.rs
+++ b/fuzzers/forkserver/forkserver_libafl_cc/src/main.rs
@@ -3,6 +3,12 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        shmem::{ShMem, ShMemProvider, UnixShMemProvider},
+        tuples::{tuple_list, Handled, MatchNameRef, Merge},
+        AsSliceMut, Truncate,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{forkserver::ForkserverExecutor, HasObservers},
@@ -17,12 +23,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     HasMetadata,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{tuple_list, Handled, MatchNameRef, Merge},
-    AsSliceMut, Truncate,
 };
 use libafl_targets::EDGES_MAP_SIZE_IN_USE;
 use nix::sys::signal::Signal;

--- a/fuzzers/frida/frida_executable_libpng/Cargo.toml
+++ b/fuzzers/frida/frida_executable_libpng/Cargo.toml
@@ -18,11 +18,21 @@ opt-level = 3
 debug = true
 
 [dependencies]
-libafl = { path = "../../../libafl/", features = [ "std", "llmp_compression", "llmp_bind_public", "frida_cli" ] } #,  "llmp_small_maps", "llmp_debug"]}
-libafl_bolts = { path = "../../../libafl_bolts/" }
-frida-gum = { version = "0.13.6", features = [ "auto-download", "event-sink", "invocation-listener"] }
+libafl = { path = "../../../libafl/", features = [
+    "std",
+    "llmp_compression",
+    "llmp_bind_public",
+    "frida_cli",
+] } #,  "llmp_small_maps", "llmp_debug"]}
+frida-gum = { version = "0.13.6", features = [
+    "auto-download",
+    "event-sink",
+    "invocation-listener",
+] }
 libafl_frida = { path = "../../../libafl_frida", features = ["cmplog"] }
-libafl_targets = { path = "../../../libafl_targets", features = ["sancov_cmplog"] }
+libafl_targets = { path = "../../../libafl_targets", features = [
+    "sancov_cmplog",
+] }
 libc = "0.2"
 libloading = "0.7"
 num-traits = "0.2"

--- a/fuzzers/frida/frida_executable_libpng/src/fuzzer.rs
+++ b/fuzzers/frida/frida_executable_libpng/src/fuzzer.rs
@@ -4,6 +4,13 @@ use std::{path::PathBuf, ptr::null};
 
 use frida_gum::Gum;
 use libafl::{
+    bolts::{
+        cli::{parse_args, FuzzerOptions},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::{launcher::Launcher, llmp::LlmpRestartingEventManager, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind, ShadowExecutor},
@@ -24,13 +31,6 @@ use libafl::{
 };
 #[cfg(unix)]
 use libafl::{feedback_and_fast, feedbacks::ConstFeedback};
-use libafl_bolts::{
-    cli::{parse_args, FuzzerOptions},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
-};
 #[cfg(unix)]
 use libafl_frida::asan::{
     asan_rt::AsanRuntime,

--- a/fuzzers/frida/frida_gdiplus/Cargo.toml
+++ b/fuzzers/frida/frida_gdiplus/Cargo.toml
@@ -15,15 +15,25 @@ opt-level = 3
 debug = true
 
 [dependencies]
-libafl = { path = "../../../libafl/", features = [ "std", "llmp_compression",
-    "llmp_bind_public", "frida_cli", "errors_backtrace" ] } #,  "llmp_small_maps", "llmp_debug"]}
-libafl_bolts = { path = "../../../libafl_bolts/" }
-frida-gum = { version = "0.13.6", features = ["auto-download", "event-sink", "invocation-listener"] }
+libafl = { path = "../../../libafl/", features = [
+    "std",
+    "llmp_compression",
+    "llmp_bind_public",
+    "frida_cli",
+    "errors_backtrace",
+] } #,  "llmp_small_maps", "llmp_debug"]}
+frida-gum = { version = "0.13.6", features = [
+    "auto-download",
+    "event-sink",
+    "invocation-listener",
+] }
 libafl_frida = { path = "../../../libafl_frida", features = ["cmplog"] }
-libafl_targets = { path = "../../../libafl_targets", features = ["sancov_cmplog"] }
+libafl_targets = { path = "../../../libafl_targets", features = [
+    "sancov_cmplog",
+] }
 libloading = "0.7"
 mimalloc = { version = "*", default-features = false }
-dlmalloc ={version = "0.2.6", features = ["global"]}
+dlmalloc = { version = "0.2.6", features = ["global"] }
 color-backtrace = "0.5"
 env_logger = "0.10.0"
 iced-x86 = { version = "1.20.0", features = ["code_asm"] }

--- a/fuzzers/frida/frida_gdiplus/src/fuzzer.rs
+++ b/fuzzers/frida/frida_gdiplus/src/fuzzer.rs
@@ -21,6 +21,13 @@ use std::path::PathBuf;
 
 use frida_gum::Gum;
 use libafl::{
+    bolts::{
+        cli::{parse_args, FuzzerOptions},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::{launcher::Launcher, llmp::LlmpRestartingEventManager, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind, ShadowExecutor},
@@ -38,13 +45,6 @@ use libafl::{
     stages::{ShadowTracingStage, StdMutationalStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    cli::{parse_args, FuzzerOptions},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_frida::{
     asan::{

--- a/fuzzers/frida/frida_libpng/Cargo.toml
+++ b/fuzzers/frida/frida_libpng/Cargo.toml
@@ -17,7 +17,6 @@ debug = true
 [dependencies]
 libafl = { path = "../../../libafl/", features = [ "std", "llmp_compression",
     "llmp_bind_public", "frida_cli", "errors_backtrace" ] } #,  "llmp_small_maps", "llmp_debug"]}
-libafl_bolts = { path = "../../../libafl_bolts/" }
 frida-gum = { version = "0.13.6", features = ["auto-download", "event-sink", "invocation-listener"] }
 libafl_frida = { path = "../../../libafl_frida", features = ["cmplog"] }
 libafl_targets = { path = "../../../libafl_targets", features = ["sancov_cmplog"] }

--- a/fuzzers/frida/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/frida/frida_libpng/src/fuzzer.rs
@@ -4,6 +4,13 @@ use std::path::PathBuf;
 
 use frida_gum::Gum;
 use libafl::{
+    bolts::{
+        cli::{parse_args, FuzzerOptions},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::{launcher::Launcher, llmp::LlmpRestartingEventManager, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind, ShadowExecutor},
@@ -24,13 +31,6 @@ use libafl::{
 };
 #[cfg(unix)]
 use libafl::{feedback_and_fast, feedbacks::ConstFeedback};
-use libafl_bolts::{
-    cli::{parse_args, FuzzerOptions},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
-};
 #[cfg(unix)]
 use libafl_frida::asan::{
     asan_rt::AsanRuntime,

--- a/fuzzers/fuzzbench/fuzzbench/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench/Cargo.toml
@@ -26,7 +26,6 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "sancov_cmplog", "libfuzzer"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/fuzzbench/fuzzbench/src/lib.rs
+++ b/fuzzers/fuzzbench/fuzzbench/src/lib.rs
@@ -16,6 +16,14 @@ use std::{
 
 use clap::{Arg, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        os::dup2,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -38,14 +46,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    os::dup2,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use libafl_targets::autotokens;

--- a/fuzzers/fuzzbench/fuzzbench_ctx/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench_ctx/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "fuzzbench_ctx"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -26,8 +29,12 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "sancov_cmplog", "libfuzzer", "sancov_ctx"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "sancov_cmplog",
+    "libfuzzer",
+    "sancov_ctx",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 clap = { version = "4.5", features = ["default"] }

--- a/fuzzers/fuzzbench/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/fuzzbench/fuzzbench_ctx/src/lib.rs
@@ -16,6 +16,15 @@ use std::{
 
 use clap::{Arg, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        os::dup2,
+        ownedref::OwnedMutSlice,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
     executors::{
@@ -41,15 +50,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    os::dup2,
-    ownedref::OwnedMutSlice,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use libafl_targets::autotokens;

--- a/fuzzers/fuzzbench/fuzzbench_fork_qemu/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench_fork_qemu/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "fuzzbench_fork_qemu"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -21,8 +24,10 @@ strip = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_qemu = { path = "../../../libafl_qemu/", features = ["x86_64", "usermode"] }
+libafl_qemu = { path = "../../../libafl_qemu/", features = [
+    "x86_64",
+    "usermode",
+] }
 
 clap = { version = "4.5", features = ["default"] }
 nix = { version = "0.29", features = ["fs"] }

--- a/fuzzers/fuzzbench/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -14,6 +14,14 @@ use std::{
 
 use clap::{Arg, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        os::{dup2, unix_signals::Signal},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice, AsSliceMut,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
     executors::{ExitKind, ShadowExecutor},
@@ -36,14 +44,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    os::{dup2, unix_signals::Signal},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice, AsSliceMut,
 };
 use libafl_qemu::{
     command::NopCommandManager,

--- a/fuzzers/fuzzbench/fuzzbench_forkserver/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench_forkserver/Cargo.toml
@@ -21,7 +21,6 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/" }
 clap = { version = "4.5", features = ["default"] }
 nix = { version = "0.29", features = ["signal"] }

--- a/fuzzers/fuzzbench/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/fuzzbench/fuzzbench_forkserver/src/main.rs
@@ -9,6 +9,14 @@ use std::{
 
 use clap::{Arg, ArgAction, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        ownedref::OwnedRefMut,
+        rands::StdRand,
+        shmem::{ShMem, ShMemProvider, UnixShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSliceMut,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::forkserver::ForkserverExecutor,
@@ -33,14 +41,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    ownedref::OwnedRefMut,
-    rands::StdRand,
-    shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSliceMut,
 };
 use libafl_targets::cmps::AFLppCmpLogMap;
 use nix::sys::signal::Signal;

--- a/fuzzers/fuzzbench/fuzzbench_forkserver_cmplog/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench_forkserver_cmplog/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "fuzzbench_forkserver_cmplog"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [profile.release]
@@ -21,7 +24,6 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/" }
 clap = { version = "4.5", features = ["default"] }
 nix = { version = "0.29", features = ["signal"] }

--- a/fuzzers/fuzzbench/fuzzbench_forkserver_cmplog/src/main.rs
+++ b/fuzzers/fuzzbench/fuzzbench_forkserver_cmplog/src/main.rs
@@ -9,6 +9,14 @@ use std::{
 
 use clap::{Arg, ArgAction, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        ownedref::OwnedRefMut,
+        rands::StdRand,
+        shmem::{ShMem, ShMemProvider, UnixShMemProvider},
+        tuples::{tuple_list, Handled, Merge},
+        AsSliceMut,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::forkserver::ForkserverExecutor,
@@ -31,14 +39,6 @@ use libafl::{
     },
     state::{HasCorpus, HasCurrentTestcase, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    ownedref::OwnedRefMut,
-    rands::StdRand,
-    shmem::{ShMem, ShMemProvider, UnixShMemProvider},
-    tuples::{tuple_list, Handled, Merge},
-    AsSliceMut,
 };
 use libafl_targets::{
     cmps::{observers::AFLppCmpLogObserver, stages::AFLppCmplogTracingStage},

--- a/fuzzers/fuzzbench/fuzzbench_qemu/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench_qemu/Cargo.toml
@@ -21,7 +21,6 @@ strip = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_qemu = { path = "../../../libafl_qemu/", features = ["x86_64", "usermode"] }
 
 clap = { version = "4.5", features = ["default"] }

--- a/fuzzers/fuzzbench/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/fuzzbench/fuzzbench_qemu/src/fuzzer.rs
@@ -13,6 +13,15 @@ use std::{
 
 use clap::{Arg, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        os::{dup2, unix_signals::Signal},
+        ownedref::OwnedMutSlice,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
     executors::{ExitKind, ShadowExecutor},
@@ -35,15 +44,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    os::{dup2, unix_signals::Signal},
-    ownedref::OwnedMutSlice,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_qemu::{
     command::NopCommandManager,

--- a/fuzzers/fuzzbench/fuzzbench_text/Cargo.toml
+++ b/fuzzers/fuzzbench/fuzzbench_text/Cargo.toml
@@ -21,7 +21,6 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "sancov_cmplog", "libfuzzer"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/fuzzbench/fuzzbench_text/src/lib.rs
+++ b/fuzzers/fuzzbench/fuzzbench_text/src/lib.rs
@@ -17,6 +17,14 @@ use std::{
 use clap::{Arg, Command};
 use content_inspector::inspect;
 use libafl::{
+    bolts::{
+        current_time,
+        os::dup2,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -44,14 +52,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    os::dup2,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use libafl_targets::autotokens;

--- a/fuzzers/libpng/libfuzzer_libpng/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libfuzzer_libpng"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -23,8 +26,11 @@ which = "6.0"
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["default"] }
 # libafl = { path = "../../../libafl/", features = ["default"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+    "sancov_cmplog",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 mimalloc = { version = "*", default-features = false }

--- a/fuzzers/libpng/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng/src/lib.rs
@@ -6,6 +6,11 @@ use std::ptr;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{setup_restarting_mgr_std, EventConfig, EventRestarter},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -25,11 +30,6 @@ use libafl::{
     stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_FOUND};
 use mimalloc::MiMalloc;

--- a/fuzzers/libpng/libfuzzer_libpng_accounting/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng_accounting/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libfuzzer_libpng_accounting"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -19,9 +22,16 @@ cc = { version = "1.0", features = ["parallel"] }
 which = "6.0"
 
 [dependencies]
-libafl = { path = "../../../libafl/", features = ["std", "derive", "llmp_compression", "introspection"] }
-libafl_bolts = { path = "../../../libafl_bolts/", features = ["std", "derive", "llmp_compression"] }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer"] }
+libafl = { path = "../../../libafl/", features = [
+    "std",
+    "derive",
+    "llmp_compression",
+    "introspection",
+] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 clap = { version = "4.5", features = ["derive"] }

--- a/fuzzers/libpng/libfuzzer_libpng_accounting/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng_accounting/src/lib.rs
@@ -7,6 +7,13 @@ use std::{env, net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{EventConfig, Launcher},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -24,13 +31,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, ACCOUNTING_MEMOP_MAP, EDGES_MAP,

--- a/fuzzers/libpng/libfuzzer_libpng_centralized/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng_centralized/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libfuzzer_libpng_launcher_centralized"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -19,9 +22,21 @@ cc = { version = "1.0", features = ["parallel"] }
 which = "6.0"
 
 [dependencies]
-libafl = { path = "../../../libafl/", features = ["std", "derive", "rand_trait", "fork", "prelude", "gzip", "regex", "scalability_introspection"] }
-libafl_bolts = { path = "../../../libafl_bolts/", features = ["errors_backtrace"] }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer"] }
+libafl = { path = "../../../libafl/", features = [
+    "std",
+    "derive",
+    "rand_trait",
+    "fork",
+    "prelude",
+    "gzip",
+    "regex",
+    "scalability_introspection",
+    "errors_backtrace",
+] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 clap = { version = "4.5", features = ["derive"] }

--- a/fuzzers/libpng/libfuzzer_libpng_centralized/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng_centralized/src/lib.rs
@@ -7,6 +7,13 @@ use std::{env, net::SocketAddr, path::PathBuf};
 
 use clap::{self, Parser};
 use libafl::{
+    bolts::{
+        core_affinity::{CoreId, Cores},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{centralized::CentralizedEventManager, launcher::CentralizedLauncher, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -24,13 +31,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::{CoreId, Cores},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 use mimalloc::MiMalloc;

--- a/fuzzers/libpng/libfuzzer_libpng_cmin/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng_cmin/Cargo.toml
@@ -24,7 +24,6 @@ which = "6.0"
 env_logger = "0.10"
 libafl = { path = "../../../libafl/", features = ["default", "cmin"] }
 # libafl = { path = "../../../libafl/", features = ["default"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/libpng/libfuzzer_libpng_cmin/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng_cmin/src/lib.rs
@@ -6,6 +6,11 @@ use std::ptr;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{
         minimizer::{CorpusMinimizer, StdCorpusMinimizer},
         Corpus, InMemoryCorpus, OnDiskCorpus,
@@ -28,11 +33,6 @@ use libafl::{
     stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 use mimalloc::MiMalloc;

--- a/fuzzers/libpng/libfuzzer_libpng_launcher/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng_launcher/Cargo.toml
@@ -20,7 +20,6 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["std", "derive", "llmp_compression", "introspection"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/libpng/libfuzzer_libpng_launcher/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng_launcher/src/lib.rs
@@ -7,6 +7,13 @@ use std::{env, net::SocketAddr, path::PathBuf};
 
 use clap::{self, Parser};
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -24,13 +31,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 use mimalloc::MiMalloc;

--- a/fuzzers/libpng/libfuzzer_libpng_norestart/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng_norestart/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libfuzzer_libpng_launcher_norestart"
 version = "0.9.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -20,9 +23,11 @@ which = "6.0"
 
 [dependencies]
 env_logger = "0.10"
-libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/", features = ["errors_backtrace"] }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer"] }
+libafl = { path = "../../../libafl/", features = ["errors_backtrace"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 clap = { version = "4.5", features = ["derive"] }

--- a/fuzzers/libpng/libfuzzer_libpng_norestart/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng_norestart/src/lib.rs
@@ -8,6 +8,13 @@ use std::{env, net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        rands::StdRand,
+        shmem::{MmapShMemProvider, ShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::{
         launcher::Launcher, llmp::LlmpShouldSaveState, EventConfig, EventRestarter,
@@ -28,13 +35,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    rands::StdRand,
-    shmem::{MmapShMemProvider, ShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 use mimalloc::MiMalloc;

--- a/fuzzers/libpng/libfuzzer_libpng_tcp_manager/Cargo.toml
+++ b/fuzzers/libpng/libfuzzer_libpng_tcp_manager/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libfuzzer_libpng_tcp_manager"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -23,8 +26,11 @@ which = "6.0"
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["default", "tcp_manager"] }
 # libafl = { path = "../../../libafl/", features = ["default"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+    "sancov_cmplog",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 mimalloc = { version = "*", default-features = false }

--- a/fuzzers/libpng/libfuzzer_libpng_tcp_manager/src/lib.rs
+++ b/fuzzers/libpng/libfuzzer_libpng_tcp_manager/src/lib.rs
@@ -6,6 +6,11 @@ use std::ptr;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{tcp::setup_restarting_mgr_tcp, EventConfig, EventRestarter},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -25,11 +30,6 @@ use libafl::{
     stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, EDGES_MAP, MAX_EDGES_FOUND};
 use mimalloc::MiMalloc;

--- a/fuzzers/nyx/nyx_libxml2_parallel/Cargo.toml
+++ b/fuzzers/nyx/nyx_libxml2_parallel/Cargo.toml
@@ -6,7 +6,6 @@ default-run = "nyx_libxml2_parallel"
 
 [dependencies]
 libafl = { path = "../../../libafl" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_cc = { path = "../../../libafl_cc" }
 libafl_nyx = { path = "../../../libafl_nyx" }
 

--- a/fuzzers/nyx/nyx_libxml2_parallel/src/main.rs
+++ b/fuzzers/nyx/nyx_libxml2_parallel/src/main.rs
@@ -1,6 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use libafl::{
+    bolts::{
+        core_affinity::{CoreId, Cores},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+    },
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus, Testcase},
     events::{launcher::Launcher, EventConfig},
     feedbacks::{CrashFeedback, MaxMapFeedback},
@@ -12,12 +18,6 @@ use libafl::{
     stages::StdMutationalStage,
     state::StdState,
     Error, Fuzzer, StdFuzzer,
-};
-use libafl_bolts::{
-    core_affinity::{CoreId, Cores},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
 };
 use libafl_nyx::{executor::NyxExecutor, helper::NyxHelper, settings::NyxSettings};
 

--- a/fuzzers/nyx/nyx_libxml2_standalone/Cargo.toml
+++ b/fuzzers/nyx/nyx_libxml2_standalone/Cargo.toml
@@ -6,7 +6,6 @@ default-run = "nyx_libxml2_standalone"
 
 [dependencies]
 libafl = { path = "../../../libafl" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_cc = { path = "../../../libafl_cc" }
 libafl_nyx = { path = "../../../libafl_nyx" }
 

--- a/fuzzers/nyx/nyx_libxml2_standalone/src/main.rs
+++ b/fuzzers/nyx/nyx_libxml2_standalone/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list},
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus, Testcase},
     events::SimpleEventManager,
     feedbacks::{CrashFeedback, MaxMapFeedback},
@@ -13,7 +14,6 @@ use libafl::{
     state::StdState,
     Fuzzer, StdFuzzer,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 use libafl_nyx::{executor::NyxExecutor, helper::NyxHelper, settings::NyxSettings};
 
 fn main() {

--- a/fuzzers/others/dynamic_analysis/Cargo.toml
+++ b/fuzzers/others/dynamic_analysis/Cargo.toml
@@ -28,7 +28,6 @@ which = "6.0"
 env_logger = "0.11"
 once_cell = "1.19"
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "sancov_cmplog", "libfuzzer", "function-logging"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/others/dynamic_analysis/src/lib.rs
+++ b/fuzzers/others/dynamic_analysis/src/lib.rs
@@ -15,6 +15,15 @@ use std::{
 
 use clap::{Arg, Command};
 use libafl::{
+    bolts::{
+        current_time,
+        os::dup2,
+        ownedref::OwnedMutPtr,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
     executors::{inprocess::HookableInProcessExecutor, ExitKind},
@@ -37,15 +46,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    current_time,
-    os::dup2,
-    ownedref::OwnedMutPtr,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use libafl_targets::autotokens;

--- a/fuzzers/others/libafl-fuzz/Cargo.toml
+++ b/fuzzers/others/libafl-fuzz/Cargo.toml
@@ -6,11 +6,16 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 env_logger = "0.11.3"
-libafl = { path = "../../../libafl", features = ["std", "derive", "track_hit_feedbacks", "clap", "errors_backtrace"]}
-libafl_bolts = { path = "../../../libafl_bolts", features = ["std", "errors_backtrace"]}
-libafl_targets = { path = "../../../libafl_targets"}
+libafl = { path = "../../../libafl", features = [
+    "std",
+    "derive",
+    "track_hit_feedbacks",
+    "clap",
+    "errors_backtrace",
+] }
+libafl_targets = { path = "../../../libafl_targets" }
 memmap2 = "0.9.4"
-nix = {version = "0.29", features = ["fs"]}
+nix = { version = "0.29", features = ["fs"] }
 regex = "1.10.5"
 serde = { version = "1.0.117", features = ["derive"] }
 

--- a/fuzzers/others/libafl-fuzz/src/afl_stats.rs
+++ b/fuzzers/others/libafl-fuzz/src/afl_stats.rs
@@ -9,6 +9,13 @@ use std::{
 };
 
 use libafl::{
+    bolts::{
+        core_affinity::CoreId,
+        current_time,
+        os::peak_rss_mb_child_processes,
+        tuples::{Handle, Handled, MatchNameRef},
+        Named,
+    },
     corpus::{Corpus, HasCurrentCorpusId, HasTestcase, SchedulerTestcaseMetadata, Testcase},
     events::EventFirer,
     executors::HasObservers,
@@ -19,13 +26,6 @@ use libafl::{
     stages::{calibrate::UnstableEntriesMetadata, Stage},
     state::{HasCorpus, HasExecutions, HasImported, HasStartTime, Stoppable, UsesState},
     Error, HasMetadata, HasNamedMetadata, HasScheduler, SerdeAny,
-};
-use libafl_bolts::{
-    core_affinity::CoreId,
-    current_time,
-    os::peak_rss_mb_child_processes,
-    tuples::{Handle, Handled, MatchNameRef},
-    Named,
 };
 use serde::{Deserialize, Serialize};
 

--- a/fuzzers/others/libafl-fuzz/src/corpus.rs
+++ b/fuzzers/others/libafl-fuzz/src/corpus.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use libafl::{
+    bolts::current_time,
     corpus::{Corpus, Testcase},
     inputs::BytesInput,
     state::{HasCorpus, HasExecutions, HasStartTime},
     Error,
 };
-use libafl_bolts::current_time;
 use nix::{
     errno::Errno,
     fcntl::{Flock, FlockArg},

--- a/fuzzers/others/libafl-fuzz/src/env_parser.rs
+++ b/fuzzers/others/libafl-fuzz/src/env_parser.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
-use libafl::Error;
-use libafl_bolts::core_affinity::Cores;
+use libafl::{bolts::core_affinity::Cores, Error};
 
 use crate::Opt;
 

--- a/fuzzers/others/libafl-fuzz/src/feedback/filepath.rs
+++ b/fuzzers/others/libafl-fuzz/src/feedback/filepath.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use libafl::{
+    bolts::{Error, Named},
     corpus::Testcase,
     events::EventFirer,
     executors::ExitKind,
@@ -14,7 +15,6 @@ use libafl::{
     observers::ObserversTuple,
     state::State,
 };
-use libafl_bolts::{Error, Named};
 use serde::{Deserialize, Serialize};
 
 /// A [`CustomFilepathToTestcaseFeedback`] takes a closure which can set the file name and path for the testcase.

--- a/fuzzers/others/libafl-fuzz/src/feedback/persistent_record.rs
+++ b/fuzzers/others/libafl-fuzz/src/feedback/persistent_record.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use libafl::{
+    bolts::{Error, Named},
     corpus::{Corpus, Testcase},
     events::EventFirer,
     executors::ExitKind,
@@ -14,7 +15,6 @@ use libafl::{
     observers::ObserversTuple,
     state::{HasCorpus, State},
 };
-use libafl_bolts::{Error, Named};
 use serde::{Deserialize, Serialize};
 
 /// A [`PersitentRecordFeedback`] tracks the last N inputs that the fuzzer has run.

--- a/fuzzers/others/libafl-fuzz/src/feedback/seed.rs
+++ b/fuzzers/others/libafl-fuzz/src/feedback/seed.rs
@@ -1,10 +1,9 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use libafl::{
-    corpus::Testcase, events::EventFirer, executors::ExitKind, feedbacks::Feedback,
+    bolts::Named, corpus::Testcase, events::EventFirer, executors::ExitKind, feedbacks::Feedback,
     observers::ObserversTuple, state::State, Error,
 };
-use libafl_bolts::Named;
 
 use crate::Opt;
 

--- a/fuzzers/others/libafl-fuzz/src/fuzzer.rs
+++ b/fuzzers/others/libafl-fuzz/src/fuzzer.rs
@@ -1,6 +1,16 @@
 use std::{borrow::Cow, marker::PhantomData, path::PathBuf, time::Duration};
 
 use libafl::{
+    bolts::{
+        core_affinity::CoreId,
+        current_nanos, current_time,
+        fs::get_unique_std_input_file,
+        ownedref::OwnedRefMut,
+        rands::StdRand,
+        shmem::{ShMem, ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Handled, Merge},
+        AsSliceMut,
+    },
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::{
         CentralizedEventManager, EventManagerHooksTuple, EventProcessor,
@@ -28,16 +38,6 @@ use libafl::{
         UsesState,
     },
     Error, Fuzzer, HasFeedback, HasMetadata, SerdeAny,
-};
-use libafl_bolts::{
-    core_affinity::CoreId,
-    current_nanos, current_time,
-    fs::get_unique_std_input_file,
-    ownedref::OwnedRefMut,
-    rands::StdRand,
-    shmem::{ShMem, ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Handled, Merge},
-    AsSliceMut,
 };
 use libafl_targets::{cmps::AFLppCmpLogMap, AFLppCmpLogObserver, AFLppCmplogTracingStage};
 use serde::{Deserialize, Serialize};

--- a/fuzzers/others/libafl-fuzz/src/hooks.rs
+++ b/fuzzers/others/libafl-fuzz/src/hooks.rs
@@ -1,9 +1,9 @@
 use libafl::{
+    bolts::ClientId,
     events::{Event, EventManagerHook},
     state::{State, Stoppable},
     Error,
 };
-use libafl_bolts::ClientId;
 
 #[derive(Clone, Copy)]
 pub struct LibAflFuzzEventHook {

--- a/fuzzers/others/libafl-fuzz/src/main.rs
+++ b/fuzzers/others/libafl-fuzz/src/main.rs
@@ -22,14 +22,14 @@ mod hooks;
 use env_parser::parse_envs;
 use fuzzer::run_client;
 use libafl::{
+    bolts::{
+        core_affinity::{CoreId, Cores},
+        shmem::{ShMemProvider, StdShMemProvider},
+    },
     events::{CentralizedLauncher, EventConfig},
     monitors::MultiMonitor,
     schedulers::powersched::PowerSchedule,
     Error,
-};
-use libafl_bolts::{
-    core_affinity::{CoreId, Cores},
-    shmem::{ShMemProvider, StdShMemProvider},
 };
 use nix::sys::signal::Signal;
 

--- a/fuzzers/others/libafl-fuzz/src/scheduler.rs
+++ b/fuzzers/others/libafl-fuzz/src/scheduler.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use libafl::{
+    bolts::{serdeany::SerdeAny, AsIter, HasRefCnt},
     corpus::{Corpus, CorpusId, HasTestcase, SchedulerTestcaseMetadata, Testcase},
     inputs::UsesInput,
     observers::{CanTrack, ObserversTuple},
@@ -10,7 +11,6 @@ use libafl::{
     state::{HasCorpus, HasRand, State, UsesState},
     Error, HasMetadata,
 };
-use libafl_bolts::{serdeany::SerdeAny, AsIter, HasRefCnt};
 
 pub enum SupportedSchedulers<S, Q, CS, F, M, O> {
     Queue(Q, PhantomData<(S, Q, CS, F, M, O)>),

--- a/fuzzers/others/libafl-fuzz/src/stages/mutational_stage.rs
+++ b/fuzzers/others/libafl-fuzz/src/stages/mutational_stage.rs
@@ -1,13 +1,13 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use libafl::{
+    bolts::Named,
     inputs::Input,
     mutators::Mutator,
     stages::{mutational::MutatedTransform, MutationalStage, Stage},
     state::{HasCorpus, HasRand, State, UsesState},
     Error, Evaluator, HasNamedMetadata,
 };
-use libafl_bolts::Named;
 
 #[derive(Debug)]
 pub enum SupportedMutationalStages<S, SM, P, E, EM, M, I, Z> {

--- a/fuzzers/others/libafl-fuzz/src/stages/time_tracker.rs
+++ b/fuzzers/others/libafl-fuzz/src/stages/time_tracker.rs
@@ -1,12 +1,12 @@
 use std::{marker::PhantomData, time::Duration};
 
 use libafl::{
+    bolts::current_time,
     inputs::UsesInput,
     stages::Stage,
     state::{State, UsesState},
     HasMetadata,
 };
-use libafl_bolts::current_time;
 
 pub struct TimeTrackingStageWrapper<T, S, ST> {
     inner: ST,
@@ -38,7 +38,7 @@ where
     M: UsesState<State = S>,
     Z: UsesState<State = S>,
     E: UsesState<State = S>,
-    T: libafl_bolts::serdeany::SerdeAny + From<Duration>,
+    T: libafl::bolts::serdeany::SerdeAny + From<Duration>,
 {
     fn perform(
         &mut self,

--- a/fuzzers/others/libafl_atheris/Cargo.toml
+++ b/fuzzers/others/libafl_atheris/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libafl_atheris"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -20,8 +23,12 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["pointer_maps", "sancov_cmplog", "libfuzzer", "sancov_8bit"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "pointer_maps",
+    "sancov_cmplog",
+    "libfuzzer",
+    "sancov_8bit",
+] }
 clap = { version = "4.5", features = ["default"] }
 
 [lib]

--- a/fuzzers/others/libafl_atheris/src/lib.rs
+++ b/fuzzers/others/libafl_atheris/src/lib.rs
@@ -12,6 +12,13 @@ use std::{
 
 use clap::{Arg, ArgAction, Command};
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -30,13 +37,6 @@ use libafl::{
     stages::{StdMutationalStage, TracingStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{extra_counters, CmpLogObserver};
 

--- a/fuzzers/others/libfuzzer_libmozjpeg/Cargo.toml
+++ b/fuzzers/others/libfuzzer_libmozjpeg/Cargo.toml
@@ -16,7 +16,6 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_edges", "sancov_value_profile", "libfuzzer"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/others/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/others/libfuzzer_libmozjpeg/src/lib.rs
@@ -7,6 +7,11 @@ static GLOBAL: MiMalloc = MiMalloc;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{setup_restarting_mgr_std, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -24,11 +29,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer, CMP_MAP,

--- a/fuzzers/others/libfuzzer_windows_asan/Cargo.toml
+++ b/fuzzers/others/libfuzzer_windows_asan/Cargo.toml
@@ -15,7 +15,6 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["libfuzzer", "sancov_pcguard_edges"] }
 libafl_cc = { path = "../../../libafl_cc/" }
 

--- a/fuzzers/others/libfuzzer_windows_asan/src/lib.rs
+++ b/fuzzers/others/libfuzzer_windows_asan/src/lib.rs
@@ -2,6 +2,11 @@ use core::time::Duration;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{
+        rands::StdRand,
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{setup_restarting_mgr_std, EventConfig, EventRestarter},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -18,11 +23,6 @@ use libafl::{
     stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage},
     state::{HasCorpus, StdState},
     Error,
-};
-use libafl_bolts::{
-    rands::StdRand,
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 #[no_mangle]

--- a/fuzzers/others/nautilus_sync/Cargo.toml
+++ b/fuzzers/others/nautilus_sync/Cargo.toml
@@ -21,7 +21,6 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["default", "nautilus"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer"] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }

--- a/fuzzers/others/nautilus_sync/src/lib.rs
+++ b/fuzzers/others/nautilus_sync/src/lib.rs
@@ -8,6 +8,12 @@ use std::{env, net::SocketAddr, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+    },
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, llmp::LlmpEventConverter, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -25,12 +31,6 @@ use libafl::{
     stages::{mutational::StdMutationalStage, sync::SyncFromBrokerStage},
     state::StdState,
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 

--- a/fuzzers/others/sqlite_centralized_multi_machine/Cargo.toml
+++ b/fuzzers/others/sqlite_centralized_multi_machine/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "libfuzzer_libpng_launcher_centralized_multi_machine"
 version = "0.12.0"
-authors = ["Romain Malmain <romain.malmain@pm.me>", "Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Romain Malmain <romain.malmain@pm.me>",
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -20,9 +24,34 @@ which = "6.0"
 
 [dependencies]
 # no llmp compression for now, better perfs.
-libafl = { path = "../../../libafl", default-features = false, features = ["std", "derive", "llmp_small_maps", "llmp_broker_timeouts", "rand_trait", "fork", "prelude", "gzip", "regex", "serdeany_autoreg", "tui_monitor", "std", "derive", "rand_trait", "fork", "prelude", "gzip", "regex", "scalability_introspection", "multi_machine", "errors_backtrace"] }
+libafl = { path = "../../../libafl", default-features = false, features = [
+    "std",
+    "derive",
+    "llmp_small_maps",
+    "llmp_broker_timeouts",
+    "rand_trait",
+    "fork",
+    "prelude",
+    "gzip",
+    "regex",
+    "serdeany_autoreg",
+    "tui_monitor",
+    "std",
+    "derive",
+    "rand_trait",
+    "fork",
+    "prelude",
+    "gzip",
+    "regex",
+    "scalability_introspection",
+    "multi_machine",
+    "errors_backtrace",
+] }
 libafl_bolts = { path = "../../../libafl_bolts", features = ["xxh3"] }
-libafl_targets = { path = "../../../libafl_targets", features = ["sancov_pcguard_hitcounts", "libfuzzer"] }
+libafl_targets = { path = "../../../libafl_targets", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+] }
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc" }
 clap = { version = "4.5", features = ["derive"] }

--- a/fuzzers/others/sqlite_centralized_multi_machine/src/lib.rs
+++ b/fuzzers/others/sqlite_centralized_multi_machine/src/lib.rs
@@ -7,6 +7,13 @@ use std::{env, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use clap::{self, Parser};
 use libafl::{
+    bolts::{
+        core_affinity::{CoreId, Cores},
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::{tuple_list, Merge},
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{
         centralized::CentralizedEventManager, launcher::CentralizedLauncher,
@@ -27,13 +34,6 @@ use libafl::{
     stages::mutational::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error, HasMetadata,
-};
-use libafl_bolts::{
-    core_affinity::{CoreId, Cores},
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::{tuple_list, Merge},
-    AsSlice,
 };
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 use mimalloc::MiMalloc;

--- a/fuzzers/others/tinyinst_simple/Cargo.toml
+++ b/fuzzers/others/tinyinst_simple/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 libafl = { path = "../../../libafl", features = ["introspection"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_tinyinst = { path = "../../../libafl_tinyinst" }
 
 [profile.release]

--- a/fuzzers/others/tinyinst_simple/src/main.rs
+++ b/fuzzers/others/tinyinst_simple/src/main.rs
@@ -1,6 +1,11 @@
 use std::{path::PathBuf, ptr::addr_of_mut, time::Duration};
 
+#[cfg(unix)]
+use libafl::bolts::shmem::UnixShMemProvider;
+#[cfg(windows)]
+use libafl::bolts::shmem::Win32ShMemProvider;
 use libafl::{
+    bolts::{ownedref::OwnedMutPtr, rands::StdRand, shmem::ShMemProvider, tuples::tuple_list},
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus, Testcase},
     events::SimpleEventManager,
     feedbacks::{CrashFeedback, ListFeedback},
@@ -12,13 +17,6 @@ use libafl::{
     stages::StdMutationalStage,
     state::StdState,
     Fuzzer, StdFuzzer,
-};
-#[cfg(unix)]
-use libafl_bolts::shmem::UnixShMemProvider;
-#[cfg(windows)]
-use libafl_bolts::shmem::Win32ShMemProvider;
-use libafl_bolts::{
-    ownedref::OwnedMutPtr, rands::StdRand, shmem::ShMemProvider, tuples::tuple_list,
 };
 use libafl_tinyinst::executor::TinyInstExecutor;
 static mut COVERAGE: Vec<u64> = vec![];

--- a/fuzzers/others/tutorial/Cargo.toml
+++ b/fuzzers/others/tutorial/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tutorial"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -20,10 +23,17 @@ which = "6.0"
 
 [dependencies]
 libafl = { path = "../../../libafl/", features = ["default", "rand_trait"] }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_hitcounts", "libfuzzer", "sancov_cmplog"] }
-serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib
-lain = { version = "0.5", features = ["serde_support"], git = "https://github.com/AFLplusplus/lain.git", rev = "208e927bcf411f62f8a1f51ac2d9f9423a1ec5d3" } # We're using a lain fork compatible with libafl's rand version
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_hitcounts",
+    "libfuzzer",
+    "sancov_cmplog",
+] }
+serde = { version = "1.0", default-features = false, features = [
+    "alloc",
+] } # serialization lib
+lain = { version = "0.5", features = [
+    "serde_support",
+], git = "https://github.com/AFLplusplus/lain.git", rev = "208e927bcf411f62f8a1f51ac2d9f9423a1ec5d3" } # We're using a lain fork compatible with libafl's rand version
 # TODO Include it only when building cc
 libafl_cc = { path = "../../../libafl_cc/" }
 

--- a/fuzzers/others/tutorial/src/input.rs
+++ b/fuzzers/others/tutorial/src/input.rs
@@ -2,10 +2,10 @@ use std::hash::Hash;
 
 use lain::prelude::*;
 use libafl::{
+    bolts::{ownedref::OwnedSlice, HasLen},
     corpus::CorpusId,
     inputs::{HasTargetBytes, Input},
 };
-use libafl_bolts::{ownedref::OwnedSlice, HasLen};
 use serde::{Deserialize, Serialize};
 
 #[derive(

--- a/fuzzers/others/tutorial/src/lib.rs
+++ b/fuzzers/others/tutorial/src/lib.rs
@@ -7,6 +7,7 @@ use core::time::Duration;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{setup_restarting_mgr_std, EventConfig, EventRestarter},
     executors::{inprocess::InProcessExecutor, ExitKind},
@@ -21,7 +22,6 @@ use libafl::{
     state::{HasCorpus, StdState},
     Error, Fuzzer,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer};
 
 mod input;

--- a/fuzzers/others/tutorial/src/metadata.rs
+++ b/fuzzers/others/tutorial/src/metadata.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use libafl::{
+    bolts::{Named, SerdeAny},
     corpus::Testcase,
     events::EventFirer,
     executors::ExitKind,
@@ -10,7 +11,6 @@ use libafl::{
     state::{HasCorpus, State},
     Error, HasMetadata,
 };
-use libafl_bolts::{Named, SerdeAny};
 use serde::{Deserialize, Serialize};
 
 use crate::input::PacketData;

--- a/fuzzers/others/tutorial/src/mutator.rs
+++ b/fuzzers/others/tutorial/src/mutator.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 
 use lain::traits::Mutatable;
 use libafl::{
+    bolts::{
+        rands::{Rand, StdRand},
+        Named,
+    },
     mutators::{MutationResult, Mutator},
     state::HasRand,
     Error,
-};
-use libafl_bolts::{
-    rands::{Rand, StdRand},
-    Named,
 };
 
 use crate::input::PacketData;

--- a/fuzzers/qemu/qemu_cmin/Cargo.toml
+++ b/fuzzers/qemu/qemu_cmin/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "qemu_cmin"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>", "WorksButNotTested"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+    "WorksButNotTested",
+]
 edition = "2021"
 
 [profile.release]
@@ -22,12 +26,18 @@ mips = ["libafl_qemu/mips"]
 ppc = ["libafl_qemu/ppc", "be"]
 
 [build-dependencies]
-vergen = { version = "8.2.1", features = ["build", "cargo", "git", "gitcl", "rustc", "si"] }
+vergen = { version = "8.2.1", features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+    "si",
+] }
 
 [dependencies]
-clap = { version = "4.5", features = ["derive", "string"]}
+clap = { version = "4.5", features = ["derive", "string"] }
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_qemu = { path = "../../../libafl_qemu/", features = ["usermode"] }
-log = {version = "0.4.20" }
+log = { version = "0.4.20" }
 rangemap = { version = "1.3" }

--- a/fuzzers/qemu/qemu_cmin/src/fuzzer.rs
+++ b/fuzzers/qemu/qemu_cmin/src/fuzzer.rs
@@ -6,6 +6,14 @@ use std::{env, io, path::PathBuf, process};
 
 use clap::{builder::Str, Parser};
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        os::unix_signals::Signal,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+        AsSlice, AsSliceMut,
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, NopCorpus},
     events::{EventRestarter, SimpleRestartingEventManager},
     executors::ExitKind,
@@ -17,14 +25,6 @@ use libafl::{
     schedulers::QueueScheduler,
     state::{HasCorpus, StdState},
     Error,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    os::unix_signals::Signal,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
-    AsSlice, AsSliceMut,
 };
 use libafl_qemu::{
     command::NopCommandManager,

--- a/fuzzers/qemu/qemu_coverage/Cargo.toml
+++ b/fuzzers/qemu/qemu_coverage/Cargo.toml
@@ -27,7 +27,6 @@ vergen = { version = "8.2.1", features = ["build", "cargo", "git", "gitcl", "rus
 [dependencies]
 clap = { version = "4.5", features = ["derive", "string"]}
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
 libafl_qemu = { path = "../../../libafl_qemu/", features = ["usermode"] }
 log = {version = "0.4.20" }
 rangemap = { version = "1.3" }

--- a/fuzzers/qemu/qemu_coverage/src/fuzzer.rs
+++ b/fuzzers/qemu/qemu_coverage/src/fuzzer.rs
@@ -7,6 +7,14 @@ use std::{env, fs::DirEntry, io, path::PathBuf, process};
 
 use clap::{builder::Str, Parser};
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        os::unix_signals::Signal,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+        AsSlice,
+    },
     corpus::{Corpus, NopCorpus},
     events::{launcher::Launcher, EventConfig, EventRestarter, LlmpRestartingEventManager},
     executors::ExitKind,
@@ -16,14 +24,6 @@ use libafl::{
     schedulers::QueueScheduler,
     state::{HasCorpus, StdState},
     Error,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    os::unix_signals::Signal,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
-    AsSlice,
 };
 use libafl_qemu::{
     command::NopCommandManager,

--- a/fuzzers/qemu/qemu_launcher/Cargo.toml
+++ b/fuzzers/qemu/qemu_launcher/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "qemu_launcher"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
@@ -33,14 +36,20 @@ opt-level = 3
 debug = true
 
 [build-dependencies]
-vergen = { version = "8.2", features = ["build", "cargo", "git", "gitcl", "rustc", "si"] }
+vergen = { version = "8.2", features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+    "si",
+] }
 
 [dependencies]
-clap = { version = "4.3", features = ["derive", "string"]}
-libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/", features = ["errors_backtrace"] }
+clap = { version = "4.3", features = ["derive", "string"] }
+libafl = { path = "../../../libafl/", features = ["errors_backtrace"] }
 libafl_qemu = { path = "../../../libafl_qemu/", features = ["usermode"] }
-log = {version = "0.4.20" }
+log = { version = "0.4.20" }
 nix = { version = "0.29", features = ["fs"] }
 rangemap = { version = "1.3" }
 readonly = { version = "0.2.10" }

--- a/fuzzers/qemu/qemu_launcher/src/client.rs
+++ b/fuzzers/qemu/qemu_launcher/src/client.rs
@@ -1,13 +1,13 @@
 use std::{env, ops::Range};
 
 use libafl::{
+    bolts::{core_affinity::CoreId, rands::StdRand, tuples::tuple_list},
     corpus::{InMemoryOnDiskCorpus, OnDiskCorpus},
     inputs::BytesInput,
     monitors::Monitor,
     state::StdState,
     Error,
 };
-use libafl_bolts::{core_affinity::CoreId, rands::StdRand, tuples::tuple_list};
 #[cfg(feature = "injections")]
 use libafl_qemu::modules::injections::InjectionModule;
 use libafl_qemu::{

--- a/fuzzers/qemu/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/qemu/qemu_launcher/src/fuzzer.rs
@@ -6,18 +6,18 @@ use std::{
 
 use clap::Parser;
 #[cfg(feature = "simplemgr")]
+use libafl::bolts::core_affinity::CoreId;
+#[cfg(not(feature = "simplemgr"))]
+use libafl::bolts::shmem::{ShMemProvider, StdShMemProvider};
+#[cfg(feature = "simplemgr")]
 use libafl::events::SimpleEventManager;
 #[cfg(not(feature = "simplemgr"))]
 use libafl::events::{EventConfig, Launcher, MonitorTypedEventManager};
 use libafl::{
+    bolts::current_time,
     monitors::{tui::TuiMonitor, Monitor, MultiMonitor},
     Error,
 };
-#[cfg(feature = "simplemgr")]
-use libafl_bolts::core_affinity::CoreId;
-use libafl_bolts::current_time;
-#[cfg(not(feature = "simplemgr"))]
-use libafl_bolts::shmem::{ShMemProvider, StdShMemProvider};
 #[cfg(unix)]
 use {
     nix::unistd::dup,

--- a/fuzzers/qemu/qemu_launcher/src/harness.rs
+++ b/fuzzers/qemu/qemu_launcher/src/harness.rs
@@ -1,9 +1,9 @@
 use libafl::{
+    bolts::AsSlice,
     executors::ExitKind,
     inputs::{BytesInput, HasTargetBytes},
     Error,
 };
-use libafl_bolts::AsSlice;
 use libafl_qemu::{ArchExtras, CallingConvention, GuestAddr, GuestReg, MmapPerms, Qemu, Regs};
 
 pub struct Harness<'a> {

--- a/fuzzers/qemu/qemu_launcher/src/instance.rs
+++ b/fuzzers/qemu/qemu_launcher/src/instance.rs
@@ -1,11 +1,19 @@
 use core::{fmt::Debug, ptr::addr_of_mut};
 use std::{marker::PhantomData, process};
 
+#[cfg(not(feature = "simplemgr"))]
+use libafl::bolts::shmem::StdShMemProvider;
 #[cfg(feature = "simplemgr")]
 use libafl::events::SimpleEventManager;
 #[cfg(not(feature = "simplemgr"))]
 use libafl::events::{LlmpRestartingEventManager, MonitorTypedEventManager};
 use libafl::{
+    bolts::{
+        core_affinity::CoreId,
+        ownedref::OwnedMutSlice,
+        rands::StdRand,
+        tuples::{tuple_list, Merge},
+    },
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::EventRestarter,
     executors::ShadowExecutor,
@@ -28,14 +36,6 @@ use libafl::{
     },
     state::{HasCorpus, StdState, UsesState},
     Error, HasMetadata,
-};
-#[cfg(not(feature = "simplemgr"))]
-use libafl_bolts::shmem::StdShMemProvider;
-use libafl_bolts::{
-    core_affinity::CoreId,
-    ownedref::OwnedMutSlice,
-    rands::StdRand,
-    tuples::{tuple_list, Merge},
 };
 use libafl_qemu::{
     command::NopCommandManager,

--- a/fuzzers/qemu/qemu_launcher/src/options.rs
+++ b/fuzzers/qemu/qemu_launcher/src/options.rs
@@ -2,8 +2,10 @@ use core::time::Duration;
 use std::{env, ops::Range, path::PathBuf};
 
 use clap::{error::ErrorKind, CommandFactory, Parser};
-use libafl::Error;
-use libafl_bolts::core_affinity::{CoreId, Cores};
+use libafl::{
+    bolts::core_affinity::{CoreId, Cores},
+    Error,
+};
 use libafl_qemu::GuestAddr;
 
 use crate::version::Version;

--- a/fuzzers/qemu/qemu_systemmode/Cargo.toml
+++ b/fuzzers/qemu/qemu_systemmode/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
 name = "qemu_systemmode"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 
 [features]
 default = ["std", "classic"]
 std = []
 
-classic = [] # The classic way to interact with LibAFL QEMU, with direct calls to QEMU's functions
-breakpoint = [] # Uses the command system, with breakpoints
-sync_exit = [] # Uses the command system, with sync exit.
+# The classic way to interact with LibAFL QEMU, with direct calls to QEMU's functions
+classic = []
+# Uses the command system, with breakpoints
+breakpoint = []
+# Uses the command system, with sync exit.
+sync_exit = []
 
 shared = ["libafl_qemu/shared"]
 
@@ -22,9 +28,14 @@ codegen-units = 1
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_qemu = { path = "../../../libafl_qemu/", features = ["arm", "systemmode"] }
-libafl_qemu_sys = { path = "../../../libafl_qemu/libafl_qemu_sys", features = ["arm", "systemmode"] }
+libafl_qemu = { path = "../../../libafl_qemu/", features = [
+    "arm",
+    "systemmode",
+] }
+libafl_qemu_sys = { path = "../../../libafl_qemu/libafl_qemu_sys", features = [
+    "arm",
+    "systemmode",
+] }
 env_logger = "*"
 
 [build-dependencies]

--- a/fuzzers/qemu/qemu_systemmode/src/fuzzer_breakpoint.rs
+++ b/fuzzers/qemu/qemu_systemmode/src/fuzzer_breakpoint.rs
@@ -4,6 +4,14 @@ use core::{ptr::addr_of_mut, time::Duration};
 use std::{env, path::PathBuf, process};
 
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        current_nanos,
+        ownedref::OwnedMutSlice,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig},
     executors::ExitKind,
@@ -18,14 +26,6 @@ use libafl::{
     stages::{CalibrationStage, StdMutationalStage},
     state::{HasCorpus, StdState},
     Error,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    current_nanos,
-    ownedref::OwnedMutSlice,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
 };
 use libafl_qemu::{
     breakpoint::Breakpoint,

--- a/fuzzers/qemu/qemu_systemmode/src/fuzzer_classic.rs
+++ b/fuzzers/qemu/qemu_systemmode/src/fuzzer_classic.rs
@@ -4,6 +4,16 @@ use core::{ptr::addr_of_mut, time::Duration};
 use std::{env, path::PathBuf, process};
 
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        current_nanos,
+        os::unix_signals::{Signal, CTRL_C_EXIT},
+        ownedref::OwnedMutSlice,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+        AsSlice,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig},
     executors::ExitKind,
@@ -18,16 +28,6 @@ use libafl::{
     stages::StdMutationalStage,
     state::{HasCorpus, StdState},
     Error,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    current_nanos,
-    os::unix_signals::{Signal, CTRL_C_EXIT},
-    ownedref::OwnedMutSlice,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
-    AsSlice,
 };
 use libafl_qemu::{
     command::NopCommandManager,

--- a/fuzzers/qemu/qemu_systemmode/src/fuzzer_sync_exit.rs
+++ b/fuzzers/qemu/qemu_systemmode/src/fuzzer_sync_exit.rs
@@ -4,6 +4,14 @@ use core::{ptr::addr_of_mut, time::Duration};
 use std::{env, path::PathBuf, process};
 
 use libafl::{
+    bolts::{
+        core_affinity::Cores,
+        current_nanos,
+        ownedref::OwnedMutSlice,
+        rands::StdRand,
+        shmem::{ShMemProvider, StdShMemProvider},
+        tuples::tuple_list,
+    },
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig},
     feedback_or, feedback_or_fast,
@@ -17,14 +25,6 @@ use libafl::{
     stages::{CalibrationStage, StdMutationalStage},
     state::{HasCorpus, StdState},
     Error,
-};
-use libafl_bolts::{
-    core_affinity::Cores,
-    current_nanos,
-    ownedref::OwnedMutSlice,
-    rands::StdRand,
-    shmem::{ShMemProvider, StdShMemProvider},
-    tuples::tuple_list,
 };
 use libafl_qemu::{
     command::StdCommandManager,

--- a/fuzzers/stb/libfuzzer_stb_image/Cargo.toml
+++ b/fuzzers/stb/libfuzzer_stb_image/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libfuzzer_stb_image"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 build = "build.rs"
 
@@ -17,8 +20,12 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_edges", "sancov_cmplog", "libfuzzer", "libfuzzer_no_link_main"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_edges",
+    "sancov_cmplog",
+    "libfuzzer",
+    "libfuzzer_no_link_main",
+] }
 mimalloc = { version = "*", default-features = false }
 
 [build-dependencies]

--- a/fuzzers/stb/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/stb/libfuzzer_stb_image/src/main.rs
@@ -7,6 +7,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 use std::{env, path::PathBuf};
 
 use libafl::{
+    bolts::{rands::StdRand, tuples::tuple_list, AsSlice},
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{setup_restarting_mgr_std, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind, ShadowExecutor},
@@ -25,7 +26,6 @@ use libafl::{
     state::{HasCorpus, StdState},
     Error,
 };
-use libafl_bolts::{rands::StdRand, tuples::tuple_list, AsSlice};
 use libafl_targets::{
     libfuzzer_initialize, libfuzzer_test_one_input, std_edges_map_observer, CmpLogObserver,
 };

--- a/fuzzers/stb/libfuzzer_stb_image_sugar/Cargo.toml
+++ b/fuzzers/stb/libfuzzer_stb_image_sugar/Cargo.toml
@@ -1,10 +1,19 @@
 [package]
 name = "libfuzzer_stb_image_sugar"
 version = "0.13.0"
-authors = ["Andrea Fioraldi <andreafioraldi@gmail.com>", "Dominik Maier <domenukk@gmail.com>"]
+authors = [
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
+]
 edition = "2021"
 build = "build.rs"
-categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
+categories = [
+    "development-tools::testing",
+    "emulators",
+    "embedded",
+    "os",
+    "no-std",
+]
 
 [features]
 default = ["std"]
@@ -18,8 +27,11 @@ debug = true
 
 [dependencies]
 libafl = { path = "../../../libafl/" }
-libafl_bolts = { path = "../../../libafl_bolts/" }
-libafl_targets = { path = "../../../libafl_targets/", features = ["sancov_pcguard_edges", "sancov_cmplog", "libfuzzer"] }
+libafl_targets = { path = "../../../libafl_targets/", features = [
+    "sancov_pcguard_edges",
+    "sancov_cmplog",
+    "libfuzzer",
+] }
 libafl_sugar = { path = "../../../libafl_sugar/" }
 mimalloc = { version = "*", default-features = false }
 

--- a/fuzzers/stb/libfuzzer_stb_image_sugar/src/main.rs
+++ b/fuzzers/stb/libfuzzer_stb_image_sugar/src/main.rs
@@ -6,7 +6,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 use std::{env, path::PathBuf};
 
-use libafl_bolts::core_affinity::Cores;
+use libafl::bolts::core_affinity::Cores;
 use libafl_sugar::InMemoryBytesCoverageSugar;
 use libafl_targets::{libfuzzer_initialize, libfuzzer_test_one_input};
 

--- a/libafl/src/lib.rs
+++ b/libafl/src/lib.rs
@@ -110,6 +110,7 @@ pub mod stages;
 pub mod state;
 
 pub use fuzzer::*;
+pub use libafl_bolts as bolts;
 pub use libafl_bolts::Error;
 
 /// The purpose of this module is to alleviate imports of many components by adding a glob import.

--- a/libafl_derive/src/lib.rs
+++ b/libafl_derive/src/lib.rs
@@ -66,6 +66,6 @@ use syn::{parse_macro_input, DeriveInput};
 pub fn libafl_serdeany_derive(input: TokenStream) -> TokenStream {
     let name = parse_macro_input!(input as DeriveInput).ident;
     TokenStream::from(quote! {
-        libafl_bolts::impl_serdeany!(#name);
+        libafl::bolts::impl_serdeany!(#name);
     })
 }

--- a/libafl_nyx/Cargo.toml
+++ b/libafl_nyx/Cargo.toml
@@ -9,15 +9,32 @@ repository = "https://github.com/AFLplusplus/LibAFL/"
 readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
-categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
+categories = [
+    "development-tools::testing",
+    "emulators",
+    "embedded",
+    "os",
+    "no-std",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libnyx = { git = "https://github.com/nyx-fuzz/libnyx.git", rev = "6833d236dfe785a8a23d8c8d79e74c99fa635004" }
-libafl = { path = "../libafl", version = "0.13.2", features = ["std", "libafl_derive", "frida_cli" ]}
-libafl_bolts = { path = "../libafl_bolts", version = "0.13.2", features = ["std", "libafl_derive", "frida_cli" ]}
-libafl_targets = { path = "../libafl_targets", version = "0.13.2", features = ["std", "sancov_cmplog"] }
+libafl = { path = "../libafl", version = "0.13.2", features = [
+    "std",
+    "derive",
+    "frida_cli",
+] }
+libafl_bolts = { path = "../libafl_bolts", version = "0.13.2", features = [
+    "std",
+    "derive",
+    "frida_cli",
+] }
+libafl_targets = { path = "../libafl_targets", version = "0.13.2", features = [
+    "std",
+    "sancov_cmplog",
+] }
 
 nix = { version = "0.29", features = ["fs"] }
 typed-builder = "0.18"

--- a/libafl_tinyinst/Cargo.toml
+++ b/libafl_tinyinst/Cargo.toml
@@ -2,9 +2,18 @@
 name = "libafl_tinyinst"
 version = "0.13.2"
 edition = "2021"
-authors = ["elbiazo <eric.l.biazo@gmail.com>", "Dongjia Zhang <tokazerkje@outlook.com>"]
+authors = [
+    "elbiazo <eric.l.biazo@gmail.com>",
+    "Dongjia Zhang <tokazerkje@outlook.com>",
+]
 repository = "https://github.com/AFLplusplus/LibAFL/"
-categories = ["development-tools::testing", "emulators", "embedded", "os", "no-std"]
+categories = [
+    "development-tools::testing",
+    "emulators",
+    "embedded",
+    "os",
+    "no-std",
+]
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
 description = "TinyInst backend for libafl"
@@ -14,11 +23,11 @@ description = "TinyInst backend for libafl"
 [dependencies]
 libafl = { path = "../libafl", version = "0.13.2", features = [
     "std",
-    "libafl_derive",
+    "derive",
 ] }
 libafl_bolts = { path = "../libafl_bolts", version = "0.13.2", features = [
     "std",
-    "libafl_derive",
+    "derive",
 ] }
 tinyinst = { git = "https://github.com/AFLplusplus/tinyinst-rs" }
 # tinyinst-rs = { path = "../../tinyinst-rs" }


### PR DESCRIPTION
Hi,

`libafl_bolts` is an unconditional dependency and is used by most downstream users of the main `libafl` crate. In many cases (_and my usage of LibAFL_), bolts and libafl are the only two crates that fuzzers depend on. Re-exporting bolts from libafl would simplify the dependencies section of these.

I guess a potential downside would be that specifying features in the main crate instead of bolts makes them slightly less descriptive?

Note: My `.toml` formatter decided that most of the lines are too long. Let me know if you'd like me to undo those changes. (That's where the additional lines are coming from)