### PR TITLE
Pre init module hooks

### DIFF
--- a/libafl_qemu/src/emu/mod.rs
+++ b/libafl_qemu/src/emu/mod.rs
@@ -325,31 +325,55 @@ where
     pub fn new(
         qemu_args: &[String],
         modules: ET,
-        drivers: ED,
-        snapshot_manager: SM,
-        command_manager: CM,
-    ) -> Result<Self, QemuInitError> {
-        let qemu = Qemu::init(qemu_args)?;
-
-        Self::new_with_qemu(qemu, modules, drivers, snapshot_manager, command_manager)
-    }
-
-    pub fn new_with_qemu(
-        qemu: Qemu,
-        modules: ET,
         driver: ED,
         snapshot_manager: SM,
         command_manager: CM,
     ) -> Result<Self, QemuInitError> {
-        Ok(Emulator {
-            modules: EmulatorModules::new(qemu, modules),
+        let mut emulator_hooks = EmulatorHooks::default();
+
+        modules.pre_qemu_init_all(&mut emulator_hooks);
+
+        let qemu = Qemu::init(qemu_args)?;
+
+        unsafe {
+            Ok(Self::new_with_qemu(
+                qemu,
+                emulator_hooks,
+                modules,
+                driver,
+                snapshot_manager,
+                command_manager,
+            ))
+        }
+    }
+
+    /// New emulator with already initialized QEMU.
+    /// We suppose modules init hooks have already been run.
+    ///
+    /// # Safety
+    ///
+    /// pre-init qemu hooks should be run by then.
+    pub(crate) unsafe fn new_with_qemu(
+        qemu: Qemu,
+        emulator_hooks: EmulatorHooks<ET, S>,
+        modules: ET,
+        driver: ED,
+        snapshot_manager: SM,
+        command_manager: CM,
+    ) -> Self {
+        let mut emulator = Emulator {
+            modules: EmulatorModules::new(qemu, emulator_hooks, modules),
             command_manager,
             snapshot_manager,
             driver,
             breakpoints_by_addr: RefCell::new(HashMap::new()),
             breakpoints_by_id: RefCell::new(HashMap::new()),
             qemu,
-        })
+        };
+
+        emulator.modules.post_qemu_init_all();
+
+        emulator
     }
 }
 

--- a/libafl_qemu/src/modules/calls.rs
+++ b/libafl_qemu/src/modules/calls.rs
@@ -399,7 +399,7 @@ where
     #[cfg(feature = "systemmode")]
     type ModulePageFilter = NopPageFilter;
 
-    fn init_module<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn post_qemu_init<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/drcov.rs
+++ b/libafl_qemu/src/modules/drcov.rs
@@ -264,7 +264,7 @@ where
     #[cfg(feature = "systemmode")]
     type ModulePageFilter = NopPageFilter;
 
-    fn init_module<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn post_qemu_init<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/mod.rs
+++ b/libafl_qemu/src/modules/mod.rs
@@ -40,7 +40,7 @@ pub mod drcov;
 #[cfg(not(cpu_target = "hexagon"))]
 pub use drcov::{DrCovMetadata, DrCovModule, DrCovModuleBuilder};
 
-use crate::{emu::EmulatorModules, Qemu};
+use crate::{emu::EmulatorModules, EmulatorHooks, Qemu};
 
 /// A module for `libafl_qemu`.
 // TODO remove 'static when specialization will be stable
@@ -58,7 +58,7 @@ where
     /// Hook run **before** QEMU is initialized.
     /// This is always run when Emulator gets initialized, in any case.
     /// Install here hooks that should be alive for the whole execution of the VM, even before QEMU gets initialized.
-    fn pre_qemu_init<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init<ET>(&self, _emulator_hooks: &mut EmulatorHooks<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -146,7 +146,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool;
 
-    fn pre_qemu_init_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init_all<ET>(&self, _emulator_hooks: &mut EmulatorHooks<ET, S>)
     where
         ET: EmulatorModuleTuple<S>;
 
@@ -199,7 +199,7 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn pre_qemu_init_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init_all<ET>(&self, _emulator_hooks: &mut EmulatorHooks<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -258,12 +258,12 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = Head::HOOKS_DO_SIDE_EFFECTS || Tail::HOOKS_DO_SIDE_EFFECTS;
 
-    fn pre_qemu_init_all<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init_all<ET>(&self, emulator_hooks: &mut EmulatorHooks<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {
-        self.0.pre_qemu_init(emulator_modules);
-        self.1.pre_qemu_init_all(emulator_modules);
+        self.0.pre_qemu_init(emulator_hooks);
+        self.1.pre_qemu_init_all(emulator_hooks);
     }
 
     fn post_qemu_init_all<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)

--- a/libafl_qemu/src/modules/mod.rs
+++ b/libafl_qemu/src/modules/mod.rs
@@ -55,10 +55,19 @@ where
 
     const HOOKS_DO_SIDE_EFFECTS: bool = true;
 
-    /// Initialize the module, mostly used to install some hooks early.
+    /// Hook run **before** QEMU is initialized.
     /// This is always run when Emulator gets initialized, in any case.
-    /// Install here hooks that should be alive for the whole execution of the VM.
-    fn init_module<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    /// Install here hooks that should be alive for the whole execution of the VM, even before QEMU gets initialized.
+    fn pre_qemu_init<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    where
+        ET: EmulatorModuleTuple<S>,
+    {
+    }
+
+    /// Hook run **after** QEMU is initialized.
+    /// This is always run when Emulator gets initialized, in any case.
+    /// Install here hooks that should be alive for the whole execution of the VM, after QEMU gets initialized.
+    fn post_qemu_init<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -137,7 +146,11 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool;
 
-    fn init_modules_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    where
+        ET: EmulatorModuleTuple<S>;
+
+    fn post_qemu_init_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>;
 
@@ -186,7 +199,13 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_modules_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
+    where
+        ET: EmulatorModuleTuple<S>,
+    {
+    }
+
+    fn post_qemu_init_all<ET>(&self, _emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {
@@ -239,12 +258,20 @@ where
 {
     const HOOKS_DO_SIDE_EFFECTS: bool = Head::HOOKS_DO_SIDE_EFFECTS || Tail::HOOKS_DO_SIDE_EFFECTS;
 
-    fn init_modules_all<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn pre_qemu_init_all<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {
-        self.0.init_module(emulator_modules);
-        self.1.init_modules_all(emulator_modules);
+        self.0.pre_qemu_init(emulator_modules);
+        self.1.pre_qemu_init_all(emulator_modules);
+    }
+
+    fn post_qemu_init_all<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    where
+        ET: EmulatorModuleTuple<S>,
+    {
+        self.0.post_qemu_init(emulator_modules);
+        self.1.post_qemu_init_all(emulator_modules);
     }
 
     fn first_exec_all<ET>(&mut self, emulator_modules: &mut EmulatorModules<ET, S>, state: &mut S)

--- a/libafl_qemu/src/modules/usermode/asan.rs
+++ b/libafl_qemu/src/modules/usermode/asan.rs
@@ -929,7 +929,7 @@ where
     type ModuleAddressFilter = StdAddressFilter;
     const HOOKS_DO_SIDE_EFFECTS: bool = false;
 
-    fn init_module<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn post_qemu_init<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/usermode/injections.rs
+++ b/libafl_qemu/src/modules/usermode/injections.rs
@@ -262,7 +262,7 @@ where
 {
     type ModuleAddressFilter = NopAddressFilter;
 
-    fn init_module<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn post_qemu_init<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {

--- a/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -675,7 +675,7 @@ where
 {
     type ModuleAddressFilter = NopAddressFilter;
 
-    fn init_module<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
+    fn post_qemu_init<ET>(&self, emulator_modules: &mut EmulatorModules<ET, S>)
     where
         ET: EmulatorModuleTuple<S>,
     {


### PR DESCRIPTION
side effect: `Emulator::new_with_qemu` is now `pub(mod)`