### PR TITLE
minor: fix mutable reference warning in examples/dynamic_analysis

### DIFF
--- a/fuzzers/inprocess/dynamic_analysis/src/lib.rs
+++ b/fuzzers/inprocess/dynamic_analysis/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     io::{self, Read, Write},
     path::PathBuf,
     process,
+    ptr::addr_of_mut,
 };
 
 use clap::{Arg, Command};
@@ -252,7 +253,8 @@ fn fuzz(
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let func_list = unsafe { OwnedMutPtr::from_raw_mut(Lazy::force_mut(&mut FUNCTION_LIST)) };
+    let func_list =
+        unsafe { OwnedMutPtr::from_raw_mut(Lazy::force_mut(&mut *addr_of_mut!(FUNCTION_LIST))) };
     let profiling_observer = ProfilingObserver::new("concatenated.json", func_list)?;
     let callhook = CallHook::new();
 


### PR DESCRIPTION
the compiler produces warnings in fuzzers/inprocess/dynamic_analysis:

```
warning: creating a mutable reference to mutable static is discouraged
   --> src/lib.rs:255:72
    |
255 |     let func_list = unsafe { OwnedMutPtr::from_raw_mut(Lazy::force_mut(&mut FUNCTION_LIST)) };
    |                                                                        ^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
    = note: this will be a hard error in the 2024 edition
    = note: this mutable reference has lifetime `'static`, but if the static gets accessed (read or written) by any other means, or any other reference is created, then any further use of this mutable reference is Undefined Behavior
    = note: `#[warn(static_mut_refs)]` on by default
help: use `addr_of_mut!` instead to create a raw pointer
    |
255 |     let func_list = unsafe { OwnedMutPtr::from_raw_mut(Lazy::force_mut(addr_of_mut!(FUNCTION_LIST))) };
    |                                                                        ~~~~~~~~~~~~~             +
```

this pr fix the warning.
