### PR TITLE
Fix metadata removal for ExecutionCountRestartHelper

### DIFF
--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -699,12 +699,12 @@ impl ExecutionCountRestartHelper {
     }
 
     /// Clear progress for the stage this wrapper wraps.
-    pub fn clear_progress<S>(&mut self, state: &mut S) -> Result<(), Error>
+    pub fn clear_progress<S>(&mut self, state: &mut S, name: &str) -> Result<(), Error>
     where
-        S: HasMetadata,
+        S: HasNamedMetadata,
     {
         self.started_at_execs = None;
-        let _metadata = state.remove_metadata::<ExecutionCountRestartHelperMetadata>();
+        let _metadata = state.remove_named_metadata::<ExecutionCountRestartHelperMetadata>(name);
         debug_assert!(_metadata.is_some(), "Called clear_progress, but should_restart was not called before (or did mutational stages get nested?)");
         Ok(())
     }

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -260,7 +260,7 @@ where
     }
 
     fn clear_progress(&mut self, state: &mut Self::State) -> Result<(), Error> {
-        self.restart_helper.clear_progress(state)
+        self.restart_helper.clear_progress(state, &self.name)
     }
 
     fn perform(

--- a/libafl/src/stages/tuneable.rs
+++ b/libafl/src/stages/tuneable.rs
@@ -296,7 +296,7 @@ where
     }
 
     fn clear_progress(&mut self, state: &mut Self::State) -> Result<(), Error> {
-        self.restart_helper.clear_progress(state)
+        self.restart_helper.clear_progress(state, &self.name)
     }
 }
 


### PR DESCRIPTION
The metadata is inserted as a named metadata. 

https://github.com/AFLplusplus/LibAFL/blob/b3d3c38b2900e45246ea8dd75648f25818226d74/libafl/src/stages/mod.rs#L693-L696

The `debug_assert!` will always fail since unnamed metadata and named metadata are stored in different fields in `StdState`

https://github.com/AFLplusplus/LibAFL/blob/b3d3c38b2900e45246ea8dd75648f25818226d74/libafl/src/state/mod.rs#L264-L267