### PR TITLE
remove test_harness from source directory

### DIFF
--- a/libafl_frida/build.rs
+++ b/libafl_frida/build.rs
@@ -1,7 +1,12 @@
 // build.rs
 #![forbid(unexpected_cfgs)]
 
+use std::{env, path::Path};
+
 fn main() {
+
+    let out_dir = env::var_os("OUT_DIR").unwrap(); 
+    let out_dir = out_dir.to_string_lossy().to_string();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os != "ios" {
         cc::Build::new().file("src/gettls.c").compile("libgettls.a");
@@ -46,7 +51,7 @@ fn main() {
                 "/libpath:{}/.cache/cargo-xwin/xwin/sdk/lib/um/x86_64/",
                 std::env::var("HOME").unwrap()
             ));
-        cmd.arg("/dll").arg("/OUT:test_harness.dll");
+        cmd.arg("/dll").arg(format!("/OUT:{}", Path::new(&out_dir).join("test_harness.so").to_str().unwrap()));
         let output = cmd.output().expect("Failed to link test_harness.dll");
         let output_str = format!(
             "{:?}\nstatus: {}\nstdout: {}\nstderr: {}",
@@ -63,6 +68,8 @@ fn main() {
             output_str.as_str()
         );
     } else {
+        
+        
         let compiler = cc::Build::new()
             .cpp(true)
             .opt_level(0)
@@ -73,7 +80,7 @@ fn main() {
         cmd.args(compiler.args())
             .arg("test_harness.cpp")
             .arg("-o")
-            .arg("test_harness.so")
+            .arg(Path::new(&out_dir).join("test_harness.so"))
             .status()
             .expect("Failed to link test_harness");
     }

--- a/libafl_frida/src/lib.rs
+++ b/libafl_frida/src/lib.rs
@@ -548,15 +548,20 @@ mod tests {
         }
 
         SimpleStdoutLogger::set_logger().unwrap();
-
+        
+        let out_dir = std::env::var_os("OUT_DIR").unwrap(); 
+        let out_dir = out_dir.to_string_lossy().to_string();
         // Check if the harness dynamic library is present, if not - skip the test
         #[cfg(unix)]
-        let test_harness = "./test_harness.so";
+        let test_harness_name = "test_harness.so";
         #[cfg(windows)]
-        let test_harness = ".\\test_harness.dll";
+        let test_harness_name = "test_harness.dll";
+
+        let test_harness = std::path::Path::new(&out_dir).join(test_harness_name);
+        
         assert!(
-            std::path::Path::new(test_harness).exists(),
-            "Skipping test, {test_harness} not found"
+            test_harness.exists(),
+            "Skipping test, {} not found", test_harness.to_str().unwrap()
         );
 
         GUM.set(Gum::obtain())
@@ -567,7 +572,7 @@ mod tests {
             "--disable-excludes",
             "--continue-on-error",
             "-H",
-            test_harness,
+            test_harness.to_str().unwrap(),
         ];
         let options: FuzzerOptions = FuzzerOptions::try_parse_from(simulated_args).unwrap();
         unsafe { test_asan(&options) }


### PR DESCRIPTION
The purpose of this pull request is to move compiling test_harness into `OUT_DIR` instead of in the source directory. 