### PR TITLE
Uniform deps versions: do not use caret requirements

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -150,7 +150,7 @@ serde_json = { version = "1.0", optional = true, default-features = false, featu
   "alloc",
 ] }
 miniz_oxide = { version = "0.7.1", optional = true }
-hostname = { version = "^0.4", optional = true } # Is there really no gethostname in the stdlib?
+hostname = { version = "0.4", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.6", optional = true }
 nix = { version = "0.29", default-features = false, optional = true, features = [
   "signal",


### PR DESCRIPTION
> Caret requirements are the default version requirement strategy, it is recommended to use the simplified syntax when possible. [Source](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)