### PR TITLE
Deriving Mapping Mutators

### DIFF
--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
@@ -139,7 +139,7 @@ pub fn main() {
     #[cfg(feature = "simple_interface")]
     let (mapped_mutators, optional_mapped_mutators) = {
         // Creating mutators that will operate on input.byte_array
-        let mapped_mutators = mapped_havoc_mutations::<_, _, MutVecInput<'_>, &[u8]>(
+        let mapped_mutators = mapped_havoc_mutations::<CustomInput, MutVecInput<'_>, &[u8]>(
             CustomInput::byte_array_mut,
             CustomInput::byte_array,
         );

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
@@ -15,6 +15,7 @@ use libafl::{
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedbacks::{CrashFeedback, MaxMapFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
+    inputs::MutVecInput,
     monitors::SimpleMonitor,
     mutators::scheduled::StdScheduledMutator,
     observers::StdMapObserver,
@@ -138,14 +139,17 @@ pub fn main() {
     #[cfg(feature = "simple_interface")]
     let (mapped_mutators, optional_mapped_mutators) = {
         // Creating mutators that will operate on input.byte_array
-        let mapped_mutators =
-            mapped_havoc_mutations(CustomInput::byte_array_mut, CustomInput::byte_array);
+        let mapped_mutators = mapped_havoc_mutations::<_, _, MutVecInput<'_>, &[u8]>(
+            CustomInput::byte_array_mut,
+            CustomInput::byte_array,
+        );
 
         // Creating mutators that will operate on input.optional_byte_array
-        let optional_mapped_mutators = optional_mapped_havoc_mutations(
-            CustomInput::optional_byte_array_mut,
-            CustomInput::optional_byte_array,
-        );
+        let optional_mapped_mutators =
+            optional_mapped_havoc_mutations::<_, Option<MutVecInput<'_>>, Option<&[u8]>>(
+                CustomInput::optional_byte_array_mut,
+                CustomInput::optional_byte_array,
+            );
         (mapped_mutators, optional_mapped_mutators)
     };
 

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -285,11 +285,10 @@ mod tests {
                 &self.vec
             }
         }
-        impl DefaultMutators<MappedHavocMutationsType<Self, MutVecInput<'static>, &'static [u8]>>
-            for CustomInput
-        {
-            fn default_mutators(
-            ) -> MappedHavocMutationsType<Self, MutVecInput<'static>, &'static [u8]> {
+        impl DefaultMutators for CustomInput {
+            type Type = MappedHavocMutationsType<Self, MutVecInput<'static>, &'static [u8]>;
+
+            fn default_mutators() -> Self::Type {
                 mapped_havoc_mutations(Self::vec_mut, Self::vec)
             }
         }

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -390,14 +390,13 @@ mod tests {
                 &self.vec
             }
         }
-        impl<S> DefaultMutators<S, MappedHavocMutationsType<S, MutVecInput<'static>, &'static [u8]>>
+        impl<S> DefaultMutators<MappedHavocMutationsType<S, MutVecInput<'static>, &'static [u8]>>
             for CustomInput
         where
             S: HasCorpus,
+            S::Corpus: Corpus<Input = Self>,
         {
             fn default_mutators() -> MappedHavocMutationsType<S, MutVecInput<'static>, &'static [u8]>
-            where
-                S::Corpus: Corpus<Input = Self>,
             {
                 mapped_havoc_mutations(Self::vec_mut, Self::vec)
             }

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -7,7 +7,6 @@ use libafl_bolts::{
 use tuple_list::{tuple_list, tuple_list_type};
 
 use crate::{
-    corpus::Corpus,
     inputs::MappedInput,
     mutators::{
         mapping::{
@@ -25,7 +24,6 @@ use crate::{
         },
         IntoOptionBytes,
     },
-    state::HasCorpus,
 };
 
 /// Tuple type of the mutations that compose the Havoc mutator without crossover mutations
@@ -71,171 +69,71 @@ pub type HavocMutationsType =
     merge_tuple_list_type!(HavocMutationsNoCrossoverType, HavocCrossoverType);
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types
-pub type MappedHavocMutationsType<S, II1, II2> = tuple_list_type!(
-    MappedInputFunctionMappingMutator<BitFlipMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteFlipMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteIncMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteDecMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteNegMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteRandMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteAddMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<WordAddMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<DwordAddMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<QwordAddMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<ByteInterestingMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<WordInterestingMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<DwordInterestingMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesExpandMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesInsertMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesRandInsertMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesSetMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesRandSetMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesCopyMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesInsertCopyMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<BytesSwapMutator, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<MappedCrossoverInsertMutator<S, II2>, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
-    MappedInputFunctionMappingMutator<MappedCrossoverReplaceMutator<S, II2>, <<S as HasCorpus>::Corpus as Corpus>::Input, II1>,
+pub type MappedHavocMutationsType<IO, II1, II2> = tuple_list_type!(
+    MappedInputFunctionMappingMutator<BitFlipMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteFlipMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteIncMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteDecMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteNegMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteRandMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteAddMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<WordAddMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<DwordAddMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<QwordAddMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<ByteInterestingMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<WordInterestingMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<DwordInterestingMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesDeleteMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesDeleteMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesDeleteMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesDeleteMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesExpandMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesInsertMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesRandInsertMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesSetMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesRandSetMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesCopyMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesInsertCopyMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<BytesSwapMutator, IO, II1>,
+    MappedInputFunctionMappingMutator<MappedCrossoverInsertMutator<IO, II2>, IO, II1>,
+    MappedInputFunctionMappingMutator<MappedCrossoverReplaceMutator<IO, II2>, IO, II1>,
 );
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types, for optional byte array input parts
-pub type OptionMappedHavocMutationsType<S, II1, II2> = tuple_list_type!(
+pub type OptionMappedHavocMutationsType<IO, II1, II2> = tuple_list_type!(
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BitFlipMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteFlipMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteIncMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteDecMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteNegMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteRandMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteAddMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<WordAddMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<DwordAddMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<QwordAddMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteInterestingMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<WordInterestingMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<DwordInterestingMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesExpandMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesInsertMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesRandInsertMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesSetMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesRandSetMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesCopyMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesInsertCopyMutator>, IO, II1>,
+    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesSwapMutator>, IO, II1>,
     MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BitFlipMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
+        OptionMappingMutator<MappedCrossoverInsertMutator<IO, II2>>,
+        IO,
         II1,
     >,
     MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteFlipMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteIncMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteDecMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteNegMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteRandMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteAddMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<WordAddMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<DwordAddMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<QwordAddMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<ByteInterestingMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<WordInterestingMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<DwordInterestingMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesDeleteMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesDeleteMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesDeleteMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesDeleteMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesExpandMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesInsertMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesRandInsertMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesSetMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesRandSetMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesCopyMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesInsertCopyMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<BytesSwapMutator>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<MappedCrossoverInsertMutator<S, II2>>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
-        II1,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<MappedCrossoverReplaceMutator<S, II2>>,
-        <<S as HasCorpus>::Corpus as Corpus>::Input,
+        OptionMappingMutator<MappedCrossoverReplaceMutator<IO, II2>>,
+        IO,
         II1,
     >
 );
@@ -282,12 +180,12 @@ pub fn havoc_crossover() -> HavocCrossoverType {
 }
 
 /// Get the mutations that compose the Havoc mutator's crossover strategy with custom corpus extraction logic
-pub fn havoc_crossover_with_corpus_mapper<S, O>(
-    input_mapper: fn(&<<S as HasCorpus>::Corpus as Corpus>::Input) -> O::Type<'_>,
-) -> MappedHavocCrossoverType<S, O>
+#[must_use]
+pub fn havoc_crossover_with_corpus_mapper<IO, II>(
+    input_mapper: fn(&IO) -> II::Type<'_>,
+) -> MappedHavocCrossoverType<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
     tuple_list!(
         MappedCrossoverInsertMutator::new(input_mapper),
@@ -296,12 +194,12 @@ where
 }
 
 /// Get the mutations that compose the Havoc mutator's crossover strategy with custom corpus extraction logic
-pub fn havoc_crossover_with_corpus_mapper_optional<S, O>(
-    input_mapper: fn(&<<S as HasCorpus>::Corpus as Corpus>::Input) -> O::Type<'_>,
-) -> MappedHavocCrossoverType<S, O>
+#[must_use]
+pub fn havoc_crossover_with_corpus_mapper_optional<IO, II>(
+    input_mapper: fn(&IO) -> II::Type<'_>,
+) -> MappedHavocCrossoverType<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
     tuple_list!(
         MappedCrossoverInsertMutator::new(input_mapper),
@@ -319,14 +217,12 @@ pub fn havoc_mutations() -> HavocMutationsType {
 ///
 /// Check the example fuzzer for details on how to use this.
 #[must_use]
-pub fn mapped_havoc_mutations<S, IO, II1, II2>(
+pub fn mapped_havoc_mutations<IO, II1, II2>(
     current_input_mapper: fn(&mut IO) -> II1::Type<'_>,
     input_from_corpus_mapper: fn(&IO) -> II2::Type<'_>,
-) -> MappedHavocMutationsType<S, II1, II2>
+) -> MappedHavocMutationsType<IO, II1, II2>
 where
-    for<'a> II1: MappedInput + 'a,
-    S::Corpus: Corpus<Input = IO>,
-    S: HasCorpus,
+    II1: MappedInput,
     II2: IntoOptionBytes,
 {
     havoc_mutations_no_crossover()
@@ -340,13 +236,12 @@ where
 ///
 /// Check the example fuzzer for details on how to use this.
 #[must_use]
-pub fn optional_mapped_havoc_mutations<S, II1, II2>(
-    current_input_mapper: fn(&mut <<S as HasCorpus>::Corpus as Corpus>::Input) -> II1::Type<'_>,
-    input_from_corpus_mapper: fn(&<<S as HasCorpus>::Corpus as Corpus>::Input) -> II2::Type<'_>,
-) -> OptionMappedHavocMutationsType<S, II1, II2>
+pub fn optional_mapped_havoc_mutations<IO, II1, II2>(
+    current_input_mapper: fn(&mut IO) -> II1::Type<'_>,
+    input_from_corpus_mapper: fn(&IO) -> II2::Type<'_>,
+) -> OptionMappedHavocMutationsType<IO, II1, II2>
 where
     II1: MappedInput,
-    S: HasCorpus,
     II2: IntoOptionBytes,
 {
     havoc_mutations_no_crossover()
@@ -372,7 +267,7 @@ mod tests {
         inputs::{Input, MutVecInput},
         mutators::{DefaultMutators, MutationResult, StdScheduledMutator, Vec},
         prelude::Mutator as _,
-        state::{HasCorpus, StdState},
+        state::StdState,
     };
 
     #[test]
@@ -390,14 +285,11 @@ mod tests {
                 &self.vec
             }
         }
-        impl<S> DefaultMutators<MappedHavocMutationsType<S, MutVecInput<'static>, &'static [u8]>>
+        impl DefaultMutators<MappedHavocMutationsType<Self, MutVecInput<'static>, &'static [u8]>>
             for CustomInput
-        where
-            S: HasCorpus,
-            S::Corpus: Corpus<Input = Self>,
         {
-            fn default_mutators() -> MappedHavocMutationsType<S, MutVecInput<'static>, &'static [u8]>
-            {
+            fn default_mutators(
+            ) -> MappedHavocMutationsType<Self, MutVecInput<'static>, &'static [u8]> {
                 mapped_havoc_mutations(Self::vec_mut, Self::vec)
             }
         }

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -1,6 +1,6 @@
 //! [`crate::mutators::Mutator`] collection equivalent to AFL++'s havoc mutations
 
-use libafl_bolts::tuples::{Map, Merge};
+use libafl_bolts::tuples::{Map, Merge, NamedTuple};
 use tuple_list::{tuple_list, tuple_list_type};
 
 use crate::mutators::{
@@ -270,4 +270,30 @@ where
         .map(ToMappedInputFunctionMappingMutatorMapper::new(
             current_input_mapper,
         ))
+}
+
+/// TODO
+pub trait HasHavocMutators {
+    /// TODO
+    fn havoc_mutators<MT: NamedTuple>() -> MT;
+}
+
+#[cfg(test)]
+mod tests {
+    use libafl_derive::HasHavocMutators;
+
+    use super::HasHavocMutators;
+    use crate::mutators::{StdScheduledMutator, Vec};
+
+    #[derive(HasHavocMutators)]
+    struct CustomInput {
+        vec: Vec<u8>,
+    }
+
+    #[test]
+    fn test_derive_has_havoc_mutators() {
+        let input = CustomInput { vec: vec![] };
+        let mutations = CustomInput::havoc_mutators();
+        let scheduler = StdScheduledMutator::new(mutations);
+    }
 }

--- a/libafl/src/mutators/mapping.rs
+++ b/libafl/src/mutators/mapping.rs
@@ -57,6 +57,7 @@ pub struct FunctionMappingMutator<M, F> {
 
 impl<M, F> FunctionMappingMutator<M, F> {
     /// Creates a new [`FunctionMappingMutator`]
+    #[must_use]
     pub fn new(mapper: F, inner: M) -> Self
     where
         M: Named,
@@ -136,6 +137,7 @@ pub struct ToFunctionMappingMutatorMapper<F> {
 
 impl<F> ToFunctionMappingMutatorMapper<F> {
     /// Creates a new [`ToFunctionMappingMutatorMapper`]
+    #[must_use]
     pub fn new(mapper: F) -> Self {
         Self { mapper }
     }
@@ -201,6 +203,7 @@ where
     II: MappedInput,
 {
     /// Creates a new [`MappedInputFunctionMappingMutator`]
+    #[must_use]
     pub fn new(mapper: for<'a> fn(&'a mut IO) -> II::Type<'a>, inner: M) -> Self
     where
         M: Named,
@@ -288,6 +291,7 @@ where
     II: MappedInput,
 {
     /// Creates a new [`ToMappedInputFunctionMappingMutatorMapper`]
+    #[must_use]
     pub fn new(mapper: for<'a> fn(&'a mut IO) -> II::Type<'a>) -> Self {
         Self { mapper }
     }
@@ -343,6 +347,7 @@ pub struct OptionMappingMutator<M> {
 
 impl<M> OptionMappingMutator<M> {
     /// Creates a new [`OptionMappingMutator`]
+    #[must_use]
     pub fn new(inner: M) -> Self
     where
         M: Named,

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -399,7 +399,7 @@ impl Named for NopMutator {
 }
 
 /// Extensions of [`crate::inputs::Input`]s that have default mutators
-pub trait DefaultMutators<MT>: Sized {
+pub trait DefaultMutators<MT> {
     /// Get the default mutators for this type
     #[must_use]
     fn default_mutators() -> MT;

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -399,8 +399,10 @@ impl Named for NopMutator {
 }
 
 /// Extensions of [`crate::inputs::Input`]s that have default mutators
-pub trait DefaultMutators<MT> {
+pub trait DefaultMutators {
+    /// The resulting mutator list type
+    type Type;
     /// Get the default mutators for this type
     #[must_use]
-    fn default_mutators() -> MT;
+    fn default_mutators() -> Self::Type;
 }

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -401,5 +401,6 @@ impl Named for NopMutator {
 /// Extensions of [`crate::inputs::Input`]s that have default mutators
 pub trait DefaultMutators<MT>: Sized {
     /// Get the default mutators for this type
+    #[must_use]
     fn default_mutators() -> MT;
 }

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -46,7 +46,11 @@ use libafl_bolts::{tuples::IntoVec, HasLen, Named};
 pub use nautilus::*;
 use tuple_list::NonEmptyTuple;
 
-use crate::{corpus::CorpusId, Error};
+use crate::{
+    corpus::{Corpus, CorpusId},
+    state::HasCorpus,
+    Error,
+};
 
 // TODO mutator stats method that produces something that can be sent with the NewTestcase event
 // We can use it to report which mutations generated the testcase in the broker logs
@@ -396,4 +400,14 @@ impl Named for NopMutator {
     fn name(&self) -> &Cow<'static, str> {
         &Cow::Borrowed("NopMutator")
     }
+}
+
+/// Extensions of [`crate::inputs::Input`]s that have default mutators
+pub trait DefaultMutators<S, MT>: Sized {
+    /// Get the default mutators for this type
+    fn default_mutators() -> MT
+    where
+        MT: MutatorsTuple<Self, S>,
+        S: HasCorpus,
+        <S as HasCorpus>::Corpus: Corpus<Input = Self>;
 }

--- a/libafl/src/mutators/mod.rs
+++ b/libafl/src/mutators/mod.rs
@@ -46,11 +46,7 @@ use libafl_bolts::{tuples::IntoVec, HasLen, Named};
 pub use nautilus::*;
 use tuple_list::NonEmptyTuple;
 
-use crate::{
-    corpus::{Corpus, CorpusId},
-    state::HasCorpus,
-    Error,
-};
+use crate::{corpus::CorpusId, Error};
 
 // TODO mutator stats method that produces something that can be sent with the NewTestcase event
 // We can use it to report which mutations generated the testcase in the broker logs
@@ -403,11 +399,7 @@ impl Named for NopMutator {
 }
 
 /// Extensions of [`crate::inputs::Input`]s that have default mutators
-pub trait DefaultMutators<S, MT>: Sized {
+pub trait DefaultMutators<MT>: Sized {
     /// Get the default mutators for this type
-    fn default_mutators() -> MT
-    where
-        MT: MutatorsTuple<Self, S>,
-        S: HasCorpus,
-        <S as HasCorpus>::Corpus: Corpus<Input = Self>;
+    fn default_mutators() -> MT;
 }

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1313,32 +1313,32 @@ impl IntoOptionBytes for Option<&[u8]> {
 
 /// Crossover insert mutation for inputs mapped to a bytes vector
 #[derive(Debug)]
-pub struct MappedCrossoverInsertMutator<S, O>
+pub struct MappedCrossoverInsertMutator<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
-    input_mapper: for<'a> fn(&'a <S::Corpus as Corpus>::Input) -> O::Type<'a>,
+    input_mapper: for<'a> fn(&'a IO) -> II::Type<'a>,
 }
 
-impl<S, O> MappedCrossoverInsertMutator<S, O>
+impl<IO, II> MappedCrossoverInsertMutator<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
     /// Creates a new [`MappedCrossoverInsertMutator`]
-    pub fn new(input_mapper: fn(&<S::Corpus as Corpus>::Input) -> O::Type<'_>) -> Self {
+    #[must_use]
+    pub fn new(input_mapper: fn(&IO) -> II::Type<'_>) -> Self {
         Self { input_mapper }
     }
 }
 
-impl<S, I, O> Mutator<I, S> for MappedCrossoverInsertMutator<S, O>
+impl<S, I, IO, II> Mutator<I, S> for MappedCrossoverInsertMutator<IO, II>
 where
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
     S: HasCorpus + HasMaxSize + HasRand,
+    S::Corpus: Corpus<Input = IO>,
     I: HasMutatorBytes,
-    for<'a> O: IntoOptionBytes,
-    for<'a> O::Type<'a>: IntoOptionBytes,
+    for<'a> II: IntoOptionBytes,
+    for<'a> II::Type<'a>: IntoOptionBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -1398,10 +1398,9 @@ where
     }
 }
 
-impl<S, O> Named for MappedCrossoverInsertMutator<S, O>
+impl<IO, II> Named for MappedCrossoverInsertMutator<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
     fn name(&self) -> &Cow<'static, str> {
         static NAME: Cow<'static, str> = Cow::Borrowed("MappedCrossoverInsertMutator");
@@ -1411,32 +1410,32 @@ where
 
 /// Crossover replace mutation for inputs mapped to a bytes vector
 #[derive(Debug)]
-pub struct MappedCrossoverReplaceMutator<S, O>
+pub struct MappedCrossoverReplaceMutator<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
-    input_mapper: for<'a> fn(&'a <<S as HasCorpus>::Corpus as Corpus>::Input) -> O::Type<'a>,
+    input_mapper: for<'a> fn(&'a IO) -> II::Type<'a>,
 }
 
-impl<S, O> MappedCrossoverReplaceMutator<S, O>
+impl<IO, II> MappedCrossoverReplaceMutator<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
     /// Creates a new [`MappedCrossoverReplaceMutator`]
-    pub fn new(input_mapper: fn(&<S::Corpus as Corpus>::Input) -> O::Type<'_>) -> Self {
+    #[must_use]
+    pub fn new(input_mapper: fn(&IO) -> II::Type<'_>) -> Self {
         Self { input_mapper }
     }
 }
 
-impl<S, I, O> Mutator<I, S> for MappedCrossoverReplaceMutator<S, O>
+impl<S, I, IO, II> Mutator<I, S> for MappedCrossoverReplaceMutator<IO, II>
 where
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
     S: HasCorpus + HasMaxSize + HasRand,
+    S::Corpus: Corpus<Input = IO>,
     I: HasMutatorBytes,
-    for<'a> O: IntoOptionBytes,
-    for<'a> O::Type<'a>: IntoOptionBytes,
+    for<'a> II: IntoOptionBytes,
+    for<'a> II::Type<'a>: IntoOptionBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -1493,10 +1492,9 @@ where
     }
 }
 
-impl<S, O> Named for MappedCrossoverReplaceMutator<S, O>
+impl<IO, II> Named for MappedCrossoverReplaceMutator<IO, II>
 where
-    S: HasCorpus,
-    O: IntoOptionBytes,
+    II: IntoOptionBytes,
 {
     fn name(&self) -> &Cow<'static, str> {
         static NAME: Cow<'static, str> = Cow::Borrowed("MappedCrossoverReplaceMutator");

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -865,6 +865,37 @@ impl<Head, Tail> PlusOne for (Head, Tail) where
 
 */
 
+/// Merge two lists of types created by the [`tuple_list_type`] macro
+///
+/// ```rust
+/// use libafl_bolts::{merge_tuple_list_type, tuples::{Merge, tuple_list, tuple_list_type}};
+/// #[derive(PartialEq, Debug)]
+/// struct T1;
+/// #[derive(PartialEq, Debug)]
+/// struct T2;
+/// #[derive(PartialEq, Debug)]
+/// struct T3;
+/// #[derive(PartialEq, Debug)]
+/// struct T4;
+/// #[derive(PartialEq, Debug)]
+/// struct T5;
+///
+/// type List1 = tuple_list_type!(T1, T2);
+/// let list1: List1 = tuple_list!(T1, T2);
+/// type List2 = tuple_list_type!(T3, T4, T5);
+/// let list2: List2 = tuple_list!(T3, T4, T5);
+/// type Combined = merge_tuple_list_type!(List1, List2);
+/// let combined: Combined = list1.merge(list2);
+/// let manual: Combined = tuple_list!(T1, T2, T3, T4, T5);
+/// assert_eq!(combined, manual);
+/// ```
+#[macro_export]
+macro_rules! merge_tuple_list_type {
+    ($Type1:ty, $Type2:ty) => {
+        <$Type1 as $crate::tuples::Merge<$Type2>>::MergeResult
+    };
+}
+
 #[cfg(test)]
 mod test {
     use tuple_list::{tuple_list, tuple_list_type};

--- a/libafl_derive/Cargo.toml
+++ b/libafl_derive/Cargo.toml
@@ -25,6 +25,7 @@ proc-macro = true
 syn = { version = "2.0.77", features = ["full", "extra-traits"] }
 quote = "1.0.37"
 proc-macro2 = "1.0.86"
+proc-macro-crate = "3.2"
 
 [lints]
 workspace = true


### PR DESCRIPTION
I'm attempting to derive everything necessary for havoc-style mutators on custom inputs using mapping mutators introduced in #2422.

Still to do:

- [ ] Fix current bug
- [ ] Introduce more struct types other than `Vec<u8>`
- [ ] Documentation