### PR TITLE
Remove prelude from default features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,9 @@
         "cargo",
         "check",
     ],
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#F39C9F",
+        "titleBar.activeBackground": "#F7BFC1",
+        "titleBar.activeForeground": "#370708"
+    },
 }

--- a/fuzzers/forkserver/libafl-fuzz/src/feedback/persistent_record.rs
+++ b/fuzzers/forkserver/libafl-fuzz/src/feedback/persistent_record.rs
@@ -3,9 +3,8 @@ use std::{borrow::Cow, collections::VecDeque};
 use libafl::{
     corpus::{Corpus, Testcase},
     executors::ExitKind,
-    feedbacks::{Feedback, FeedbackFactory},
+    feedbacks::{Feedback, FeedbackFactory, StateInitializer},
     inputs::Input,
-    prelude::StateInitializer,
     state::HasCorpus,
 };
 use libafl_bolts::{Error, Named};

--- a/fuzzers/forkserver/libafl-fuzz/src/feedback/seed.rs
+++ b/fuzzers/forkserver/libafl-fuzz/src/feedback/seed.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use libafl::{
-    corpus::Testcase, executors::ExitKind, feedbacks::Feedback, prelude::StateInitializer, Error,
+    corpus::Testcase,
+    executors::ExitKind,
+    feedbacks::{Feedback, StateInitializer},
+    Error,
 };
 use libafl_bolts::Named;
 

--- a/fuzzers/forkserver/libafl-fuzz/src/stages/time_tracker.rs
+++ b/fuzzers/forkserver/libafl-fuzz/src/stages/time_tracker.rs
@@ -6,7 +6,7 @@ use libafl::{
     state::{State, UsesState},
     HasMetadata,
 };
-use libafl_bolts::current_time;
+use libafl_bolts::{current_time, Error};
 
 pub struct TimeTrackingStageWrapper<T, S, ST> {
     inner: ST,
@@ -46,7 +46,7 @@ where
         executor: &mut E,
         state: &mut Self::State,
         manager: &mut M,
-    ) -> Result<(), libafl::prelude::Error> {
+    ) -> Result<(), Error> {
         let before_run = current_time();
         self.inner.perform(fuzzer, executor, state, manager)?;
         let after_run = current_time();
@@ -55,11 +55,11 @@ where
         Ok(())
     }
 
-    fn should_restart(&mut self, state: &mut Self::State) -> Result<bool, libafl::prelude::Error> {
+    fn should_restart(&mut self, state: &mut Self::State) -> Result<bool, Error> {
         self.inner.should_restart(state)
     }
 
-    fn clear_progress(&mut self, state: &mut Self::State) -> Result<(), libafl::prelude::Error> {
+    fn clear_progress(&mut self, state: &mut Self::State) -> Result<(), Error> {
         self.inner.clear_progress(state)
     }
 
@@ -69,7 +69,7 @@ where
         executor: &mut E,
         state: &mut Self::State,
         manager: &mut M,
-    ) -> Result<(), libafl::prelude::Error> {
+    ) -> Result<(), Error> {
         self.inner
             .perform_restartable(fuzzer, executor, state, manager)
     }

--- a/fuzzers/fuzz_anything/push_harness/src/main.rs
+++ b/fuzzers/fuzz_anything/push_harness/src/main.rs
@@ -39,7 +39,7 @@ fn input_generator() {
         ExitKind::Ok
     };
 
-    let signals_ptr = addr_of_mut!(SIGNALS);
+    let signals_ptr = unsafe { addr_of_mut!(SIGNALS) };
     let signals_len = unsafe { *signals_ptr }.len();
 
     // Create an observation channel using the signals map

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/input.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/input.rs
@@ -5,10 +5,9 @@ use std::{
 
 use libafl::{
     corpus::CorpusId,
-    generators::Generator,
+    generators::{Generator, RandBytesGenerator},
     inputs::{BytesInput, HasTargetBytes, Input, MutVecInput},
     mutators::{MutationResult, Mutator},
-    prelude::RandBytesGenerator,
     state::HasRand,
     Error, SerdeAny,
 };

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
@@ -42,7 +42,7 @@ use {
 /// Coverage map with explicit assignments due to the lack of instrumentation
 const SIGNALS_LEN: usize = 16;
 static mut SIGNALS: [u8; SIGNALS_LEN] = [0; 16];
-static mut SIGNALS_PTR: *mut u8 = addr_of_mut!(SIGNALS) as _;
+static mut SIGNALS_PTR: *mut u8 = unsafe { addr_of_mut!(SIGNALS) as _ };
 
 /// Assign a signal to the signals map
 fn signals_set(idx: usize) {

--- a/fuzzers/structure_aware/baby_fuzzer_gramatron/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_gramatron/src/main.rs
@@ -30,7 +30,7 @@ use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 /// Coverage map with explicit assignments due to the lack of instrumentation
 const SIGNALS_LEN: usize = 16;
 static mut SIGNALS: [u8; SIGNALS_LEN] = [0; SIGNALS_LEN];
-static mut SIGNALS_PTR: *mut u8 = addr_of_mut!(SIGNALS) as _;
+static mut SIGNALS_PTR: *mut u8 = unsafe { addr_of_mut!(SIGNALS) as _};
 /*
 /// Assign a signal to the signals map
 fn signals_set(idx: usize) {

--- a/fuzzers/structure_aware/baby_fuzzer_gramatron/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_gramatron/src/main.rs
@@ -30,7 +30,7 @@ use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 /// Coverage map with explicit assignments due to the lack of instrumentation
 const SIGNALS_LEN: usize = 16;
 static mut SIGNALS: [u8; SIGNALS_LEN] = [0; SIGNALS_LEN];
-static mut SIGNALS_PTR: *mut u8 = unsafe { addr_of_mut!(SIGNALS) as _};
+static mut SIGNALS_PTR: *mut u8 = unsafe { addr_of_mut!(SIGNALS) as _ };
 /*
 /// Assign a signal to the signals map
 fn signals_set(idx: usize) {

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -34,7 +34,6 @@ default = [
   "llmp_broker_timeouts",
   "rand_trait",
   "fork",
-  "prelude",
   "gzip",
   "regex",
   "serdeany_autoreg",

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -9,7 +9,7 @@ use core::{
 use std::{
     env,
     ffi::{OsStr, OsString},
-    io::{self, prelude::*, ErrorKind},
+    io::{self, ErrorKind, Read, Write},
     os::{
         fd::{AsRawFd, BorrowedFd},
         unix::{io::RawFd, process::CommandExt},

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -32,7 +32,6 @@ default = [
   "llmp_compression",
   "llmp_small_maps",
   "rand_trait",
-  "prelude",
   "gzip",
   "serdeany_autoreg",
   "alloc",

--- a/libafl_bolts/examples/llmp_test/main.rs
+++ b/libafl_bolts/examples/llmp_test/main.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 #[cfg(all(feature = "std", not(target_os = "haiku")))]
 use std::{num::NonZeroUsize, thread, time};
 
-use libafl_bolts::{bolts_prelude::LlmpMsgHookResult, llmp::LlmpBrokerInner};
+use libafl_bolts::llmp::{LlmpBrokerInner, LlmpMsgHookResult};
 #[cfg(all(feature = "std", not(target_os = "haiku")))]
 use libafl_bolts::{
     llmp::{self, Flags, LlmpHook, Tag},


### PR DESCRIPTION
Unless if you only use prelude _exclusively_, there's no reason to use prelude at all.
This removes the default feature. It can still be used by adding it in Cargo.toml.

This will stop confusing rust-analyzer etc.