### PR TITLE
Continue loading inputs even if some fail to deserialize

### DIFF
--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -752,8 +752,14 @@ where
         EM: EventFirer<State = Self>,
         Z: Evaluator<E, EM, I, Self>,
     {
-        log::info!("Loading file {:?} ...", &path);
-        let input = (config.loader)(fuzzer, self, path)?;
+        log::info!("Loading file {path:?} ...");
+        let input = match (config.loader)(fuzzer, self, path) {
+            Ok(input) => input
+            Err(err) => {
+                log::error("Skipping input that we could not load from {path:?}: {err:?}")
+                return Ok(ExecuteInputResult::None)
+            }
+        }
         if config.forced {
             let _: CorpusId = fuzzer.add_input(self, executor, manager, input)?;
             Ok(ExecuteInputResult::Corpus)

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -754,12 +754,12 @@ where
     {
         log::info!("Loading file {path:?} ...");
         let input = match (config.loader)(fuzzer, self, path) {
-            Ok(input) => input
+            Ok(input) => input,
             Err(err) => {
-                log::error("Skipping input that we could not load from {path:?}: {err:?}")
-                return Ok(ExecuteInputResult::None)
+                log::error("Skipping input that we could not load from {path:?}: {err:?}");
+                return Ok(ExecuteInputResult::None);
             }
-        }
+        };
         if config.forced {
             let _: CorpusId = fuzzer.add_input(self, executor, manager, input)?;
             Ok(ExecuteInputResult::Corpus)

--- a/libafl/src/state/mod.rs
+++ b/libafl/src/state/mod.rs
@@ -756,7 +756,7 @@ where
         let input = match (config.loader)(fuzzer, self, path) {
             Ok(input) => input,
             Err(err) => {
-                log::error("Skipping input that we could not load from {path:?}: {err:?}");
+                log::error!("Skipping input that we could not load from {path:?}: {err:?}");
                 return Ok(ExecuteInputResult::None);
             }
         };


### PR DESCRIPTION
I have some non-multi-input files in my multi-input corpus - they don't serialize for obvious reasons.