### PR TITLE
Remove MutVecInput and MappedInput in Favour of Impls on References

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,7 +5,8 @@
 - `StatsStage` is deleted, and it is superceded by `AflStatsStage`
 - Changed mapping mutators to take borrows directly instead of `MappedInput`s. See `baby_fuzzer_custom_input` for example usage
   - Related: `MutVecInput` is deprecated in favor of directly using `&mut Vec<u8>`
-  - Related: `MappedInputFunctionMappingMutator` and `ToMappedInputFunctionMappingMutatorMapper` have been removed as now duplicates of `MappingMutator` (previously `FunctionMappingMutator`) and `ToMappingMutatorMapper` (previously `ToFunctionMappingMutatorMapper`)
+  - Related: `MappedInputFunctionMappingMutator` and `ToMappedInputFunctionMappingMutatorMapper` have been removed as now duplicates of `MappingMutator` (previously `FunctionMappingMutator`) and `ToMappingMutator` (previously `ToFunctionMappingMutatorMapper`)
+  - `ToOptionMappingMutatorMapper` and `ToFunctionMappingMutatorMapper` have been renamed to `ToOptionalMutator` and `ToMappingMutator` respectively
 
 # 0.14.0 -> 0.14.1
 - Removed `with_observers` from `Executor` trait.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,7 +5,7 @@
 - `StatsStage` is deleted, and it is superceded by `AflStatsStage`
 - Changed mapping mutators to take borrows directly instead of `MappedInput`s. See `baby_fuzzer_custom_input` for example usage
   - Related: `MutVecInput` is deprecated in favor of directly using `&mut Vec<u8>`
-  - Related: `MappedInputFunctionMappingMutator` and `ToMappedInputFunctionMappingMutatorMapper` have been removed as now duplicates of `FunctionMappingMutator` `ToFunctionMappingMutatorMapper`
+  - Related: `MappedInputFunctionMappingMutator` and `ToMappedInputFunctionMappingMutatorMapper` have been removed as now duplicates of `MappingMutator` (previously `FunctionMappingMutator`) and `ToMappingMutatorMapper` (previously `ToFunctionMappingMutatorMapper`)
 
 # 0.14.0 -> 0.14.1
 - Removed `with_observers` from `Executor` trait.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,15 @@
-# Pre 0.9 -> 0.9
-- [Migrating from LibAFL <0.9 to 0.9](https://aflplus.plus/libafl-book/design/migration-0.9.html)
-
-# 0.14.0 -> 0.14.1
-- Removed `with_observers` from `Executor` trait.
-- `MmapShMemProvider::new_shmem_persistent` has been removed in favour of `MmapShMem::persist`. You probably want to do something like this: `let shmem = MmapShMemProvider::new()?.new_shmem(size)?.persist()?;`
 
 # 0.14.1 -> 0.15.0
 - `MmapShMem::new` and `MmapShMemProvider::new_shmem_with_id` now take `AsRef<Path>` instead of a byte array for the filename/id.
 - The closure passed to a `DumpToDiskStage` now provides the `Testcase` instead of just the `Input`.
 - `StatsStage` is deleted, and it is superceded by `AflStatsStage`
-- 
+- Changed mapping mutators to take borrows directly instead of `MappedInput`s. See `baby_fuzzer_custom_input` for example usage
+  - Related: `MutVecInput` is deprecated in favor of directly using `&mut Vec<u8>`
+  - Related: `MappedInputFunctionMappingMutator` and `ToMappedInputFunctionMappingMutatorMapper` have been removed as now duplicates of `FunctionMappingMutator` `ToFunctionMappingMutatorMapper`
+
+# 0.14.0 -> 0.14.1
+- Removed `with_observers` from `Executor` trait.
+- `MmapShMemProvider::new_shmem_persistent` has been removed in favour of `MmapShMem::persist`. You probably want to do something like this: `let shmem = MmapShMemProvider::new()?.new_shmem(size)?.persist()?;`
+
+# Pre 0.9 -> 0.9
+- [Migrating from LibAFL <0.9 to 0.9](https://aflplus.plus/libafl-book/design/migration-0.9.html)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,10 +3,10 @@
 - `MmapShMem::new` and `MmapShMemProvider::new_shmem_with_id` now take `AsRef<Path>` instead of a byte array for the filename/id.
 - The closure passed to a `DumpToDiskStage` now provides the `Testcase` instead of just the `Input`.
 - `StatsStage` is deleted, and it is superceded by `AflStatsStage`
-- Changed mapping mutators to take borrows directly instead of `MappedInput`s. See `baby_fuzzer_custom_input` for example usage
+- Renamed and changed mapping mutators to take borrows directly instead of `MappedInput`s. See `baby_fuzzer_custom_input` for example usage
   - Related: `MutVecInput` is deprecated in favor of directly using `&mut Vec<u8>`
   - Related: `MappedInputFunctionMappingMutator` and `ToMappedInputFunctionMappingMutatorMapper` have been removed as now duplicates of `MappingMutator` (previously `FunctionMappingMutator`) and `ToMappingMutator` (previously `ToFunctionMappingMutatorMapper`)
-  - `ToOptionMappingMutatorMapper` and `ToFunctionMappingMutatorMapper` have been renamed to `ToOptionalMutator` and `ToMappingMutator` respectively
+  - Related: `ToOptionMappingMutatorMapper` and `ToFunctionMappingMutatorMapper` have been renamed to `ToOptionalMutator` and `ToMappingMutator` respectively
 
 # 0.14.0 -> 0.14.1
 - Removed `with_observers` from `Executor` trait.

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/input.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/input.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, hash::Hash};
 use libafl::{
     corpus::CorpusId,
     generators::{Generator, RandBytesGenerator},
-    inputs::{value::MutI16Input, BytesInput, HasTargetBytes, Input, MutVecInput},
+    inputs::{BytesInput, HasTargetBytes, Input},
     mutators::{MutationResult, Mutator},
     state::HasRand,
     Error, SerdeAny,
@@ -36,28 +36,28 @@ impl Input for CustomInput {
 
 impl CustomInput {
     /// Returns a mutable reference to the byte array
-    pub fn byte_array_mut(&mut self) -> MutVecInput<'_> {
-        (&mut self.byte_array).into()
+    pub fn byte_array_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.byte_array
     }
 
     /// Returns an immutable reference to the byte array
-    pub fn byte_array(&self) -> &[u8] {
+    pub fn byte_array(&self) -> &Vec<u8> {
         &self.byte_array
     }
 
     /// Returns a mutable reference to the optional byte array
-    pub fn optional_byte_array_mut(&mut self) -> Option<MutVecInput<'_>> {
-        self.optional_byte_array.as_mut().map(|e| e.into())
+    pub fn optional_byte_array_mut(&mut self) -> &mut Option<Vec<u8>> {
+        &mut self.optional_byte_array
     }
 
     /// Returns an immutable reference to the optional byte array
-    pub fn optional_byte_array(&self) -> Option<&[u8]> {
-        self.optional_byte_array.as_deref()
+    pub fn optional_byte_array(&self) -> &Option<Vec<u8>> {
+        &self.optional_byte_array
     }
 
     /// Returns a mutable reference to the number
-    pub fn num_mut(&mut self) -> MutI16Input<'_> {
-        (&mut self.num).into()
+    pub fn num_mut(&mut self) -> &mut i16 {
+        &mut self.num
     }
 
     /// Returns an immutable reference to the number

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
@@ -34,7 +34,7 @@ use libafl_bolts::{
 use {
     libafl::mutators::{
         havoc_mutations::{havoc_crossover_with_corpus_mapper, havoc_mutations_no_crossover},
-        mapping::{ToFunctionMappingMutatorMapper, ToOptionMappingMutatorMapper},
+        mapping::{ToMappingMutatorMapper, ToOptionalMutatorMapper},
         numeric::{int_mutators_no_crossover, mapped_int_mutators_crossover},
     },
     libafl_bolts::tuples::Map,
@@ -164,24 +164,22 @@ pub fn main() {
         // Creating mutators that will operate on input.byte_array
         let mapped_mutators = havoc_mutations_no_crossover()
             .merge(havoc_crossover_with_corpus_mapper(CustomInput::byte_array))
-            .map(ToFunctionMappingMutatorMapper::new(
-                CustomInput::byte_array_mut,
-            ));
+            .map(ToMappingMutatorMapper::new(CustomInput::byte_array_mut));
 
         // Creating mutators that will operate on input.optional_byte_array
         let optional_mapped_mutators = havoc_mutations_no_crossover()
             .merge(havoc_crossover_with_corpus_mapper(
                 CustomInput::optional_byte_array,
             ))
-            .map(ToOptionMappingMutatorMapper)
-            .map(ToFunctionMappingMutatorMapper::new(
+            .map(ToOptionalMutatorMapper)
+            .map(ToMappingMutatorMapper::new(
                 CustomInput::optional_byte_array_mut,
             ));
 
         // Creating mutators that will operate on input.num
         let int_mutators = int_mutators_no_crossover()
             .merge(mapped_int_mutators_crossover(CustomInput::num))
-            .map(ToFunctionMappingMutatorMapper::new(CustomInput::num_mut));
+            .map(ToMappingMutatorMapper::new(CustomInput::num_mut));
         (mapped_mutators, optional_mapped_mutators, int_mutators)
     };
 

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
@@ -34,7 +34,7 @@ use libafl_bolts::{
 use {
     libafl::mutators::{
         havoc_mutations::{havoc_crossover_with_corpus_mapper, havoc_mutations_no_crossover},
-        mapping::{ToMappingMutatorMapper, ToOptionalMutatorMapper},
+        mapping::{ToMappingMutator, ToOptionalMutator},
         numeric::{int_mutators_no_crossover, mapped_int_mutators_crossover},
     },
     libafl_bolts::tuples::Map,
@@ -164,22 +164,20 @@ pub fn main() {
         // Creating mutators that will operate on input.byte_array
         let mapped_mutators = havoc_mutations_no_crossover()
             .merge(havoc_crossover_with_corpus_mapper(CustomInput::byte_array))
-            .map(ToMappingMutatorMapper::new(CustomInput::byte_array_mut));
+            .map(ToMappingMutator::new(CustomInput::byte_array_mut));
 
         // Creating mutators that will operate on input.optional_byte_array
         let optional_mapped_mutators = havoc_mutations_no_crossover()
             .merge(havoc_crossover_with_corpus_mapper(
                 CustomInput::optional_byte_array,
             ))
-            .map(ToOptionalMutatorMapper)
-            .map(ToMappingMutatorMapper::new(
-                CustomInput::optional_byte_array_mut,
-            ));
+            .map(ToOptionalMutator)
+            .map(ToMappingMutator::new(CustomInput::optional_byte_array_mut));
 
         // Creating mutators that will operate on input.num
         let int_mutators = int_mutators_no_crossover()
             .merge(mapped_int_mutators_crossover(CustomInput::num))
-            .map(ToMappingMutatorMapper::new(CustomInput::num_mut));
+            .map(ToMappingMutator::new(CustomInput::num_mut));
         (mapped_mutators, optional_mapped_mutators, int_mutators)
     };
 

--- a/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_custom_input/src/main.rs
@@ -34,7 +34,7 @@ use libafl_bolts::{
 use {
     libafl::mutators::{
         havoc_mutations::{havoc_crossover_with_corpus_mapper, havoc_mutations_no_crossover},
-        mapping::{ToMappedInputFunctionMappingMutatorMapper, ToOptionMappingMutatorMapper},
+        mapping::{ToFunctionMappingMutatorMapper, ToOptionMappingMutatorMapper},
         numeric::{int_mutators_no_crossover, mapped_int_mutators_crossover},
     },
     libafl_bolts::tuples::Map,
@@ -164,7 +164,7 @@ pub fn main() {
         // Creating mutators that will operate on input.byte_array
         let mapped_mutators = havoc_mutations_no_crossover()
             .merge(havoc_crossover_with_corpus_mapper(CustomInput::byte_array))
-            .map(ToMappedInputFunctionMappingMutatorMapper::new(
+            .map(ToFunctionMappingMutatorMapper::new(
                 CustomInput::byte_array_mut,
             ));
 
@@ -174,16 +174,14 @@ pub fn main() {
                 CustomInput::optional_byte_array,
             ))
             .map(ToOptionMappingMutatorMapper)
-            .map(ToMappedInputFunctionMappingMutatorMapper::new(
+            .map(ToFunctionMappingMutatorMapper::new(
                 CustomInput::optional_byte_array_mut,
             ));
 
         // Creating mutators that will operate on input.num
         let int_mutators = int_mutators_no_crossover()
             .merge(mapped_int_mutators_crossover(CustomInput::num))
-            .map(ToMappedInputFunctionMappingMutatorMapper::new(
-                CustomInput::num_mut,
-            ));
+            .map(ToFunctionMappingMutatorMapper::new(CustomInput::num_mut));
         (mapped_mutators, optional_mapped_mutators, int_mutators)
     };
 

--- a/libafl/src/inputs/bytes.rs
+++ b/libafl/src/inputs/bytes.rs
@@ -37,7 +37,7 @@ impl HasMutatorBytes for BytesInput {
     }
 
     fn extend<'a, I: IntoIterator<Item = &'a u8>>(&mut self, iter: I) {
-        self.as_mut().extend(iter);
+        <Vec<u8> as Extend<I::Item>>::extend(self.as_mut(), iter);
     }
 
     fn splice<R, I>(&mut self, range: R, replace_with: I) -> vec::Splice<'_, I::IntoIter>

--- a/libafl/src/inputs/bytessub.rs
+++ b/libafl/src/inputs/bytessub.rs
@@ -11,7 +11,7 @@ use libafl_bolts::{
     HasLen,
 };
 
-use crate::inputs::{HasMutatorBytes, MappedInput};
+use crate::inputs::HasMutatorBytes;
 
 /// The [`BytesSubInput`] makes it possible to use [`crate::mutators::Mutator`]`s` that work on
 /// inputs implementing the [`HasMutatorBytes`] for a sub-range of this input.
@@ -201,23 +201,14 @@ where
         self.range.len()
     }
 }
-
-impl<I> MappedInput for BytesSubInput<'_, I> {
-    type Type<'b>
-        = BytesSubInput<'b, I>
-    where
-        Self: 'b;
-}
-
 #[cfg(test)]
 mod tests {
-
     use alloc::vec::Vec;
 
     use libafl_bolts::HasLen;
 
     use crate::{
-        inputs::{BytesInput, HasMutatorBytes, MutVecInput, NopInput},
+        inputs::{BytesInput, HasMutatorBytes, NopInput},
         mutators::{havoc_mutations_no_crossover, MutatorsTuple},
         state::NopState,
     };
@@ -346,7 +337,6 @@ mod tests {
     #[test]
     fn test_bytessubinput_use_vec() {
         let mut test_vec = vec![0, 1, 2, 3, 4];
-        let mut test_vec = MutVecInput::from(&mut test_vec);
         let mut sub_vec = test_vec.sub_input(1..2);
         drop(sub_vec.drain(..));
         assert_eq!(test_vec.len(), 4);

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -3,11 +3,9 @@
 use libafl_bolts::tuples::{Map, Merge};
 use tuple_list::{tuple_list, tuple_list_type};
 
+use super::{FunctionMappingMutator, ToFunctionMappingMutatorMapper};
 use crate::mutators::{
-    mapping::{
-        MappedInputFunctionMappingMutator, OptionMappingMutator,
-        ToMappedInputFunctionMappingMutatorMapper, ToOptionMappingMutatorMapper,
-    },
+    mapping::{OptionMappingMutator, ToOptionMappingMutatorMapper},
     mutations::{
         BitFlipMutator, ByteAddMutator, ByteDecMutator, ByteFlipMutator, ByteIncMutator,
         ByteInterestingMutator, ByteNegMutator, ByteRandMutator, BytesCopyMutator,
@@ -89,73 +87,65 @@ pub type HavocMutationsType = tuple_list_type!(
 );
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types
-pub type MappedHavocMutationsType<F1, F2, II, O> = tuple_list_type!(
-    MappedInputFunctionMappingMutator<BitFlipMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteFlipMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteIncMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteDecMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteNegMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteRandMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteAddMutator, F1, II>,
-    MappedInputFunctionMappingMutator<WordAddMutator, F1, II>,
-    MappedInputFunctionMappingMutator<DwordAddMutator, F1, II>,
-    MappedInputFunctionMappingMutator<QwordAddMutator, F1, II>,
-    MappedInputFunctionMappingMutator<ByteInterestingMutator, F1, II>,
-    MappedInputFunctionMappingMutator<WordInterestingMutator, F1, II>,
-    MappedInputFunctionMappingMutator<DwordInterestingMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesDeleteMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesExpandMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesInsertMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesRandInsertMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesSetMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesRandSetMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesCopyMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesInsertCopyMutator, F1, II>,
-    MappedInputFunctionMappingMutator<BytesSwapMutator, F1, II>,
-    MappedInputFunctionMappingMutator<MappedCrossoverInsertMutator<F2, O>, F1, II>,
-    MappedInputFunctionMappingMutator<MappedCrossoverReplaceMutator<F2, O>, F1, II>,
+pub type MappedHavocMutationsType<F1, F2, O> = tuple_list_type!(
+    FunctionMappingMutator<BitFlipMutator, F1>,
+    FunctionMappingMutator<ByteFlipMutator, F1>,
+    FunctionMappingMutator<ByteIncMutator, F1>,
+    FunctionMappingMutator<ByteDecMutator, F1>,
+    FunctionMappingMutator<ByteNegMutator, F1>,
+    FunctionMappingMutator<ByteRandMutator, F1>,
+    FunctionMappingMutator<ByteAddMutator, F1>,
+    FunctionMappingMutator<WordAddMutator, F1>,
+    FunctionMappingMutator<DwordAddMutator, F1>,
+    FunctionMappingMutator<QwordAddMutator, F1>,
+    FunctionMappingMutator<ByteInterestingMutator, F1>,
+    FunctionMappingMutator<WordInterestingMutator, F1>,
+    FunctionMappingMutator<DwordInterestingMutator, F1>,
+    FunctionMappingMutator<BytesDeleteMutator, F1>,
+    FunctionMappingMutator<BytesDeleteMutator, F1>,
+    FunctionMappingMutator<BytesDeleteMutator, F1>,
+    FunctionMappingMutator<BytesDeleteMutator, F1>,
+    FunctionMappingMutator<BytesExpandMutator, F1>,
+    FunctionMappingMutator<BytesInsertMutator, F1>,
+    FunctionMappingMutator<BytesRandInsertMutator, F1>,
+    FunctionMappingMutator<BytesSetMutator, F1>,
+    FunctionMappingMutator<BytesRandSetMutator, F1>,
+    FunctionMappingMutator<BytesCopyMutator, F1>,
+    FunctionMappingMutator<BytesInsertCopyMutator, F1>,
+    FunctionMappingMutator<BytesSwapMutator, F1>,
+    FunctionMappingMutator<MappedCrossoverInsertMutator<F2, O>, F1>,
+    FunctionMappingMutator<MappedCrossoverReplaceMutator<F2, O>, F1>,
 );
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types, for optional byte array input parts
-pub type OptionMappedHavocMutationsType<F1, F2, II, O> = tuple_list_type!(
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BitFlipMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteFlipMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteIncMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteDecMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteNegMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteRandMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteAddMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<WordAddMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<DwordAddMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<QwordAddMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<ByteInterestingMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<WordInterestingMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<DwordInterestingMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesExpandMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesInsertMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesRandInsertMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesSetMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesRandSetMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesCopyMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesInsertCopyMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<OptionMappingMutator<BytesSwapMutator>, F1, II>,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<MappedCrossoverInsertMutator<F2, O>>,
-        F1,
-        II,
-    >,
-    MappedInputFunctionMappingMutator<
-        OptionMappingMutator<MappedCrossoverReplaceMutator<F2, O>>,
-        F1,
-        II,
-    >,
+pub type OptionMappedHavocMutationsType<F1, F2, O> = tuple_list_type!(
+    FunctionMappingMutator<OptionMappingMutator<BitFlipMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteFlipMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteIncMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteDecMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteNegMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteRandMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteAddMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<WordAddMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<DwordAddMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<QwordAddMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<ByteInterestingMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<WordInterestingMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<DwordInterestingMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesExpandMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesInsertMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesRandInsertMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesSetMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesRandSetMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesCopyMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesInsertCopyMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<BytesSwapMutator>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<MappedCrossoverInsertMutator<F2, O>>, F1>,
+    FunctionMappingMutator<OptionMappingMutator<MappedCrossoverReplaceMutator<F2, O>>, F1>,
 );
 
 /// Get the mutations that compose the Havoc mutator (only applied to single inputs)
@@ -204,7 +194,7 @@ pub fn havoc_crossover_with_corpus_mapper<F, IO, O>(
     input_mapper: F,
 ) -> MappedHavocCrossoverType<F, O>
 where
-    F: Clone + Fn(IO) -> O,
+    F: Clone + Fn(&IO) -> &O,
 {
     tuple_list!(
         MappedCrossoverInsertMutator::new(input_mapper.clone()),
@@ -238,16 +228,14 @@ pub fn havoc_mutations() -> HavocMutationsType {
 pub fn mapped_havoc_mutations<F1, F2, IO1, IO2, II, O>(
     current_input_mapper: F1,
     input_from_corpus_mapper: F2,
-) -> MappedHavocMutationsType<F1, F2, II, O>
+) -> MappedHavocMutationsType<F1, F2, O>
 where
-    F1: Clone + FnMut(IO1) -> II,
-    F2: Clone + Fn(IO2) -> O,
+    F1: Clone + FnMut(&mut IO1) -> &mut II,
+    F2: Clone + Fn(&IO2) -> &O,
 {
     havoc_mutations_no_crossover()
         .merge(havoc_crossover_with_corpus_mapper(input_from_corpus_mapper))
-        .map(ToMappedInputFunctionMappingMutatorMapper::new(
-            current_input_mapper,
-        ))
+        .map(ToFunctionMappingMutatorMapper::new(current_input_mapper))
 }
 
 /// Get the mutations that compose the Havoc mutator for mapped input types, for optional input parts
@@ -257,17 +245,15 @@ where
 pub fn optional_mapped_havoc_mutations<F1, F2, IO1, IO2, II, O>(
     current_input_mapper: F1,
     input_from_corpus_mapper: F2,
-) -> OptionMappedHavocMutationsType<F1, F2, II, O>
+) -> OptionMappedHavocMutationsType<F1, F2, O>
 where
-    F1: Clone + FnMut(IO1) -> II,
-    F2: Clone + Fn(IO2) -> O,
+    F1: Clone + FnMut(&mut IO1) -> &mut II,
+    F2: Clone + Fn(&IO2) -> &O,
 {
     havoc_mutations_no_crossover()
         .merge(havoc_crossover_with_corpus_mapper_optional(
             input_from_corpus_mapper,
         ))
         .map(ToOptionMappingMutatorMapper)
-        .map(ToMappedInputFunctionMappingMutatorMapper::new(
-            current_input_mapper,
-        ))
+        .map(ToFunctionMappingMutatorMapper::new(current_input_mapper))
 }

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -3,9 +3,9 @@
 use libafl_bolts::tuples::{Map, Merge};
 use tuple_list::{tuple_list, tuple_list_type};
 
-use super::{MappingMutator, ToMappingMutatorMapper};
+use super::{MappingMutator, ToMappingMutator};
 use crate::mutators::{
-    mapping::{OptionalMutator, ToOptionalMutatorMapper},
+    mapping::{OptionalMutator, ToOptionalMutator},
     mutations::{
         BitFlipMutator, ByteAddMutator, ByteDecMutator, ByteFlipMutator, ByteIncMutator,
         ByteInterestingMutator, ByteNegMutator, ByteRandMutator, BytesCopyMutator,
@@ -235,7 +235,7 @@ where
 {
     havoc_mutations_no_crossover()
         .merge(havoc_crossover_with_corpus_mapper(input_from_corpus_mapper))
-        .map(ToMappingMutatorMapper::new(current_input_mapper))
+        .map(ToMappingMutator::new(current_input_mapper))
 }
 
 /// Get the mutations that compose the Havoc mutator for mapped input types, for optional input parts
@@ -254,6 +254,6 @@ where
         .merge(havoc_crossover_with_corpus_mapper_optional(
             input_from_corpus_mapper,
         ))
-        .map(ToOptionalMutatorMapper)
-        .map(ToMappingMutatorMapper::new(current_input_mapper))
+        .map(ToOptionalMutator)
+        .map(ToMappingMutator::new(current_input_mapper))
 }

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -3,9 +3,9 @@
 use libafl_bolts::tuples::{Map, Merge};
 use tuple_list::{tuple_list, tuple_list_type};
 
-use super::{FunctionMappingMutator, ToFunctionMappingMutatorMapper};
+use super::{MappingMutator, ToMappingMutatorMapper};
 use crate::mutators::{
-    mapping::{OptionMappingMutator, ToOptionMappingMutatorMapper},
+    mapping::{OptionalMutator, ToOptionalMutatorMapper},
     mutations::{
         BitFlipMutator, ByteAddMutator, ByteDecMutator, ByteFlipMutator, ByteIncMutator,
         ByteInterestingMutator, ByteNegMutator, ByteRandMutator, BytesCopyMutator,
@@ -88,64 +88,64 @@ pub type HavocMutationsType = tuple_list_type!(
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types
 pub type MappedHavocMutationsType<F1, F2, O> = tuple_list_type!(
-    FunctionMappingMutator<BitFlipMutator, F1>,
-    FunctionMappingMutator<ByteFlipMutator, F1>,
-    FunctionMappingMutator<ByteIncMutator, F1>,
-    FunctionMappingMutator<ByteDecMutator, F1>,
-    FunctionMappingMutator<ByteNegMutator, F1>,
-    FunctionMappingMutator<ByteRandMutator, F1>,
-    FunctionMappingMutator<ByteAddMutator, F1>,
-    FunctionMappingMutator<WordAddMutator, F1>,
-    FunctionMappingMutator<DwordAddMutator, F1>,
-    FunctionMappingMutator<QwordAddMutator, F1>,
-    FunctionMappingMutator<ByteInterestingMutator, F1>,
-    FunctionMappingMutator<WordInterestingMutator, F1>,
-    FunctionMappingMutator<DwordInterestingMutator, F1>,
-    FunctionMappingMutator<BytesDeleteMutator, F1>,
-    FunctionMappingMutator<BytesDeleteMutator, F1>,
-    FunctionMappingMutator<BytesDeleteMutator, F1>,
-    FunctionMappingMutator<BytesDeleteMutator, F1>,
-    FunctionMappingMutator<BytesExpandMutator, F1>,
-    FunctionMappingMutator<BytesInsertMutator, F1>,
-    FunctionMappingMutator<BytesRandInsertMutator, F1>,
-    FunctionMappingMutator<BytesSetMutator, F1>,
-    FunctionMappingMutator<BytesRandSetMutator, F1>,
-    FunctionMappingMutator<BytesCopyMutator, F1>,
-    FunctionMappingMutator<BytesInsertCopyMutator, F1>,
-    FunctionMappingMutator<BytesSwapMutator, F1>,
-    FunctionMappingMutator<MappedCrossoverInsertMutator<F2, O>, F1>,
-    FunctionMappingMutator<MappedCrossoverReplaceMutator<F2, O>, F1>,
+    MappingMutator<BitFlipMutator, F1>,
+    MappingMutator<ByteFlipMutator, F1>,
+    MappingMutator<ByteIncMutator, F1>,
+    MappingMutator<ByteDecMutator, F1>,
+    MappingMutator<ByteNegMutator, F1>,
+    MappingMutator<ByteRandMutator, F1>,
+    MappingMutator<ByteAddMutator, F1>,
+    MappingMutator<WordAddMutator, F1>,
+    MappingMutator<DwordAddMutator, F1>,
+    MappingMutator<QwordAddMutator, F1>,
+    MappingMutator<ByteInterestingMutator, F1>,
+    MappingMutator<WordInterestingMutator, F1>,
+    MappingMutator<DwordInterestingMutator, F1>,
+    MappingMutator<BytesDeleteMutator, F1>,
+    MappingMutator<BytesDeleteMutator, F1>,
+    MappingMutator<BytesDeleteMutator, F1>,
+    MappingMutator<BytesDeleteMutator, F1>,
+    MappingMutator<BytesExpandMutator, F1>,
+    MappingMutator<BytesInsertMutator, F1>,
+    MappingMutator<BytesRandInsertMutator, F1>,
+    MappingMutator<BytesSetMutator, F1>,
+    MappingMutator<BytesRandSetMutator, F1>,
+    MappingMutator<BytesCopyMutator, F1>,
+    MappingMutator<BytesInsertCopyMutator, F1>,
+    MappingMutator<BytesSwapMutator, F1>,
+    MappingMutator<MappedCrossoverInsertMutator<F2, O>, F1>,
+    MappingMutator<MappedCrossoverReplaceMutator<F2, O>, F1>,
 );
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types, for optional byte array input parts
 pub type OptionMappedHavocMutationsType<F1, F2, O> = tuple_list_type!(
-    FunctionMappingMutator<OptionMappingMutator<BitFlipMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteFlipMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteIncMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteDecMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteNegMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteRandMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteAddMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<WordAddMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<DwordAddMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<QwordAddMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<ByteInterestingMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<WordInterestingMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<DwordInterestingMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesDeleteMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesExpandMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesInsertMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesRandInsertMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesSetMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesRandSetMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesCopyMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesInsertCopyMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<BytesSwapMutator>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<MappedCrossoverInsertMutator<F2, O>>, F1>,
-    FunctionMappingMutator<OptionMappingMutator<MappedCrossoverReplaceMutator<F2, O>>, F1>,
+    MappingMutator<OptionalMutator<BitFlipMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteFlipMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteIncMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteDecMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteNegMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteRandMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteAddMutator>, F1>,
+    MappingMutator<OptionalMutator<WordAddMutator>, F1>,
+    MappingMutator<OptionalMutator<DwordAddMutator>, F1>,
+    MappingMutator<OptionalMutator<QwordAddMutator>, F1>,
+    MappingMutator<OptionalMutator<ByteInterestingMutator>, F1>,
+    MappingMutator<OptionalMutator<WordInterestingMutator>, F1>,
+    MappingMutator<OptionalMutator<DwordInterestingMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesExpandMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesInsertMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesRandInsertMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesSetMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesRandSetMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesCopyMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesInsertCopyMutator>, F1>,
+    MappingMutator<OptionalMutator<BytesSwapMutator>, F1>,
+    MappingMutator<OptionalMutator<MappedCrossoverInsertMutator<F2, O>>, F1>,
+    MappingMutator<OptionalMutator<MappedCrossoverReplaceMutator<F2, O>>, F1>,
 );
 
 /// Get the mutations that compose the Havoc mutator (only applied to single inputs)
@@ -235,7 +235,7 @@ where
 {
     havoc_mutations_no_crossover()
         .merge(havoc_crossover_with_corpus_mapper(input_from_corpus_mapper))
-        .map(ToFunctionMappingMutatorMapper::new(current_input_mapper))
+        .map(ToMappingMutatorMapper::new(current_input_mapper))
 }
 
 /// Get the mutations that compose the Havoc mutator for mapped input types, for optional input parts
@@ -254,6 +254,6 @@ where
         .merge(havoc_crossover_with_corpus_mapper_optional(
             input_from_corpus_mapper,
         ))
-        .map(ToOptionMappingMutatorMapper)
-        .map(ToFunctionMappingMutatorMapper::new(current_input_mapper))
+        .map(ToOptionalMutatorMapper)
+        .map(ToMappingMutatorMapper::new(current_input_mapper))
 }

--- a/libafl/src/mutators/mapping.rs
+++ b/libafl/src/mutators/mapping.rs
@@ -112,7 +112,7 @@ impl<M, F> Named for MappingMutator<M, F> {
 /// let mutators = tuple_list!(ByteIncMutator::new(), ByteIncMutator::new());
 /// // construct a mutator that works on &mut CustomInput
 /// let mut mapped_mutators =
-///     mutators.map(ToFunctionMappingMutatorMapper::new(CustomInput::vec_mut));
+///     mutators.map(ToMappingMutatorMapper::new(CustomInput::vec_mut));
 ///  
 /// let mut input = CustomInput(vec![1]);
 ///  

--- a/libafl/src/mutators/mapping.rs
+++ b/libafl/src/mutators/mapping.rs
@@ -81,7 +81,7 @@ impl<M, F> Named for MappingMutator<M, F> {
     }
 }
 
-/// Mapper to use to map a [`tuple_list`] of [`Mutator`]s using [`ToMappingMutatorMapper`]s.
+/// Mapper to use to map a [`tuple_list`] of [`Mutator`]s using [`ToMappingMutator`]s.
 ///
 /// See the explanation of [`MappingMutator`] for details.
 ///
@@ -127,7 +127,7 @@ pub struct ToMappingMutator<F> {
 }
 
 impl<F> ToMappingMutator<F> {
-    /// Creates a new [`ToMappingMutatorMapper`]
+    /// Creates a new [`ToMappingMutator`]
     pub fn new(mapper: F) -> Self {
         Self { mapper }
     }

--- a/libafl/src/mutators/mapping.rs
+++ b/libafl/src/mutators/mapping.rs
@@ -18,7 +18,7 @@ use crate::{
 /// use std::vec::Vec;
 ///
 /// use libafl::{
-///     mutators::{ByteIncMutator, FunctionMappingMutator, MutationResult, Mutator},
+///     mutators::{ByteIncMutator, MappingMutator, MutationResult, Mutator},
 ///     state::NopState,
 /// };
 ///
@@ -34,7 +34,7 @@ use crate::{
 /// // construct a mutator that works on &mut Vec<u8> (since it impls `HasMutatorBytes`)
 /// let inner = ByteIncMutator::new();
 /// // construct a mutator that works on &mut CustomInput
-/// let mut outer = FunctionMappingMutator::new(CustomInput::vec_mut, inner);
+/// let mut outer = MappingMutator::new(CustomInput::vec_mut, inner);
 ///
 /// let mut input = CustomInput(vec![1]);
 ///
@@ -44,19 +44,19 @@ use crate::{
 /// assert_eq!(input, CustomInput(vec![2],));
 /// ```
 #[derive(Debug)]
-pub struct FunctionMappingMutator<M, F> {
+pub struct MappingMutator<M, F> {
     mapper: F,
     inner: M,
     name: Cow<'static, str>,
 }
 
-impl<M, F> FunctionMappingMutator<M, F> {
-    /// Creates a new [`FunctionMappingMutator`]
+impl<M, F> MappingMutator<M, F> {
+    /// Creates a new [`MappingMutator`]
     pub fn new(mapper: F, inner: M) -> Self
     where
         M: Named,
     {
-        let name = Cow::Owned(format!("FunctionMappingMutator<{}>", inner.name()));
+        let name = Cow::Owned(format!("MappingMutator<{}>", inner.name()));
         Self {
             mapper,
             inner,
@@ -65,7 +65,7 @@ impl<M, F> FunctionMappingMutator<M, F> {
     }
 }
 
-impl<M, S, F, IO, II> Mutator<IO, S> for FunctionMappingMutator<M, F>
+impl<M, S, F, IO, II> Mutator<IO, S> for MappingMutator<M, F>
 where
     F: FnMut(&mut IO) -> &mut II,
     M: Mutator<II, S>,
@@ -75,15 +75,15 @@ where
     }
 }
 
-impl<M, F> Named for FunctionMappingMutator<M, F> {
+impl<M, F> Named for MappingMutator<M, F> {
     fn name(&self) -> &Cow<'static, str> {
         &self.name
     }
 }
 
-/// Mapper to use to map a [`tuple_list`] of [`Mutator`]s using [`ToFunctionMappingMutatorMapper`]s.
+/// Mapper to use to map a [`tuple_list`] of [`Mutator`]s using [`ToMappingMutatorMapper`]s.
 ///
-/// See the explanation of [`ToFunctionMappingMutatorMapper`] for details.
+/// See the explanation of [`MappingMutator`] for details.
 ///
 /// # Example
 #[cfg_attr(feature = "std", doc = " ```")]
@@ -92,7 +92,7 @@ impl<M, F> Named for FunctionMappingMutator<M, F> {
 ///
 /// use libafl::{
 ///     mutators::{
-///         ByteIncMutator, MutationResult, MutatorsTuple, ToFunctionMappingMutatorMapper,
+///         ByteIncMutator, MutationResult, MutatorsTuple, ToMappingMutatorMapper,
 ///     },
 ///     state::NopState,
 /// };
@@ -122,26 +122,26 @@ impl<M, F> Named for FunctionMappingMutator<M, F> {
 /// assert_eq!(input, CustomInput(vec![3],));
 /// ```
 #[derive(Debug)]
-pub struct ToFunctionMappingMutatorMapper<F> {
+pub struct ToMappingMutatorMapper<F> {
     mapper: F,
 }
 
-impl<F> ToFunctionMappingMutatorMapper<F> {
-    /// Creates a new [`ToFunctionMappingMutatorMapper`]
+impl<F> ToMappingMutatorMapper<F> {
+    /// Creates a new [`ToMappingMutatorMapper`]
     pub fn new(mapper: F) -> Self {
         Self { mapper }
     }
 }
 
-impl<M, F> MappingFunctor<M> for ToFunctionMappingMutatorMapper<F>
+impl<M, F> MappingFunctor<M> for ToMappingMutatorMapper<F>
 where
     F: Clone,
     M: Named,
 {
-    type Output = FunctionMappingMutator<M, F>;
+    type Output = MappingMutator<M, F>;
 
     fn apply(&mut self, from: M) -> Self::Output {
-        FunctionMappingMutator::new(self.mapper.clone(), from)
+        MappingMutator::new(self.mapper.clone(), from)
     }
 }
 
@@ -156,12 +156,12 @@ where
 #[cfg_attr(not(feature = "std"), doc = " ```ignore")]
 /// use libafl::{
 ///     inputs::MutVecInput,
-///     mutators::{ByteIncMutator, MutationResult, Mutator, OptionMappingMutator},
+///     mutators::{ByteIncMutator, MutationResult, Mutator, OptionalMutator},
 ///     state::NopState,
 /// };
 ///
 /// let inner = ByteIncMutator::new();
-/// let mut outer = OptionMappingMutator::new(inner);
+/// let mut outer = OptionalMutator::new(inner);
 ///
 /// let mut input_raw = vec![1];
 /// let input: MutVecInput = (&mut input_raw).into();
@@ -176,23 +176,23 @@ where
 /// assert_eq!(res2, MutationResult::Skipped);
 /// ```
 #[derive(Debug)]
-pub struct OptionMappingMutator<M> {
+pub struct OptionalMutator<M> {
     inner: M,
     name: Cow<'static, str>,
 }
 
-impl<M> OptionMappingMutator<M> {
-    /// Creates a new [`OptionMappingMutator`]
+impl<M> OptionalMutator<M> {
+    /// Creates a new [`OptionalMutator`]
     pub fn new(inner: M) -> Self
     where
         M: Named,
     {
-        let name = Cow::Owned(format!("OptionMappingMutator<{}>", inner.name()));
+        let name = Cow::Owned(format!("OptionalMutator<{}>", inner.name()));
         Self { inner, name }
     }
 }
 
-impl<I, S, M> Mutator<Option<I>, S> for OptionMappingMutator<M>
+impl<I, S, M> Mutator<Option<I>, S> for OptionalMutator<M>
 where
     M: Mutator<I, S>,
 {
@@ -204,7 +204,7 @@ where
     }
 }
 
-impl<M> Named for OptionMappingMutator<M>
+impl<M> Named for OptionalMutator<M>
 where
     M: Named,
 {
@@ -213,22 +213,22 @@ where
     }
 }
 
-/// Mapper to use to map a [`tuple_list`] of [`Mutator`]s using [`OptionMappingMutator`]s.
+/// Mapper to use to map a [`tuple_list`] of [`Mutator`]s using [`OptionalMutator`]s.
 ///
-/// See the explanation of [`OptionMappingMutator`] for details.
+/// See the explanation of [`OptionalMutator`] for details.
 ///
 /// # Example
 #[cfg_attr(feature = "std", doc = " ```")]
 #[cfg_attr(not(feature = "std"), doc = " ```ignore")]
 /// use libafl::{
 ///     inputs::MutVecInput,
-///     mutators::{ByteIncMutator, MutationResult, Mutator, ToOptionMappingMutatorMapper},
+///     mutators::{ByteIncMutator, MutationResult, Mutator, ToOptionalMutatorMapper},
 ///     state::NopState,
 /// };
 /// use libafl_bolts::tuples::{tuple_list, Map};
 ///
 /// let inner = tuple_list!(ByteIncMutator::new());
-/// let outer_list = inner.map(ToOptionMappingMutatorMapper);
+/// let outer_list = inner.map(ToOptionalMutatorMapper);
 /// let mut outer = outer_list.0;
 ///
 /// let mut input_raw = vec![1];
@@ -244,15 +244,15 @@ where
 /// assert_eq!(res2, MutationResult::Skipped);
 /// ```
 #[derive(Debug)]
-pub struct ToOptionMappingMutatorMapper;
+pub struct ToOptionalMutatorMapper;
 
-impl<M> MappingFunctor<M> for ToOptionMappingMutatorMapper
+impl<M> MappingFunctor<M> for ToOptionalMutatorMapper
 where
     M: Named,
 {
-    type Output = OptionMappingMutator<M>;
+    type Output = OptionalMutator<M>;
 
     fn apply(&mut self, from: M) -> Self::Output {
-        OptionMappingMutator::new(from)
+        OptionalMutator::new(from)
     }
 }

--- a/libafl/src/mutators/mapping.rs
+++ b/libafl/src/mutators/mapping.rs
@@ -92,7 +92,7 @@ impl<M, F> Named for MappingMutator<M, F> {
 ///
 /// use libafl::{
 ///     mutators::{
-///         ByteIncMutator, MutationResult, MutatorsTuple, ToMappingMutatorMapper,
+///         ByteIncMutator, MutationResult, MutatorsTuple, ToMappingMutator,
 ///     },
 ///     state::NopState,
 /// };
@@ -112,7 +112,7 @@ impl<M, F> Named for MappingMutator<M, F> {
 /// let mutators = tuple_list!(ByteIncMutator::new(), ByteIncMutator::new());
 /// // construct a mutator that works on &mut CustomInput
 /// let mut mapped_mutators =
-///     mutators.map(ToMappingMutatorMapper::new(CustomInput::vec_mut));
+///     mutators.map(ToMappingMutator::new(CustomInput::vec_mut));
 ///  
 /// let mut input = CustomInput(vec![1]);
 ///  
@@ -122,18 +122,18 @@ impl<M, F> Named for MappingMutator<M, F> {
 /// assert_eq!(input, CustomInput(vec![3],));
 /// ```
 #[derive(Debug)]
-pub struct ToMappingMutatorMapper<F> {
+pub struct ToMappingMutator<F> {
     mapper: F,
 }
 
-impl<F> ToMappingMutatorMapper<F> {
+impl<F> ToMappingMutator<F> {
     /// Creates a new [`ToMappingMutatorMapper`]
     pub fn new(mapper: F) -> Self {
         Self { mapper }
     }
 }
 
-impl<M, F> MappingFunctor<M> for ToMappingMutatorMapper<F>
+impl<M, F> MappingFunctor<M> for ToMappingMutator<F>
 where
     F: Clone,
     M: Named,
@@ -222,13 +222,13 @@ where
 #[cfg_attr(not(feature = "std"), doc = " ```ignore")]
 /// use libafl::{
 ///     inputs::MutVecInput,
-///     mutators::{ByteIncMutator, MutationResult, Mutator, ToOptionalMutatorMapper},
+///     mutators::{ByteIncMutator, MutationResult, Mutator, ToOptionalMutator},
 ///     state::NopState,
 /// };
 /// use libafl_bolts::tuples::{tuple_list, Map};
 ///
 /// let inner = tuple_list!(ByteIncMutator::new());
-/// let outer_list = inner.map(ToOptionalMutatorMapper);
+/// let outer_list = inner.map(ToOptionalMutator);
 /// let mut outer = outer_list.0;
 ///
 /// let mut input_raw = vec![1];
@@ -244,9 +244,9 @@ where
 /// assert_eq!(res2, MutationResult::Skipped);
 /// ```
 #[derive(Debug)]
-pub struct ToOptionalMutatorMapper;
+pub struct ToOptionalMutator;
 
-impl<M> MappingFunctor<M> for ToOptionalMutatorMapper
+impl<M> MappingFunctor<M> for ToOptionalMutator
 where
     M: Named,
 {

--- a/libafl/src/mutators/numeric.rs
+++ b/libafl/src/mutators/numeric.rs
@@ -9,7 +9,7 @@ use libafl_bolts::{
 };
 use tuple_list::{tuple_list, tuple_list_type};
 
-use super::{MappingMutator, MutationResult, Mutator, ToMappingMutatorMapper};
+use super::{MappingMutator, MutationResult, Mutator, ToMappingMutator};
 use crate::{
     corpus::Corpus,
     random_corpus_id_with_disabled,
@@ -93,7 +93,7 @@ where
 {
     int_mutators_no_crossover()
         .merge(mapped_int_mutators_crossover(input_from_corpus_mapper))
-        .map(ToMappingMutatorMapper::new(current_input_mapper))
+        .map(ToMappingMutator::new(current_input_mapper))
 }
 /// Functionality required for Numeric Mutators (see [`int_mutators`])
 pub trait Numeric {

--- a/libafl/src/mutators/numeric.rs
+++ b/libafl/src/mutators/numeric.rs
@@ -9,7 +9,7 @@ use libafl_bolts::{
 };
 use tuple_list::{tuple_list, tuple_list_type};
 
-use super::{FunctionMappingMutator, MutationResult, Mutator, ToFunctionMappingMutatorMapper};
+use super::{MappingMutator, MutationResult, Mutator, ToMappingMutatorMapper};
 use crate::{
     corpus::Corpus,
     random_corpus_id_with_disabled,
@@ -72,13 +72,13 @@ pub fn int_mutators() -> IntMutatorsType {
 
 /// Mapped mutators for integer-like inputs
 pub type MappedIntMutatorsType<F1, F2> = tuple_list_type!(
-    FunctionMappingMutator<BitFlipMutator,F1>,
-    FunctionMappingMutator<NegateMutator,F1>,
-    FunctionMappingMutator<IncMutator,F1>,
-    FunctionMappingMutator<DecMutator,F1>,
-    FunctionMappingMutator<TwosComplementMutator,F1>,
-    FunctionMappingMutator<RandMutator,F1>,
-    FunctionMappingMutator<MappedCrossoverMutator<F2>,F1>
+    MappingMutator<BitFlipMutator,F1>,
+    MappingMutator<NegateMutator,F1>,
+    MappingMutator<IncMutator,F1>,
+    MappingMutator<DecMutator,F1>,
+    MappingMutator<TwosComplementMutator,F1>,
+    MappingMutator<RandMutator,F1>,
+    MappingMutator<MappedCrossoverMutator<F2>,F1>
 );
 
 /// Mapped mutators for integer-like inputs
@@ -93,7 +93,7 @@ where
 {
     int_mutators_no_crossover()
         .merge(mapped_int_mutators_crossover(input_from_corpus_mapper))
-        .map(ToFunctionMappingMutatorMapper::new(current_input_mapper))
+        .map(ToMappingMutatorMapper::new(current_input_mapper))
 }
 /// Functionality required for Numeric Mutators (see [`int_mutators`])
 pub trait Numeric {

--- a/libafl_bolts/src/lib.rs
+++ b/libafl_bolts/src/lib.rs
@@ -850,6 +850,12 @@ impl<T> HasLen for Vec<T> {
     }
 }
 
+impl<T: HasLen> HasLen for &mut T {
+    fn len(&self) -> usize {
+        self.deref().len()
+    }
+}
+
 /// Has a ref count
 pub trait HasRefCnt {
     /// The ref count


### PR DESCRIPTION
Turns out implementing the required traits directly on the borrows is possible and much cleaner.

This also allows removing `MappedInput`, which caused significant headaches for mapping mutators.