### PR TITLE
Minimizer fix

### DIFF
--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -231,10 +231,14 @@ where
                     .scheduler_mut()
                     .on_remove(state, idx, &Some(removed))?;
             }
+
+            *state.corpus().current() = None;
             Ok(())
         } else {
             Err(Error::unknown("Corpus minimization failed; unsat."))
         };
+
+        
 
         res
     }

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -232,7 +232,7 @@ where
                     .on_remove(state, idx, &Some(removed))?;
             }
 
-            *state.corpus().current() = None;
+            *state.corpus_mut().current_mut() = None; //we may have removed the current ID from the corpus
             Ok(())
         } else {
             Err(Error::unknown("Corpus minimization failed; unsat."))

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -238,8 +238,6 @@ where
             Err(Error::unknown("Corpus minimization failed; unsat."))
         };
 
-        
-
         res
     }
 }


### PR DESCRIPTION
There is an issue in the interaction between StdWeightedScheduler and CorpusMinimizers. 

StdWeightedScheduler calls [on_next_metadata](https://docs.rs/libafl/latest/src/libafl/schedulers/mod.rs.html#143) which in turns calls `state.corpus().current()`. Because the current entry is not made None, the current could be outdated. 

