### PR TITLE
Handle "--" in libafl_cc

### DIFF
--- a/libafl_cc/src/clang.rs
+++ b/libafl_cc/src/clang.rs
@@ -176,6 +176,10 @@ impl ToolWrapper for ClangWrapper {
             }
 
             match args[i].as_ref() {
+                "--" => {
+                    i += 1;
+                    continue;
+                }
                 "--libafl-no-link" => {
                     suppress_linking += 1;
                     self.has_libafl_arg = true;


### PR DESCRIPTION
because cc-rs wants to add this "--"
https://github.com/rust-lang/cc-rs/pull/1328
if we use `libafl_cc` with `cc`, it'll cause problem because everything after "--" is ignored.

so for now just skip "--" in the option parser