### PR TITLE
Revert #2768 fix bitbybit CI by locking bitbybit <1.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,11 +80,13 @@ libafl_benches = { path = "./utils/libafl_benches", version = "0.14.1", default-
 libafl_jumper = { path = "./utils/libafl_jumper", version = "0.14.1", default-features = false }
 
 # External deps
-ahash = { version = "0.8.11", default-features = false } # The hash function already used in hashbrown
-arbitrary-int = "1.2.7" # arbitrary sized integers, useful in combination with bitfields (bitbybit crate)
+ahash = { version = "0.8.11", default-features = false }     # The hash function already used in hashbrown
+arbitrary-int = "1.2.7"                                      # arbitrary sized integers, useful in combination with bitfields (bitbybit crate)
 backtrace = { version = "0.3.74", default-features = false } # Used to get the stacktrace in StacktraceObserver
 bindgen = "0.71.1"
-bitbybit = "1.3.3" # bitfields, use this for bit fields and bit enums
+# 2024-12-16: bitbybit 1.3.3 is leading CI to fail due to missing docs.
+# fixme: Change this to 1.3.3 when the issue https://github.com/danlehmann/bitfield/issues/66 is resolved.
+bitbybit = ">= 1, < 1.3.3" # bitfields, use this for bit fields and bit enums
 clap = "4.5.18"
 cc = "1.1.21"
 cmake = "0.1.51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ backtrace = { version = "0.3.74", default-features = false } # Used to get the s
 bindgen = "0.71.1"
 # 2024-12-16: bitbybit 1.3.3 is leading CI to fail due to missing docs.
 # fixme: Change this to 1.3.3 when the issue https://github.com/danlehmann/bitfield/issues/66 is resolved.
-bitbybit = ">= 1, < 1.3.3" # bitfields, use this for bit fields and bit enums
+bitbybit = "=1.3.2" # bitfields, use this for bit fields and bit enums
 clap = "4.5.18"
 cc = "1.1.21"
 cmake = "0.1.51"

--- a/libafl_intelpt/src/lib.rs
+++ b/libafl_intelpt/src/lib.rs
@@ -695,7 +695,6 @@ impl IntelPTBuilder {
 /// Perf event config for `IntelPT`
 ///
 /// (This is almost mapped to `IA32_RTIT_CTL MSR` by perf)
-#[allow(missing_docs)] // 2024-12-15: bitfield is leading CI to fail due to missing docs.
 #[cfg(target_os = "linux")]
 #[bitfield(u64, default = 0)]
 struct PtConfig {


### PR DESCRIPTION
The `missing_docs` issue was introduced in 1.3.3
We can use 1.3.2 until [this](https://github.com/danlehmann/bitfield/issues/66) gets fixed

This PR reverts #2768 