### PR TITLE
Fix panic in mmap shmem when full_file_name is less than MAX_MMAP_FILENAME_LEN

### DIFF
--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -698,7 +698,7 @@ pub mod unix_shmem {
                     full_file_name.truncate(MAX_MMAP_FILENAME_LEN);
                     let mut filename_path = [0_u8; MAX_MMAP_FILENAME_LEN];
                     filename_path[0..full_file_name.len()]
-                        .copy_from_slice(&full_file_name.as_bytes());
+                        .copy_from_slice(full_file_name.as_bytes());
                     filename_path[MAX_MMAP_FILENAME_LEN - 1] = 0; // Null terminate!
                     log::info!(
                         "{} Creating shmem {} {:#?}",

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -695,11 +695,12 @@ pub mod unix_shmem {
             pub fn new(map_size: usize, rand_id: u32) -> Result<Self, Error> {
                 unsafe {
                     let mut full_file_name = format!("/libafl_{}_{}", process::id(), rand_id);
-                    full_file_name.truncate(MAX_MMAP_FILENAME_LEN);
+                    // leave one byte space for the null byte.
+                    full_file_name.truncate(MAX_MMAP_FILENAME_LEN - 1);
                     let mut filename_path = [0_u8; MAX_MMAP_FILENAME_LEN];
                     filename_path[0..full_file_name.len()]
                         .copy_from_slice(full_file_name.as_bytes());
-                    filename_path[MAX_MMAP_FILENAME_LEN - 1] = 0; // Null terminate!
+                    filename_path[full_file_name.len()] = 0; // Null terminate!
                     log::info!(
                         "{} Creating shmem {} {:#?}",
                         map_size,

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -694,10 +694,10 @@ pub mod unix_shmem {
             /// This will *NOT* automatically delete the shmem files, meaning that it's user's responsibility to delete all `/dev/shm/libafl_*` after fuzzing
             pub fn new(map_size: usize, rand_id: u32) -> Result<Self, Error> {
                 unsafe {
-                    let full_file_name = format!("/libafl_{}_{}", process::id(), rand_id);
+                    let mut full_file_name = format!("/libafl_{}_{}", process::id(), rand_id);
+                    full_file_name.truncate(MAX_MMAP_FILENAME_LEN);
                     let mut filename_path = [0_u8; MAX_MMAP_FILENAME_LEN];
-                    filename_path
-                        .copy_from_slice(&full_file_name.as_bytes()[..MAX_MMAP_FILENAME_LEN]);
+                    filename_path.copy_from_slice(&full_file_name.as_bytes());
                     filename_path[MAX_MMAP_FILENAME_LEN - 1] = 0; // Null terminate!
                     log::info!(
                         "{} Creating shmem {} {:#?}",

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -697,7 +697,8 @@ pub mod unix_shmem {
                     let mut full_file_name = format!("/libafl_{}_{}", process::id(), rand_id);
                     full_file_name.truncate(MAX_MMAP_FILENAME_LEN);
                     let mut filename_path = [0_u8; MAX_MMAP_FILENAME_LEN];
-                    filename_path.copy_from_slice(&full_file_name.as_bytes());
+                    filename_path[0..full_file_name.len()]
+                        .copy_from_slice(&full_file_name.as_bytes());
                     filename_path[MAX_MMAP_FILENAME_LEN - 1] = 0; // Null terminate!
                     log::info!(
                         "{} Creating shmem {} {:#?}",


### PR DESCRIPTION
This PR fix this panic on macOS:

```
thread '<unnamed>' panicked at /Users/jeremie/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libafl_bolts-0.13.2/src/shmem.rs:695:68:
range end index 20 out of range for slice of length 19
```