### PR TITLE
Bring back placeholder value in CommandExecutor to fix #2541

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -105,7 +105,7 @@ where
 
                 for (i, arg) in args.enumerate() {
                     if i == *argnum {
-                        debug_assert_eq!(arg, "DUMMY");
+                        debug_assert_eq!(arg, "PLACEHOLDER");
                         #[cfg(unix)]
                         cmd.arg(OsStr::from_bytes(input.target_bytes().as_slice()));
                         // There is an issue here that the chars on Windows are 16 bit wide.
@@ -379,7 +379,8 @@ impl CommandExecutorBuilder {
     pub fn arg_input_arg(&mut self) -> &mut Self {
         let argnum = self.args.len();
         self.input(InputLocation::Arg { argnum });
-        // self.arg("DUMMY");
+        // Placeholder arg that gets replaced with the input name later.
+        self.arg("PLACEHOLDER");
         self
     }
 

--- a/libafl/src/observers/concolic/serialization_format.rs
+++ b/libafl/src/observers/concolic/serialization_format.rs
@@ -242,7 +242,7 @@ impl<W: Write + Seek> MessageFileWriter<W> {
     /// Create a `MessageFileWriter` from the given [`Write`].
     pub fn from_writer(mut writer: W) -> io::Result<Self> {
         let writer_start_position = writer.stream_position()?;
-        // write dummy trace length
+        // write preliminary trace length
         writer.write_all(&0_u64.to_le_bytes())?;
         Ok(Self {
             id_counter: 1,


### PR DESCRIPTION
This fixes #2541 by un-commenting what was commented out in #2167