### PR TITLE
Add macros to libafl_bolts tuples for mapping and merging types

### DIFF
--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -2,9 +2,8 @@
 
 use libafl_bolts::{
     map_tuple_list_type, merge_tuple_list_type,
-    tuples::{Map, Merge},
+    tuples::{tuple_list, tuple_list_type, Map, Merge},
 };
-use tuple_list::{tuple_list, tuple_list_type};
 
 use crate::mutators::{
     mapping::{ToMappingMutator, ToOptionalMutator},

--- a/libafl/src/mutators/havoc_mutations.rs
+++ b/libafl/src/mutators/havoc_mutations.rs
@@ -1,11 +1,13 @@
 //! [`crate::mutators::Mutator`] collection equivalent to AFL++'s havoc mutations
 
-use libafl_bolts::tuples::{Map, Merge};
+use libafl_bolts::{
+    map_tuple_list_type, merge_tuple_list_type,
+    tuples::{Map, Merge},
+};
 use tuple_list::{tuple_list, tuple_list_type};
 
-use super::{MappingMutator, ToMappingMutator};
 use crate::mutators::{
-    mapping::{OptionalMutator, ToOptionalMutator},
+    mapping::{ToMappingMutator, ToOptionalMutator},
     mutations::{
         BitFlipMutator, ByteAddMutator, ByteDecMutator, ByteFlipMutator, ByteIncMutator,
         ByteInterestingMutator, ByteNegMutator, ByteRandMutator, BytesCopyMutator,
@@ -56,96 +58,22 @@ pub type MappedHavocCrossoverType<F, O> = tuple_list_type!(
 );
 
 /// Tuple type of the mutations that compose the Havoc mutator
-pub type HavocMutationsType = tuple_list_type!(
-    BitFlipMutator,
-    ByteFlipMutator,
-    ByteIncMutator,
-    ByteDecMutator,
-    ByteNegMutator,
-    ByteRandMutator,
-    ByteAddMutator,
-    WordAddMutator,
-    DwordAddMutator,
-    QwordAddMutator,
-    ByteInterestingMutator,
-    WordInterestingMutator,
-    DwordInterestingMutator,
-    BytesDeleteMutator,
-    BytesDeleteMutator,
-    BytesDeleteMutator,
-    BytesDeleteMutator,
-    BytesExpandMutator,
-    BytesInsertMutator,
-    BytesRandInsertMutator,
-    BytesSetMutator,
-    BytesRandSetMutator,
-    BytesCopyMutator,
-    BytesInsertCopyMutator,
-    BytesSwapMutator,
-    CrossoverInsertMutator,
-    CrossoverReplaceMutator,
-);
+pub type HavocMutationsType =
+    merge_tuple_list_type!(HavocMutationsNoCrossoverType, HavocCrossoverType);
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types
-pub type MappedHavocMutationsType<F1, F2, O> = tuple_list_type!(
-    MappingMutator<BitFlipMutator, F1>,
-    MappingMutator<ByteFlipMutator, F1>,
-    MappingMutator<ByteIncMutator, F1>,
-    MappingMutator<ByteDecMutator, F1>,
-    MappingMutator<ByteNegMutator, F1>,
-    MappingMutator<ByteRandMutator, F1>,
-    MappingMutator<ByteAddMutator, F1>,
-    MappingMutator<WordAddMutator, F1>,
-    MappingMutator<DwordAddMutator, F1>,
-    MappingMutator<QwordAddMutator, F1>,
-    MappingMutator<ByteInterestingMutator, F1>,
-    MappingMutator<WordInterestingMutator, F1>,
-    MappingMutator<DwordInterestingMutator, F1>,
-    MappingMutator<BytesDeleteMutator, F1>,
-    MappingMutator<BytesDeleteMutator, F1>,
-    MappingMutator<BytesDeleteMutator, F1>,
-    MappingMutator<BytesDeleteMutator, F1>,
-    MappingMutator<BytesExpandMutator, F1>,
-    MappingMutator<BytesInsertMutator, F1>,
-    MappingMutator<BytesRandInsertMutator, F1>,
-    MappingMutator<BytesSetMutator, F1>,
-    MappingMutator<BytesRandSetMutator, F1>,
-    MappingMutator<BytesCopyMutator, F1>,
-    MappingMutator<BytesInsertCopyMutator, F1>,
-    MappingMutator<BytesSwapMutator, F1>,
-    MappingMutator<MappedCrossoverInsertMutator<F2, O>, F1>,
-    MappingMutator<MappedCrossoverReplaceMutator<F2, O>, F1>,
+pub type MappedHavocMutationsType<F1, F2, O> = map_tuple_list_type!(
+    merge_tuple_list_type!(HavocMutationsNoCrossoverType, MappedHavocCrossoverType<F2,O>),
+    ToMappingMutator<F1>
 );
 
 /// Tuple type of the mutations that compose the Havoc mutator for mapped input types, for optional byte array input parts
-pub type OptionMappedHavocMutationsType<F1, F2, O> = tuple_list_type!(
-    MappingMutator<OptionalMutator<BitFlipMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteFlipMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteIncMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteDecMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteNegMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteRandMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteAddMutator>, F1>,
-    MappingMutator<OptionalMutator<WordAddMutator>, F1>,
-    MappingMutator<OptionalMutator<DwordAddMutator>, F1>,
-    MappingMutator<OptionalMutator<QwordAddMutator>, F1>,
-    MappingMutator<OptionalMutator<ByteInterestingMutator>, F1>,
-    MappingMutator<OptionalMutator<WordInterestingMutator>, F1>,
-    MappingMutator<OptionalMutator<DwordInterestingMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesDeleteMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesExpandMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesInsertMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesRandInsertMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesSetMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesRandSetMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesCopyMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesInsertCopyMutator>, F1>,
-    MappingMutator<OptionalMutator<BytesSwapMutator>, F1>,
-    MappingMutator<OptionalMutator<MappedCrossoverInsertMutator<F2, O>>, F1>,
-    MappingMutator<OptionalMutator<MappedCrossoverReplaceMutator<F2, O>>, F1>,
+pub type OptionMappedHavocMutationsType<F1, F2, O> = map_tuple_list_type!(
+    map_tuple_list_type!(
+        merge_tuple_list_type!(HavocMutationsNoCrossoverType, MappedHavocCrossoverType<F2,O>),
+        ToOptionalMutator
+    ),
+    ToMappingMutator<F1>
 );
 
 /// Get the mutations that compose the Havoc mutator (only applied to single inputs)

--- a/libafl_bolts/src/shmem.rs
+++ b/libafl_bolts/src/shmem.rs
@@ -624,12 +624,12 @@ where
 /// Is needed on top.
 #[cfg(all(unix, feature = "std", not(target_os = "haiku")))]
 pub mod unix_shmem {
-    /// Mmap [`ShMem`] for Unix
-    #[cfg(not(target_os = "android"))]
-    pub use default::MmapShMem;
     /// Mmap [`ShMemProvider`] for Unix
     #[cfg(not(target_os = "android"))]
     pub use default::MmapShMemProvider;
+    /// Mmap [`ShMem`] for Unix
+    #[cfg(not(target_os = "android"))]
+    pub use default::{MmapShMem, MAX_MMAP_FILENAME_LEN};
 
     #[cfg(doc)]
     use crate::shmem::{ShMem, ShMemProvider};
@@ -669,7 +669,8 @@ pub mod unix_shmem {
             Error,
         };
 
-        const MAX_MMAP_FILENAME_LEN: usize = 20;
+        /// The size of the buffer of the filename of mmap mapped memory regions
+        pub const MAX_MMAP_FILENAME_LEN: usize = 20;
 
         /// Mmap-based The sharedmap impl for unix using [`shm_open`] and [`mmap`].
         /// Default on `MacOS` and `iOS`, where we need a central point to unmap

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -868,7 +868,7 @@ macro_rules! map_tuple_list_type {
     };
 }
 
-/// Merges the types of two merged [`tuple_list`]s
+/// Merges the types of two merged [`tuple_list!`]s
 ///
 /// ```rust
 /// use libafl_bolts::{merge_tuple_list_type, tuples::{Merge, tuple_list, tuple_list_type}};

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -925,6 +925,8 @@ impl<Head, Tail> PlusOne for (Head, Tail) where
 
 #[cfg(test)]
 mod test {
+    use core::marker::PhantomData;
+
     use tuple_list::{tuple_list, tuple_list_type};
 
     #[cfg(feature = "alloc")]
@@ -977,9 +979,9 @@ mod test {
     #[test]
     fn test_mapper() {
         struct W<T>(T);
-        struct MyMapper;
+        struct MyMapper<P>(PhantomData<P>);
 
-        impl<T> MappingFunctor<T> for MyMapper {
+        impl<T, P> MappingFunctor<T> for MyMapper<P> {
             type Output = W<T>;
 
             fn apply(&mut self, from: T) -> Self::Output {
@@ -992,9 +994,9 @@ mod test {
         struct C;
 
         type OrigType = tuple_list_type!(A, B, C);
-        type MappedType = map_tuple_list_type!(OrigType, MyMapper);
+        type MappedType = map_tuple_list_type!(OrigType, MyMapper<usize>);
         let orig: OrigType = tuple_list!(A, B, C);
-        let _mapped: MappedType = orig.map(MyMapper);
+        let _mapped: MappedType = orig.map(MyMapper(PhantomData::<usize>));
     }
 
     #[test]


### PR DESCRIPTION
Check out an initial application in `havoc_mutations.rs`.