### PR TITLE
Fixing Crossover Mutators for Empty Multipart Inputs

### DIFF
--- a/libafl/src/mutators/multi.rs
+++ b/libafl/src/mutators/multi.rs
@@ -135,6 +135,9 @@ where
         let id = random_corpus_id!(state.corpus(), state.rand_mut());
         if let Some(cur) = state.corpus().current() {
             if id == *cur {
+                if input.names().is_empty() {
+                    return Ok(MutationResult::Skipped);
+                }
                 let choice = name_choice % input.names().len();
                 let name = input.names()[choice].clone();
 
@@ -264,6 +267,9 @@ where
         let id = random_corpus_id!(state.corpus(), state.rand_mut());
         if let Some(cur) = state.corpus().current() {
             if id == *cur {
+                if input.names().is_empty() {
+                    return Ok(MutationResult::Skipped);
+                }
                 let choice = name_choice % input.names().len();
                 let name = input.names()[choice].clone();
 


### PR DESCRIPTION
If a multipart input is empty, crossover mutators make the program crash with a divide by zero exception:

<details><summary>Backtrace</summary>

```

thread 'main' panicked at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/multi.rs:267:30:
attempt to calculate the remainder with a divisor of zero
stack backtrace:
   0:     0x555f9cb4c7fa - std::backtrace_rs::backtrace::libunwind::trace::h99efb0985cae5d78
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1:     0x555f9cb4c7fa - std::backtrace_rs::backtrace::trace_unsynchronized::he2c1aa63b3f7fad8
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x555f9cb4c7fa - std::sys::backtrace::_print_fmt::h8a221d40f5e0f88b
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/sys/backtrace.rs:66:9
   3:     0x555f9cb4c7fa - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h304520fd6a30aa07
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/sys/backtrace.rs:39:26
   4:     0x555f9cb775ab - core::fmt::rt::Argument::fmt::h5da9c218ec984eaf
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/fmt/rt.rs:177:76
   5:     0x555f9cb775ab - core::fmt::write::hf5713710ce10ff22
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/fmt/mod.rs:1178:21
   6:     0x555f9cb48273 - std::io::Write::write_fmt::hda708db57927dacf
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/io/mod.rs:1823:15
   7:     0x555f9cb4dec2 - std::sys::backtrace::BacktraceLock::print::hbcdbec4d97c91528
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/sys/backtrace.rs:42:9
   8:     0x555f9cb4dec2 - std::panicking::default_hook::{{closure}}::he1ad87607d0c11c5
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:266:22
   9:     0x555f9cb4db2e - std::panicking::default_hook::h81c8cd2e7c59ee33
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:293:9
  10:     0x555f9cb4e6bf - std::panicking::rust_panic_with_hook::had2118629c312a4a
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:797:13
  11:     0x555f9cb4e403 - std::panicking::begin_panic_handler::{{closure}}::h7fa5985d111bafa2
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:664:13
  12:     0x555f9cb4ccd9 - std::sys::backtrace::__rust_end_short_backtrace::h704d151dbefa09c5
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/sys/backtrace.rs:170:18
  13:     0x555f9cb4e0c4 - rust_begin_unwind
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:662:5
  14:     0x555f9c7b37e3 - core::panicking::panic_fmt::h3eea515d05f7a35e
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/panicking.rs:74:14
  15:     0x555f9c7b3f67 - core::panicking::panic_const::panic_const_rem_by_zero::h2f8d4b40bf67f2e1
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/panicking.rs:181:21
  16:     0x555f9c7fcb91 - libafl::mutators::multi::<impl libafl::mutators::Mutator<libafl::inputs::multi::MultipartInput<I>,S> for libafl::mutators::mutations::CrossoverReplaceMutator>::mutate::had96bf823153843b
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/multi.rs:267:30
  17:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hf9588a7d0c0aed28
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:232:13
  18:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h827aa0f4814bbb4b
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  19:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::heea69315146b8854
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  20:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::ha26976aaba24a8d3
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  21:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h56223399286dd7b3
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  22:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h9385f94a56a350e9
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  23:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h5f5273460cb15276
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  24:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h27e6b049266702d2
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  25:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h476b329c9c685b9e
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  26:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hf63ce7926391583c
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  27:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h5a2ee424c2702667
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  28:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hdfadacb9c9238bd4
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  29:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hc88e3bd7b4b75b08
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  30:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hd98aa0c25392d5b5
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  31:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::ha9b0d57f10257f35
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  32:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h76fee58ef860afb4
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  33:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h1043d87a31661c84
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  34:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h89cbf057596e5f1e
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  35:     0x555f9c7fcb91 - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h7d76e0803a5d9ea6
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  36:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hf29c7dc03c9f7c8f
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  37:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h58bc804d06d66975
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  38:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h791c6f0e36123fd6
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  39:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hc0a1ac19456004d1
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  40:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hdc05126bc05eeaee
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  41:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::ha59e7bfe68ea4c4f
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  42:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::h2c0cdc1a90d8c087
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  43:     0x555f9c7fd3ae - <(Head,Tail) as libafl::mutators::MutatorsTuple<I,S>>::get_and_mutate::hbaa01bd543107181
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/mod.rs:234:13
  44:     0x555f9c80d4bf - libafl::mutators::scheduled::ScheduledMutator::scheduled_mutate::he432cb0fef685510
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/scheduled.rs:92:27
  45:     0x555f9c80d4bf - <libafl::mutators::scheduled::StdScheduledMutator<MT> as libafl::mutators::Mutator<I,S>>::mutate::h8d866a165954ec6d
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/mutators/scheduled.rs:122:9
  46:     0x555f9c80d4bf - libafl::stages::mutational::MutationalStage::perform_mutational::h77767dccc9c3a804
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/stages/mutational.rs:133:27
  47:     0x555f9c80d4bf - <libafl::stages::mutational::StdMutationalStage<E,EM,I,M,Z> as libafl::stages::Stage<E,EM,Z>>::perform::h5842cc09d035a0ca
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/stages/mutational.rs:236:19
  48:     0x555f9c80d4bf - libafl::stages::Stage::perform_restartable::h7da89109cc36c616
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/stages/mod.rs:135:13
  49:     0x555f9c809531 - <(Head,Tail) as libafl::stages::StagesTuple<E,EM,<Head as libafl::state::UsesState>::State,Z>>::perform_all::h88bfb813e0699d9f
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/stages/mod.rs:222:17
  50:     0x555f9c7bc582 - <libafl::fuzzer::StdFuzzer<CS,F,OF,S> as libafl::fuzzer::Fuzzer<E,EM,ST>>::fuzz_one::h6fe54112dd296198
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/fuzzer/mod.rs:791:9
  51:     0x555f9c7e7412 - fuzzer::fuzzer::fuzz::{{closure}}::haf8c56f67d9447d1
                               at /home/ubuntu/fuzzing-zephyr-network-stack/fuzzer/src/fuzzer.rs:111:9
  52:     0x555f9c7e467c - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once::hbf24c1f76cf5722c
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:305:13
  53:     0x555f9c7e467c - libafl::events::launcher::Launcher<CF,MT,SP>::launch_with_hooks::h24ac8ed1962b2819
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/events/launcher.rs:289:32
  54:     0x555f9c7e467c - libafl::events::launcher::Launcher<CF,MT,SP>::launch::hd81061f196cca5c7
                               at /home/ubuntu/fuzzing-zephyr-network-stack/LibAFL/libafl/src/events/launcher.rs:181:9
  55:     0x555f9c7e467c - fuzzer::fuzzer::fuzz::h7e9e85ce79a2a1e0
                               at /home/ubuntu/fuzzing-zephyr-network-stack/fuzzer/src/fuzzer.rs:136:10
  56:     0x555f9c813290 - fuzzer::main::hd7b59142a6860c09
                               at /home/ubuntu/fuzzing-zephyr-network-stack/fuzzer/src/main.rs:42:5
  57:     0x555f9c7e9eb3 - core::ops::function::FnOnce::call_once::h4c731cde5cb2416f
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:250:5
  58:     0x555f9c7e9eb3 - std::sys::backtrace::__rust_begin_short_backtrace::h94a5ceeb8e9b1da6
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/sys/backtrace.rs:154:18
  59:     0x555f9c8136c9 - std::rt::lang_start::{{closure}}::hca210acd046e9a9a
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:164:18
  60:     0x555f9cb420e0 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h08ecba131ab90ec4
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:284:13
  61:     0x555f9cb420e0 - std::panicking::try::do_call::hf33a59fd8ce953f4
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:554:40
  62:     0x555f9cb420e0 - std::panicking::try::h5005ce80ce949fd8
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:518:19
  63:     0x555f9cb420e0 - std::panic::catch_unwind::hfbae19e2e2c5b7ed
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panic.rs:345:14
  64:     0x555f9cb420e0 - std::rt::lang_start_internal::{{closure}}::ha0331c3690741813
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:143:48
  65:     0x555f9cb420e0 - std::panicking::try::do_call::hcdcbdb616b4d0295
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:554:40
  66:     0x555f9cb420e0 - std::panicking::try::h3f2f1725a07d2256
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:518:19
  67:     0x555f9cb420e0 - std::panic::catch_unwind::h51869e04b56b2dc3
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panic.rs:345:14
  68:     0x555f9cb420e0 - std::rt::lang_start_internal::h4d90db0530245041
                               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/rt.rs:143:20
  69:     0x555f9c81334c - main
  70:     0x7f4fa576bd90 - __libc_start_call_main
                               at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  71:     0x7f4fa576be40 - __libc_start_main_impl
                               at ./csu/../csu/libc-start.c:392:3
  72:     0x555f9c7b4915 - _start
  73:                0x0 - <unknown>

```

</details>