### PR TITLE
Move cfg to avoid unused import error on cargo test

### DIFF
--- a/libafl/src/executors/inprocess_fork/mod.rs
+++ b/libafl/src/executors/inprocess_fork/mod.rs
@@ -366,6 +366,7 @@ pub mod child_signal_handlers {
 }
 
 #[cfg(test)]
+#[cfg(all(feature = "std", feature = "fork", unix))]
 mod tests {
     use libafl_bolts::tuples::tuple_list;
     use serial_test::serial;
@@ -378,7 +379,6 @@ mod tests {
     #[test]
     #[serial]
     #[cfg_attr(miri, ignore)]
-    #[cfg(all(feature = "std", feature = "fork", unix))]
     fn test_inprocessfork_exec() {
         use core::marker::PhantomData;
 


### PR DESCRIPTION
`cargo test -p libafl --no-default-features --features=std ` results into a bunch of unused import errors, moving the cfg at mod level fixes the issue.
Thanks