### PR TITLE
imemory_ondisk: Don't fail write under any circumstances if locking is disabled

### DIFF
--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -441,7 +441,7 @@ impl<I> InMemoryOnDiskCorpus<I> {
             fs::rename(&tmpfile_path, &metafile_path)?;
             *testcase.metadata_path_mut() = Some(metafile_path);
         }
-    
+
         if self.locking {
             self.store_input_from(testcase)?;
         } else {

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -442,13 +442,11 @@ impl<I> InMemoryOnDiskCorpus<I> {
             *testcase.metadata_path_mut() = Some(metafile_path);
         }
 
-        if self.locking {
-            self.store_input_from(testcase)?;
-        } else if let Err(error) = self.store_input_from(testcase) {
-            log::error!(
-                "An error occurred when trying to write a testcase without locking: {}",
-                error
-            );
+        if let Err(err) = self.store_input_from(testcase) {
+            if self.locking {
+                return Err(err);
+            }
+            log::error!("An error occurred when trying to write a testcase without locking: {err}");
         }
         Ok(())
     }

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -445,7 +445,12 @@ impl<I> InMemoryOnDiskCorpus<I> {
         if self.locking {
             self.store_input_from(testcase)?;
         } else {
-            let _ = self.store_input_from(testcase);
+            if let Err(error) = self.store_input_from(testcase) {
+                log::error!(
+                    "An error occurred when trying to write a testcase without locking: {}",
+                    error
+                );
+            }
         }
         Ok(())
     }

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -441,8 +441,12 @@ impl<I> InMemoryOnDiskCorpus<I> {
             fs::rename(&tmpfile_path, &metafile_path)?;
             *testcase.metadata_path_mut() = Some(metafile_path);
         }
-
-        self.store_input_from(testcase)?;
+    
+        if self.locking {
+            self.store_input_from(testcase)?;
+        } else {
+            let _ = self.store_input_from(testcase);
+        }
         Ok(())
     }
 

--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -444,13 +444,11 @@ impl<I> InMemoryOnDiskCorpus<I> {
 
         if self.locking {
             self.store_input_from(testcase)?;
-        } else {
-            if let Err(error) = self.store_input_from(testcase) {
-                log::error!(
-                    "An error occurred when trying to write a testcase without locking: {}",
-                    error
-                );
-            }
+        } else if let Err(error) = self.store_input_from(testcase) {
+            log::error!(
+                "An error occurred when trying to write a testcase without locking: {}",
+                error
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
This is necessary if you want to disable locking for a corpus.