### PR TITLE
Fix command line parsing of ranges in `qemu_launcher`

### DIFF
--- a/fuzzers/binary_only/qemu_launcher/src/options.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/options.rs
@@ -92,33 +92,23 @@ impl FuzzerOptions {
         Ok(Duration::from_millis(src.parse()?))
     }
 
-    fn parse_ranges(src: &str) -> Result<Vec<Range<GuestAddr>>, Error> {
-        src.split(',')
-            .map(|r| {
-                let parts = r.split('-').collect::<Vec<&str>>();
-                if parts.len() == 2 {
-                    let start = GuestAddr::from_str_radix(parts[0].trim_start_matches("0x"), 16)
-                        .map_err(|e| {
-                            Error::illegal_argument(format!(
-                                "Invalid start address: {} ({e:})",
-                                parts[0]
-                            ))
-                        })?;
-                    let end = GuestAddr::from_str_radix(parts[1].trim_start_matches("0x"), 16)
-                        .map_err(|e| {
-                            Error::illegal_argument(format!(
-                                "Invalid end address: {} ({e:})",
-                                parts[1]
-                            ))
-                        })?;
-                    Ok(Range { start, end })
-                } else {
-                    Err(Error::illegal_argument(format!(
-                        "Invalid range provided: {r:}"
-                    )))
-                }
-            })
-            .collect::<Result<Vec<Range<GuestAddr>>, Error>>()
+    fn parse_ranges(src: &str) -> Result<Range<GuestAddr>, Error> {
+        let parts = src.split('-').collect::<Vec<&str>>();
+        if parts.len() == 2 {
+            let start =
+                GuestAddr::from_str_radix(parts[0].trim_start_matches("0x"), 16).map_err(|e| {
+                    Error::illegal_argument(format!("Invalid start address: {} ({e:})", parts[0]))
+                })?;
+            let end =
+                GuestAddr::from_str_radix(parts[1].trim_start_matches("0x"), 16).map_err(|e| {
+                    Error::illegal_argument(format!("Invalid end address: {} ({e:})", parts[1]))
+                })?;
+            Ok(Range { start, end })
+        } else {
+            Err(Error::illegal_argument(format!(
+                "Invalid range provided: {src:}"
+            )))
+        }
     }
 
     pub fn is_asan_core(&self, core_id: CoreId) -> bool {


### PR DESCRIPTION
Seems that `clap` has changed the way it parses arguments with multiple options. Now rather than...
```--include 0x1000-0x2000,0x3000-0x4000```
It expects...
```--include 0x1000-0x2000 --include 0x3000-0x4000```
The code needs to change accordingly.