### PR TITLE
Link libresolv on all apple OSs

### DIFF
--- a/libafl_frida/build.rs
+++ b/libafl_frida/build.rs
@@ -18,6 +18,9 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=c++");
     }
 
+    #[cfg(target_vendor = "apple")]
+    println!("cargo:rustc-link-lib=dylib=resolv");
+
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=test_harness.cpp");
     println!("cargo:rerun-if-changed=src/gettls.c");


### PR DESCRIPTION
Currently, there is a problem where, when linking frida-gum, glib cannot find certain symbols because libresolv is not linked properly. The error is below:

```
Undefined symbols for architecture arm64:
            "_res_9_dn_expand", referenced from:
                _OUTLINED_FUNCTION_16 in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
            "_res_9_ndestroy", referenced from:
                _do_lookup_records in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
            "_res_9_ninit", referenced from:
                _do_lookup_records in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
            "_res_9_nquery", referenced from:
                _do_lookup_records in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is a temporary fix until the following PR is merged in frida-rust: https://github.com/frida/frida-rust/pull/180