### PR TITLE
Libafl workspace internal deps in workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,30 +54,30 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # Internal deps
-libafl = { path = "./libafl", version = "0.13.2", default-features = false }
-libafl_bolts = { path = "./libafl_bolts", version = "0.13.2", default-features = false }
-libafl_cc = { path = "./libafl_cc", version = "0.13.2", default-features = false }
-symcc_runtime = { path = "./libafl_concolic/symcc_runtime", version = "0.13.2", default-features = false }
-symcc_libafl = { path = "./libafl_concolic/symcc_libafl", version = "0.13.2", default-features = false }
-libafl_derive = { path = "./libafl_derive", version = "0.13.2", default-features = false }
-libafl_frida = { path = "./libafl_frida", version = "0.13.2", default-features = false }
-libafl_intelpt = { path = "./libafl_intelpt", version = "0.13.2", default-features = false }
-libafl_libfuzzer = { path = "./libafl_libfuzzer", version = "0.13.2", default-features = false }
-libafl_nyx = { path = "./libafl_nyx", version = "0.13.2", default-features = false }
-libafl_targets = { path = "./libafl_targets", version = "0.13.2", default-features = false }
-libafl_tinyinst = { path = "./libafl_tinyinst", version = "0.13.2", default-features = false }
-libafl_qemu = { path = "./libafl_qemu", version = "0.13.2", default-features = false }
-libafl_qemu_build = { path = "./libafl_qemu/libafl_qemu_build", version = "0.13.2", default-features = false }
-libafl_qemu_sys = { path = "./libafl_qemu/libafl_qemu_sys", version = "0.13.2", default-features = false }
-libafl_sugar = { path = "./libafl_sugar", version = "0.13.2", default-features = false }
-dump_constraints = { path = "./libafl_concolic/test/dump_constraints", version = "0.13.2", default-features = false }
-runtime_test = { path = "./libafl_concolic/test/runtime_test", version = "0.13.2", default-features = false }
-build_and_test_fuzzers = { path = "./utils/build_and_test_fuzzers", version = "0.13.2", default-features = false }
-deexit = { path = "./utils/deexit", version = "0.13.2", default-features = false }
-drcov_utils = { path = "./utils/drcov_utils", version = "0.13.2", default-features = false }
-construct_automata = { path = "./utils/gramatron/construct_automata", version = "0.13.2", default-features = false }
-libafl_benches = { path = "./utils/libafl_benches", version = "0.13.2", default-features = false }
-libafl_jumper = { path = "./utils/libafl_jumper", version = "0.13.2", default-features = false }
+libafl = { path = "./libafl", version = "0.14.0", default-features = false }
+libafl_bolts = { path = "./libafl_bolts", version = "0.14.0", default-features = false }
+libafl_cc = { path = "./libafl_cc", version = "0.14.0", default-features = false }
+symcc_runtime = { path = "./libafl_concolic/symcc_runtime", version = "0.14.0", default-features = false }
+symcc_libafl = { path = "./libafl_concolic/symcc_libafl", version = "0.14.0", default-features = false }
+libafl_derive = { path = "./libafl_derive", version = "0.14.0", default-features = false }
+libafl_frida = { path = "./libafl_frida", version = "0.14.0", default-features = false }
+libafl_intelpt = { path = "./libafl_intelpt", version = "0.14.0", default-features = false }
+libafl_libfuzzer = { path = "./libafl_libfuzzer", version = "0.14.0", default-features = false }
+libafl_nyx = { path = "./libafl_nyx", version = "0.14.0", default-features = false }
+libafl_targets = { path = "./libafl_targets", version = "0.14.0", default-features = false }
+libafl_tinyinst = { path = "./libafl_tinyinst", version = "0.14.0", default-features = false }
+libafl_qemu = { path = "./libafl_qemu", version = "0.14.0", default-features = false }
+libafl_qemu_build = { path = "./libafl_qemu/libafl_qemu_build", version = "0.14.0", default-features = false }
+libafl_qemu_sys = { path = "./libafl_qemu/libafl_qemu_sys", version = "0.14.0", default-features = false }
+libafl_sugar = { path = "./libafl_sugar", version = "0.14.0", default-features = false }
+dump_constraints = { path = "./libafl_concolic/test/dump_constraints", version = "0.14.0", default-features = false }
+runtime_test = { path = "./libafl_concolic/test/runtime_test", version = "0.14.0", default-features = false }
+build_and_test_fuzzers = { path = "./utils/build_and_test_fuzzers", version = "0.14.0", default-features = false }
+deexit = { path = "./utils/deexit", version = "0.14.0", default-features = false }
+drcov_utils = { path = "./utils/drcov_utils", version = "0.14.0", default-features = false }
+construct_automata = { path = "./utils/gramatron/construct_automata", version = "0.14.0", default-features = false }
+libafl_benches = { path = "./utils/libafl_benches", version = "0.14.0", default-features = false }
+libafl_jumper = { path = "./utils/libafl_jumper", version = "0.14.0", default-features = false }
 
 # External deps
 ahash = { version = "0.8.11", default-features = false } # The hash function already used in hashbrown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,33 @@ version = "0.13.2"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+# Internal deps
+libafl = { path = "./libafl", version = "0.13.2", default-features = false }
+libafl_bolts = { path = "./libafl_bolts", version = "0.13.2", default-features = false }
+libafl_cc = { path = "./libafl_cc", version = "0.13.2", default-features = false }
+symcc_runtime = { path = "./libafl_concolic/symcc_runtime", version = "0.13.2", default-features = false }
+symcc_libafl = { path = "./libafl_concolic/symcc_libafl", version = "0.13.2", default-features = false }
+libafl_derive = { path = "./libafl_derive", version = "0.13.2", default-features = false }
+libafl_frida = { path = "./libafl_frida", version = "0.13.2", default-features = false }
+libafl_intelpt = { path = "./libafl_intelpt", version = "0.13.2", default-features = false }
+libafl_libfuzzer = { path = "./libafl_libfuzzer", version = "0.13.2", default-features = false }
+libafl_nyx = { path = "./libafl_nyx", version = "0.13.2", default-features = false }
+libafl_targets = { path = "./libafl_targets", version = "0.13.2", default-features = false }
+libafl_tinyinst = { path = "./libafl_tinyinst", version = "0.13.2", default-features = false }
+libafl_qemu = { path = "./libafl_qemu", version = "0.13.2", default-features = false }
+libafl_qemu_build = { path = "./libafl_qemu/libafl_qemu_build", version = "0.13.2", default-features = false }
+libafl_qemu_sys = { path = "./libafl_qemu/libafl_qemu_sys", version = "0.13.2", default-features = false }
+libafl_sugar = { path = "./libafl_sugar", version = "0.13.2", default-features = false }
+dump_constraints = { path = "./libafl_concolic/test/dump_constraints", version = "0.13.2", default-features = false }
+runtime_test = { path = "./libafl_concolic/test/runtime_test", version = "0.13.2", default-features = false }
+build_and_test_fuzzers = { path = "./utils/build_and_test_fuzzers", version = "0.13.2", default-features = false }
+deexit = { path = "./utils/deexit", version = "0.13.2", default-features = false }
+drcov_utils = { path = "./utils/drcov_utils", version = "0.13.2", default-features = false }
+construct_automata = { path = "./utils/gramatron/construct_automata", version = "0.13.2", default-features = false }
+libafl_benches = { path = "./utils/libafl_benches", version = "0.13.2", default-features = false }
+libafl_jumper = { path = "./utils/libafl_jumper", version = "0.13.2", default-features = false }
+
+# External deps
 ahash = { version = "0.8.11", default-features = false } # The hash function already used in hashbrown
 backtrace = { version = "0.3.74", default-features = false } # Used to get the stacktrace in StacktraceObserver
 bindgen = "0.70.1"

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -205,11 +205,9 @@ bytecount = "0.6.8"
 static_assertions = { workspace = true }
 
 [dependencies]
-libafl_bolts = { version = "0.13.2", path = "../libafl_bolts", default-features = false, features = [
-  "alloc",
-] }
-libafl_derive = { version = "0.13.2", path = "../libafl_derive", optional = true }
-libafl_intelpt = { path = "../libafl_intelpt", optional = true }
+libafl_bolts = { workspace = true, features = ["alloc"] }
+libafl_derive = { workspace = true, default-features = true, optional = true }
+libafl_intelpt = { workspace = true, default-features = true, optional = true }
 
 rustversion = { workspace = true }
 tuple_list = { version = "0.1.3" }

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -119,7 +119,7 @@ llmp_small_maps = ["alloc"]
 rustversion = { workspace = true }
 
 [dependencies]
-libafl_derive = { version = "0.13.2", optional = true, path = "../libafl_derive" }
+libafl_derive = { workspace = true, default-features = true, optional = true }
 static_assertions = { workspace = true }
 
 tuple_list = { version = "0.1.3" }

--- a/libafl_concolic/symcc_runtime/Cargo.toml
+++ b/libafl_concolic/symcc_runtime/Cargo.toml
@@ -32,14 +32,8 @@ all-features = true
 no-cpp-runtime = []
 
 [dependencies]
-libafl = { path = "../../libafl", version = "0.14.0", default-features = false, features = [
-  "std",
-  "serdeany_autoreg",
-] }
-libafl_bolts = { path = "../../libafl_bolts", version = "0.14.0", default-features = false, features = [
-  "std",
-  "serdeany_autoreg",
-] }
+libafl = { workspace = true, features = ["std", "serdeany_autoreg"] }
+libafl_bolts = { workspace = true, features = ["std", "serdeany_autoreg"] }
 
 unchecked_unwrap = "4.0.0"
 ctor = "0.2.8"
@@ -50,7 +44,7 @@ cmake = { workspace = true }
 bindgen = { workspace = true }
 regex = { workspace = true }
 which = { workspace = true }
-symcc_libafl = { path = "../symcc_libafl", version = "0.14.0" }
+symcc_libafl = { workspace = true, default-features = true, version = "0.14.0" }
 
 [lints]
 workspace = true

--- a/libafl_concolic/test/dump_constraints/Cargo.toml
+++ b/libafl_concolic/test/dump_constraints/Cargo.toml
@@ -20,8 +20,8 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libafl = { path = "../../../libafl" }
-libafl_bolts = { path = "../../../libafl_bolts" }
+libafl = { workspace = true, default-features = true }
+libafl_bolts = { workspace = true, default-features = true }
 clap = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/libafl_frida/Cargo.toml
+++ b/libafl_frida/Cargo.toml
@@ -47,17 +47,9 @@ auto-download = ["frida-gum-sys/auto-download", "frida-gum/auto-download"]
 cc = { workspace = true, features = ["parallel"] }
 
 [dependencies]
-libafl = { path = "../libafl", default-features = false, version = "0.14.0", features = [
-  "std",
-  "derive",
-  "frida_cli",
-] }
-libafl_bolts = { path = "../libafl_bolts", version = "0.14.0", default-features = false, features = [
-  "std",
-  "derive",
-  "frida_cli",
-] }
-libafl_targets = { path = "../libafl_targets", version = "0.14.0", features = [
+libafl = { workspace = true, features = ["std", "derive", "frida_cli"] }
+libafl_bolts = { workspace = true, features = ["std", "derive", "frida_cli"] }
+libafl_targets = { workspace = true, default-features = true, features = [
   "std",
   "sancov_cmplog",
 ] }

--- a/libafl_intelpt/Cargo.toml
+++ b/libafl_intelpt/Cargo.toml
@@ -26,7 +26,7 @@ proc-maps = "0.4.0"
 [dependencies]
 arbitrary-int = { workspace = true }
 bitbybit = { workspace = true }
-libafl_bolts = { version = "0.14.0", path = "../libafl_bolts", default-features = false }
+libafl_bolts = { workspace = true }
 libc = { workspace = true }
 libipt = { workspace = true, optional = true }
 log = { workspace = true }

--- a/libafl_nyx/Cargo.toml
+++ b/libafl_nyx/Cargo.toml
@@ -21,17 +21,17 @@ categories = [
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libnyx = { git = "https://github.com/nyx-fuzz/libnyx.git", rev = "ea6ceb994ab975b81aea0daaf64b92a3066c1e8d" }
-libafl = { path = "../libafl", version = "0.14.0", features = [
+libafl = { workspace = true, default-features = true, features = [
   "std",
   "libafl_derive",
   "frida_cli",
 ] }
-libafl_bolts = { path = "../libafl_bolts", version = "0.14.0", features = [
+libafl_bolts = { workspace = true, default-features = true, features = [
   "std",
   "libafl_derive",
   "frida_cli",
 ] }
-libafl_targets = { path = "../libafl_targets", version = "0.14.0", features = [
+libafl_targets = { workspace = true, default-features = true, features = [
   "std",
   "sancov_cmplog",
 ] }

--- a/libafl_qemu/Cargo.toml
+++ b/libafl_qemu/Cargo.toml
@@ -88,18 +88,11 @@ shared = ["libafl_qemu_sys/shared"]
 clippy = ["libafl_qemu_sys/clippy"]
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.14.0", default-features = false, features = [
-  "std",
-  "derive",
-  "regex",
-] }
-libafl_bolts = { path = "../libafl_bolts", version = "0.14.0", default-features = false, features = [
-  "std",
-  "derive",
-] }
-libafl_targets = { path = "../libafl_targets", version = "0.14.0" }
-libafl_qemu_sys = { path = "./libafl_qemu_sys", version = "0.14.0", default-features = false }
-libafl_derive = { path = "../libafl_derive", version = "0.14.0" }
+libafl = { workspace = true, features = ["std", "derive", "regex"] }
+libafl_bolts = { workspace = true, features = ["std", "derive"] }
+libafl_targets = { workspace = true, default-features = true, version = "0.14.0" }
+libafl_qemu_sys = { workspace = true }
+libafl_derive = { workspace = true, default-features = true }
 
 serde = { workspace = true, default-features = false, features = [
   "alloc",
@@ -138,7 +131,7 @@ getset = "0.1.3"
 document-features = { workspace = true, optional = true }
 
 [build-dependencies]
-libafl_qemu_build = { path = "./libafl_qemu_build", version = "0.14.0" }
+libafl_qemu_build = { workspace = true, default-features = true, version = "0.14.0" }
 pyo3-build-config = { version = "0.22.3", optional = true }
 rustversion = { workspace = true }
 bindgen = { workspace = true }

--- a/libafl_qemu/libafl_qemu_sys/Cargo.toml
+++ b/libafl_qemu/libafl_qemu_sys/Cargo.toml
@@ -66,7 +66,7 @@ strum_macros = { workspace = true }
 pyo3 = { version = "0.22.3", optional = true }
 
 [build-dependencies]
-libafl_qemu_build = { path = "../libafl_qemu_build", version = "0.14.0" }
+libafl_qemu_build = { workspace = true, default-features = true }
 pyo3-build-config = { version = "0.22.3", optional = true }
 rustversion = { workspace = true }
 

--- a/libafl_sugar/Cargo.toml
+++ b/libafl_sugar/Cargo.toml
@@ -60,9 +60,9 @@ riscv64 = ["libafl_qemu/riscv64"]
 pyo3-build-config = { version = "0.22.3", optional = true }
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.14.0" }
-libafl_bolts = { path = "../libafl_bolts", version = "0.14.0" }
-libafl_targets = { path = "../libafl_targets", version = "0.14.0" }
+libafl = { workspace = true, default-features = true }
+libafl_bolts = { workspace = true, default-features = true }
+libafl_targets = { workspace = true, default-features = true }
 
 # Document all features of this crate (for `cargo doc`)
 document-features = { workspace = true, optional = true }
@@ -72,7 +72,7 @@ pyo3 = { version = "0.22.3", optional = true }
 log = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libafl_qemu = { path = "../libafl_qemu", version = "0.14.0" }
+libafl_qemu = { workspace = true, default-features = true }
 
 [lib]
 name = "libafl_sugar"

--- a/libafl_targets/Cargo.toml
+++ b/libafl_targets/Cargo.toml
@@ -70,10 +70,8 @@ cc = { version = "1.1.21", features = ["parallel"] }
 rustversion = "1.0.17"
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.14.0", default-features = false, features = [
-] }
-libafl_bolts = { path = "../libafl_bolts", version = "0.14.0", default-features = false, features = [
-] }
+libafl = { workspace = true, features = [] }
+libafl_bolts = { workspace = true, features = [] }
 libc = { workspace = true }
 hashbrown = { workspace = true, default-features = true }
 once_cell = "1.19.0"

--- a/libafl_tinyinst/Cargo.toml
+++ b/libafl_tinyinst/Cargo.toml
@@ -21,11 +21,11 @@ description = "TinyInst backend for libafl"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libafl = { path = "../libafl", version = "0.14.0", features = [
+libafl = { workspace = true, default-features = true, features = [
   "std",
   "libafl_derive",
 ] }
-libafl_bolts = { path = "../libafl_bolts", version = "0.14.0", features = [
+libafl_bolts = { workspace = true, default-features = true, features = [
   "std",
   "libafl_derive",
 ] }

--- a/utils/drcov_utils/Cargo.toml
+++ b/utils/drcov_utils/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["development-tools"]
 keywords = ["fuzzing", "libafl", "drcov"]
 
 [dependencies]
-libafl_targets = { path = "../../libafl_targets" }
+libafl_targets = { workspace = true, default-features = true }
 clap = { workspace = true, features = ["derive", "wrap_help"] }
 
 [lints]

--- a/utils/gramatron/construct_automata/Cargo.toml
+++ b/utils/gramatron/construct_automata/Cargo.toml
@@ -24,7 +24,7 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libafl = { path = "../../../libafl", default-features = false }
+libafl = { workspace = true }
 serde_json = { workspace = true, default-features = true }
 regex = { workspace = true }
 postcard = { workspace = true, features = [

--- a/utils/libafl_benches/Cargo.toml
+++ b/utils/libafl_benches/Cargo.toml
@@ -21,10 +21,7 @@ categories = [
 ]
 
 [dev-dependencies]
-libafl_bolts = { path = "../../libafl_bolts", default-features = false, features = [
-  "xxh3",
-  "alloc",
-] } # libafl_bolts
+libafl_bolts = { workspace = true, features = ["xxh3", "alloc"] } # libafl_bolts
 
 criterion = "0.5.1" # Benchmarking
 ahash = { workspace = true, default-features = false } # The hash function already used in hashbrown


### PR DESCRIPTION
improvements:
- no redundant `path`
- no redundant `version` (easier libafl version bumps I guess)

drawbacks:
- `default-features` must be explicitly enabled in packages if required

Just an idea, open for feedbacks