### PR TITLE
libafl_{cc,derive}: Bump MSRV to 1.82 for `home` crate update

### DIFF
--- a/libafl_cc/Cargo.toml
+++ b/libafl_cc/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing", "compiler"]
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.82"
 categories = [
   "development-tools::testing",
   "emulators",

--- a/libafl_cc/src/cfg.rs
+++ b/libafl_cc/src/cfg.rs
@@ -317,7 +317,7 @@ where
                     let new_distance = distance + successor_info.get_weight();
                     let is_shorter = distances
                         .get(successor)
-                        .map_or(true, |&current| new_distance < current);
+                        .is_none_or(|&current| new_distance < current);
 
                     if is_shorter {
                         distances.insert(*successor, new_distance);

--- a/libafl_derive/Cargo.toml
+++ b/libafl_derive/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["fuzzing", "testing"]
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.82"
 categories = [
   "development-tools::testing",
   "emulators",


### PR DESCRIPTION
This brings the MSRV in line with the other core crates (`libafl`, `libafl_bolts`), which (sadly) is outside of the "packaged Rust in distros" range (Ubuntu 24.04 is at `1.80`, 25.04 is at `1.81` :melting_face:).

With the upcoming 2024 edition we should also set `resolver = "3"` in the workspace's Cargo.toml at some point to opt into the new MSRV-aware dependency resolver. This would fix the breakage we encountered with dependencies that bump their MSRV in a minor version update.


CC #2754