### PR TITLE
frida: make hooks thread local

### DIFF
--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -95,7 +95,7 @@ pub const ASAN_SAVE_REGISTER_NAMES: [&str; ASAN_SAVE_REGISTER_COUNT] = [
 ];
 
 thread_local! {
-    static ASAN_IN_HOOK: Cell<bool> = Cell::new(false);
+    static ASAN_IN_HOOK: Cell<bool> = const { Cell::new(false) };
 }
 
 /// The count of registers that need to be saved by the asan runtime

--- a/libafl_frida/src/asan/asan_rt.rs
+++ b/libafl_frida/src/asan/asan_rt.rs
@@ -11,7 +11,11 @@ use core::{
     ptr::addr_of_mut,
 };
 use std::{
-    cell::Cell, ffi::{c_char, c_void}, ptr::write_volatile, rc::Rc, sync::MutexGuard
+    cell::Cell,
+    ffi::{c_char, c_void},
+    ptr::write_volatile,
+    rc::Rc,
+    sync::MutexGuard,
 };
 
 use backtrace::Backtrace;


### PR DESCRIPTION
This attempts to fix multi-threaded target issues with hooking, by making sure that the 'recursion blocker' is thread local, instead of using the global `hooks_enabled` variable.