### PR TITLE
Remove serde_json dependency from libafl_bolts

### DIFF
--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -424,7 +424,7 @@ impl<I> InMemoryOnDiskCorpus<I> {
             let mut tmpfile = File::create(&tmpfile_path)?;
 
             let json_error =
-                |err| Error::illegal_state(format!("Failed to json-ify metadata: {err:?}"));
+                |err| Error::serialize(format!("Failed to json-ify metadata: {err:?}"));
 
             let serialized = match self.meta_format.as_ref().unwrap() {
                 OnDiskMetadataFormat::Postcard => postcard::to_allocvec(&ondisk_meta)?,

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -423,14 +423,20 @@ impl<I> InMemoryOnDiskCorpus<I> {
 
             let mut tmpfile = File::create(&tmpfile_path)?;
 
+            let json_error =
+                |err| Error::illegal_state(format!("Failed to json-ify metadata: {err:?}"));
+
             let serialized = match self.meta_format.as_ref().unwrap() {
                 OnDiskMetadataFormat::Postcard => postcard::to_allocvec(&ondisk_meta)?,
-                OnDiskMetadataFormat::Json => serde_json::to_vec(&ondisk_meta)?,
-                OnDiskMetadataFormat::JsonPretty => serde_json::to_vec_pretty(&ondisk_meta)?,
-                #[cfg(feature = "gzip")]
-                OnDiskMetadataFormat::JsonGzip => {
-                    GzipCompressor::new().compress(&serde_json::to_vec_pretty(&ondisk_meta)?)
+                OnDiskMetadataFormat::Json => {
+                    serde_json::to_vec(&ondisk_meta).map_err(json_error)?
                 }
+                OnDiskMetadataFormat::JsonPretty => {
+                    serde_json::to_vec_pretty(&ondisk_meta).map_err(json_error)?
+                }
+                #[cfg(feature = "gzip")]
+                OnDiskMetadataFormat::JsonGzip => GzipCompressor::new()
+                    .compress(&serde_json::to_vec_pretty(&ondisk_meta).map_err(json_error)?),
             };
             tmpfile.write_all(&serialized)?;
             fs::rename(&tmpfile_path, &metafile_path)?;

--- a/libafl/src/generators/nautilus.rs
+++ b/libafl/src/generators/nautilus.rs
@@ -86,7 +86,8 @@ impl NautilusContext {
 
     /// Create a new [`NautilusContext`] from a file
     pub fn from_file<P: AsRef<Path>>(tree_depth: usize, grammar_file: P) -> Result<Self, Error> {
-        if grammar_file.as_ref().extension().unwrap_or_default() == "py" {
+        let grammar_file = grammar_file.as_ref();
+        if grammar_file.extension().unwrap_or_default() == "py" {
             log::debug!("Creating NautilusContext from python grammar");
             let ctx = python_grammar_loader::load_python_grammar(
                 fs::read_to_string(grammar_file)?.as_str(),
@@ -96,7 +97,11 @@ impl NautilusContext {
         log::debug!("Creating NautilusContext from json grammar");
         let file = fs::File::open(grammar_file)?;
         let reader = BufReader::new(file);
-        let rules: Vec<Vec<String>> = serde_json::from_reader(reader)?;
+        let rules: Vec<Vec<String>> = serde_json::from_reader(reader).map_err(|err| {
+            Error::illegal_argument(format!(
+                "Error loading context from json grammar file {grammar_file:?}: {err:?}"
+            ))
+        })?;
         Ok(Self::new(tree_depth, &rules))
     }
 }

--- a/libafl/src/observers/profiling.rs
+++ b/libafl/src/observers/profiling.rs
@@ -85,9 +85,12 @@ impl ProfilingObserver {
     where
         P: AsRef<Path>,
     {
-        let f = File::open(json_path)?;
+        let f = File::open(json_path.as_ref())?;
         let reader = BufReader::new(f);
-        let analysis_data: AnalysisData = serde_json::from_reader(reader)?;
+        let analysis_data: AnalysisData = serde_json::from_reader(reader).map_err(|err| {
+            let path = json_path.as_ref().to_string_lossy();
+            Error::illegal_argument(format!("Failed to read from path {path}: {err:?}"))
+        })?;
         // debug
         /*
         for record in &analysis_data.data {

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -44,8 +44,6 @@ document-features = ["dep:document-features"]
 
 ## Enables features that need rust's `std` lib to work, like print, env, ... support
 std = [
-  "serde_json",
-  "serde_json/std",
   "hostname",
   "nix",
   "serde/std",
@@ -143,9 +141,6 @@ ahash = { workspace = true, optional = true } # The hash function already used i
 backtrace = { workspace = true, default-features = true, optional = true } # Used to get the stacktrace in StacktraceObserver
 
 ctor = { optional = true, version = "0.2.8" }
-serde_json = { workspace = true, optional = true, default-features = false, features = [
-  "alloc",
-] }
 miniz_oxide = { version = "0.8.0", optional = true }
 hostname = { version = "0.4.0", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.6.4", optional = true }

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -532,14 +532,6 @@ impl From<postcard::Error> for Error {
     }
 }
 
-/// Stringify the json serializer error
-#[cfg(feature = "std")]
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Self::serialize(format!("{err:?}"))
-    }
-}
-
 #[cfg(all(unix, feature = "std"))]
 impl From<nix::Error> for Error {
     fn from(err: nix::Error) -> Self {

--- a/libafl_bolts/src/serdeany.rs
+++ b/libafl_bolts/src/serdeany.rs
@@ -266,22 +266,6 @@ pub mod serdeany_registry {
         }
     }
 
-    /*
-    #[cfg(feature = "anymap_debug")]
-    impl fmt::Debug for SerdeAnyMap {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let json = serde_json::to_string(&self);
-            write!(f, "SerdeAnyMap: [{:?}]", json)
-        }
-    }
-
-    #[cfg(not(feature = "anymap_debug"))]
-    impl fmt::Debug for SerdeAnyMap {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(f, "SerdeAnymap with {} elements", self.len())
-        }
-    }*/
-
     #[allow(unused_qualifications)]
     impl SerdeAnyMap {
         /// Get an element from the map.


### PR DESCRIPTION
Not sure if we want this, it makes using serde_json a bit more annoying (errors need to be mapped).
Then again, it makes libafl_bolts a bit more lightweight.

Related to #2638