### PR TITLE
Fix snapshot reset function when brk shrunk below the snapshotted value

### DIFF
--- a/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -857,14 +857,15 @@ where
         SYS_brk => {
             let h = emulator_modules.get_mut::<SnapshotModule>().unwrap();
             if h.brk != result && result != 0 && result > h.initial_brk {
-                /* brk has changed, and it doesn't shrink below initial_brk. We change mapping from the snapshotted initial brk address to the new target_brk
-                 * If no brk mapping has been made until now, change_mapped won't change anything and just create a new mapping.
-                 * It is safe to assume RW perms here
+                /* brk has changed, and it doesn't shrink below initial_brk. 
+                 * We change the snapshot mapping based on the new (result) and old (h.brk) brk values, then we update the current brk.
+                 * It is safe to assume RW perms here.
                  */
                 h.change_brk(
                     h.brk,
                     result,
                 );
+                h.brk = result;
             }
         }
         // mmap syscalls

--- a/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -396,8 +396,8 @@ impl SnapshotModule {
             if new_brk < self.brk {
                 // The heap has shrunk below the snapshotted brk value. We need to remap those pages in the target.
                 // The next for loop will restore their content if needed.
-                let aligned_new_brk = (new_brk + ((SNAPSHOT_PAGE_SIZE - 1) as u64))
-                    & (!(SNAPSHOT_PAGE_SIZE - 1) as u64);
+                let aligned_new_brk = (new_brk + ((SNAPSHOT_PAGE_SIZE - 1) as GuestAddr))
+                    & (!(SNAPSHOT_PAGE_SIZE - 1) as GuestAddr);
                 log::debug!("New brk ({:#x?}) < snapshotted brk ({:#x?})! Mapping back in the target {:#x?} - {:#x?}", new_brk, self.brk, aligned_new_brk, aligned_new_brk + (self.brk - aligned_new_brk));
                 drop(qemu.map_fixed(
                     aligned_new_brk,


### PR DESCRIPTION
It looks like my previous fix wasn't ideal and I was still getting SIGSEGVs during fuzzing run because of brk operations.

This time, to be sure 100%, I created [this](https://github.com/cube0x8/libafl_qemu_snapshot_test) fuzzer, which is a simple program that does things with brk, like increasing it or shrinking it below the snapshotted brk value. I used it to properly debug the snapshot feature behavior and then I let it run for almost 1 week. No more crashes came up, either with this fuzzer or with my other targets.