### PR TITLE
libafl: Implement FeedbackFactory for {Const,Not}Feedback

### DIFF
--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -1289,6 +1289,12 @@ impl From<ConstFeedback> for bool {
     }
 }
 
+impl<T> FeedbackFactory<ConstFeedback, T> for ConstFeedback {
+    fn create_feedback(&self, _ctx: &T) -> ConstFeedback {
+        *self
+    }
+}
+
 #[cfg(feature = "track_hit_feedbacks")]
 /// Error if [`Feedback::last_result`] is called before the `Feedback` is actually run.
 pub(crate) fn premature_last_result_err() -> Error {

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -818,6 +818,16 @@ where
     }
 }
 
+impl<A, S, T> FeedbackFactory<NotFeedback<A, S>, T> for NotFeedback<A, S>
+where
+    A: Feedback<S> + FeedbackFactory<A, T>,
+    S: State,
+{
+    fn create_feedback(&self, ctx: &T) -> NotFeedback<A, S> {
+        NotFeedback::new(self.first.create_feedback(ctx))
+    }
+}
+
 impl<A, S> NotFeedback<A, S>
 where
     A: Feedback<S>,


### PR DESCRIPTION
It is currently not possible to use a `NotFeedback` or `ConstFeedback` (or a combination thereof) for a `StdTMinMutationalStage`, because both of these feedback types do not implement `FeedbackFactory`.

This PR implements `FeedbackFactory` for both.