### PR TITLE
Remove CustomBufHandlers

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,7 @@
 - `Qemu` cannot be used to initialize `Emulator` directly anymore. Instead, `Qemu` should be initialized through `Emulator` systematically if `Emulator` should be used.
   - Related: `EmulatorBuilder` uses a single function to provide a `Qemu` initializer: `EmulatorBuilder::qemu_parameters`. For now, it can be either a `Vec<String>` or a `QemuConfig` instance.
   - Related: Qemu's `AsanModule` does not need any special call to `Qemu` init methods anymore. It is now possible to simply initialize `AsanModule` (or `AsanGuestModule`) with a reference to the environment as parameter.
-
+  - `CustomBufHandlers` has been deleted. Please use `EventManagerHooksTuple` from now on.
 # 0.14.0 -> 0.14.1
 - Removed `with_observers` from `Executor` trait.
 - `MmapShMemProvider::new_shmem_persistent` has been removed in favour of `MmapShMem::persist`. You probably want to do something like this: `let shmem = MmapShMemProvider::new()?.new_shmem(size)?.persist()?;`

--- a/libafl/src/events/broker_hooks/mod.rs
+++ b/libafl/src/events/broker_hooks/mod.rs
@@ -194,7 +194,6 @@ where
                 log::log!((*severity_level).into(), "{message}");
                 Ok(BrokerEventResult::Handled)
             }
-            Event::CustomBuf { .. } => Ok(BrokerEventResult::Forward),
             Event::Stop => Ok(BrokerEventResult::Forward),
             //_ => Ok(BrokerEventResult::Forward),
         }

--- a/libafl/src/events/centralized.rs
+++ b/libafl/src/events/centralized.rs
@@ -7,7 +7,7 @@
 // 3. The "main evaluator", the evaluator node that will evaluate all the testcases pass by the centralized event manager to see if the testcases are worth propagating
 // 4. The "main broker", the gathers the stats from the fuzzer clients and broadcast the newly found testcases from the main evaluator.
 
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use core::{fmt::Debug, time::Duration};
 use std::{marker::PhantomData, process};
 
@@ -30,9 +30,9 @@ use crate::events::llmp::COMPRESS_THRESHOLD;
 use crate::{
     corpus::Corpus,
     events::{
-        AdaptiveSerializer, CustomBufEventResult, Event, EventConfig, EventFirer, EventManager,
-        EventManagerHooksTuple, EventManagerId, EventProcessor, EventRestarter,
-        HasCustomBufHandlers, HasEventManagerId, LogSeverity, ProgressReporter,
+        AdaptiveSerializer, Event, EventConfig, EventFirer, EventManager, EventManagerHooksTuple,
+        EventManagerId, EventProcessor, EventRestarter, HasEventManagerId, LogSeverity,
+        ProgressReporter,
     },
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
@@ -415,24 +415,6 @@ where
     Z: EvaluatorObservers<E, Self, <S::Corpus as Corpus>::Input, S>
         + ExecutionProcessor<Self, <S::Corpus as Corpus>::Input, E::Observers, S>,
 {
-}
-
-impl<EM, EMH, S, SP> HasCustomBufHandlers for CentralizedEventManager<EM, EMH, S, SP>
-where
-    EM: HasCustomBufHandlers<State = S>,
-    EMH: EventManagerHooksTuple<S>,
-    S: State,
-    SP: ShMemProvider,
-{
-    /// Adds a custom buffer handler that will run for each incoming `CustomBuf` event.
-    fn add_custom_buf_handler(
-        &mut self,
-        handler: Box<
-            dyn FnMut(&mut Self::State, &str, &[u8]) -> Result<CustomBufEventResult, Error>,
-        >,
-    ) {
-        self.inner.add_custom_buf_handler(handler);
-    }
 }
 
 impl<EM, EMH, S, SP> ProgressReporter for CentralizedEventManager<EM, EMH, S, SP>

--- a/libafl/src/events/llmp/mgr.rs
+++ b/libafl/src/events/llmp/mgr.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "std")]
 use alloc::string::ToString;
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use core::{marker::PhantomData, time::Duration};
 #[cfg(feature = "std")]
 use std::net::TcpStream;
@@ -33,9 +33,8 @@ use crate::{
     corpus::Corpus,
     events::{
         llmp::{LLMP_TAG_EVENT_TO_BOTH, _LLMP_TAG_EVENT_TO_BROKER},
-        AdaptiveSerializer, CustomBufEventResult, CustomBufHandlerFn, Event, EventConfig,
-        EventFirer, EventManager, EventManagerHooksTuple, EventManagerId, EventProcessor,
-        EventRestarter, HasCustomBufHandlers, HasEventManagerId, ProgressReporter,
+        AdaptiveSerializer, Event, EventConfig, EventFirer, EventManager, EventManagerHooksTuple,
+        EventManagerId, EventProcessor, EventRestarter, HasEventManagerId, ProgressReporter,
     },
     executors::{Executor, HasObservers},
     fuzzer::{Evaluator, EvaluatorObservers, ExecutionProcessor},
@@ -64,8 +63,6 @@ where
     hooks: EMH,
     /// The LLMP client for inter process communication
     llmp: LlmpClient<SP>,
-    /// The custom buf handler
-    custom_buf_handlers: Vec<Box<CustomBufHandlerFn<S>>>,
     #[cfg(feature = "llmp_compression")]
     compressor: GzipCompressor,
     /// The configuration defines this specific fuzzer.
@@ -168,7 +165,6 @@ impl<EMH> LlmpEventManagerBuilder<EMH> {
             should_serialize_cnt: 0,
             time_ref,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
             event_buffer: Vec::with_capacity(INITIAL_EVENT_BUFFER_SIZE),
         })
     }
@@ -203,7 +199,6 @@ impl<EMH> LlmpEventManagerBuilder<EMH> {
             should_serialize_cnt: 0,
             time_ref,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
             event_buffer: Vec::with_capacity(INITIAL_EVENT_BUFFER_SIZE),
         })
     }
@@ -238,7 +233,6 @@ impl<EMH> LlmpEventManagerBuilder<EMH> {
             should_serialize_cnt: 0,
             time_ref,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
             event_buffer: Vec::with_capacity(INITIAL_EVENT_BUFFER_SIZE),
         })
     }
@@ -271,7 +265,6 @@ impl<EMH> LlmpEventManagerBuilder<EMH> {
             should_serialize_cnt: 0,
             time_ref,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
             event_buffer: Vec::with_capacity(INITIAL_EVENT_BUFFER_SIZE),
         })
     }
@@ -466,13 +459,6 @@ where
                         log::debug!("Added received Testcase {evt_name} as item #{item}");
                     } else {
                         log::debug!("Testcase {evt_name} was discarded");
-                    }
-                }
-            }
-            Event::CustomBuf { tag, buf } => {
-                for handler in &mut self.custom_buf_handlers {
-                    if handler(state, &tag, &buf)? == CustomBufEventResult::Handled {
-                        break;
                     }
                 }
             }
@@ -677,19 +663,6 @@ where
         + EvaluatorObservers<E, Self, <S::Corpus as Corpus>::Input, S>
         + Evaluator<E, Self, <S::Corpus as Corpus>::Input, S>,
 {
-}
-
-impl<EMH, S, SP> HasCustomBufHandlers for LlmpEventManager<EMH, S, SP>
-where
-    S: State,
-    SP: ShMemProvider,
-{
-    fn add_custom_buf_handler(
-        &mut self,
-        handler: Box<dyn FnMut(&mut S, &str, &[u8]) -> Result<CustomBufEventResult, Error>>,
-    ) {
-        self.custom_buf_handlers.push(handler);
-    }
 }
 
 impl<EMH, S, SP> ProgressReporter for LlmpEventManager<EMH, S, SP>

--- a/libafl/src/events/llmp/mod.rs
+++ b/libafl/src/events/llmp/mod.rs
@@ -1,6 +1,5 @@
 //! LLMP-backed event manager for scalable multi-processed fuzzing
 
-use alloc::{boxed::Box, vec::Vec};
 use core::{marker::PhantomData, time::Duration};
 
 #[cfg(feature = "llmp_compression")]
@@ -17,7 +16,7 @@ use serde::Deserialize;
 
 use crate::{
     corpus::Corpus,
-    events::{CustomBufEventResult, CustomBufHandlerFn, Event, EventFirer},
+    events::{Event, EventFirer},
     executors::{Executor, HasObservers},
     fuzzer::{EvaluatorObservers, ExecutionProcessor},
     inputs::{Input, InputConverter, NopInput, NopInputConverter, UsesInput},
@@ -96,8 +95,6 @@ where
     throttle: Option<Duration>,
     llmp: LlmpClient<SP>,
     last_sent: Duration,
-    /// The custom buf handler
-    custom_buf_handlers: Vec<Box<CustomBufHandlerFn<S>>>,
     #[cfg(feature = "llmp_compression")]
     compressor: GzipCompressor,
     converter: Option<IC>,
@@ -165,7 +162,6 @@ impl LlmpEventConverterBuilder {
             converter,
             converter_back,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
         })
     }
 
@@ -195,7 +191,6 @@ impl LlmpEventConverterBuilder {
             converter,
             converter_back,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
         })
     }
 
@@ -225,7 +220,6 @@ impl LlmpEventConverterBuilder {
             converter,
             converter_back,
             phantom: PhantomData,
-            custom_buf_handlers: vec![],
         })
     }
 }
@@ -321,14 +315,6 @@ where
 
                 if let Some(item) = res.1 {
                     log::info!("Added received Testcase as item #{item}");
-                }
-                Ok(())
-            }
-            Event::CustomBuf { tag, buf } => {
-                for handler in &mut self.custom_buf_handlers {
-                    if handler(state, &tag, &buf)? == CustomBufEventResult::Handled {
-                        break;
-                    }
                 }
                 Ok(())
             }
@@ -449,7 +435,6 @@ where
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id,
             },
-            Event::CustomBuf { buf, tag } => Event::CustomBuf { buf, tag },
             _ => {
                 return Ok(());
             }
@@ -506,10 +491,6 @@ where
                 #[cfg(all(unix, feature = "std", feature = "multi_machine"))]
                 node_id,
             },
-            Event::CustomBuf { buf, tag } => Event::CustomBuf { buf, tag },
-            _ => {
-                return Ok(());
-            }
         };
         let serialized = postcard::to_allocvec(&converted_event)?;
         self.llmp.send_buf(LLMP_TAG_EVENT_TO_BOTH, &serialized)?;

--- a/libafl/src/events/llmp/restarting.rs
+++ b/libafl/src/events/llmp/restarting.rs
@@ -3,7 +3,7 @@
 //! When the target crashes, a watch process (the parent) will
 //! restart/refork it.
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use core::{
     marker::PhantomData,
     num::NonZeroUsize,
@@ -34,10 +34,10 @@ use crate::events::EVENTMGR_SIGHANDLER_STATE;
 use crate::{
     corpus::Corpus,
     events::{
-        launcher::ClientDescription, AdaptiveSerializer, CustomBufEventResult, Event, EventConfig,
-        EventFirer, EventManager, EventManagerHooksTuple, EventManagerId, EventProcessor,
-        EventRestarter, HasCustomBufHandlers, HasEventManagerId, LlmpEventManager,
-        LlmpShouldSaveState, ProgressReporter, StdLlmpEventHook,
+        launcher::ClientDescription, AdaptiveSerializer, Event, EventConfig, EventFirer,
+        EventManager, EventManagerHooksTuple, EventManagerId, EventProcessor, EventRestarter,
+        HasEventManagerId, LlmpEventManager, LlmpShouldSaveState, ProgressReporter,
+        StdLlmpEventHook,
     },
     executors::{Executor, HasObservers},
     fuzzer::{Evaluator, EvaluatorObservers, ExecutionProcessor},
@@ -243,19 +243,6 @@ where
 {
     fn mgr_id(&self) -> EventManagerId {
         self.llmp_mgr.mgr_id()
-    }
-}
-
-impl<EMH, S, SP> HasCustomBufHandlers for LlmpRestartingEventManager<EMH, S, SP>
-where
-    S: State,
-    SP: ShMemProvider,
-{
-    fn add_custom_buf_handler(
-        &mut self,
-        handler: Box<dyn FnMut(&mut S, &str, &[u8]) -> Result<CustomBufEventResult, Error>>,
-    ) {
-        self.llmp_mgr.add_custom_buf_handler(handler);
     }
 }
 

--- a/libafl/src/events/mod.rs
+++ b/libafl/src/events/mod.rs
@@ -19,7 +19,7 @@ pub use llmp::*;
 pub mod tcp;
 
 pub mod broker_hooks;
-use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
+use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::{
     fmt,
     hash::{BuildHasher, Hasher},
@@ -152,15 +152,6 @@ impl fmt::Display for LogSeverity {
             LogSeverity::Error => write!(f, "Error"),
         }
     }
-}
-
-/// The result of a custom buf handler added using [`HasCustomBufHandlers::add_custom_buf_handler`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CustomBufEventResult {
-    /// Exit early from event handling
-    Handled,
-    /// Call the next handler, if available
-    Next,
 }
 
 /// Indicate if an event worked or not
@@ -337,13 +328,6 @@ where
         /// `PhantomData`
         phantom: PhantomData<I>,
     },
-    /// Sends a custom buffer to other clients
-    CustomBuf {
-        /// The buffer
-        buf: Vec<u8>,
-        /// Tag of this buffer
-        tag: String,
-    },
     /// Exit gracefully
     Stop,
     /*/// A custom type
@@ -367,7 +351,6 @@ where
             Event::UpdatePerfMonitor { .. } => "PerfMonitor",
             Event::Objective { .. } => "Objective",
             Event::Log { .. } => "Log",
-            Event::CustomBuf { .. } => "CustomBuf",
             /*Event::Custom {
                 sender_id: _, /*custom_event} => custom_event.name()*/
             } => "todo",*/
@@ -387,7 +370,6 @@ where
             Event::UpdatePerfMonitor { .. } => Cow::Borrowed("PerfMonitor"),
             Event::Objective { .. } => Cow::Borrowed("Objective"),
             Event::Log { .. } => Cow::Borrowed("Log"),
-            Event::CustomBuf { .. } => Cow::Borrowed("CustomBuf"),
             Event::Stop => Cow::Borrowed("Stop"),
             /*Event::Custom {
                 sender_id: _, /*custom_event} => custom_event.name()*/
@@ -598,15 +580,6 @@ where
 {
 }
 
-/// The handler function for custom buffers exchanged via [`EventManager`]
-type CustomBufHandlerFn<S> = dyn FnMut(&mut S, &str, &[u8]) -> Result<CustomBufEventResult, Error>;
-
-/// Supports custom buf handlers to handle `CustomBuf` events.
-pub trait HasCustomBufHandlers: UsesState {
-    /// Adds a custom buffer handler that will run for each incoming `CustomBuf` event.
-    fn add_custom_buf_handler(&mut self, handler: Box<CustomBufHandlerFn<Self::State>>);
-}
-
 /// An eventmgr for tests, and as placeholder if you really don't need an event manager.
 #[derive(Copy, Clone, Debug)]
 pub struct NopEventManager<S> {
@@ -676,19 +649,6 @@ where
 impl<E, S, Z> EventManager<E, Z> for NopEventManager<S> where
     S: State + HasExecutions + HasLastReportTime + HasMetadata
 {
-}
-
-impl<S> HasCustomBufHandlers for NopEventManager<S>
-where
-    S: State,
-{
-    fn add_custom_buf_handler(
-        &mut self,
-        _handler: Box<
-            dyn FnMut(&mut Self::State, &str, &[u8]) -> Result<CustomBufEventResult, Error>,
-        >,
-    ) {
-    }
 }
 
 impl<S> ProgressReporter for NopEventManager<S> where
@@ -813,22 +773,6 @@ where
     EM: EventManager<E, Z>,
     Self::State: HasLastReportTime + HasExecutions + HasMetadata,
 {
-}
-
-impl<EM, M> HasCustomBufHandlers for MonitorTypedEventManager<EM, M>
-where
-    Self: UsesState,
-    EM: HasCustomBufHandlers<State = Self::State>,
-{
-    #[inline]
-    fn add_custom_buf_handler(
-        &mut self,
-        handler: Box<
-            dyn FnMut(&mut Self::State, &str, &[u8]) -> Result<CustomBufEventResult, Error>,
-        >,
-    ) {
-        self.inner.add_custom_buf_handler(handler);
-    }
 }
 
 impl<EM, M> ProgressReporter for MonitorTypedEventManager<EM, M>


### PR DESCRIPTION
Before I do the final refactoring of event manager. I want to make things a bit cleaner.
CustomBufHandlers should be replaced with EventManagerHooks