### PR TITLE
Change Qemu hook signature

### DIFF
--- a/libafl_qemu/src/emu/hooks.rs
+++ b/libafl_qemu/src/emu/hooks.rs
@@ -1118,17 +1118,17 @@ where
         modules
     }
 
-    pub fn first_exec_all(&mut self) {
+    pub fn first_exec_all(&mut self, state: &mut S) {
         unsafe {
             self.modules_mut()
-                .first_exec_all(Self::emulator_modules_mut_unchecked());
+                .first_exec_all(Self::emulator_modules_mut_unchecked(), state);
         }
     }
 
-    pub fn pre_exec_all(&mut self, input: &S::Input) {
+    pub fn pre_exec_all(&mut self, input: &S::Input, state: &mut S) {
         unsafe {
             self.modules_mut()
-                .pre_exec_all(Self::emulator_modules_mut_unchecked(), input);
+                .pre_exec_all(Self::emulator_modules_mut_unchecked(), input, state);
         }
     }
 
@@ -1136,6 +1136,7 @@ where
         &mut self,
         input: &S::Input,
         observers: &mut OT,
+        state: &mut S,
         exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,
@@ -1145,6 +1146,7 @@ where
                 Self::emulator_modules_mut_unchecked(),
                 input,
                 observers,
+                state,
                 exit_kind,
             );
         }

--- a/libafl_qemu/src/emu/mod.rs
+++ b/libafl_qemu/src/emu/mod.rs
@@ -338,26 +338,28 @@ where
         })
     }
 
-    pub fn first_exec_all(&mut self) {
+    pub fn first_exec_all(&mut self, state: &mut S) {
         if self.first_exec {
-            self.modules.first_exec_all();
+            self.modules.first_exec_all(state);
             self.first_exec = false;
         }
     }
 
-    pub fn pre_exec_all(&mut self, input: &S::Input) {
-        self.modules.pre_exec_all(input);
+    pub fn pre_exec_all(&mut self, input: &S::Input, state: &mut S) {
+        self.modules.pre_exec_all(input, state);
     }
 
     pub fn post_exec_all<OT>(
         &mut self,
         input: &S::Input,
         observers: &mut OT,
+        state: &mut S,
         exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,
     {
-        self.modules.post_exec_all(input, observers, exit_kind);
+        self.modules
+            .post_exec_all(input, observers, state, exit_kind);
     }
 }
 

--- a/libafl_qemu/src/executor.rs
+++ b/libafl_qemu/src/executor.rs
@@ -205,15 +205,20 @@ where
         mgr: &mut EM,
         input: &Self::Input,
     ) -> Result<ExitKind, Error> {
-        self.inner.exposed_executor_state_mut().first_exec_all();
+        self.inner
+            .exposed_executor_state_mut()
+            .first_exec_all(state);
 
-        self.inner.exposed_executor_state_mut().pre_exec_all(input);
+        self.inner
+            .exposed_executor_state_mut()
+            .pre_exec_all(input, state);
 
         let mut exit_kind = self.inner.run_target(fuzzer, state, mgr, input)?;
 
         self.inner.exposed_executor_state.post_exec_all(
             input,
             &mut *self.inner.inner.observers_mut(),
+            state,
             &mut exit_kind,
         );
 

--- a/libafl_qemu/src/modules/calls.rs
+++ b/libafl_qemu/src/modules/calls.rs
@@ -412,8 +412,12 @@ where
         );
     }
 
-    fn pre_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, input: &S::Input)
-    where
+    fn pre_exec<ET>(
+        &mut self,
+        emulator_modules: &mut EmulatorModules<ET, S>,
+        input: &S::Input,
+        _state: &mut S,
+    ) where
         ET: EmulatorModuleTuple<S>,
     {
         self.collectors
@@ -427,6 +431,7 @@ where
         emulator_modules: &mut EmulatorModules<ET, S>,
         input: &S::Input,
         observers: &mut OT,
+        _state: &mut S,
         exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,

--- a/libafl_qemu/src/modules/cmplog.rs
+++ b/libafl_qemu/src/modules/cmplog.rs
@@ -81,7 +81,7 @@ impl<S> EmulatorModule<S> for CmpLogModule
 where
     S: Unpin + UsesInput + HasMetadata,
 {
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -124,7 +124,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -363,7 +363,7 @@ impl<S> EmulatorModule<S> for CmpLogRoutinesModule
 where
     S: Unpin + UsesInput,
 {
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/edges.rs
+++ b/libafl_qemu/src/modules/edges.rs
@@ -157,7 +157,7 @@ impl<S> EmulatorModule<S> for EdgeCoverageModule
 where
     S: Unpin + UsesInput + HasMetadata,
 {
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -308,7 +308,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -454,7 +454,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/mod.rs
+++ b/libafl_qemu/src/modules/mod.rs
@@ -48,14 +48,18 @@ where
     {
     }
 
-    fn first_exec<ET>(&mut self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, _emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
     }
 
-    fn pre_exec<ET>(&mut self, _emulator_modules: &mut EmulatorModules<ET, S>, _input: &S::Input)
-    where
+    fn pre_exec<ET>(
+        &mut self,
+        _emulator_modules: &mut EmulatorModules<ET, S>,
+        _input: &S::Input,
+        _state: &mut S,
+    ) where
         ET: EmulatorModuleTuple<S>,
     {
     }
@@ -65,6 +69,7 @@ where
         _emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
         _observers: &mut OT,
+        _state: &mut S,
         _exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,
@@ -84,14 +89,18 @@ where
     where
         ET: EmulatorModuleTuple<S>;
 
-    fn first_exec_all<ET>(&mut self, _emulator_modules: &mut EmulatorModules<ET, S>)
-    where
+    fn first_exec_all<ET>(
+        &mut self,
+        _emulator_modules: &mut EmulatorModules<ET, S>,
+        _state: &mut S,
+    ) where
         ET: EmulatorModuleTuple<S>;
 
     fn pre_exec_all<ET>(
         &mut self,
         _emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
+        _state: &mut S,
     ) where
         ET: EmulatorModuleTuple<S>;
 
@@ -100,6 +109,7 @@ where
         _emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
         _observers: &mut OT,
+        _state: &mut S,
         _exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,
@@ -118,7 +128,7 @@ where
     {
     }
 
-    fn first_exec_all<ET>(&mut self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec_all<ET>(&mut self, _emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -128,6 +138,7 @@ where
         &mut self,
         _emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
+        _state: &mut S,
     ) where
         ET: EmulatorModuleTuple<S>,
     {
@@ -138,6 +149,7 @@ where
         _emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
         _observers: &mut OT,
+        _state: &mut S,
         _exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,
@@ -162,20 +174,24 @@ where
         self.1.init_modules_all(emulator_modules);
     }
 
-    fn first_exec_all<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec_all<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
-        self.0.first_exec(emulator_modules);
-        self.1.first_exec_all(emulator_modules);
+        self.0.first_exec(emulator_modules, state);
+        self.1.first_exec_all(emulator_modules, state);
     }
 
-    fn pre_exec_all<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, input: &S::Input)
-    where
+    fn pre_exec_all<ET>(
+        &mut self,
+        emulator_modules: &mut EmulatorModules<ET, S>,
+        input: &S::Input,
+        state: &mut S,
+    ) where
         ET: EmulatorModuleTuple<S>,
     {
-        self.0.pre_exec(emulator_modules, input);
-        self.1.pre_exec_all(emulator_modules, input);
+        self.0.pre_exec(emulator_modules, input, state);
+        self.1.pre_exec_all(emulator_modules, input, state);
     }
 
     fn post_exec_all<OT, ET>(
@@ -183,15 +199,16 @@ where
         emulator_modules: &mut EmulatorModules<ET, S>,
         input: &S::Input,
         observers: &mut OT,
+        state: &mut S,
         exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,
         ET: EmulatorModuleTuple<S>,
     {
         self.0
-            .post_exec(emulator_modules, input, observers, exit_kind);
+            .post_exec(emulator_modules, input, observers, state, exit_kind);
         self.1
-            .post_exec_all(emulator_modules, input, observers, exit_kind);
+            .post_exec_all(emulator_modules, input, observers, state, exit_kind);
     }
 }
 

--- a/libafl_qemu/src/modules/usermode/asan.rs
+++ b/libafl_qemu/src/modules/usermode/asan.rs
@@ -940,7 +940,7 @@ where
         }
     }
 
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -975,8 +975,12 @@ where
         }
     }
 
-    fn pre_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _input: &S::Input)
-    where
+    fn pre_exec<ET>(
+        &mut self,
+        emulator_modules: &mut EmulatorModules<ET, S>,
+        _input: &S::Input,
+        _state: &mut S,
+    ) where
         ET: EmulatorModuleTuple<S>,
     {
         if self.empty {
@@ -990,6 +994,7 @@ where
         emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
         _observers: &mut OT,
+        _state: &mut S,
         exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,

--- a/libafl_qemu/src/modules/usermode/asan_guest.rs
+++ b/libafl_qemu/src/modules/usermode/asan_guest.rs
@@ -273,7 +273,7 @@ impl<S> EmulatorModule<S> for AsanGuestModule
 where
     S: Unpin + UsesInput,
 {
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
         S: Unpin + UsesInput,

--- a/libafl_qemu/src/modules/usermode/drcov.rs
+++ b/libafl_qemu/src/modules/usermode/drcov.rs
@@ -100,7 +100,7 @@ where
         );
     }
 
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -124,6 +124,7 @@ where
         _emulator_modules: &mut EmulatorModules<ET, S>,
         _input: &S::Input,
         _observers: &mut OT,
+        _state: &mut S,
         _exit_kind: &mut ExitKind,
     ) where
         OT: ObserversTuple<S>,

--- a/libafl_qemu/src/modules/usermode/injections.rs
+++ b/libafl_qemu/src/modules/usermode/injections.rs
@@ -267,7 +267,7 @@ where
         emulator_modules.syscalls(Hook::Function(syscall_hook::<ET, S>));
     }
 
-    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn first_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _state: &mut S)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -689,8 +689,12 @@ where
         emulator_modules.after_syscalls(Hook::Function(trace_mmap_snapshot::<ET, S>));
     }
 
-    fn pre_exec<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, _input: &S::Input)
-    where
+    fn pre_exec<ET>(
+        &mut self,
+        emulator_modules: &mut EmulatorModules<ET, S>,
+        _input: &S::Input,
+        _state: &mut S,
+    ) where
         ET: EmulatorModuleTuple<S>,
     {
         if self.empty {


### PR DESCRIPTION
I modified emulator hooks to have state as the argument. in this way we can, for example, change the metadata before and after the execution.

