### PR TITLE
Fix libafl_targets cmplog linking

### DIFF
--- a/libafl_targets/build.rs
+++ b/libafl_targets/build.rs
@@ -125,11 +125,11 @@ fn main() {
         {
             sancov_cmp.define("SANCOV_CMPLOG", "1");
 
-            println!("cargo:rustc-link-arg=--undefined=__sanitizer_weak_hook_memcmp");
-            println!("cargo:rustc-link-arg=--undefined=__sanitizer_weak_hook_strncmp");
-            println!("cargo:rustc-link-arg=--undefined=__sanitizer_weak_hook_strncasecmp");
-            println!("cargo:rustc-link-arg=--undefined=__sanitizer_weak_hook_strcmp");
-            println!("cargo:rustc-link-arg=--undefined=__sanitizer_weak_hook_strcasecmp");
+            println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_weak_hook_memcmp");
+            println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_weak_hook_strncmp");
+            println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_weak_hook_strncasecmp");
+            println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_weak_hook_strcmp");
+            println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_weak_hook_strcasecmp");
         }
 
         sancov_cmp
@@ -139,17 +139,17 @@ fn main() {
             .file(src_dir.join("sancov_cmp.c"))
             .compile("sancov_cmp");
 
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_cmp1");
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_cmp2");
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_cmp4");
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_cmp8");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_cmp1");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_cmp2");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_cmp4");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_cmp8");
 
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_const_cmp1");
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_const_cmp2");
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_const_cmp4");
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_const_cmp8");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_const_cmp1");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_const_cmp2");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_const_cmp4");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_const_cmp8");
 
-        println!("cargo:rustc-link-arg=--undefined=__sanitizer_cov_trace_switch");
+        println!("cargo:rustc-link-arg=-Wl,--undefined=__sanitizer_cov_trace_switch");
     }
 
     #[cfg(feature = "libfuzzer")]


### PR DESCRIPTION
`--undefined` flags must be passed to the linker instead of being given to the compiler. Some compilers are not aware of the `--undefined` flag. 