### PR TITLE
Qemu launcher bugfix

### DIFF
--- a/fuzzers/binary_only/qemu_launcher/src/client.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/client.rs
@@ -9,10 +9,8 @@ use libafl::{
     Error,
 };
 use libafl_bolts::{rands::StdRand, tuples::tuple_list};
-#[cfg(feature = "injections")]
-use libafl_qemu::modules::injections::InjectionModule;
 use libafl_qemu::modules::{
-    asan::AsanModule, asan_guest::AsanGuestModule, cmplog::CmpLogModule, DrCovModule,
+    asan::AsanModule, asan_guest::AsanGuestModule, cmplog::CmpLogModule, DrCovModule, InjectionModule,
 };
 
 use crate::{
@@ -75,7 +73,7 @@ impl Client<'_> {
         }
 
         #[cfg(not(feature = "injections"))]
-        let injection_module = None;
+        let injection_module = Option::<InjectionModule>::None;
 
         #[cfg(feature = "injections")]
         let injection_module = self
@@ -94,11 +92,15 @@ impl Client<'_> {
             });
 
         let is_cmplog = self.options.is_cmplog_core(core_id);
-
-        let extra_tokens = injection_module
-            .as_ref()
-            .map(|h| h.tokens.clone())
-            .unwrap_or_default();
+        
+        let extra_tokens = if cfg!(feature = "injections") {
+            injection_module
+                .as_ref()
+                .map(|h| h.tokens.clone())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
 
         let instance_builder = Instance::builder()
             .options(self.options)

--- a/fuzzers/binary_only/qemu_launcher/src/client.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/client.rs
@@ -10,7 +10,8 @@ use libafl::{
 };
 use libafl_bolts::{rands::StdRand, tuples::tuple_list};
 use libafl_qemu::modules::{
-    asan::AsanModule, asan_guest::AsanGuestModule, cmplog::CmpLogModule, DrCovModule, InjectionModule,
+    asan::AsanModule, asan_guest::AsanGuestModule, cmplog::CmpLogModule, DrCovModule,
+    InjectionModule,
 };
 
 use crate::{
@@ -92,7 +93,7 @@ impl Client<'_> {
             });
 
         let is_cmplog = self.options.is_cmplog_core(core_id);
-        
+
         let extra_tokens = if cfg!(feature = "injections") {
             injection_module
                 .as_ref()

--- a/fuzzers/binary_only/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/fuzzer.rs
@@ -129,7 +129,11 @@ impl Fuzzer {
         }
 
         #[cfg(feature = "simplemgr")]
-        return client.run(None, SimpleEventManager::new(monitor), ClientDescription::new(0, 0, CoreId(0)));
+        return client.run(
+            None,
+            SimpleEventManager::new(monitor),
+            ClientDescription::new(0, 0, CoreId(0)),
+        );
 
         // Build and run the Launcher / fuzzer.
         #[cfg(not(feature = "simplemgr"))]

--- a/fuzzers/binary_only/qemu_launcher/src/fuzzer.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/fuzzer.rs
@@ -129,7 +129,7 @@ impl Fuzzer {
         }
 
         #[cfg(feature = "simplemgr")]
-        return client.run(None, SimpleEventManager::new(monitor), CoreId(0));
+        return client.run(None, SimpleEventManager::new(monitor), ClientDescription::new(0, 0, CoreId(0)));
 
         // Build and run the Launcher / fuzzer.
         #[cfg(not(feature = "simplemgr"))]

--- a/fuzzers/binary_only/qemu_launcher/src/instance.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/instance.rs
@@ -241,9 +241,9 @@ impl<M: Monitor> Instance<'_, M> {
 
             executor
                 .run_target(
-                    &mut NopFuzzer::new(),
+                    &mut fuzzer,
                     &mut state,
-                    &mut NopEventManager::new(),
+                    &mut self.mgr,
                     &input,
                 )
                 .expect("Error running target");

--- a/fuzzers/binary_only/qemu_launcher/src/instance.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/instance.rs
@@ -55,7 +55,7 @@ pub type ClientState =
     StdState<BytesInput, InMemoryOnDiskCorpus<BytesInput>, StdRand, OnDiskCorpus<BytesInput>>;
 
 #[cfg(feature = "simplemgr")]
-pub type ClientMgr<M> = SimpleEventManager<M, ClientState>;
+pub type ClientMgr<M> = SimpleEventManager<BytesInput, M, ClientState>;
 #[cfg(not(feature = "simplemgr"))]
 pub type ClientMgr<M> =
     MonitorTypedEventManager<LlmpRestartingEventManager<(), ClientState, StdShMemProvider>, M>;

--- a/fuzzers/binary_only/qemu_launcher/src/instance.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/instance.rs
@@ -240,12 +240,7 @@ impl<M: Monitor> Instance<'_, M> {
             )?;
 
             executor
-                .run_target(
-                    &mut fuzzer,
-                    &mut state,
-                    &mut self.mgr,
-                    &input,
-                )
+                .run_target(&mut fuzzer, &mut state, &mut self.mgr, &input)
                 .expect("Error running target");
             // We're done :)
             process::exit(0);


### PR DESCRIPTION
1. Fixed the issue where compilation failed under the `simplemgr` features in `Cargo.toml`
2. Fixed the issue where the crash handler would fail during rerun. This issue was discovered with the guidance of @tokatoka , and its root cause is quite complex, as detailed in #2837.
(P.S. Currently, another issue potentially related to the `AsanModule` has been observed and may be further discussed in #2837.)