### PR TITLE
Snapshot size assertion

### DIFF
--- a/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -257,7 +257,7 @@ impl SnapshotModule {
 
     pub fn access(&mut self, addr: GuestAddr, size: usize) {
         // ASSUMPTION: the access can only cross 2 pages
-        debug_assert!(size > 0 && size < SNAPSHOT_PAGE_SIZE);
+        debug_assert!(size > 0 && size <= SNAPSHOT_PAGE_SIZE);
         let page = addr & SNAPSHOT_PAGE_MASK;
         self.page_access(page);
         let second_page = (addr + size as GuestAddr - 1) & SNAPSHOT_PAGE_MASK;


### PR DESCRIPTION
Very simple PR.

While messing around with some snapshot stuff, I was failing this assertion because the size was `4096` which was equal to `SNAPSHOT_PAGE_SIZE`.