### PR TITLE
Multi-machine: make sure only testcases are sent over the wire

### DIFF
--- a/fuzzers/inprocess/sqlite_centralized_multi_machine/build.sh
+++ b/fuzzers/inprocess/sqlite_centralized_multi_machine/build.sh
@@ -32,11 +32,11 @@ make -j$(nproc)
 make sqlite3.c
 popd
 
-if [ "$1" = "release" ]; then
-  ./target/release/libafl_cc --libafl -I ./sqlite3 -c ./sqlite3/test/ossfuzz.c -o ./sqlite3/test/ossfuzz.o
-  ./target/release/libafl_cxx --libafl -o ossfuzz ./sqlite3/test/ossfuzz.o ./sqlite3/sqlite3.o -pthread -ldl -lz
-else
+if [ "$1" = "d" ]; then
   ./target/debug/libafl_cc --libafl -I ./sqlite3 -c ./sqlite3/test/ossfuzz.c -o ./sqlite3/test/ossfuzz.o
   ./target/debug/libafl_cxx --libafl -o ossfuzz ./sqlite3/test/ossfuzz.o ./sqlite3/sqlite3.o -pthread -ldl -lz
+else
+  ./target/release/libafl_cc --libafl -I ./sqlite3 -c ./sqlite3/test/ossfuzz.c -o ./sqlite3/test/ossfuzz.o
+  ./target/release/libafl_cxx --libafl -o ossfuzz ./sqlite3/test/ossfuzz.o ./sqlite3/sqlite3.o -pthread -ldl -lz
 fi
 

--- a/fuzzers/inprocess/sqlite_centralized_multi_machine/run_child.sh
+++ b/fuzzers/inprocess/sqlite_centralized_multi_machine/run_child.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./ossfuzz --cores 0-3 --input ./corpus --parent-addr 0.0.0.0:50000 --broker-port 3000
+./ossfuzz --cores 2-3 --input ./corpus --parent-addr 0.0.0.0:50000 --broker-port 3000

--- a/libafl/src/events/launcher.rs
+++ b/libafl/src/events/launcher.rs
@@ -747,8 +747,9 @@ where
         }
 
         // Create this after forks, to avoid problems with tokio runtime
-
+        //
         // # Safety
+        //
         // The `multi_machine_receiver_hook` needs messages to outlive the receiver.
         // The underlying memory region for incoming messages lives longer than the async thread processing them.
         #[cfg(feature = "multi_machine")]

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -488,7 +488,7 @@ where
         let executions = *state.executions();
         let cur = current_time();
 
-        // Default no introspection implmentation
+        // Default no introspection implementation
         #[cfg(not(feature = "introspection"))]
         self.fire(
             state,


### PR DESCRIPTION
reverts #2583 and #2584.
i'll put the flag on the sender side instead.