### PR TITLE
Remove MapObserver dependency from observer-dependent stages and schedulers in favour of generic hashing

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,6 +16,8 @@
   - For the structs/traits that used to use `UsesState`, we bring back the generic for the state.
   - For `UsesState`, you can access to the input type through `HasCorpus` and `Corpus` traits
   - The `State` trait is now private in favour of individual and more specific traits
+- Restrictions from certain schedulers and stages that required their inner observer to implement `MapObserver` have been lifted in favor of requiring `Hash`
+  - Related: removed `hash_simple` from `MapObserver`
 
 # 0.14.0 -> 0.14.1
 - Removed `with_observers` from `Executor` trait.

--- a/fuzzers/baby/baby_fuzzer_minimizing/src/main.rs
+++ b/fuzzers/baby/baby_fuzzer_minimizing/src/main.rs
@@ -39,7 +39,7 @@ pub fn main() -> Result<(), Error> {
     #[allow(static_mut_refs)] // only a problem in nightly
     let observer = unsafe { StdMapObserver::from_mut_ptr("signals", SIGNALS_PTR, SIGNALS.len()) };
 
-    let factory = MapEqualityFactory::new(&observer);
+    let factory = ObserverEqualityFactory::new(&observer);
 
     // Feedback to rate the interestingness of an input
     let mut feedback = MaxMapFeedback::new(&observer);

--- a/libafl/src/observers/map/const_map.rs
+++ b/libafl/src/observers/map/const_map.rs
@@ -13,7 +13,7 @@ use libafl_bolts::{ownedref::OwnedMutSizedSlice, HasLen, Named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, ConstLenMapObserver, Observer},
+    observers::{map::MapObserver, ConstLenMapObserver, Observer, SimpleHash},
     Error,
 };
 
@@ -72,6 +72,16 @@ impl<T, const N: usize> AsMut<Self> for ConstMapObserver<'_, T, N> {
     }
 }
 
+impl<T, const N: usize> SimpleHash for ConstMapObserver<'_, T, N>
+where
+    T: Hash,
+{
+    #[inline]
+    fn hash_simple(&self) -> u64 {
+        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
+    }
+}
+
 impl<T, const N: usize> MapObserver for ConstMapObserver<'_, T, N>
 where
     T: PartialEq + Copy + Hash + Serialize + DeserializeOwned + Debug + 'static,
@@ -109,11 +119,6 @@ where
 
     fn usable_count(&self) -> usize {
         self.len()
-    }
-
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 
     /// Reset the map

--- a/libafl/src/observers/map/const_map.rs
+++ b/libafl/src/observers/map/const_map.rs
@@ -8,12 +8,11 @@ use core::{
     ptr::NonNull,
 };
 
-use ahash::RandomState;
 use libafl_bolts::{ownedref::OwnedMutSizedSlice, HasLen, Named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, ConstLenMapObserver, Observer, SimpleHash},
+    observers::{map::MapObserver, ConstLenMapObserver, Observer},
     Error,
 };
 
@@ -69,16 +68,6 @@ impl<T, const N: usize> AsRef<Self> for ConstMapObserver<'_, T, N> {
 impl<T, const N: usize> AsMut<Self> for ConstMapObserver<'_, T, N> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<T, const N: usize> SimpleHash for ConstMapObserver<'_, T, N>
-where
-    T: Hash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 }
 

--- a/libafl/src/observers/map/hitcount_map.rs
+++ b/libafl/src/observers/map/hitcount_map.rs
@@ -14,8 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     executors::ExitKind,
     observers::{
-        map::MapObserver, ConstLenMapObserver, DifferentialObserver, Observer, SimpleHash,
-        VarLenMapObserver,
+        map::MapObserver, ConstLenMapObserver, DifferentialObserver, Observer, VarLenMapObserver,
     },
     Error,
 };
@@ -182,16 +181,6 @@ impl<M> AsRef<Self> for HitcountsMapObserver<M> {
 impl<M> AsMut<Self> for HitcountsMapObserver<M> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<M> SimpleHash for HitcountsMapObserver<M>
-where
-    M: SimpleHash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        self.base.hash_simple()
     }
 }
 
@@ -409,16 +398,6 @@ impl<M> AsRef<Self> for HitcountsIterableMapObserver<M> {
 impl<M> AsMut<Self> for HitcountsIterableMapObserver<M> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<M> SimpleHash for HitcountsIterableMapObserver<M>
-where
-    M: SimpleHash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        self.base.hash_simple()
     }
 }
 

--- a/libafl/src/observers/map/hitcount_map.rs
+++ b/libafl/src/observers/map/hitcount_map.rs
@@ -14,7 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     executors::ExitKind,
     observers::{
-        map::MapObserver, ConstLenMapObserver, DifferentialObserver, Observer, VarLenMapObserver,
+        map::MapObserver, ConstLenMapObserver, DifferentialObserver, Observer, SimpleHash,
+        VarLenMapObserver,
     },
     Error,
 };
@@ -184,6 +185,16 @@ impl<M> AsMut<Self> for HitcountsMapObserver<M> {
     }
 }
 
+impl<M> SimpleHash for HitcountsMapObserver<M>
+where
+    M: SimpleHash,
+{
+    #[inline]
+    fn hash_simple(&self) -> u64 {
+        self.base.hash_simple()
+    }
+}
+
 impl<M> MapObserver for HitcountsMapObserver<M>
 where
     M: MapObserver<Entry = u8>,
@@ -219,11 +230,6 @@ where
     #[inline]
     fn reset_map(&mut self) -> Result<(), Error> {
         self.base.reset_map()
-    }
-
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        self.base.hash_simple()
     }
 
     fn to_vec(&self) -> Vec<u8> {
@@ -406,6 +412,16 @@ impl<M> AsMut<Self> for HitcountsIterableMapObserver<M> {
     }
 }
 
+impl<M> SimpleHash for HitcountsIterableMapObserver<M>
+where
+    M: SimpleHash,
+{
+    #[inline]
+    fn hash_simple(&self) -> u64 {
+        self.base.hash_simple()
+    }
+}
+
 impl<M> MapObserver for HitcountsIterableMapObserver<M>
 where
     M: MapObserver<Entry = u8>,
@@ -443,10 +459,6 @@ where
         self.base.reset_map()
     }
 
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        self.base.hash_simple()
-    }
     fn to_vec(&self) -> Vec<u8> {
         self.base.to_vec()
     }

--- a/libafl/src/observers/map/mod.rs
+++ b/libafl/src/observers/map/mod.rs
@@ -349,7 +349,7 @@ pub mod macros {
 ///
 /// TODO: enforce `iter() -> AssociatedTypeIter` when generic associated types stabilize
 pub trait MapObserver:
-    HasLen + Named + Serialize + DeserializeOwned + AsRef<Self> + AsMut<Self> + Hash
+    HasLen + Named + Serialize + DeserializeOwned + AsRef<Self> + AsMut<Self>
 // where
 //     for<'it> &'it Self: IntoIterator<Item = &'it Self::Entry>
 {

--- a/libafl/src/observers/map/mod.rs
+++ b/libafl/src/observers/map/mod.rs
@@ -7,7 +7,6 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use ahash::RandomState;
 use libafl_bolts::{ownedref::OwnedMutSlice, AsSlice, AsSliceMut, HasLen, Named, Truncate};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -338,12 +337,6 @@ pub mod macros {
     }
 }
 
-/// Can calculate a simple hash function, usually used in conjunction with a [`MapObserver`]
-pub trait SimpleHash {
-    /// Compute the hash of the map without needing to provide a hasher
-    fn hash_simple(&self) -> u64;
-}
-
 /// A [`MapObserver`] observes the static map, as oftentimes used for AFL-like coverage information
 ///
 /// When referring to this type in a constraint (e.g. `O: MapObserver`), ensure that you only refer
@@ -492,16 +485,6 @@ impl<T, const DIFFERENTIAL: bool> AsRef<Self> for StdMapObserver<'_, T, DIFFEREN
 impl<T, const DIFFERENTIAL: bool> AsMut<Self> for StdMapObserver<'_, T, DIFFERENTIAL> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<T, const DIFFERENTIAL: bool> SimpleHash for StdMapObserver<'_, T, DIFFERENTIAL>
-where
-    T: Hash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 }
 

--- a/libafl/src/observers/map/multi_map.rs
+++ b/libafl/src/observers/map/multi_map.rs
@@ -16,7 +16,7 @@ use meminterval::IntervalTree;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, DifferentialObserver, Observer},
+    observers::{map::MapObserver, DifferentialObserver, Observer, SimpleHash},
     Error,
 };
 
@@ -84,6 +84,16 @@ impl<T, const DIFFERENTIAL: bool> AsMut<Self> for MultiMapObserver<'_, T, DIFFER
     }
 }
 
+impl<T, const DIFFERENTIAL: bool> SimpleHash for MultiMapObserver<'_, T, DIFFERENTIAL>
+where
+    T: Hash,
+{
+    #[inline]
+    fn hash_simple(&self) -> u64 {
+        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
+    }
+}
+
 impl<T, const DIFFERENTIAL: bool> MapObserver for MultiMapObserver<'_, T, DIFFERENTIAL>
 where
     T: PartialEq + Copy + Hash + Serialize + DeserializeOwned + Debug,
@@ -122,11 +132,6 @@ where
             }
         }
         res
-    }
-
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 
     fn reset_map(&mut self) -> Result<(), Error> {

--- a/libafl/src/observers/map/multi_map.rs
+++ b/libafl/src/observers/map/multi_map.rs
@@ -8,7 +8,6 @@ use core::{
     slice::{Iter, IterMut},
 };
 
-use ahash::RandomState;
 use libafl_bolts::{
     ownedref::OwnedMutSlice, AsIter, AsIterMut, AsSlice, AsSliceMut, HasLen, Named,
 };
@@ -16,7 +15,7 @@ use meminterval::IntervalTree;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, DifferentialObserver, Observer, SimpleHash},
+    observers::{map::MapObserver, DifferentialObserver, Observer},
     Error,
 };
 
@@ -81,16 +80,6 @@ impl<T, const DIFFERENTIAL: bool> AsRef<Self> for MultiMapObserver<'_, T, DIFFER
 impl<T, const DIFFERENTIAL: bool> AsMut<Self> for MultiMapObserver<'_, T, DIFFERENTIAL> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<T, const DIFFERENTIAL: bool> SimpleHash for MultiMapObserver<'_, T, DIFFERENTIAL>
-where
-    T: Hash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 }
 

--- a/libafl/src/observers/map/owned_map.rs
+++ b/libafl/src/observers/map/owned_map.rs
@@ -12,7 +12,7 @@ use libafl_bolts::{AsSlice, AsSliceMut, HasLen, Named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, Observer},
+    observers::{map::MapObserver, Observer, SimpleHash},
     Error,
 };
 
@@ -70,6 +70,16 @@ impl<T> AsMut<Self> for OwnedMapObserver<T> {
     }
 }
 
+impl<T> SimpleHash for OwnedMapObserver<T>
+where
+    T: Hash,
+{
+    #[inline]
+    fn hash_simple(&self) -> u64 {
+        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
+    }
+}
+
 impl<T> MapObserver for OwnedMapObserver<T>
 where
     T: PartialEq + Copy + Hash + Serialize + DeserializeOwned + Debug,
@@ -103,11 +113,6 @@ where
     #[inline]
     fn usable_count(&self) -> usize {
         self.as_slice().len()
-    }
-
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 
     #[inline]

--- a/libafl/src/observers/map/owned_map.rs
+++ b/libafl/src/observers/map/owned_map.rs
@@ -7,12 +7,11 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use ahash::RandomState;
 use libafl_bolts::{AsSlice, AsSliceMut, HasLen, Named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, Observer, SimpleHash},
+    observers::{map::MapObserver, Observer},
     Error,
 };
 
@@ -67,16 +66,6 @@ impl<T> AsRef<Self> for OwnedMapObserver<T> {
 impl<T> AsMut<Self> for OwnedMapObserver<T> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<T> SimpleHash for OwnedMapObserver<T>
-where
-    T: Hash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 }
 

--- a/libafl/src/observers/map/variable_map.rs
+++ b/libafl/src/observers/map/variable_map.rs
@@ -7,7 +7,6 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use ahash::RandomState;
 use libafl_bolts::{
     ownedref::{OwnedMutPtr, OwnedMutSlice},
     AsSlice, AsSliceMut, HasLen, Named,
@@ -15,7 +14,7 @@ use libafl_bolts::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, Observer, SimpleHash, VarLenMapObserver},
+    observers::{map::MapObserver, Observer, VarLenMapObserver},
     Error,
 };
 
@@ -72,16 +71,6 @@ impl<T> AsRef<Self> for VariableMapObserver<'_, T> {
 impl<T> AsMut<Self> for VariableMapObserver<'_, T> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<T> SimpleHash for VariableMapObserver<'_, T>
-where
-    T: Hash,
-{
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 }
 

--- a/libafl/src/observers/map/variable_map.rs
+++ b/libafl/src/observers/map/variable_map.rs
@@ -15,7 +15,7 @@ use libafl_bolts::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    observers::{map::MapObserver, Observer, VarLenMapObserver},
+    observers::{map::MapObserver, Observer, SimpleHash, VarLenMapObserver},
     Error,
 };
 
@@ -75,6 +75,16 @@ impl<T> AsMut<Self> for VariableMapObserver<'_, T> {
     }
 }
 
+impl<T> SimpleHash for VariableMapObserver<'_, T>
+where
+    T: Hash,
+{
+    #[inline]
+    fn hash_simple(&self) -> u64 {
+        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
+    }
+}
+
 impl<T> MapObserver for VariableMapObserver<'_, T>
 where
     T: PartialEq + Copy + Hash + Serialize + DeserializeOwned + Debug,
@@ -111,11 +121,6 @@ where
             }
         }
         res
-    }
-
-    #[inline]
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 
     /// Reset the map

--- a/libafl/src/observers/value.rs
+++ b/libafl/src/observers/value.rs
@@ -12,9 +12,8 @@ use ahash::RandomState;
 use libafl_bolts::{ownedref::OwnedRef, AsIter, AsIterMut, AsSlice, AsSliceMut, HasLen, Named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use super::{Observer, SimpleHash};
 use crate::{
-    observers::{MapObserver, ObserverWithHashField},
+    observers::{MapObserver, Observer, ObserverWithHashField},
     Error,
 };
 
@@ -287,17 +286,6 @@ impl<T> AsRef<Self> for RefCellValueObserver<'_, T> {
 impl<T> AsMut<Self> for RefCellValueObserver<'_, T> {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-impl<T> SimpleHash for RefCellValueObserver<'_, T>
-where
-    T: Hash,
-{
-    /// Panics if the contained value is already mutably borrowed (calls
-    /// [`RefCell::borrow`]).
-    fn hash_simple(&self) -> u64 {
-        RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
     }
 }
 

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -35,7 +35,7 @@ pub use tuneable::*;
 
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, SchedulerTestcaseMetadata, Testcase},
-    observers::MapObserver,
+    observers::SimpleHash,
     random_corpus_id,
     state::{HasCorpus, HasRand},
     Error, HasMetadata,
@@ -109,7 +109,7 @@ where
     CS: AflScheduler,
     CS::MapObserverRef: AsRef<O>,
     S: HasMetadata,
-    O: MapObserver,
+    O: SimpleHash,
     OT: MatchName,
 {
     let observer = observers

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -1,7 +1,7 @@
 //! Schedule the access to the Corpus.
 
 use alloc::{borrow::ToOwned, string::ToString};
-use core::marker::PhantomData;
+use core::{hash::Hash, marker::PhantomData};
 
 pub mod testcase_score;
 pub use testcase_score::{LenTimeMulTestcaseScore, TestcaseScore};
@@ -28,6 +28,7 @@ pub use weighted::{StdWeightedScheduler, WeightedScheduler};
 
 pub mod tuneable;
 use libafl_bolts::{
+    generic_hash_std,
     rands::Rand,
     tuples::{Handle, MatchName, MatchNameRef},
 };
@@ -35,7 +36,6 @@ pub use tuneable::*;
 
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, SchedulerTestcaseMetadata, Testcase},
-    observers::SimpleHash,
     random_corpus_id,
     state::{HasCorpus, HasRand},
     Error, HasMetadata,
@@ -109,7 +109,7 @@ where
     CS: AflScheduler,
     CS::MapObserverRef: AsRef<O>,
     S: HasMetadata,
-    O: SimpleHash,
+    O: Hash,
     OT: MatchName,
 {
     let observer = observers
@@ -117,7 +117,7 @@ where
         .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
         .as_ref();
 
-    let mut hash = observer.hash_simple() as usize;
+    let mut hash = generic_hash_std(observer) as usize;
 
     let psmeta = state.metadata_mut::<SchedulerMetadata>()?;
 

--- a/libafl/src/schedulers/mod.rs
+++ b/libafl/src/schedulers/mod.rs
@@ -107,14 +107,14 @@ pub fn on_evaluation_metadata_default<CS, O, OT, S>(
 ) -> Result<(), Error>
 where
     CS: AflScheduler,
-    CS::MapObserverRef: AsRef<O>,
+    CS::ObserverRef: AsRef<O>,
     S: HasMetadata,
     O: Hash,
     OT: MatchName,
 {
     let observer = observers
-        .get(scheduler.map_observer_handle())
-        .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?
+        .get(scheduler.observer_handle())
+        .ok_or_else(|| Error::key_not_found("Observer not found".to_string()))?
         .as_ref();
 
     let mut hash = generic_hash_std(observer) as usize;
@@ -153,8 +153,8 @@ where
 
 /// Defines the common metadata operations for the AFL-style schedulers
 pub trait AflScheduler {
-    /// The type of [`MapObserver`] that this scheduler will use as reference
-    type MapObserverRef;
+    /// The type of [`crate::observers::Observer`] that this scheduler will use as reference
+    type ObserverRef;
 
     /// Return the last hash
     fn last_hash(&self) -> usize;
@@ -162,8 +162,8 @@ pub trait AflScheduler {
     /// Set the last hash
     fn set_last_hash(&mut self, value: usize);
 
-    /// Get the observer map observer name
-    fn map_observer_handle(&self) -> &Handle<Self::MapObserverRef>;
+    /// Get the observer handle
+    fn observer_handle(&self) -> &Handle<Self::ObserverRef>;
 }
 
 /// Trait for Schedulers which track queue cycles

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
-    observers::MapObserver,
     schedulers::{
         on_add_metadata_default, on_evaluation_metadata_default, on_next_metadata_default,
         AflScheduler, HasQueueCycles, RemovableScheduler, Scheduler,
@@ -276,7 +275,7 @@ pub enum BaseSchedule {
 pub struct PowerQueueScheduler<C, O> {
     queue_cycles: u64,
     strat: PowerSchedule,
-    map_observer_handle: Handle<C>,
+    observer_handle: Handle<C>,
     last_hash: usize,
     phantom: PhantomData<O>,
 }
@@ -304,7 +303,7 @@ impl<C, I, O, S> RemovableScheduler<I, S> for PowerQueueScheduler<C, O> {
 }
 
 impl<C, O> AflScheduler for PowerQueueScheduler<C, O> {
-    type MapObserverRef = C;
+    type ObserverRef = C;
 
     fn last_hash(&self) -> usize {
         self.last_hash
@@ -314,8 +313,8 @@ impl<C, O> AflScheduler for PowerQueueScheduler<C, O> {
         self.last_hash = hash;
     }
 
-    fn map_observer_handle(&self) -> &Handle<C> {
-        &self.map_observer_handle
+    fn observer_handle(&self) -> &Handle<C> {
+        &self.observer_handle
     }
 }
 
@@ -383,12 +382,12 @@ where
 
 impl<C, O> PowerQueueScheduler<C, O>
 where
-    O: MapObserver,
+    O: Hash,
     C: AsRef<O> + Named,
 {
     /// Create a new [`PowerQueueScheduler`]
     #[must_use]
-    pub fn new<S>(state: &mut S, map_observer: &C, strat: PowerSchedule) -> Self
+    pub fn new<S>(state: &mut S, observer: &C, strat: PowerSchedule) -> Self
     where
         S: HasMetadata,
     {
@@ -398,7 +397,7 @@ where
         PowerQueueScheduler {
             queue_cycles: 0,
             strat,
-            map_observer_handle: map_observer.handle(),
+            observer_handle: observer.handle(),
             last_hash: 0,
             phantom: PhantomData,
         }

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
-    observers::MapObserver,
+    observers::{MapObserver, SimpleHash},
     schedulers::{
         on_add_metadata_default, on_evaluation_metadata_default, on_next_metadata_default,
         AflScheduler, HasQueueCycles, RemovableScheduler, Scheduler,
@@ -328,7 +328,7 @@ impl<C, O> HasQueueCycles for PowerQueueScheduler<C, O> {
 impl<C, I, O, S> Scheduler<I, S> for PowerQueueScheduler<C, O>
 where
     S: HasCorpus + HasMetadata + HasTestcase,
-    O: MapObserver,
+    O: SimpleHash,
     C: AsRef<O>,
 {
     /// Called when a [`Testcase`] is added to the corpus

--- a/libafl/src/schedulers/powersched.rs
+++ b/libafl/src/schedulers/powersched.rs
@@ -1,7 +1,7 @@
 //! The queue corpus scheduler for power schedules.
 
 use alloc::vec::Vec;
-use core::{marker::PhantomData, time::Duration};
+use core::{hash::Hash, marker::PhantomData, time::Duration};
 
 use libafl_bolts::{
     tuples::{Handle, Handled, MatchName},
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
-    observers::{MapObserver, SimpleHash},
+    observers::MapObserver,
     schedulers::{
         on_add_metadata_default, on_evaluation_metadata_default, on_next_metadata_default,
         AflScheduler, HasQueueCycles, RemovableScheduler, Scheduler,
@@ -328,7 +328,7 @@ impl<C, O> HasQueueCycles for PowerQueueScheduler<C, O> {
 impl<C, I, O, S> Scheduler<I, S> for PowerQueueScheduler<C, O>
 where
     S: HasCorpus + HasMetadata + HasTestcase,
-    O: SimpleHash,
+    O: Hash,
     C: AsRef<O>,
 {
     /// Called when a [`Testcase`] is added to the corpus

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use super::powersched::PowerSchedule;
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
-    observers::MapObserver,
+    observers::SimpleHash,
     random_corpus_id,
     schedulers::{
         on_add_metadata_default, on_evaluation_metadata_default, on_next_metadata_default,
@@ -309,7 +309,7 @@ impl<C, F, O, S> Scheduler<<S::Corpus as Corpus>::Input, S> for WeightedSchedule
 where
     C: AsRef<O> + Named,
     F: TestcaseScore<S>,
-    O: MapObserver,
+    O: SimpleHash,
     S: HasCorpus + HasMetadata + HasRand + HasTestcase,
 {
     /// Called when a [`Testcase`] is added to the corpus

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -3,7 +3,7 @@
 //! The queue corpus scheduler with weighted queue item selection [from AFL++](https://github.com/AFLplusplus/AFLplusplus/blob/1d4f1e48797c064ee71441ba555b29fc3f467983/src/afl-fuzz-queue.c#L32).
 //! This queue corpus scheduler needs calibration stage.
 
-use core::marker::PhantomData;
+use core::{hash::Hash, marker::PhantomData};
 
 use hashbrown::HashMap;
 use libafl_bolts::{
@@ -13,14 +13,12 @@ use libafl_bolts::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::powersched::PowerSchedule;
 use crate::{
     corpus::{Corpus, CorpusId, HasTestcase, Testcase},
-    observers::SimpleHash,
     random_corpus_id,
     schedulers::{
         on_add_metadata_default, on_evaluation_metadata_default, on_next_metadata_default,
-        powersched::{BaseSchedule, SchedulerMetadata},
+        powersched::{BaseSchedule, PowerSchedule, SchedulerMetadata},
         testcase_score::{CorpusWeightTestcaseScore, TestcaseScore},
         AflScheduler, HasQueueCycles, RemovableScheduler, Scheduler,
     },
@@ -309,7 +307,7 @@ impl<C, F, O, S> Scheduler<<S::Corpus as Corpus>::Input, S> for WeightedSchedule
 where
     C: AsRef<O> + Named,
     F: TestcaseScore<S>,
-    O: SimpleHash,
+    O: Hash,
     S: HasCorpus + HasMetadata + HasRand + HasTestcase,
 {
     /// Called when a [`Testcase`] is added to the corpus

--- a/libafl/src/schedulers/weighted.rs
+++ b/libafl/src/schedulers/weighted.rs
@@ -99,7 +99,7 @@ libafl_bolts::impl_serdeany!(WeightedScheduleMetadata);
 pub struct WeightedScheduler<C, F, O> {
     table_invalidated: bool,
     strat: Option<PowerSchedule>,
-    map_observer_handle: Handle<C>,
+    observer_handle: Handle<C>,
     last_hash: usize,
     queue_cycles: u64,
     phantom: PhantomData<(F, O)>,
@@ -113,16 +113,16 @@ where
 {
     /// Create a new [`WeightedScheduler`] without any power schedule
     #[must_use]
-    pub fn new<S>(state: &mut S, map_observer: &C) -> Self
+    pub fn new<S>(state: &mut S, observer: &C) -> Self
     where
         S: HasMetadata,
     {
-        Self::with_schedule(state, map_observer, None)
+        Self::with_schedule(state, observer, None)
     }
 
     /// Create a new [`WeightedScheduler`]
     #[must_use]
-    pub fn with_schedule<S>(state: &mut S, map_observer: &C, strat: Option<PowerSchedule>) -> Self
+    pub fn with_schedule<S>(state: &mut S, observer: &C, strat: Option<PowerSchedule>) -> Self
     where
         S: HasMetadata,
     {
@@ -131,7 +131,7 @@ where
 
         Self {
             strat,
-            map_observer_handle: map_observer.handle(),
+            observer_handle: observer.handle(),
             last_hash: 0,
             queue_cycles: 0,
             table_invalidated: true,
@@ -282,7 +282,7 @@ impl<C, F, I, O, S> RemovableScheduler<I, S> for WeightedScheduler<C, F, O> {
 }
 
 impl<C, F, O> AflScheduler for WeightedScheduler<C, F, O> {
-    type MapObserverRef = C;
+    type ObserverRef = C;
 
     fn last_hash(&self) -> usize {
         self.last_hash
@@ -292,8 +292,8 @@ impl<C, F, O> AflScheduler for WeightedScheduler<C, F, O> {
         self.last_hash = hash;
     }
 
-    fn map_observer_handle(&self) -> &Handle<C> {
-        &self.map_observer_handle
+    fn observer_handle(&self) -> &Handle<C> {
+        &self.observer_handle
     }
 }
 

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -20,7 +20,7 @@ use crate::{
     inputs::HasMutatorBytes,
     mutators::mutations::buffer_copy,
     nonzero,
-    observers::{MapObserver, ObserversTuple},
+    observers::{ObserversTuple, SimpleHash},
     stages::{RetryCountRestartHelper, Stage},
     state::{HasCorpus, HasCurrentTestcase, HasRand},
     Error, HasMetadata, HasNamedMetadata,
@@ -81,7 +81,7 @@ where
     S: HasCorpus + HasMetadata + HasRand + HasNamedMetadata + HasCurrentCorpusId,
     E::Observers: ObserversTuple<<S::Corpus as Corpus>::Input, S>,
     <S::Corpus as Corpus>::Input: HasMutatorBytes + Clone,
-    O: MapObserver,
+    O: SimpleHash,
     C: AsRef<O> + Named,
 {
     #[inline]
@@ -152,7 +152,7 @@ libafl_bolts::impl_serdeany!(TaintMetadata);
 impl<C, E, EM, O, S, Z> ColorizationStage<C, E, EM, O, S, Z>
 where
     EM: EventFirer<<S::Corpus as Corpus>::Input, S>,
-    O: MapObserver,
+    O: SimpleHash,
     C: AsRef<O> + Named,
     E: HasObservers + Executor<EM, <S::Corpus as Corpus>::Input, S, Z>,
     E::Observers: ObserversTuple<<S::Corpus as Corpus>::Input, S>,

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 pub use sync::*;
 #[cfg(feature = "std")]
 pub use time_tracker::TimeTrackingStageWrapper;
-pub use tmin::{MapEqualityFactory, MapEqualityFeedback, StdTMinMutationalStage};
+pub use tmin::{ObserverEqualityFactory, ObserverEqualityFeedback, StdTMinMutationalStage};
 pub use tracing::{ShadowTracingStage, TracingStage};
 pub use tuneable::*;
 use tuple_list::NonEmptyTuple;

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -25,7 +25,7 @@ use crate::{
     inputs::Input,
     mark_feature_time,
     mutators::{MutationResult, Mutator},
-    observers::{MapObserver, ObserversTuple},
+    observers::{MapObserver, ObserversTuple, SimpleHash},
     schedulers::RemovableScheduler,
     stages::{
         mutational::{MutatedTransform, MutatedTransformPost},
@@ -360,7 +360,7 @@ impl<C, M, S> StateInitializer<S> for MapEqualityFeedback<C, M, S> {}
 
 impl<C, EM, I, M, OT, S> Feedback<EM, I, OT, S> for MapEqualityFeedback<C, M, S>
 where
-    M: MapObserver,
+    M: SimpleHash,
     C: AsRef<M>,
     OT: MatchName,
 {
@@ -419,7 +419,7 @@ impl<C, M, S> HasObserverHandle for MapEqualityFactory<C, M, S> {
 
 impl<C, M, OT, S> FeedbackFactory<MapEqualityFeedback<C, M, S>, OT> for MapEqualityFactory<C, M, S>
 where
-    M: MapObserver,
+    M: SimpleHash,
     C: AsRef<M> + Handled,
     OT: ObserversTuple<<S::Corpus as Corpus>::Input, S>,
     S: HasCorpus,

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -26,7 +26,7 @@ use crate::{
     inputs::Input,
     mark_feature_time,
     mutators::{MutationResult, Mutator},
-    observers::{MapObserver, ObserversTuple},
+    observers::ObserversTuple,
     schedulers::RemovableScheduler,
     stages::{
         mutational::{MutatedTransform, MutatedTransformPost},
@@ -330,12 +330,12 @@ impl<E, EM, F, FF, M, S, Z> StdTMinMutationalStage<E, EM, F, FF, M, S, Z> {
     }
 }
 
-/// A feedback which checks if the hash of the currently observed map is equal to the original hash
+/// A feedback which checks if the hash of the current observed value is equal to the original hash
 /// provided
 #[derive(Clone, Debug)]
-pub struct MapEqualityFeedback<C, M, S> {
+pub struct ObserverEqualityFeedback<C, M, S> {
     name: Cow<'static, str>,
-    map_ref: Handle<C>,
+    observer_handle: Handle<C>,
     orig_hash: u64,
     #[cfg(feature = "track_hit_feedbacks")]
     // The previous run's result of `Self::is_interesting`
@@ -343,23 +343,23 @@ pub struct MapEqualityFeedback<C, M, S> {
     phantom: PhantomData<(M, S)>,
 }
 
-impl<C, M, S> Named for MapEqualityFeedback<C, M, S> {
+impl<C, M, S> Named for ObserverEqualityFeedback<C, M, S> {
     fn name(&self) -> &Cow<'static, str> {
         &self.name
     }
 }
 
-impl<C, M, S> HasObserverHandle for MapEqualityFeedback<C, M, S> {
+impl<C, M, S> HasObserverHandle for ObserverEqualityFeedback<C, M, S> {
     type Observer = C;
 
     fn observer_handle(&self) -> &Handle<Self::Observer> {
-        &self.map_ref
+        &self.observer_handle
     }
 }
 
-impl<C, M, S> StateInitializer<S> for MapEqualityFeedback<C, M, S> {}
+impl<C, M, S> StateInitializer<S> for ObserverEqualityFeedback<C, M, S> {}
 
-impl<C, EM, I, M, OT, S> Feedback<EM, I, OT, S> for MapEqualityFeedback<C, M, S>
+impl<C, EM, I, M, OT, S> Feedback<EM, I, OT, S> for ObserverEqualityFeedback<C, M, S>
 where
     M: Hash,
     C: AsRef<M>,
@@ -389,49 +389,50 @@ where
     }
 }
 
-/// A feedback factory for ensuring that the maps for minimized inputs are the same
+/// A feedback factory for ensuring that the values of the observers for minimized inputs are the same
 #[derive(Debug, Clone)]
-pub struct MapEqualityFactory<C, M, S> {
-    map_ref: Handle<C>,
+pub struct ObserverEqualityFactory<C, M, S> {
+    observer_handle: Handle<C>,
     phantom: PhantomData<(C, M, S)>,
 }
 
-impl<C, M, S> MapEqualityFactory<C, M, S>
+impl<C, M, S> ObserverEqualityFactory<C, M, S>
 where
-    M: MapObserver,
+    M: Hash,
     C: AsRef<M> + Handled,
 {
-    /// Creates a new map equality feedback for the given observer
+    /// Creates a new observer equality feedback for the given observer
     pub fn new(obs: &C) -> Self {
         Self {
-            map_ref: obs.handle(),
+            observer_handle: obs.handle(),
             phantom: PhantomData,
         }
     }
 }
 
-impl<C, M, S> HasObserverHandle for MapEqualityFactory<C, M, S> {
+impl<C, M, S> HasObserverHandle for ObserverEqualityFactory<C, M, S> {
     type Observer = C;
 
     fn observer_handle(&self) -> &Handle<C> {
-        &self.map_ref
+        &self.observer_handle
     }
 }
 
-impl<C, M, OT, S> FeedbackFactory<MapEqualityFeedback<C, M, S>, OT> for MapEqualityFactory<C, M, S>
+impl<C, M, OT, S> FeedbackFactory<ObserverEqualityFeedback<C, M, S>, OT>
+    for ObserverEqualityFactory<C, M, S>
 where
     M: Hash,
     C: AsRef<M> + Handled,
     OT: ObserversTuple<<S::Corpus as Corpus>::Input, S>,
     S: HasCorpus,
 {
-    fn create_feedback(&self, observers: &OT) -> MapEqualityFeedback<C, M, S> {
+    fn create_feedback(&self, observers: &OT) -> ObserverEqualityFeedback<C, M, S> {
         let obs = observers
             .get(self.observer_handle())
             .expect("Should have been provided valid observer name.");
-        MapEqualityFeedback {
-            name: Cow::from("MapEq"),
-            map_ref: obs.handle(),
+        ObserverEqualityFeedback {
+            name: Cow::from("ObserverEq"),
+            observer_handle: obs.handle(),
             orig_hash: generic_hash_std(obs.as_ref()),
             #[cfg(feature = "track_hit_feedbacks")]
             last_result: None,

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -1,5 +1,6 @@
 //! [`LLVM` `8-bit-counters`](https://clang.llvm.org/docs/SanitizerCoverage.html#tracing-pcs-with-guards) runtime for `LibAFL`.
 use alloc::vec::Vec;
+use core::hash::Hash;
 
 use libafl_bolts::{ownedref::OwnedMutSlice, AsSlice, AsSliceMut};
 
@@ -127,7 +128,7 @@ mod observers {
 
     /// The [`CountersMultiMapObserver`] observes all the counters that may be set by
     /// `SanitizerCoverage` in [`super::COUNTERS_MAPS`]
-    #[derive(Serialize, Deserialize, Debug)]
+    #[derive(Serialize, Deserialize, Debug, Hash)]
     #[expect(clippy::unsafe_derive_deserialize)]
     pub struct CountersMultiMapObserver<const DIFFERENTIAL: bool> {
         intervals: IntervalTree<usize, usize>,
@@ -228,11 +229,6 @@ mod observers {
                 }
             }
             res
-        }
-
-        #[inline]
-        fn hash_simple(&self) -> u64 {
-            RandomState::with_seeds(0, 0, 0, 0).hash_one(self)
         }
 
         fn reset_map(&mut self) -> Result<(), Error> {

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -1,6 +1,5 @@
 //! [`LLVM` `8-bit-counters`](https://clang.llvm.org/docs/SanitizerCoverage.html#tracing-pcs-with-guards) runtime for `LibAFL`.
 use alloc::vec::Vec;
-use core::hash::Hash;
 
 use libafl_bolts::{ownedref::OwnedMutSlice, AsSlice, AsSliceMut};
 

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -128,7 +128,7 @@ mod observers {
 
     /// The [`CountersMultiMapObserver`] observes all the counters that may be set by
     /// `SanitizerCoverage` in [`super::COUNTERS_MAPS`]
-    #[derive(Serialize, Deserialize, Debug, Hash)]
+    #[derive(Serialize, Deserialize, Debug)]
     #[expect(clippy::unsafe_derive_deserialize)]
     pub struct CountersMultiMapObserver<const DIFFERENTIAL: bool> {
         intervals: IntervalTree<usize, usize>,

--- a/libafl_targets/src/sancov_8bit.rs
+++ b/libafl_targets/src/sancov_8bit.rs
@@ -83,7 +83,6 @@ mod observers {
         slice::{from_raw_parts, Iter, IterMut},
     };
 
-    use ahash::RandomState;
     use libafl::{
         observers::{DifferentialObserver, MapObserver, Observer},
         Error,


### PR DESCRIPTION
This is useful if one wants to use a map-ish `Observer` for certain `Scheduler`s. I'm currently tracking a very sparse map (~0.01% of entries usually set), and memory consumption is eating me alive. But implementing `MapObserver` also means implementing functions that would need to allocate the entire `Vec` again, so not really feasible. Hence the separation into two traits where the scheduling algorithms only need `SimpleHash`.