### PR TITLE
Fix Empty Multipart Crossover Bug

### DIFF
--- a/libafl/src/mutators/multi.rs
+++ b/libafl/src/mutators/multi.rs
@@ -198,6 +198,10 @@ where
         let mut other_testcase = state.corpus().get(id)?.borrow_mut();
         let other = other_testcase.load_input(state.corpus())?;
 
+        if other.names().is_empty() {
+            return Ok(MutationResult::Skipped);
+        }
+
         let choice = name_choice % other.names().len();
         let name = &other.names()[choice];
 
@@ -323,6 +327,10 @@ where
 
         let mut other_testcase = state.corpus().get(id)?.borrow_mut();
         let other = other_testcase.load_input(state.corpus())?;
+
+        if other.names().is_empty() {
+            return Ok(MutationResult::Skipped);
+        }
 
         let choice = name_choice % other.names().len();
         let name = &other.names()[choice];


### PR DESCRIPTION
When `other` is empty, the mod calculation following the changed code throws a divided by 0 panic.