### PR TITLE
`StdMOptMutator::new`: remove unused type parameter

### DIFF
--- a/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -307,7 +307,7 @@ fn fuzz(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/binary_only/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/binary_only/fuzzbench_qemu/src/fuzzer.rs
@@ -310,7 +310,7 @@ fn fuzz(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/binary_only/qemu_launcher/src/instance.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/instance.rs
@@ -263,7 +263,7 @@ impl<M: Monitor> Instance<'_, M> {
             )));
 
             // Setup a MOPT mutator
-            let mutator = StdMOptMutator::new::<BytesInput, _>(
+            let mutator = StdMOptMutator::new(
                 &mut state,
                 havoc_mutations().merge(tokens_mutations()),
                 7,

--- a/fuzzers/forkserver/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver/src/main.rs
@@ -291,7 +291,7 @@ fn fuzz(
     println!("Let's fuzz :)");
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/forkserver/fuzzbench_forkserver_cmplog/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver_cmplog/src/main.rs
@@ -293,7 +293,7 @@ fn fuzz(
     println!("Let's fuzz :)");
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/inprocess/dynamic_analysis/src/lib.rs
+++ b/fuzzers/inprocess/dynamic_analysis/src/lib.rs
@@ -307,7 +307,7 @@ fn fuzz(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/inprocess/fuzzbench/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench/src/lib.rs
@@ -300,7 +300,7 @@ fn fuzz(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
@@ -310,7 +310,7 @@ fn fuzz(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/fuzzers/inprocess/fuzzbench_text/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_text/src/lib.rs
@@ -367,7 +367,7 @@ fn fuzz_binary(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,
@@ -582,7 +582,7 @@ fn fuzz_text(
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));
 
     // Setup a MOPT mutator
-    let mutator = StdMOptMutator::new::<BytesInput, _>(
+    let mutator = StdMOptMutator::new(
         &mut state,
         havoc_mutations().merge(tokens_mutations()),
         7,

--- a/libafl/src/mutators/mopt_mutator.rs
+++ b/libafl/src/mutators/mopt_mutator.rs
@@ -497,7 +497,7 @@ where
 
 impl<MT> StdMOptMutator<MT> {
     /// Create a new [`StdMOptMutator`].
-    pub fn new<I, S>(
+    pub fn new<S>(
         state: &mut S,
         mutations: MT,
         max_stack_pow: usize,


### PR DESCRIPTION
`I` is unused in `::new` and thus requires callers to explicitly specify any type as it can't be determined by type inference.

Clippy's `extra_unused_type_parameters` should pick this up, but is tuned a bit too conservative in order to avoid false positives AFAICT.

If the type parameter was deliberate in order to easily set the mutator's input type we could also add the missing type bound. Here, I'm letting type inference figure it out.. :shrug: 

Note: The CI failure seems like an unrelated flaky test.