### PR TITLE
Delete with_observers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,1 +1,2 @@
 # 0.14.0 -> 0.14.1
+    - Removed `with_observers` from `Executor` trait.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,5 @@
 # Pre 0.9 -> 0.9
-    - [https://aflplus.plus/libafl-book/design/migration-0.9.html](https://aflplus.plus/libafl-book/design/migration-0.9.html)
+- [Migrating from LibAFL <0.9 to 0.9](https://aflplus.plus/libafl-book/design/migration-0.9.html)
+
 # 0.14.0 -> 0.14.1
-    - Removed `with_observers` from `Executor` trait.
+- Removed `with_observers` from `Executor` trait.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,2 +1,4 @@
+# Pre 0.9 -> 0.9
+    - [https://aflplus.plus/libafl-book/design/migration-0.9.html](https://aflplus.plus/libafl-book/design/migration-0.9.html)
 # 0.14.0 -> 0.14.1
     - Removed `with_observers` from `Executor` trait.

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -130,18 +130,6 @@ where
         mgr: &mut EM,
         input: &Self::Input,
     ) -> Result<ExitKind, Error>;
-
-    /// Wraps this Executor with the given [`ObserversTuple`] to implement [`HasObservers`].
-    ///
-    /// If the executor already implements [`HasObservers`], then the original implementation will be overshadowed by
-    /// the implementation of this wrapper.
-    fn with_observers<OT>(self, observers: OT) -> WithObservers<Self, OT>
-    where
-        Self: Sized,
-        OT: ObserversTuple<Self::Input, Self::State>,
-    {
-        WithObservers::new(self, observers)
-    }
 }
 
 /// A trait that allows to get/set an `Executor`'s timeout thresold

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 pub use shadow::ShadowExecutor;
 pub use with_observers::WithObservers;
 
-use crate::{observers::ObserversTuple, state::UsesState, Error};
+use crate::{state::UsesState, Error};
 
 pub mod combined;
 #[cfg(all(feature = "std", any(unix, doc)))]


### PR DESCRIPTION
This function doesn't work for a executor that doesn't have EM, Z in its struct. thus it is inappropriate to include in Executor