### PR TITLE
Reducing type parameters and bounds from Scheduler

### DIFF
--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -17,7 +17,6 @@ use crate::{
     corpus::Corpus,
     events::{Event, EventFirer, LogSeverity},
     executors::{Executor, HasObservers},
-    inputs::UsesInput,
     monitors::{AggregatorOps, UserStats, UserStatsValue},
     observers::{MapObserver, ObserversTuple},
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
@@ -57,13 +56,7 @@ pub struct MapCorpusMinimizer<C, E, O, T, TS> {
 }
 
 /// Standard corpus minimizer, which weights inputs by length and time.
-pub type StdCorpusMinimizer<C, E, O, T> = MapCorpusMinimizer<
-    C,
-    E,
-    O,
-    T,
-    LenTimeMulTestcaseScore<<E as UsesInput>::Input, <E as UsesState>::State>,
->;
+pub type StdCorpusMinimizer<C, E, O, T> = MapCorpusMinimizer<C, E, O, T, LenTimeMulTestcaseScore>;
 
 impl<C, E, O, T, TS> MapCorpusMinimizer<C, E, O, T, TS>
 where

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -15,11 +15,7 @@ use libafl_bolts::{serdeany::SerdeAnyMap, HasLen};
 use serde::{Deserialize, Serialize};
 
 use super::Corpus;
-use crate::{
-    corpus::CorpusId,
-    inputs::{Input, UsesInput},
-    Error, HasMetadata,
-};
+use crate::{corpus::CorpusId, inputs::UsesInput, Error, HasMetadata};
 
 /// Shorthand to receive a [`Ref`] or [`RefMut`] to a stored [`Testcase`], by [`CorpusId`].
 /// For a normal state, this should return a [`Testcase`] in the corpus, not the objectives.
@@ -38,11 +34,7 @@ pub trait HasTestcase: UsesInput {
 
 /// An entry in the [`Testcase`] Corpus
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "I: serde::de::DeserializeOwned")]
-pub struct Testcase<I>
-where
-    I: Input,
-{
+pub struct Testcase<I> {
     /// The [`Input`] of this [`Testcase`], or `None`, if it is not currently in memory
     input: Option<I>,
     /// The filename for this [`Testcase`]
@@ -77,10 +69,7 @@ where
     hit_objectives: Vec<Cow<'static, str>>,
 }
 
-impl<I> HasMetadata for Testcase<I>
-where
-    I: Input,
-{
+impl<I> HasMetadata for Testcase<I> {
     /// Get all the metadata into an [`hashbrown::HashMap`]
     #[inline]
     fn metadata_map(&self) -> &SerdeAnyMap {
@@ -95,10 +84,7 @@ where
 }
 
 /// Impl of a testcase
-impl<I> Testcase<I>
-where
-    I: Input,
-{
+impl<I> Testcase<I> {
     /// Returns this [`Testcase`] with a loaded `Input`]
     pub fn load_input<C: Corpus<Input = I>>(&mut self, corpus: &C) -> Result<&I, Error> {
         corpus.load_input_into(self)?;
@@ -120,8 +106,7 @@ where
 
     /// Set the input
     #[inline]
-    pub fn set_input(&mut self, mut input: I) {
-        input.wrapped_as_testcase();
+    pub fn set_input(&mut self, input: I) {
         self.input = Some(input);
     }
 
@@ -249,8 +234,7 @@ where
 
     /// Create a new Testcase instance given an input
     #[inline]
-    pub fn new(mut input: I) -> Self {
-        input.wrapped_as_testcase();
+    pub fn new(input: I) -> Self {
         Self {
             input: Some(input),
             filename: None,
@@ -275,8 +259,7 @@ where
 
     /// Creates a testcase, attaching the id of the parent
     /// that this [`Testcase`] was derived from on creation
-    pub fn with_parent_id(mut input: I, parent_id: CorpusId) -> Self {
-        input.wrapped_as_testcase();
+    pub fn with_parent_id(input: I, parent_id: CorpusId) -> Self {
         Testcase {
             input: Some(input),
             filename: None,
@@ -301,8 +284,7 @@ where
 
     /// Create a new Testcase instance given an [`Input`] and a `filename`
     #[inline]
-    pub fn with_filename(mut input: I, filename: String) -> Self {
-        input.wrapped_as_testcase();
+    pub fn with_filename(input: I, filename: String) -> Self {
         Self {
             input: Some(input),
             filename: Some(filename),
@@ -327,8 +309,7 @@ where
 
     /// Create a new Testcase instance given an [`Input`] and the number of executions
     #[inline]
-    pub fn with_executions(mut input: I, executions: u64) -> Self {
-        input.wrapped_as_testcase();
+    pub fn with_executions(input: I, executions: u64) -> Self {
         Self {
             input: Some(input),
             filename: None,
@@ -378,10 +359,7 @@ where
     }
 }
 
-impl<I> Default for Testcase<I>
-where
-    I: Input,
-{
+impl<I> Default for Testcase<I> {
     /// Create a new default Testcase
     #[inline]
     fn default() -> Self {
@@ -411,7 +389,7 @@ where
 /// Impl of a testcase when the input has len
 impl<I> Testcase<I>
 where
-    I: Input + HasLen,
+    I: HasLen,
 {
     /// Get the cached `len`. Will `Error::EmptyOptional` if `len` is not yet cached.
     #[inline]
@@ -441,10 +419,7 @@ where
 }
 
 /// Create a testcase from an input
-impl<I> From<I> for Testcase<I>
-where
-    I: Input,
-{
+impl<I> From<I> for Testcase<I> {
     fn from(input: I) -> Self {
         Testcase::new(input)
     }
@@ -563,10 +538,7 @@ impl SchedulerTestcaseMetadata {
 libafl_bolts::impl_serdeany!(SchedulerTestcaseMetadata);
 
 #[cfg(feature = "std")]
-impl<I> Drop for Testcase<I>
-where
-    I: Input,
-{
+impl<I> Drop for Testcase<I> {
     fn drop(&mut self) {
         if let Some(filename) = &self.filename {
             let mut path = PathBuf::from(filename);

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -60,9 +60,6 @@ pub trait Input: Clone + Serialize + serde::de::DeserializeOwned + Debug {
 
     /// Generate a name for this input
     fn generate_name(&self, id: Option<CorpusId>) -> String;
-
-    /// An hook executed if the input is stored as `Testcase`
-    fn wrapped_as_testcase(&mut self) {}
 }
 
 /// An input for the target
@@ -89,9 +86,6 @@ pub trait Input: Clone + Serialize + serde::de::DeserializeOwned + Debug {
 
     /// Generate a name for this input, the user is responsible for making each name of testcase unique.
     fn generate_name(&self, id: Option<CorpusId>) -> String;
-
-    /// An hook executed if the input is stored as `Testcase`
-    fn wrapped_as_testcase(&mut self) {}
 }
 
 /// Convert between two input types with a state

--- a/libafl/src/schedulers/minimizer.rs
+++ b/libafl/src/schedulers/minimizer.rs
@@ -5,14 +5,13 @@ use alloc::vec::Vec;
 use core::{any::type_name, cmp::Ordering, marker::PhantomData};
 
 use hashbrown::{HashMap, HashSet};
-use libafl_bolts::{rands::Rand, serdeany::SerdeAny, AsIter, HasRefCnt};
+use libafl_bolts::{rands::Rand, serdeany::SerdeAny, tuples::MatchName, AsIter, HasRefCnt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     corpus::{Corpus, CorpusId, Testcase},
     feedbacks::MapIndexesMetadata,
-    inputs::Input,
-    observers::{CanTrack, ObserversTuple},
+    prelude::CanTrack,
     require_index_tracking,
     schedulers::{LenTimeMulTestcaseScore, RemovableScheduler, Scheduler, TestcaseScore},
     state::{HasCorpus, HasRand},
@@ -72,21 +71,19 @@ impl Default for TopRatedsMetadata {
 ///
 /// E.g., it can use all the coverage seen so far to prioritize [`Testcase`]`s` using a [`TestcaseScore`].
 #[derive(Debug, Clone)]
-pub struct MinimizerScheduler<CS, F, I, M, O, S> {
+pub struct MinimizerScheduler<CS, F, M, S> {
     base: CS,
     skip_non_favored_prob: f64,
     remove_metadata: bool,
-    phantom: PhantomData<(F, I, M, O, S)>,
+    phantom: PhantomData<(F, M, S)>,
 }
 
-impl<CS, F, I, M, O, S> RemovableScheduler<I, S> for MinimizerScheduler<CS, F, I, M, O, S>
+impl<CS, F, I, M, O, S> RemovableScheduler<I, S> for MinimizerScheduler<CS, F, M, O>
 where
     CS: RemovableScheduler<I, S> + Scheduler<I, S>,
-    I: Input,
     F: TestcaseScore<I, S>,
     M: for<'a> AsIter<'a, Item = usize> + SerdeAny + HasRefCnt,
     S: HasCorpus<Input = I> + HasMetadata + HasRand,
-    O: CanTrack,
 {
     /// Replaces the [`Testcase`] at the given [`CorpusId`]
     fn on_replace(
@@ -188,14 +185,12 @@ where
     }
 }
 
-impl<CS, F, I, M, O, S> Scheduler<I, S> for MinimizerScheduler<CS, F, I, M, O, S>
+impl<CS, F, I, M, O, S> Scheduler<I, S> for MinimizerScheduler<CS, F, M, O>
 where
     CS: Scheduler<I, S>,
     F: TestcaseScore<I, S>,
-    I: Input,
     M: for<'a> AsIter<'a, Item = usize> + SerdeAny + HasRefCnt,
     S: HasCorpus<Input = I> + HasMetadata + HasRand,
-    O: CanTrack,
 {
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add(&mut self, state: &mut S, id: CorpusId) -> Result<(), Error> {
@@ -206,7 +201,7 @@ where
     /// An input has been evaluated
     fn on_evaluation<OT>(&mut self, state: &mut S, input: &I, observers: &OT) -> Result<(), Error>
     where
-        OT: ObserversTuple<S>,
+        OT: MatchName,
     {
         self.base.on_evaluation(state, input, observers)
     }
@@ -240,19 +235,18 @@ where
     }
 }
 
-impl<CS, F, I, M, O, S> MinimizerScheduler<CS, F, I, M, O, S>
+impl<CS, F, M, O> MinimizerScheduler<CS, F, M, O>
 where
-    CS: Scheduler<I, S>,
-    F: TestcaseScore<I, S>,
-    I: Input,
     M: for<'a> AsIter<'a, Item = usize> + SerdeAny + HasRefCnt,
-    S: HasCorpus<Input = I> + HasMetadata + HasRand,
-    O: CanTrack,
 {
     /// Update the [`Corpus`] score using the [`MinimizerScheduler`]
     #[allow(clippy::unused_self)]
     #[allow(clippy::cast_possible_wrap)]
-    pub fn update_score(&self, state: &mut S, id: CorpusId) -> Result<(), Error> {
+    pub fn update_score<I, S>(&self, state: &mut S, id: CorpusId) -> Result<(), Error>
+    where
+        F: TestcaseScore<I, S>,
+        S: HasCorpus<Input = I> + HasMetadata,
+    {
         // Create a new top rated meta if not existing
         if state.metadata_map().get::<TopRatedsMetadata>().is_none() {
             state.add_metadata(TopRatedsMetadata::new());
@@ -326,7 +320,10 @@ where
 
     /// Cull the [`Corpus`] using the [`MinimizerScheduler`]
     #[allow(clippy::unused_self)]
-    pub fn cull(&self, state: &S) -> Result<(), Error> {
+    pub fn cull<S>(&self, state: &S) -> Result<(), Error>
+    where
+        S: HasCorpus + HasMetadata,
+    {
         let Some(top_rated) = state.metadata_map().get::<TopRatedsMetadata>() else {
             return Ok(());
         };
@@ -352,7 +349,12 @@ where
 
         Ok(())
     }
+}
 
+impl<CS, F, M, O> MinimizerScheduler<CS, F, M, O>
+where
+    O: CanTrack,
+{
     /// Get a reference to the base scheduler
     pub fn base(&self) -> &CS {
         &self.base
@@ -410,10 +412,10 @@ where
 }
 
 /// A [`MinimizerScheduler`] with [`LenTimeMulTestcaseScore`] to prioritize quick and small [`Testcase`]`s`.
-pub type LenTimeMinimizerScheduler<CS, I, M, O, S> =
-    MinimizerScheduler<CS, LenTimeMulTestcaseScore<I, S>, I, M, O, S>;
+pub type LenTimeMinimizerScheduler<CS, M, O> =
+    MinimizerScheduler<CS, LenTimeMulTestcaseScore, M, O>;
 
 /// A [`MinimizerScheduler`] with [`LenTimeMulTestcaseScore`] to prioritize quick and small [`Testcase`]`s`
 /// that exercise all the entries registered in the [`MapIndexesMetadata`].
-pub type IndexesLenTimeMinimizerScheduler<CS, I, O, S> =
-    MinimizerScheduler<CS, LenTimeMulTestcaseScore<I, S>, I, MapIndexesMetadata, O, S>;
+pub type IndexesLenTimeMinimizerScheduler<CS, O> =
+    MinimizerScheduler<CS, LenTimeMulTestcaseScore, MapIndexesMetadata, O>;

--- a/libafl/src/schedulers/testcase_score.rs
+++ b/libafl/src/schedulers/testcase_score.rs
@@ -1,13 +1,11 @@
 //! The `TestcaseScore` is an evaluator providing scores of corpus items.
 use alloc::string::{String, ToString};
-use core::marker::PhantomData;
 
 use libafl_bolts::{HasLen, HasRefCnt};
 
 use crate::{
     corpus::{Corpus, SchedulerTestcaseMetadata, Testcase},
     feedbacks::MapIndexesMetadata,
-    inputs::Input,
     schedulers::{
         minimizer::{IsFavoredMetadata, TopRatedsMetadata},
         powersched::{BaseSchedule, SchedulerMetadata},
@@ -17,11 +15,7 @@ use crate::{
 };
 
 /// Compute the favor factor of a [`Testcase`]. Higher is better.
-pub trait TestcaseScore<I, S>
-where
-    S: HasMetadata + HasCorpus,
-    I: Input,
-{
+pub trait TestcaseScore<I, S> {
     /// Computes the favor factor of a [`Testcase`]. Higher is better.
     fn compute(state: &S, entry: &mut Testcase<I>) -> Result<f64, Error>;
 }
@@ -29,14 +23,12 @@ where
 /// Multiply the testcase size with the execution time.
 /// This favors small and quick testcases.
 #[derive(Debug, Clone)]
-pub struct LenTimeMulTestcaseScore<I, S> {
-    phantom: PhantomData<(I, S)>,
-}
+pub struct LenTimeMulTestcaseScore {}
 
-impl<I, S> TestcaseScore<I, S> for LenTimeMulTestcaseScore<I, S>
+impl<I, S> TestcaseScore<I, S> for LenTimeMulTestcaseScore
 where
-    S: HasCorpus<Input = I> + HasMetadata,
-    I: HasLen + Input,
+    S: HasCorpus<Input = I>,
+    I: HasLen,
 {
     #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
     fn compute(state: &S, entry: &mut Testcase<I>) -> Result<f64, Error> {
@@ -54,14 +46,11 @@ const HAVOC_MAX_MULT: f64 = 64.0;
 /// The power assigned to each corpus entry
 /// This result is used for power scheduling
 #[derive(Debug, Clone)]
-pub struct CorpusPowerTestcaseScore<S> {
-    phantom: PhantomData<S>,
-}
+pub struct CorpusPowerTestcaseScore {}
 
-impl<I, S> TestcaseScore<I, S> for CorpusPowerTestcaseScore<S>
+impl<I, S> TestcaseScore<I, S> for CorpusPowerTestcaseScore
 where
     S: HasCorpus + HasMetadata,
-    I: Input,
 {
     /// Compute the `power` we assign to each corpus entry
     #[allow(
@@ -276,14 +265,11 @@ where
 /// The weight for each corpus entry
 /// This result is used for corpus scheduling
 #[derive(Debug, Clone)]
-pub struct CorpusWeightTestcaseScore<S> {
-    phantom: PhantomData<S>,
-}
+pub struct CorpusWeightTestcaseScore {}
 
-impl<I, S> TestcaseScore<I, S> for CorpusWeightTestcaseScore<S>
+impl<I, S> TestcaseScore<I, S> for CorpusWeightTestcaseScore
 where
     S: HasCorpus + HasMetadata,
-    I: Input,
 {
     /// Compute the `weight` used in weighted corpus entry selection algo
     #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use hashbrown::HashMap;
 use libafl_bolts::{
     rands::Rand,
-    tuples::{Handle, Handled},
+    tuples::{Handle, Handled, MatchName},
     Named,
 };
 use serde::{Deserialize, Serialize};
@@ -17,14 +17,15 @@ use super::powersched::PowerSchedule;
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
     inputs::Input,
-    observers::{MapObserver, ObserversTuple},
+    observers::MapObserver,
     random_corpus_id,
     schedulers::{
+        on_add_metadata_default, on_evaluation_metadata_default, on_next_metadata_default,
         powersched::{BaseSchedule, SchedulerMetadata},
         testcase_score::{CorpusWeightTestcaseScore, TestcaseScore},
         AflScheduler, HasQueueCycles, RemovableScheduler, Scheduler,
     },
-    state::{HasCorpus, HasRand, State},
+    state::{HasCorpus, HasRand},
     Error, HasMetadata,
 };
 
@@ -98,34 +99,36 @@ libafl_bolts::impl_serdeany!(WeightedScheduleMetadata);
 
 /// A corpus scheduler using power schedules with weighted queue item selection algo.
 #[derive(Clone, Debug)]
-pub struct WeightedScheduler<C, F, I, O, S> {
+pub struct WeightedScheduler<C, F, O> {
     table_invalidated: bool,
     strat: Option<PowerSchedule>,
     map_observer_handle: Handle<C>,
     last_hash: usize,
     queue_cycles: u64,
-    phantom: PhantomData<(F, I, O, S)>,
+    phantom: PhantomData<(F, O)>,
     /// Cycle `PowerSchedule` on completion of every queue cycle.
     cycle_schedules: bool,
 }
 
-impl<C, F, I, O, S> WeightedScheduler<C, F, I, O, S>
+impl<C, F, O> WeightedScheduler<C, F, O>
 where
-    F: TestcaseScore<I, S>,
-    I: Input,
-    O: MapObserver,
-    S: HasCorpus<Input = I> + HasMetadata + HasRand,
-    C: AsRef<O> + Named,
+    C: Named,
 {
     /// Create a new [`WeightedScheduler`] without any power schedule
     #[must_use]
-    pub fn new(state: &mut S, map_observer: &C) -> Self {
+    pub fn new<S>(state: &mut S, map_observer: &C) -> Self
+    where
+        S: HasMetadata,
+    {
         Self::with_schedule(state, map_observer, None)
     }
 
     /// Create a new [`WeightedScheduler`]
     #[must_use]
-    pub fn with_schedule(state: &mut S, map_observer: &C, strat: Option<PowerSchedule>) -> Self {
+    pub fn with_schedule<S>(state: &mut S, map_observer: &C, strat: Option<PowerSchedule>) -> Self
+    where
+        S: HasMetadata,
+    {
         let _ = state.metadata_or_insert_with(|| SchedulerMetadata::new(strat));
         let _ = state.metadata_or_insert_with(WeightedScheduleMetadata::new);
 
@@ -160,7 +163,12 @@ where
         clippy::cast_precision_loss,
         clippy::cast_lossless
     )]
-    pub fn create_alias_table(&self, state: &mut S) -> Result<(), Error> {
+    pub fn create_alias_table<I, S>(&self, state: &mut S) -> Result<(), Error>
+    where
+        F: TestcaseScore<I, S>,
+        I: Input,
+        S: HasCorpus<Input = I> + HasMetadata,
+    {
         let n = state.corpus().count();
 
         let mut alias_table: HashMap<CorpusId, CorpusId> = HashMap::default();
@@ -258,14 +266,7 @@ where
     }
 }
 
-impl<C, F, I, O, S> RemovableScheduler<I, S> for WeightedScheduler<C, F, I, O, S>
-where
-    F: TestcaseScore<I, S>,
-    O: MapObserver,
-    I: Input,
-    S: HasCorpus + HasMetadata + HasRand + HasTestcase + State,
-    C: AsRef<O> + Named,
-{
+impl<C, F, I, O, S> RemovableScheduler<I, S> for WeightedScheduler<C, F, O> {
     /// This will *NOT* neutralize the effect of this removed testcase from the global data such as `SchedulerMetadata`
     fn on_remove(
         &mut self,
@@ -289,14 +290,7 @@ where
     }
 }
 
-impl<C, I, F, O, S> AflScheduler<I, O, S> for WeightedScheduler<C, F, I, O, S>
-where
-    F: TestcaseScore<I, S>,
-    I: Input,
-    O: MapObserver,
-    S: HasCorpus + HasMetadata + HasTestcase + HasRand + State,
-    C: AsRef<O> + Named,
-{
+impl<C, F, O> AflScheduler for WeightedScheduler<C, F, O> {
     type MapObserverRef = C;
 
     fn last_hash(&self) -> usize {
@@ -312,39 +306,32 @@ where
     }
 }
 
-impl<C, F, I, O, S> HasQueueCycles for WeightedScheduler<C, F, I, O, S>
-where
-    F: TestcaseScore<I, S>,
-    I: Input,
-    O: MapObserver,
-    S: HasCorpus + HasMetadata + HasRand + HasTestcase + State,
-    C: AsRef<O> + Named,
-{
+impl<C, F, O> HasQueueCycles for WeightedScheduler<C, F, O> {
     fn queue_cycles(&self) -> u64 {
         self.queue_cycles
     }
 }
 
-impl<C, F, I, O, S> Scheduler<I, S> for WeightedScheduler<C, F, I, O, S>
+impl<C, F, I, O, S> Scheduler<I, S> for WeightedScheduler<C, F, O>
 where
+    C: AsRef<O> + Named,
     F: TestcaseScore<I, S>,
     I: Input,
     O: MapObserver,
-    S: HasCorpus<Input = I> + HasMetadata + HasRand + HasTestcase + State,
-    C: AsRef<O> + Named,
+    S: HasCorpus<Input = I> + HasMetadata + HasRand + HasTestcase,
 {
     /// Called when a [`Testcase`] is added to the corpus
     fn on_add(&mut self, state: &mut S, id: CorpusId) -> Result<(), Error> {
-        self.on_add_metadata(state, id)?;
+        on_add_metadata_default(self, state, id)?;
         self.table_invalidated = true;
         Ok(())
     }
 
-    fn on_evaluation<OT>(&mut self, state: &mut S, input: &I, observers: &OT) -> Result<(), Error>
+    fn on_evaluation<OT>(&mut self, state: &mut S, _input: &I, observers: &OT) -> Result<(), Error>
     where
-        OT: ObserversTuple<S>,
+        OT: MatchName,
     {
-        self.on_evaluation_metadata(state, input, observers)
+        on_evaluation_metadata_default(self, state, observers)
     }
 
     #[allow(clippy::similar_names, clippy::cast_precision_loss)]
@@ -402,7 +389,7 @@ where
         state: &mut S,
         next_id: Option<CorpusId>,
     ) -> Result<(), Error> {
-        self.on_next_metadata(state, next_id)?;
+        on_next_metadata_default(state)?;
 
         *state.corpus_mut().current_mut() = next_id;
         Ok(())
@@ -410,5 +397,4 @@ where
 }
 
 /// The standard corpus weight, same as in `AFL++`
-pub type StdWeightedScheduler<C, I, O, S> =
-    WeightedScheduler<C, CorpusWeightTestcaseScore<S>, I, O, S>;
+pub type StdWeightedScheduler<C, O> = WeightedScheduler<C, CorpusWeightTestcaseScore, O>;

--- a/libafl/src/stages/power.rs
+++ b/libafl/src/stages/power.rs
@@ -143,4 +143,4 @@ where
 
 /// The standard powerscheduling stage
 pub type StdPowerMutationalStage<E, EM, I, M, Z> =
-    PowerMutationalStage<E, CorpusPowerTestcaseScore<<E as UsesState>::State>, EM, I, M, Z>;
+    PowerMutationalStage<E, CorpusPowerTestcaseScore, EM, I, M, Z>;


### PR DESCRIPTION
Basically same as addison's work in https://github.com/AFLplusplus/LibAFL/pull/2438

But I made trait `Scheduler` not to have OT, as it is only required for power schedules
