### PR TITLE
Fix pipe I/O in forkserver

### DIFF
--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -511,7 +511,10 @@ impl Forkserver {
         // SAFETY: `buf` will not be returned with `Ok` unless it is filled with `size` bytes.
         //         So it is ok to set the length to `size` such that the length of `&mut buf` is `size`
         //         and the `read_exact` call will try to read `size` bytes.
-        #[allow(clippy::uninit_vec, reason = "The vec will be filled right after setting the length.")]
+        #[allow(
+            clippy::uninit_vec,
+            reason = "The vec will be filled right after setting the length."
+        )]
         unsafe {
             buf.set_len(size);
         }

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -499,8 +499,14 @@ impl Forkserver {
     /// Read bytes of any length from the st pipe
     pub fn read_st_size(&mut self, size: usize) -> Result<(usize, Vec<u8>), Error> {
         let mut buf = vec![0; size];
-
-        let rlen = self.st_pipe.read(&mut buf)?;
+        let mut rlen = 0;
+        while rlen < size {
+            let bytes_read = self.st_pipe.read(&mut buf[rlen..])?;
+            if bytes_read == 0 {
+                break;
+            }
+            rlen += bytes_read;
+        }
         Ok((rlen, buf))
     }
 

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -490,31 +490,22 @@ impl Forkserver {
     /// Read from the st pipe
     pub fn read_st(&mut self) -> Result<(usize, i32), Error> {
         let mut buf: [u8; 4] = [0_u8; 4];
-
-        let rlen = self.st_pipe.read(&mut buf)?;
+        self.st_pipe.read_exact(&mut buf)?;
         let val: i32 = i32::from_ne_bytes(buf);
-        Ok((rlen, val))
+        Ok((size_of::<i32>(), val))
     }
 
     /// Read bytes of any length from the st pipe
     pub fn read_st_size(&mut self, size: usize) -> Result<(usize, Vec<u8>), Error> {
-        let mut buf = vec![0; size];
-        let mut rlen = 0;
-        while rlen < size {
-            let bytes_read = self.st_pipe.read(&mut buf[rlen..])?;
-            if bytes_read == 0 {
-                break;
-            }
-            rlen += bytes_read;
-        }
-        Ok((rlen, buf))
+        let mut buf = vec![0u8; size];
+        self.st_pipe.read_exact(&mut buf)?;
+        Ok((size, buf))
     }
 
     /// Write to the ctl pipe
     pub fn write_ctl(&mut self, val: i32) -> Result<usize, Error> {
-        let slen = self.ctl_pipe.write(&val.to_ne_bytes())?;
-
-        Ok(slen)
+        self.ctl_pipe.write_all(&val.to_ne_bytes())?;
+        Ok(size_of::<i32>())
     }
 
     /// Read a message from the child process.

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -507,7 +507,14 @@ impl Forkserver {
 
     /// Read bytes of any length from the st pipe
     pub fn read_st_size(&mut self, size: usize) -> Result<Vec<u8>, Error> {
-        let mut buf = vec![0u8; size];
+        let mut buf = Vec::with_capacity(size);
+        // SAFETY: `buf` will not be returned with `Ok` unless it is filled with `size` bytes.
+        //         So it is ok to set the length to `size` such that the length of `&mut buf` is `size`
+        //         and the `read_exact` call will try to read `size` bytes.
+        #[allow(clippy::uninit_vec, reason = "The vec will be filled right after setting the length.")]
+        unsafe {
+            buf.set_len(size);
+        }
         self.st_pipe.read_exact(&mut buf)?;
         Ok(buf)
     }


### PR DESCRIPTION
When the fork server read a value from the pipe via `read_st_size`, the call `self.st_pipe.read()` may not read exactly `size` bytes. This happens when `size` is large (e.g., > 65535). In this case, we will run into the error at line 958 when the AUTODICT in the target is large.

https://github.com/AFLplusplus/LibAFL/blob/a69cd9843248665c3f6e5b519e045eada091c6d3/libafl/src/executors/forkserver.rs#L955-L959

When `size` is large, multiple reads are required to fill the buffer until `read` returns 0.