### PR TITLE
Add memfd shmem backend

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -149,6 +149,7 @@ miniz_oxide = { version = "0.8.0", optional = true }
 hostname = { version = "0.4.0", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.6.4", optional = true }
 nix = { version = "0.29.0", optional = true, default-features = false, features = [
+  "fs",
   "signal",
   "socket",
   "poll",


### PR DESCRIPTION
memfd backed shmprovider. Tested on android with ForkserverExecutor but should be usable on other Linux flavors. Minor caveat: Android 7 and older as well as old linux kernel (AFAICT < 3.17) are unsupported.