### PR TITLE
Do not embed client exec count in testcase and objective

### DIFF
--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -419,7 +419,6 @@ impl<I> InMemoryOnDiskCorpus<I> {
             let ondisk_meta = OnDiskMetadata {
                 metadata: testcase.metadata_map(),
                 exec_time: testcase.exec_time(),
-                executions: testcase.executions(),
             };
 
             let mut tmpfile = File::create(&tmpfile_path)?;

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -44,8 +44,6 @@ pub struct OnDiskMetadata<'a> {
     pub metadata: &'a SerdeAnyMap,
     /// The exec time for this [`Testcase`]
     pub exec_time: &'a Option<Duration>,
-    /// The amount of executions for this [`Testcase`]
-    pub executions: &'a u64,
 }
 
 /// A corpus able to store [`Testcase`]s to disk, and load them from disk, when they are being used.

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -54,8 +54,6 @@ pub struct Testcase<I> {
     exec_time: Option<Duration>,
     /// Cached len of the input, if any
     cached_len: Option<usize>,
-    /// Number of executions done at discovery time
-    executions: u64,
     /// Number of fuzzing iterations of this particular input updated in `perform_mutational`
     scheduled_count: usize,
     /// Parent [`CorpusId`], if known
@@ -171,18 +169,6 @@ impl<I> Testcase<I> {
         self.exec_time = Some(time);
     }
 
-    /// Get the executions
-    #[inline]
-    pub fn executions(&self) -> &u64 {
-        &self.executions
-    }
-
-    /// Get the executions (mutable)
-    #[inline]
-    pub fn executions_mut(&mut self) -> &mut u64 {
-        &mut self.executions
-    }
-
     /// Get the `scheduled_count`
     #[inline]
     pub fn scheduled_count(&self) -> usize {
@@ -248,7 +234,6 @@ impl<I> Testcase<I> {
             metadata_path: None,
             exec_time: None,
             cached_len: None,
-            executions: 0,
             scheduled_count: 0,
             parent_id: None,
             disabled: false,
@@ -273,7 +258,6 @@ impl<I> Testcase<I> {
             metadata_path: None,
             exec_time: None,
             cached_len: None,
-            executions: 0,
             scheduled_count: 0,
             parent_id: Some(parent_id),
             disabled: false,
@@ -298,32 +282,6 @@ impl<I> Testcase<I> {
             metadata_path: None,
             exec_time: None,
             cached_len: None,
-            executions: 0,
-            scheduled_count: 0,
-            parent_id: None,
-            disabled: false,
-            objectives_found: 0,
-            #[cfg(feature = "track_hit_feedbacks")]
-            hit_feedbacks: Vec::new(),
-            #[cfg(feature = "track_hit_feedbacks")]
-            hit_objectives: Vec::new(),
-        }
-    }
-
-    /// Create a new Testcase instance given an input and the number of executions
-    #[inline]
-    pub fn with_executions(input: I, executions: u64) -> Self {
-        Self {
-            input: Some(input),
-            filename: None,
-            #[cfg(feature = "std")]
-            file_path: None,
-            metadata: SerdeAnyMap::default(),
-            #[cfg(feature = "std")]
-            metadata_path: None,
-            exec_time: None,
-            cached_len: None,
-            executions,
             scheduled_count: 0,
             parent_id: None,
             disabled: false,
@@ -373,7 +331,6 @@ impl<I> Default for Testcase<I> {
             exec_time: None,
             cached_len: None,
             scheduled_count: 0,
-            executions: 0,
             parent_id: None,
             #[cfg(feature = "std")]
             file_path: None,

--- a/libafl/src/events/broker_hooks/mod.rs
+++ b/libafl/src/events/broker_hooks/mod.rs
@@ -177,10 +177,7 @@ where
                 // Correctly handled the event
                 Ok(BrokerEventResult::Handled)
             }
-            Event::Objective {
-                objective_size,
-                ..
-            } => {
+            Event::Objective { objective_size, .. } => {
                 monitor.client_stats_insert(client_id);
                 let client = monitor.client_stats_mut_for(client_id);
                 client.update_objective_size(*objective_size as u64);

--- a/libafl/src/events/broker_hooks/mod.rs
+++ b/libafl/src/events/broker_hooks/mod.rs
@@ -113,8 +113,6 @@ where
         match &event {
             Event::NewTestcase {
                 corpus_size,
-                time,
-                executions,
                 forward_id,
                 ..
             } => {
@@ -127,12 +125,6 @@ where
                 monitor.client_stats_insert(id);
                 let client = monitor.client_stats_mut_for(id);
                 client.update_corpus_size(*corpus_size as u64);
-                if id == client_id {
-                    // do not update executions for forwarded messages, otherwise we loose the total order
-                    // as a forwarded msg with a lower executions may arrive after a stats msg with an higher executions
-                    // this also means when you wrap this event manger with centralized EM, you will **NOT** get executions update with the new tc message
-                    client.update_executions(*executions, *time);
-                }
                 monitor.display(event.name(), id);
                 Ok(BrokerEventResult::Forward)
             }

--- a/libafl/src/events/broker_hooks/mod.rs
+++ b/libafl/src/events/broker_hooks/mod.rs
@@ -179,13 +179,11 @@ where
             }
             Event::Objective {
                 objective_size,
-                executions,
-                time,
+                ..
             } => {
                 monitor.client_stats_insert(client_id);
                 let client = monitor.client_stats_mut_for(client_id);
                 client.update_objective_size(*objective_size as u64);
-                client.update_executions(*executions, *time);
                 monitor.display(event.name(), client_id);
                 Ok(BrokerEventResult::Handled)
             }

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -600,7 +600,6 @@ where
                 corpus_size,
                 observers_buf,
                 time,
-                executions,
                 forward_id,
                 #[cfg(feature = "multi_machine")]
                 node_id,
@@ -658,7 +657,6 @@ where
                         corpus_size,
                         observers_buf,
                         time,
-                        executions,
                         forward_id,
                         #[cfg(feature = "multi_machine")]
                         node_id,

--- a/libafl/src/events/llmp/mod.rs
+++ b/libafl/src/events/llmp/mod.rs
@@ -431,7 +431,6 @@ where
                 corpus_size,
                 observers_buf,
                 time,
-                executions,
                 forward_id,
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id,
@@ -442,7 +441,6 @@ where
                 corpus_size,
                 observers_buf,
                 time,
-                executions,
                 forward_id,
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id,
@@ -490,7 +488,6 @@ where
                 corpus_size,
                 observers_buf,
                 time,
-                executions,
                 forward_id,
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id,
@@ -501,7 +498,6 @@ where
                 corpus_size,
                 observers_buf,
                 time,
-                executions,
                 forward_id,
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id,

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -325,8 +325,6 @@ where
     Objective {
         /// Objective corpus size
         objective_size: usize,
-        /// The total number of executions when this objective is found
-        executions: u64,
         /// The time when this event was created
         time: Duration,
     },

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -210,7 +210,7 @@ impl EventConfig {
         }
     }
 
-    /// Match if the currenti [`EventConfig`] matches another given config
+    /// Match if the current [`EventConfig`] matches another given config
     #[must_use]
     pub fn match_with(&self, other: &EventConfig) -> bool {
         match self {
@@ -284,8 +284,6 @@ where
         client_config: EventConfig,
         /// The time of generation of the event
         time: Duration,
-        /// The executions of this client
-        executions: u64,
         /// The original sender if, if forwarded
         forward_id: Option<ClientId>,
         /// The (multi-machine) node from which the tc is from, if any
@@ -969,7 +967,6 @@ mod tests {
             corpus_size: 123,
             client_config: EventConfig::AlwaysUnique,
             time: current_time(),
-            executions: 0,
             forward_id: None,
             #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
             node_id: None,

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -252,10 +252,7 @@ where
                 monitor.display(event.name(), ClientId(0));
                 Ok(BrokerEventResult::Handled)
             }
-            Event::Objective {
-                objective_size,
-                ..
-            } => {
+            Event::Objective { objective_size, .. } => {
                 monitor.client_stats_insert(ClientId(0));
                 monitor
                     .client_stats_mut_for(ClientId(0))

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -254,16 +254,12 @@ where
             }
             Event::Objective {
                 objective_size,
-                executions,
-                time,
+                ..
             } => {
                 monitor.client_stats_insert(ClientId(0));
                 monitor
                     .client_stats_mut_for(ClientId(0))
                     .update_objective_size(*objective_size as u64);
-                monitor
-                    .client_stats_mut_for(ClientId(0))
-                    .update_executions(*executions, *time);
                 monitor.display(event.name(), ClientId(0));
                 Ok(BrokerEventResult::Handled)
             }

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -208,19 +208,11 @@ where
         event: &Event<S::Input>,
     ) -> Result<BrokerEventResult, Error> {
         match event {
-            Event::NewTestcase {
-                corpus_size,
-                time,
-                executions,
-                ..
-            } => {
+            Event::NewTestcase { corpus_size, .. } => {
                 monitor.client_stats_insert(ClientId(0));
                 monitor
                     .client_stats_mut_for(ClientId(0))
                     .update_corpus_size(*corpus_size as u64);
-                monitor
-                    .client_stats_mut_for(ClientId(0))
-                    .update_executions(*executions, *time);
                 monitor.display(event.name(), ClientId(0));
                 Ok(BrokerEventResult::Handled)
             }

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -384,10 +384,7 @@ where
                 // Correctly handled the event
                 Ok(BrokerEventResult::Handled)
             }
-            Event::Objective {
-                objective_size,
-                ..
-            } => {
+            Event::Objective { objective_size, .. } => {
                 monitor.client_stats_insert(client_id);
                 let client = monitor.client_stats_mut_for(client_id);
                 client.update_objective_size(*objective_size as u64);

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -321,8 +321,6 @@ where
         match &event {
             Event::NewTestcase {
                 corpus_size,
-                time,
-                executions,
                 forward_id,
                 ..
             } => {
@@ -334,7 +332,6 @@ where
                 monitor.client_stats_insert(id);
                 let client = monitor.client_stats_mut_for(id);
                 client.update_corpus_size(*corpus_size as u64);
-                client.update_executions(*executions, *time);
                 monitor.display(event.name(), id);
                 Ok(BrokerEventResult::Forward)
             }

--- a/libafl/src/events/tcp.rs
+++ b/libafl/src/events/tcp.rs
@@ -386,13 +386,11 @@ where
             }
             Event::Objective {
                 objective_size,
-                executions,
-                time,
+                ..
             } => {
                 monitor.client_stats_insert(client_id);
                 let client = monitor.client_stats_mut_for(client_id);
                 client.update_objective_size(*objective_size as u64);
-                client.update_executions(*executions, *time);
                 monitor.display(event.name(), client_id);
                 Ok(BrokerEventResult::Handled)
             }

--- a/libafl/src/executors/inprocess/mod.rs
+++ b/libafl/src/executors/inprocess/mod.rs
@@ -459,7 +459,6 @@ pub fn run_observers_and_save_state<E, EM, OF, Z>(
         .expect("In run_observers_and_save_state objective failure.");
 
     if interesting {
-        let executions = *state.executions();
         let mut new_testcase = Testcase::from(input.clone());
         new_testcase.add_metadata(exitkind);
         new_testcase.set_parent_id_optional(*state.corpus().current());
@@ -481,7 +480,6 @@ pub fn run_observers_and_save_state<E, EM, OF, Z>(
                 state,
                 Event::Objective {
                     objective_size: state.solutions().count(),
-                    executions,
                     time: libafl_bolts::current_time(),
                 },
             )

--- a/libafl/src/executors/inprocess/mod.rs
+++ b/libafl/src/executors/inprocess/mod.rs
@@ -460,7 +460,7 @@ pub fn run_observers_and_save_state<E, EM, OF, Z>(
 
     if interesting {
         let executions = *state.executions();
-        let mut new_testcase = Testcase::with_executions(input.clone(), executions);
+        let mut new_testcase = Testcase::from(input.clone());
         new_testcase.add_metadata(exitkind);
         new_testcase.set_parent_id_optional(*state.corpus().current());
 

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -505,12 +505,10 @@ where
             }
             ExecuteInputResult::Solution => {
                 if manager.should_send() {
-                    let executions = *state.executions();
                     manager.fire(
                         state,
                         Event::Objective {
                             objective_size: state.solutions().count(),
-                            executions,
                             time: current_time(),
                         },
                     )?;
@@ -685,12 +683,10 @@ where
                 .append_metadata(state, manager, &*observers, &mut testcase)?;
             let id = state.solutions_mut().add(testcase)?;
 
-            let executions = *state.executions();
             manager.fire(
                 state,
                 Event::Objective {
                     objective_size: state.solutions().count(),
-                    executions,
                     time: current_time(),
                 },
             )?;

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -496,7 +496,6 @@ where
                             corpus_size: state.corpus().count(),
                             client_config: manager.configuration(),
                             time: current_time(),
-                            executions: *state.executions(),
                             forward_id: None,
                             #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                             node_id: None,
@@ -546,7 +545,7 @@ where
                 self.objective_mut().discard_metadata(state, input)?;
 
                 // Add the input to the main corpus
-                let mut testcase = Testcase::with_executions(input.clone(), *state.executions());
+                let mut testcase = Testcase::from(input.clone());
                 #[cfg(feature = "track_hit_feedbacks")]
                 self.feedback_mut()
                     .append_hit_feedbacks(testcase.hit_feedbacks_mut())?;
@@ -561,9 +560,8 @@ where
                 // Not interesting
                 self.feedback_mut().discard_metadata(state, input)?;
 
-                let executions = *state.executions();
                 // The input is a solution, add it to the respective corpus
-                let mut testcase = Testcase::with_executions(input.clone(), executions);
+                let mut testcase = Testcase::from(input.clone());
                 testcase.set_parent_id_optional(*state.corpus().current());
                 if let Ok(mut tc) = state.current_testcase_mut() {
                     tc.found_objective();
@@ -643,7 +641,7 @@ where
         state: &mut Self::State,
         input: <Self::State as UsesInput>::Input,
     ) -> Result<CorpusId, Error> {
-        let mut testcase = Testcase::with_executions(input.clone(), *state.executions());
+        let mut testcase = Testcase::from(input.clone());
         testcase.set_disabled(true);
         // Add the disabled input to the main corpus
         let id = state.corpus_mut().add_disabled(testcase)?;
@@ -662,7 +660,7 @@ where
         let exit_kind = self.execute_input(state, executor, manager, &input)?;
         let observers = executor.observers();
         // Always consider this to be "interesting"
-        let mut testcase = Testcase::with_executions(input.clone(), *state.executions());
+        let mut testcase = Testcase::from(input.clone());
 
         // Maybe a solution
         #[cfg(not(feature = "introspection"))]
@@ -741,7 +739,6 @@ where
                 corpus_size: state.corpus().count(),
                 client_config: manager.configuration(),
                 time: current_time(),
-                executions: *state.executions(),
                 forward_id: None,
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id: None,

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -372,7 +372,7 @@ pub struct ClientStats {
 }
 
 impl ClientStats {
-    /// We got a new information about executions for this client, insert them.
+    /// We got new information about executions for this client, insert them.
     #[cfg(feature = "afl_exec_sec")]
     pub fn update_executions(&mut self, executions: u64, cur_time: Duration) {
         let diff = cur_time
@@ -400,7 +400,7 @@ impl ClientStats {
         self.executions = self.prev_state_executions + executions;
     }
 
-    /// We got a new information about corpus size for this client, insert them.
+    /// We got new information about corpus size for this client, insert them.
     pub fn update_corpus_size(&mut self, corpus_size: u64) {
         self.corpus_size = corpus_size;
         self.last_corpus_time = current_time();

--- a/libafl/src/stages/sync.rs
+++ b/libafl/src/stages/sync.rs
@@ -290,7 +290,6 @@ where
                         corpus_size: 0, // TODO choose if sending 0 or the actual real value
                         client_config: EventConfig::AlwaysUnique,
                         time: current_time(),
-                        executions: 0,
                         forward_id: None,
                         #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                         node_id: None,

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -190,7 +190,7 @@ where
             fuzzer
                 .feedback_mut()
                 .is_interesting(state, manager, &base, &*observers, &exit_kind)?;
-            let mut testcase = Testcase::with_executions(base, *state.executions());
+            let mut testcase = Testcase::from(base);
             fuzzer
                 .feedback_mut()
                 .append_metadata(state, manager, &*observers, &mut testcase)?;

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -70,7 +70,6 @@ RUST_BACKTRACE=full cargo +nightly clippy --all --all-features --no-deps --tests
 
 # Loop through each project and run Clippy
 for project in "${PROJECTS[@]}"; do
-   echo "aa"
    # Trim leading and trailing whitespace
    project=$(echo "$project" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
    if [ -d "$project" ]; then


### PR DESCRIPTION
adding exec count info into a testcase (or objective) event does not feel right. i don't think knowing how many execs were required to find a testcase is important (afaik)

the main downside is that it reduces the responsiveness of the monitor.
imho we should send more heartbeats if we want to increase it.