### PR TITLE
better definition for PROFILE_DIR in all Makefile.toml files

### DIFF
--- a/fuzzers/binary_only/frida_executable_libpng/Makefile.toml
+++ b/fuzzers/binary_only/frida_executable_libpng/Makefile.toml
@@ -4,7 +4,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = [
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/binary_only/frida_libpng/Makefile.toml
+++ b/fuzzers/binary_only/frida_libpng/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = [
 ] } }
 FUZZER_NAME = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "frida_fuzzer", mapping = { "linux" = "frida_fuzzer", "macos" = "frida_fuzzer", "windows" = "frida_fuzzer.exe" } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/binary_only/frida_windows_gdiplus/Makefile.toml
+++ b/fuzzers/binary_only/frida_windows_gdiplus/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = [
 ] } }
 FUZZER_NAME = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "frida_windows_gdiplus", mapping = { "linux" = "frida_windows_gdiplus", "macos" = "frida_windows_gdiplus", "windows" = "frida_windows_gdiplus.exe" } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/binary_only/fuzzbench_qemu/Makefile.toml
+++ b/fuzzers/binary_only/fuzzbench_qemu/Makefile.toml
@@ -3,7 +3,7 @@
 FUZZER_NAME = 'harness'
 PROJECT_DIR = { script = ["pwd"] }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 TARGET_DIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}"

--- a/fuzzers/binary_only/qemu_cmin/Makefile.toml
+++ b/fuzzers/binary_only/qemu_cmin/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 CROSS_CC = "x86_64-linux-gnu-gcc"

--- a/fuzzers/binary_only/qemu_coverage/Makefile.toml
+++ b/fuzzers/binary_only/qemu_coverage/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 CROSS_CC = "x86_64-linux-gnu-gcc"

--- a/fuzzers/binary_only/qemu_launcher/Makefile.toml
+++ b/fuzzers/binary_only/qemu_launcher/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 CROSS_CC = "x86_64-linux-gnu-gcc"

--- a/fuzzers/binary_only/tinyinst_simple/Makefile.toml
+++ b/fuzzers/binary_only/tinyinst_simple/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 CARGO_TARGET_DIR = { value = "target", condition = { env_not_set = [

--- a/fuzzers/forkserver/forkserver_libafl_cc/Makefile.toml
+++ b/fuzzers/forkserver/forkserver_libafl_cc/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/forkserver/libafl-fuzz/Makefile.toml
+++ b/fuzzers/forkserver/libafl-fuzz/Makefile.toml
@@ -4,7 +4,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 FUZZER_NAME = 'libafl-fuzz'

--- a/fuzzers/fuzz_anything/baby_no_std/Makefile.toml
+++ b/fuzzers/fuzz_anything/baby_no_std/Makefile.toml
@@ -2,7 +2,7 @@
 FUZZER_NAME = "fuzzer"
 PROJECT_DIR = { script = ["pwd"] }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/inprocess/dynamic_analysis/Makefile.toml
+++ b/fuzzers/inprocess/dynamic_analysis/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
 ] } }
 FUZZER_NAME = "fuzzer"
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/inprocess/fuzzbench/Makefile.toml
+++ b/fuzzers/inprocess/fuzzbench/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
 ] } }
 FUZZER_NAME = "fuzzer"
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/inprocess/fuzzbench_ctx/Makefile.toml
+++ b/fuzzers/inprocess/fuzzbench_ctx/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
 ] } }
 FUZZER_NAME = "fuzzer"
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/inprocess/fuzzbench_text/Makefile.toml
+++ b/fuzzers/inprocess/fuzzbench_text/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
 ] } }
 FUZZER_NAME = "fuzzer"
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/inprocess/libfuzzer_libmozjpeg/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libmozjpeg/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_libpng/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng/Makefile.toml
@@ -6,7 +6,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_libpng_accounting/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng_accounting/Makefile.toml
@@ -4,7 +4,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 FUZZER_NAME = 'fuzzer_libpng_accounting'

--- a/fuzzers/inprocess/libfuzzer_libpng_centralized/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng_centralized/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_libpng_cmin/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng_cmin/Makefile.toml
@@ -6,7 +6,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_libpng_launcher/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng_launcher/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_libpng_norestart/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng_norestart/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_libpng_tcp_manager/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_libpng_tcp_manager/Makefile.toml
@@ -6,7 +6,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'

--- a/fuzzers/inprocess/libfuzzer_windows_asan/Makefile.toml
+++ b/fuzzers/inprocess/libfuzzer_windows_asan/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "./target", condition = { env_not_set = [
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 

--- a/fuzzers/structure_aware/nautilus_sync/Makefile.toml
+++ b/fuzzers/structure_aware/nautilus_sync/Makefile.toml
@@ -5,7 +5,7 @@ CARGO_TARGET_DIR = { value = "${PROJECT_DIR}/target", condition = { env_not_set 
   "CARGO_TARGET_DIR",
 ] } }
 PROFILE = { value = "release", condition = { env_not_set = ["PROFILE"] } }
-PROFILE_DIR = { value = "release", condition = { env_not_set = [
+PROFILE_DIR = { source = "${PROFILE}", default_value = "release", mapping = { "release" = "release", "dev" = "debug" }, condition = { env_not_set = [
   "PROFILE_DIR",
 ] } }
 LIBAFL_CC = '${CARGO_TARGET_DIR}/${PROFILE_DIR}/libafl_cc'


### PR DESCRIPTION
Use `mapping` to deduce `PROFILE_DIR` variable from `PROFILE` if possible. makes it easier to switch from `release` to `dev` builds