### PR TITLE
Add support for env_logger for qemu binary only fuzzers

### DIFF
--- a/fuzzers/binary_only/qemu_cmin/Cargo.toml
+++ b/fuzzers/binary_only/qemu_cmin/Cargo.toml
@@ -31,6 +31,7 @@ vergen-git2 = "1.0.1"
 
 [dependencies]
 clap = { version = "4.5.18", features = ["derive", "string"] }
+env_logger = { version = "0.11.5" }
 libafl = { path = "../../../libafl" }
 libafl_bolts = { path = "../../../libafl_bolts" }
 libafl_qemu = { path = "../../../libafl_qemu", features = ["usermode"] }

--- a/fuzzers/binary_only/qemu_cmin/src/fuzzer.rs
+++ b/fuzzers/binary_only/qemu_cmin/src/fuzzer.rs
@@ -95,6 +95,7 @@ pub struct FuzzerOptions {
 pub const MAX_INPUT_SIZE: usize = 1048576; // 1MB
 
 pub fn fuzz() -> Result<(), Error> {
+    env_logger::init();
     let mut options = FuzzerOptions::parse();
 
     let corpus_dir = PathBuf::from(options.input);
@@ -107,10 +108,10 @@ pub fn fuzz() -> Result<(), Error> {
         .expect("Failed to read dir entry");
 
     let program = env::args().next().unwrap();
-    log::debug!("Program: {program:}");
+    log::info!("Program: {program:}");
 
     options.args.insert(0, program);
-    log::debug!("ARGS: {:#?}", options.args);
+    log::info!("ARGS: {:#?}", options.args);
 
     env::remove_var("LD_LIBRARY_PATH");
 
@@ -145,21 +146,21 @@ pub fn fuzz() -> Result<(), Error> {
     let test_one_input_ptr = elf
         .resolve_symbol("LLVMFuzzerTestOneInput", qemu.load_addr())
         .expect("Symbol LLVMFuzzerTestOneInput not found");
-    log::debug!("LLVMFuzzerTestOneInput @ {test_one_input_ptr:#x}");
+    log::info!("LLVMFuzzerTestOneInput @ {test_one_input_ptr:#x}");
 
     qemu.entry_break(test_one_input_ptr);
 
     let pc: GuestReg = qemu.read_reg(Regs::Pc).unwrap();
-    log::debug!("Break at {pc:#x}");
+    log::info!("Break at {pc:#x}");
 
     let ret_addr: GuestAddr = qemu.read_return_address().unwrap();
-    log::debug!("Return address = {ret_addr:#x}");
+    log::info!("Return address = {ret_addr:#x}");
     qemu.set_breakpoint(ret_addr);
 
     let input_addr = qemu
         .map_private(0, MAX_INPUT_SIZE, MmapPerms::ReadWrite)
         .unwrap();
-    log::debug!("Placing input at {input_addr:#x}");
+    log::info!("Placing input at {input_addr:#x}");
 
     let stack_ptr: GuestAddr = qemu.read_reg(Regs::Sp).unwrap();
 

--- a/fuzzers/binary_only/qemu_coverage/Cargo.toml
+++ b/fuzzers/binary_only/qemu_coverage/Cargo.toml
@@ -31,6 +31,7 @@ vergen-git2 = "1.0.1"
 
 [dependencies]
 clap = { version = "4.5.18", features = ["derive", "string"] }
+env_logger = { version = "0.11.5" }
 libafl = { path = "../../../libafl" }
 libafl_bolts = { path = "../../../libafl_bolts" }
 libafl_qemu = { path = "../../../libafl_qemu", features = ["usermode"] }

--- a/fuzzers/binary_only/qemu_launcher/Cargo.toml
+++ b/fuzzers/binary_only/qemu_launcher/Cargo.toml
@@ -42,6 +42,7 @@ vergen-git2 = "1.0.1"
 
 [dependencies]
 clap = { version = "4.5.18", features = ["derive", "string"] }
+env_logger = { version = "0.11.5" }
 libafl = { path = "../../../libafl", features = ["tui_monitor"] }
 libafl_bolts = { path = "../../../libafl_bolts", features = [
   "errors_backtrace",

--- a/fuzzers/binary_only/qemu_launcher/src/client.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/client.rs
@@ -60,11 +60,11 @@ impl Client<'_> {
         let core_id = client_description.core_id();
         let mut args = self.args()?;
         Harness::edit_args(&mut args);
-        log::debug!("ARGS: {:#?}", args);
+        log::info!("ARGS: {:#?}", args);
 
         let mut env = self.env();
         Harness::edit_env(&mut env);
-        log::debug!("ENV: {:#?}", env);
+        log::info!("ENV: {:#?}", env);
 
         let is_asan = self.options.is_asan_core(core_id);
         let is_asan_guest = self.options.is_asan_guest_core(core_id);

--- a/fuzzers/binary_only/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/fuzzer.rs
@@ -34,6 +34,7 @@ pub struct Fuzzer {
 
 impl Fuzzer {
     pub fn new() -> Fuzzer {
+        env_logger::init();
         let options = FuzzerOptions::parse();
         options.validate();
         Fuzzer { options }

--- a/fuzzers/binary_only/qemu_launcher/src/harness.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/harness.rs
@@ -43,14 +43,14 @@ impl Harness {
     /// Initialize the emulator, run to the entrypoint (or jump there) and return the [`Harness`] struct
     pub fn init(qemu: Qemu) -> Result<Harness, Error> {
         let start_pc = Self::start_pc(qemu)?;
-        log::debug!("start_pc @ {start_pc:#x}");
+        log::info!("start_pc @ {start_pc:#x}");
 
         qemu.entry_break(start_pc);
 
         let ret_addr: GuestAddr = qemu
             .read_return_address()
             .map_err(|e| Error::unknown(format!("Failed to read return address: {e:?}")))?;
-        log::debug!("ret_addr = {ret_addr:#x}");
+        log::info!("ret_addr = {ret_addr:#x}");
         qemu.set_breakpoint(ret_addr);
 
         let input_addr = qemu


### PR DESCRIPTION
Log messages changed to `log::info` so they aren't compiled out of release builds. They are in non-performance critical portions of code.