### PR TITLE
Actually make ConstMapObserver work, introduce `nonnull_raw_mut` macro

### DIFF
--- a/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_fork_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_fork_executor/src/main.rs
@@ -47,9 +47,11 @@ pub fn main() {
     };
     // Create an observation channel using the signals map
     let observer = unsafe {
-        ConstMapObserver::<u8, 3>::from_mut_ptr(
+        ConstMapObserver::from_mut_ptr(
             "signals",
-            NonNull::new(map_ptr).expect("map ptr is null."),
+            NonNull::new(map_ptr)
+                .expect("map ptr is null.")
+                .cast::<[u8; 3]>(),
         )
     };
     // Create a stacktrace observer

--- a/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_inprocess_executor/src/main.rs
+++ b/fuzzers/baby/backtrace_baby_fuzzers/c_code_with_inprocess_executor/src/main.rs
@@ -36,9 +36,11 @@ pub fn main() {
     };
     // Create an observation channel using the signals map
     let observer = unsafe {
-        ConstMapObserver::<u8, 3>::from_mut_ptr(
+        ConstMapObserver::from_mut_ptr(
             "signals",
-            NonNull::new(array_ptr).expect("map ptr is null"),
+            NonNull::new(array_ptr)
+                .expect("map ptr is null")
+                .cast::<[u8; 3]>(),
         )
     };
     // Create a stacktrace observer

--- a/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -161,7 +161,7 @@ fn fuzz(
     let mut edges_observer = unsafe {
         HitcountsMapObserver::new(ConstMapObserver::<_, EDGES_MAP_DEFAULT_SIZE>::from_mut_ptr(
             "edges",
-            NonNull::new(edges.as_mut_ptr()).expect("map ptr is null."),
+            NonNull::new(edges.as_mut_ptr()).expect("map ptr is null.") as _,
         ))
         .track_indices()
     };

--- a/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -159,9 +159,11 @@ fn fuzz(
 
     // Create an observation channel using the coverage map
     let mut edges_observer = unsafe {
-        HitcountsMapObserver::new(ConstMapObserver::<_, EDGES_MAP_DEFAULT_SIZE>::from_mut_ptr(
+        HitcountsMapObserver::new(ConstMapObserver::from_mut_ptr(
             "edges",
-            NonNull::new(edges.as_mut_ptr()).expect("map ptr is null.") as _,
+            NonNull::new(edges.as_mut_ptr())
+                .expect("map ptr is null.")
+                .cast::<[u8; EDGES_MAP_DEFAULT_SIZE]>(),
         ))
         .track_indices()
     };

--- a/fuzzers/binary_only/qemu_cmin/src/fuzzer.rs
+++ b/fuzzers/binary_only/qemu_cmin/src/fuzzer.rs
@@ -162,9 +162,11 @@ pub fn fuzz() -> Result<(), Error> {
     unsafe { EDGES_MAP_PTR = edges.as_mut_ptr() };
 
     let mut edges_observer = unsafe {
-        HitcountsMapObserver::new(ConstMapObserver::<_, EDGES_MAP_DEFAULT_SIZE>::from_mut_ptr(
+        HitcountsMapObserver::new(ConstMapObserver::from_mut_ptr(
             "edges",
-            NonNull::new(edges.as_mut_ptr()).expect("The edge map pointer is null.") as _,
+            NonNull::new(edges.as_mut_ptr())
+                .expect("The edge map pointer is null.")
+                .cast::<[u8; EDGES_MAP_DEFAULT_SIZE]>(),
         ))
     };
 

--- a/fuzzers/binary_only/qemu_cmin/src/fuzzer.rs
+++ b/fuzzers/binary_only/qemu_cmin/src/fuzzer.rs
@@ -164,7 +164,7 @@ pub fn fuzz() -> Result<(), Error> {
     let mut edges_observer = unsafe {
         HitcountsMapObserver::new(ConstMapObserver::<_, EDGES_MAP_DEFAULT_SIZE>::from_mut_ptr(
             "edges",
-            NonNull::new(edges.as_mut_ptr()).expect("The edge map pointer is null."),
+            NonNull::new(edges.as_mut_ptr()).expect("The edge map pointer is null.") as _,
         ))
     };
 

--- a/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.toml
+++ b/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.toml
@@ -24,8 +24,6 @@ opt-level = 3
 debug = true
 
 [dependencies]
-libafl = { path = "../../../libafl", features = [
-  "multipart_inputs",
-] }
+libafl = { path = "../../../libafl", features = ["multipart_inputs"] }
 libafl_bolts = { path = "../../../libafl_bolts" }
 log = { version = "0.4.22", features = ["release_max_level_info"] }

--- a/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.toml
+++ b/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-tui = []
+tui = ["libafl/tui_monitor"]
 std = []
 
 [profile.dev]
@@ -26,7 +26,6 @@ debug = true
 [dependencies]
 libafl = { path = "../../../libafl", features = [
   "multipart_inputs",
-  "tui_monitor",
 ] }
 libafl_bolts = { path = "../../../libafl_bolts" }
 log = { version = "0.4.22", features = ["release_max_level_info"] }

--- a/fuzzers/structure_aware/baby_fuzzer_multi/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_multi/src/main.rs
@@ -1,6 +1,6 @@
+use std::path::PathBuf;
 #[cfg(windows)]
 use std::ptr::write_volatile;
-use std::path::PathBuf;
 
 #[cfg(feature = "tui")]
 use libafl::monitors::tui::TuiMonitor;

--- a/libafl/src/observers/map/const_map.rs
+++ b/libafl/src/observers/map/const_map.rs
@@ -199,11 +199,16 @@ where
     /// # Safety
     /// Will dereference the `map_ptr` with up to len elements.
     #[must_use]
-    pub unsafe fn from_mut_ptr(name: &'static str, map_ptr: NonNull<T>) -> Self {
+    pub unsafe fn from_mut_ptr(name: &'static str, map_ptr: NonNull<[T; N]>) -> Self {
         ConstMapObserver {
             map: OwnedMutSizedSlice::from_raw_mut(map_ptr),
             name: Cow::from(name),
             initial: T::default(),
         }
+    }
+
+    /// Gets the initial value for this map, mutably
+    pub fn initial_mut(&mut self) -> &mut T {
+        &mut self.initial
     }
 }

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -1124,7 +1124,7 @@ macro_rules! nonzero {
 
 /// Get a [`core::ptr::NonNull`] to a global static mut (or similar).
 /// 
-/// The same as [`core::ptr::addr_of_mut`] or `&raw mut`, but wrapped in NonNull.
+/// The same as [`core::ptr::addr_of_mut`] or `&raw mut`, but wrapped in said [`NonNull`](core::ptr::NonNull).
 #[macro_export]
 macro_rules! nonnull_raw_mut {
     ($val:expr) => {

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -1123,7 +1123,7 @@ macro_rules! nonzero {
 }
 
 /// Get a [`core::ptr::NonNull`] to a global static mut (or similar).
-/// 
+///
 /// The same as [`core::ptr::addr_of_mut`] or `&raw mut`, but wrapped in said [`NonNull`](core::ptr::NonNull).
 #[macro_export]
 macro_rules! nonnull_raw_mut {

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -1122,6 +1122,18 @@ macro_rules! nonzero {
     };
 }
 
+/// Get a [`core::ptr::NonNull`] to a global static mut (or similar).
+/// 
+/// The same as [`core::ptr::addr_of_mut`] or `&raw mut`, but wrapped in NonNull.
+#[macro_export]
+macro_rules! nonnull_raw_mut {
+    ($val:expr) => {
+        // # Safety
+        // The pointer to a value will never be null (unless we're on an archaic OS in a CTF challenge).
+        unsafe { core::ptr::NonNull::new(&raw mut $val).unwrap_unchecked() }
+    };
+}
+
 #[cfg(feature = "python")]
 #[allow(missing_docs)]
 pub mod pybind {

--- a/libafl_bolts/src/ownedref.rs
+++ b/libafl_bolts/src/ownedref.rs
@@ -946,10 +946,7 @@ impl<'a, T: 'a + Sized, const N: usize> OwnedMutSizedSlice<'a, T, N> {
     #[must_use]
     pub unsafe fn from_raw_mut(ptr: NonNull<[T; N]>) -> OwnedMutSizedSlice<'a, T, N> {
         Self {
-            inner: OwnedMutSizedSliceInner::RefRaw(
-                ptr.as_ptr(),
-                UnsafeMarker::new(),
-            ),
+            inner: OwnedMutSizedSliceInner::RefRaw(ptr.as_ptr(), UnsafeMarker::new()),
         }
     }
 

--- a/libafl_bolts/src/ownedref.rs
+++ b/libafl_bolts/src/ownedref.rs
@@ -947,7 +947,7 @@ impl<'a, T: 'a + Sized, const N: usize> OwnedMutSizedSlice<'a, T, N> {
     pub unsafe fn from_raw_mut(ptr: NonNull<[T; N]>) -> OwnedMutSizedSlice<'a, T, N> {
         Self {
             inner: OwnedMutSizedSliceInner::RefRaw(
-                ptr.as_ptr() as *mut [T; N],
+                ptr.as_ptr(),
                 UnsafeMarker::new(),
             ),
         }

--- a/libafl_bolts/src/ownedref.rs
+++ b/libafl_bolts/src/ownedref.rs
@@ -944,7 +944,7 @@ impl<'a, T: 'a + Sized, const N: usize> OwnedMutSizedSlice<'a, T, N> {
     /// The pointer must be valid and point to a map of the size `size_of<T>() * N`
     /// The content will be dereferenced in subsequent operations.
     #[must_use]
-    pub unsafe fn from_raw_mut(ptr: NonNull<T>) -> OwnedMutSizedSlice<'a, T, N> {
+    pub unsafe fn from_raw_mut(ptr: NonNull<[T; N]>) -> OwnedMutSizedSlice<'a, T, N> {
         Self {
             inner: OwnedMutSizedSliceInner::RefRaw(
                 ptr.as_ptr() as *mut [T; N],


### PR DESCRIPTION
The `ConstMapObserver` wasn't really usable after #2592