### PR TITLE
Small improvements to the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 	// "forwardPorts": [],
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
 	// Install development components that shouldn't be in the main Dockerfile
-	"postCreateCommand": "rustup component add --toolchain nightly rustfmt clippy llvm-tools-preview && cargo install --locked cargo-make",
+	"postCreateCommand": "rustup component add --toolchain nightly rustfmt clippy llvm-tools-preview && cargo binstall --locked cargo-make",
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,10 @@
 	"customizations": {
 		"vscode": {
 			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": ["matklad.rust-analyzer", "microsoft.Docker"],
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"microsoft.Docker"
+			],
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"rust-analyzer.cargo.noDefaultFeatures": true

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt update && apt install -y build-essential gdb git wget python3-venv ninja
 RUN set -ex &&\
     wget https://apt.llvm.org/llvm.sh &&\
     chmod +x llvm.sh &&\
-    ./llvm.sh
+    ./llvm.sh ${LLVM_VERSION}
 
 
 # Copy a dummy.rs and Cargo.toml first, so that dependencies are cached
@@ -37,6 +37,10 @@ COPY scripts/dummy.rs libafl_derive/src/lib.rs
 
 COPY libafl/Cargo.toml libafl/build.rs libafl/README.md libafl/
 COPY scripts/dummy.rs libafl/src/lib.rs
+
+# Set up LLVM aliases
+COPY scripts/createAliases.sh libafl/
+RUN bash libafl/createAliases.sh
 
 COPY libafl_bolts/Cargo.toml libafl_bolts/build.rs libafl_bolts/README.md libafl_bolts/
 COPY libafl_bolts/examples libafl_bolts/examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM rust:1.76.0 AS libafl
 LABEL "maintainer"="afl++ team <afl@aflplus.plus>"
 LABEL "about"="LibAFL Docker image"
 
+# Install cargo-binstall to download the sccache build
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 # install sccache to cache subsequent builds of dependencies
-RUN cargo install --locked sccache
+RUN cargo binstall --no-confirm sccache
 
 ENV HOME=/root
 ENV SCCACHE_CACHE_SIZE="1G"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,11 @@ RUN rustup component add rustfmt clippy
 # Install clang 18, common build tools
 ENV LLVM_VERSION=18
 RUN apt update && apt install -y build-essential gdb git wget python3-venv ninja-build lsb-release software-properties-common gnupg cmake
-# Workaround until https://github.com/llvm/llvm-project/issues/62475 is resolved
 RUN set -ex &&\
-    echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/apt.llvm.org.list &&\
-    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key |  tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&\
-    apt update &&\
-    apt-get install -y clang-${LLVM_VERSION} lldb-${LLVM_VERSION} lld-${LLVM_VERSION} clangd-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} clang-format-${LLVM_VERSION} clang-tools-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev lld-${LLVM_VERSION} lldb-${LLVM_VERSION} llvm-${LLVM_VERSION}-tools libomp-${LLVM_VERSION}-dev libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev libclang-common-${LLVM_VERSION}-dev libclang-${LLVM_VERSION}-dev libclang-cpp${LLVM_VERSION}-dev libunwind-${LLVM_VERSION}-dev libclang-rt-${LLVM_VERSION}-dev libpolly-${LLVM_VERSION}-dev
+    wget https://apt.llvm.org/llvm.sh &&\
+    chmod +x llvm.sh &&\
+    ./llvm.sh
+
 
 # Copy a dummy.rs and Cargo.toml first, so that dependencies are cached
 WORKDIR /libafl

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY scripts/dummy.rs libafl/src/lib.rs
 
 # Set up LLVM aliases
 COPY scripts/createAliases.sh libafl/
-RUN bash libafl/createAliases.sh
+RUN bash libafl/createAliases.sh ${LLVM_VERSION}
 
 COPY libafl_bolts/Cargo.toml libafl_bolts/build.rs libafl_bolts/README.md libafl_bolts/
 COPY libafl_bolts/examples libafl_bolts/examples

--- a/scripts/createAliases.sh
+++ b/scripts/createAliases.sh
@@ -13,8 +13,8 @@ for f in $LLVMFILES $CLANGFILES $LLC $OPT $LLD
 do
 	link=${f::-3}
 	echo "linking" "$f" "to" "$link"
-	ln -s $f $link
-	if [ -e $f ]
-	  then cp $link /usr/local/bin/
+	ln -s "$f" "$link"
+	if [ -e "$f" ]
+	  then cp "$link" /usr/local/bin/
 	fi
 done

--- a/scripts/createAliases.sh
+++ b/scripts/createAliases.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# creates a symbolic link from bin-x.x to bin
+# This just strips off last 3 characters when creating a link
+
+LLVMFILES=/usr/bin/llvm*
+CLANGFILES=/usr/bin/clang*
+LLC=/usr/bin/llc-17
+OPT=/usr/bin/opt-17
+LLD=/usr/bin/lld-17
+
+for f in $LLVMFILES $CLANGFILES $LLC $OPT $LLD
+do
+	link=${f::-3}
+	echo "linking" $f "to" $link
+	ln -s $f $link
+	if [ -e $f ]
+	  then cp $link /usr/local/bin/
+	fi
+done

--- a/scripts/createAliases.sh
+++ b/scripts/createAliases.sh
@@ -5,9 +5,9 @@
 
 LLVMFILES=/usr/bin/llvm*
 CLANGFILES=/usr/bin/clang*
-LLC=/usr/bin/llc-17
-OPT=/usr/bin/opt-17
-LLD=/usr/bin/lld-17
+LLC=/usr/bin/llc-$1
+OPT=/usr/bin/opt-$1
+LLD=/usr/bin/lld-$1
 
 for f in $LLVMFILES $CLANGFILES $LLC $OPT $LLD
 do

--- a/scripts/createAliases.sh
+++ b/scripts/createAliases.sh
@@ -3,8 +3,8 @@
 # creates a symbolic link from bin-x.x to bin
 # This just strips off last 3 characters when creating a link
 
-LLVMFILES=/usr/bin/llvm*
-CLANGFILES=/usr/bin/clang*
+LLVMFILES="/usr/bin/llvm*"
+CLANGFILES="/usr/bin/clang*"
 LLC=/usr/bin/llc-$1
 OPT=/usr/bin/opt-$1
 LLD=/usr/bin/lld-$1
@@ -12,7 +12,7 @@ LLD=/usr/bin/lld-$1
 for f in $LLVMFILES $CLANGFILES $LLC $OPT $LLD
 do
 	link=${f::-3}
-	echo "linking" $f "to" $link
+	echo "linking" "$f" "to" "$link"
 	ln -s $f $link
 	if [ -e $f ]
 	  then cp $link /usr/local/bin/


### PR DESCRIPTION
This removes a workaround no longer necessary to install LLVM and updates the rust-analyzer plugin to use the official name, although the old one is aliased to my knowledge. 

A possible improvement to the build time of the Devcontainer image would be to utilize [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to download the binary release for sccache. Let me know if that is a worthwhile improvement and i'll add it. 