### PR TITLE
Do not start another logger in prometheus

### DIFF
--- a/libafl/src/monitors/prometheus.rs
+++ b/libafl/src/monitors/prometheus.rs
@@ -305,8 +305,6 @@ pub(crate) async fn serve_metrics(
     clients_count: Family<Labels, Gauge>,
     custom_stat: Family<Labels, Gauge<f64, AtomicU64>>,
 ) -> Result<(), std::io::Error> {
-    tide::log::start();
-
     let mut registry = Registry::default();
 
     registry.register("corpus_count", "Number of test cases in the corpus", corpus);


### PR DESCRIPTION
If a user starts a logger doing `env_logger::init()` in their fuzzer, it will collide with the logger started in prometheus (`tide::log::start();`).

@peterwhitingyb @domenukk what's the purpose of `tide::log::start()`? Should we remove it or it's me that doesn't know how to use `env_logger`?