### PR TITLE
Specify minimum supported Rust version and check in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -222,6 +222,14 @@ jobs:
       #     fail_on_error: 'true'
       #     config_file: '.github/.linkspector.yml'
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+      # Note: We currently only specify minimum rust versions for the default workspace members
+      - run: cargo hack check --rust-version -p libafl -p libafl_bolts -p libafl_derive -p libafl_cc -p libafl_targets
+
   fuzzers-preflight:
     runs-on: ubuntu-24.04
     steps:

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
 edition = "2021"
+rust-version = "1.82"
 categories = [
   "development-tools::testing",
   "emulators",

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -12,6 +12,7 @@ readme = "./README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "security"]
 edition = "2021"
+rust-version = "1.82"
 categories = [
   "development-tools::testing",
   "emulators",

--- a/libafl_cc/Cargo.toml
+++ b/libafl_cc/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "compiler"]
 edition = "2021"
+rust-version = "1.78"
 categories = [
   "development-tools::testing",
   "emulators",

--- a/libafl_derive/Cargo.toml
+++ b/libafl_derive/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing"]
 edition = "2021"
+rust-version = "1.78"
 categories = [
   "development-tools::testing",
   "emulators",

--- a/libafl_targets/Cargo.toml
+++ b/libafl_targets/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing"]
 edition = "2021"
+rust-version = "1.82"
 categories = [
   "development-tools::testing",
   "emulators",


### PR DESCRIPTION
Hi,

specifying `rust-version= ".."` in Cargo.toml is nice because it gives a descriptive error message when people try to use LibAFL on older Rust versions. I've added the MSRV for the core-ish `libafl` crates and added a check in CI that makes sure these are up-to-date.

Thanks!

Note: The CI failure is unrelated :upside_down_face: 