### PR TITLE
fix error[E0308]: mismatched types for libafl_qemu_init

### DIFF
--- a/libafl_qemu/src/qemu/mod.rs
+++ b/libafl_qemu/src/qemu/mod.rs
@@ -552,7 +552,7 @@ impl Qemu {
         argv.push(ptr::null()); // argv is always null terminated.
 
         unsafe {
-            libafl_qemu_init(argc, argv.as_ptr() as *mut *mut i8);
+            libafl_qemu_init(argc, argv.as_ptr() as *mut *mut ::std::os::raw::c_char);
         }
 
         #[cfg(emulation_mode = "systemmode")]


### PR DESCRIPTION
This error happens when building fuzzers/binary_only/qemu_launcher with cargo check for example