### PR TITLE
Rename `HasMutatorBytes` to `HasFixedMutatorBytes`, and `HasMutatorResizableBytes` to `HasMutatorBytes`.

### DIFF
--- a/libafl/src/inputs/bytes.rs
+++ b/libafl/src/inputs/bytes.rs
@@ -11,7 +11,7 @@ use core::cell::RefCell;
 use libafl_bolts::{ownedref::OwnedSlice, HasLen};
 
 use super::ValueInput;
-use crate::inputs::{HasMutatorBytes, HasMutatorResizableBytes, HasTargetBytes};
+use crate::inputs::{HasFixedMutatorBytes, HasMutatorBytes, HasTargetBytes};
 
 /// A bytes input is the basic input
 pub type BytesInput = ValueInput<Vec<u8>>;
@@ -23,7 +23,7 @@ impl From<BytesInput> for Rc<RefCell<BytesInput>> {
     }
 }
 
-impl HasMutatorBytes for BytesInput {
+impl HasFixedMutatorBytes for BytesInput {
     fn bytes(&self) -> &[u8] {
         self.as_ref()
     }
@@ -33,7 +33,7 @@ impl HasMutatorBytes for BytesInput {
     }
 }
 
-impl HasMutatorResizableBytes for BytesInput {
+impl HasMutatorBytes for BytesInput {
     fn resize(&mut self, new_len: usize, value: u8) {
         self.as_mut().resize(new_len, value);
     }

--- a/libafl/src/inputs/bytessub.rs
+++ b/libafl/src/inputs/bytessub.rs
@@ -11,16 +11,16 @@ use libafl_bolts::{
     HasLen,
 };
 
-use crate::inputs::{HasMutatorBytes, HasMutatorResizableBytes};
+use crate::inputs::{HasFixedMutatorBytes, HasMutatorBytes};
 
 /// The [`BytesSubInput`] makes it possible to use [`crate::mutators::Mutator`]`s` that work on
-/// inputs implementing the [`HasMutatorBytes`] for a sub-range of this input.
+/// inputs implementing the [`HasFixedMutatorBytes`] for a sub-range of this input.
 ///
 /// For example, we can do the following:
 /// ```rust
 /// # extern crate alloc;
 /// # extern crate libafl;
-/// # use libafl::inputs::{BytesInput, HasMutatorBytes};
+/// # use libafl::inputs::{BytesInput, HasFixedMutatorBytes};
 /// # use alloc::vec::Vec;
 /// #
 /// # #[cfg(not(feature = "std"))]
@@ -37,7 +37,7 @@ use crate::inputs::{HasMutatorBytes, HasMutatorResizableBytes};
 /// assert_eq!(bytes_input.bytes()[1], 42);
 /// ```
 ///
-/// If inputs implement the [`HasMutatorResizableBytes`] trait, growing or shrinking the sub input
+/// If inputs implement the [`HasMutatorBytes`] trait, growing or shrinking the sub input
 /// will grow or shrink the parent input,
 /// and keep elements around the current range untouched / move them accordingly.
 ///
@@ -45,7 +45,7 @@ use crate::inputs::{HasMutatorBytes, HasMutatorResizableBytes};
 /// ```rust
 /// # extern crate alloc;
 /// # extern crate libafl;
-/// # use libafl::inputs::{BytesInput, HasMutatorBytes, HasMutatorResizableBytes};
+/// # use libafl::inputs::{BytesInput, HasFixedMutatorBytes, HasMutatorBytes};
 /// # use alloc::vec::Vec;
 /// #
 /// # #[cfg(not(feature = "std"))]
@@ -77,7 +77,7 @@ pub struct BytesSubInput<'a, I: ?Sized> {
 
 impl<'a, I> BytesSubInput<'a, I>
 where
-    I: HasMutatorBytes + ?Sized,
+    I: HasFixedMutatorBytes + ?Sized,
 {
     /// Creates a new [`BytesSubInput`] that's a view on an input with mutator bytes.
     /// The sub input can then be used to mutate parts of the original input.
@@ -97,9 +97,9 @@ where
     }
 }
 
-impl<I> HasMutatorBytes for BytesSubInput<'_, I>
+impl<I> HasFixedMutatorBytes for BytesSubInput<'_, I>
 where
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     #[inline]
     fn bytes(&self) -> &[u8] {
@@ -112,9 +112,9 @@ where
     }
 }
 
-impl<I> HasMutatorResizableBytes for BytesSubInput<'_, I>
+impl<I> HasMutatorBytes for BytesSubInput<'_, I>
 where
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn resize(&mut self, new_len: usize, value: u8) {
         let start_index = self.range.start;
@@ -200,7 +200,7 @@ where
 
 impl<I> HasLen for BytesSubInput<'_, I>
 where
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -214,7 +214,7 @@ mod tests {
     use libafl_bolts::HasLen;
 
     use crate::{
-        inputs::{BytesInput, HasMutatorBytes, HasMutatorResizableBytes, NopInput},
+        inputs::{BytesInput, HasFixedMutatorBytes, HasMutatorBytes, NopInput},
         mutators::{havoc_mutations_no_crossover, MutatorsTuple},
         state::NopState,
     };

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -156,7 +156,7 @@ pub trait HasTargetBytes {
 }
 
 /// Contains mutable bytes
-pub trait HasMutatorBytes: HasLen {
+pub trait HasFixedMutatorBytes: HasLen {
     /// The bytes
     fn bytes(&self) -> &[u8];
 
@@ -188,7 +188,7 @@ pub trait HasMutatorBytes: HasLen {
     }
 }
 
-impl HasMutatorBytes for Vec<u8> {
+impl HasFixedMutatorBytes for Vec<u8> {
     fn bytes(&self) -> &[u8] {
         self.as_ref()
     }
@@ -202,7 +202,7 @@ impl HasMutatorBytes for Vec<u8> {
 #[deprecated(since = "0.15.0", note = "Use &mut Vec<u8> directly")]
 pub type MutVecInput<'a> = &'a mut Vec<u8>;
 
-impl HasMutatorBytes for &'_ mut Vec<u8> {
+impl HasFixedMutatorBytes for &'_ mut Vec<u8> {
     fn bytes(&self) -> &[u8] {
         self
     }
@@ -213,7 +213,7 @@ impl HasMutatorBytes for &'_ mut Vec<u8> {
 }
 
 /// Contains mutable and resizable bytes
-pub trait HasMutatorResizableBytes: HasMutatorBytes {
+pub trait HasMutatorBytes: HasFixedMutatorBytes {
     /// Resize the mutator bytes to a given new size.
     /// Use `value` to fill new slots in case the buffer grows.
     /// See [`Vec::splice`].
@@ -234,7 +234,7 @@ pub trait HasMutatorResizableBytes: HasMutatorBytes {
         R: RangeBounds<usize>;
 }
 
-impl HasMutatorResizableBytes for Vec<u8> {
+impl HasMutatorBytes for Vec<u8> {
     fn resize(&mut self, new_len: usize, value: u8) {
         <Vec<u8>>::resize(self, new_len, value);
     }
@@ -259,7 +259,7 @@ impl HasMutatorResizableBytes for Vec<u8> {
     }
 }
 
-impl HasMutatorResizableBytes for &mut Vec<u8> {
+impl HasMutatorBytes for &mut Vec<u8> {
     fn resize(&mut self, new_len: usize, value: u8) {
         self.deref_mut().resize(new_len, value);
     }

--- a/libafl/src/mutators/multi.rs
+++ b/libafl/src/mutators/multi.rs
@@ -10,7 +10,7 @@ use libafl_bolts::{rands::Rand, Error};
 use crate::{
     corpus::{Corpus, CorpusId},
     impl_default_multipart,
-    inputs::{multi::MultipartInput, HasMutatorResizableBytes, Input},
+    inputs::{multi::MultipartInput, HasMutatorBytes, Input},
     mutators::{
         mutations::{
             rand_range, BitFlipMutator, ByteAddMutator, ByteDecMutator, ByteFlipMutator,
@@ -119,7 +119,7 @@ impl_default_multipart!(
 impl<I, S> Mutator<MultipartInput<I>, S> for CrossoverInsertMutator
 where
     S: HasCorpus<MultipartInput<I>> + HasMaxSize + HasRand,
-    I: Input + HasMutatorResizableBytes,
+    I: Input + HasMutatorBytes,
 {
     fn mutate(
         &mut self,
@@ -254,7 +254,7 @@ where
 impl<I, S> Mutator<MultipartInput<I>, S> for CrossoverReplaceMutator
 where
     S: HasCorpus<MultipartInput<I>> + HasMaxSize + HasRand,
-    I: Input + HasMutatorResizableBytes,
+    I: Input + HasMutatorBytes,
 {
     fn mutate(
         &mut self,

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -16,7 +16,7 @@ use libafl_bolts::{rands::Rand, Named};
 
 use crate::{
     corpus::Corpus,
-    inputs::{HasMutatorBytes, HasMutatorResizableBytes},
+    inputs::{HasFixedMutatorBytes, HasMutatorBytes},
     mutators::{MutationResult, Mutator},
     nonzero, random_corpus_id_with_disabled,
     state::{HasCorpus, HasMaxSize, HasRand},
@@ -129,7 +129,7 @@ pub struct BitFlipMutator;
 impl<I, S> Mutator<I, S> for BitFlipMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
@@ -165,7 +165,7 @@ pub struct ByteFlipMutator;
 impl<I, S> Mutator<I, S> for ByteFlipMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
@@ -199,7 +199,7 @@ pub struct ByteIncMutator;
 impl<I, S> Mutator<I, S> for ByteIncMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
@@ -234,7 +234,7 @@ pub struct ByteDecMutator;
 impl<I, S> Mutator<I, S> for ByteDecMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
@@ -269,7 +269,7 @@ pub struct ByteNegMutator;
 impl<I, S> Mutator<I, S> for ByteNegMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
@@ -304,7 +304,7 @@ pub struct ByteRandMutator;
 impl<I, S> Mutator<I, S> for ByteRandMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         if input.bytes().is_empty() {
@@ -464,7 +464,7 @@ pub struct BytesDeleteMutator;
 impl<I, S> Mutator<I, S> for BytesDeleteMutator
 where
     S: HasRand,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -506,7 +506,7 @@ pub struct BytesExpandMutator;
 impl<I, S> Mutator<I, S> for BytesExpandMutator
 where
     S: HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
@@ -557,7 +557,7 @@ pub struct BytesInsertMutator;
 impl<I, S> Mutator<I, S> for BytesInsertMutator
 where
     S: HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
@@ -620,7 +620,7 @@ pub struct BytesRandInsertMutator;
 impl<I, S> Mutator<I, S> for BytesRandInsertMutator
 where
     S: HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
@@ -678,7 +678,7 @@ pub struct BytesSetMutator;
 impl<I, S> Mutator<I, S> for BytesSetMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -721,7 +721,7 @@ pub struct BytesRandSetMutator;
 impl<I, S> Mutator<I, S> for BytesRandSetMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -764,7 +764,7 @@ pub struct BytesCopyMutator;
 impl<I, S> Mutator<I, S> for BytesCopyMutator
 where
     S: HasRand,
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -815,7 +815,7 @@ pub struct BytesInsertCopyMutator {
 impl<I, S> Mutator<I, S> for BytesInsertCopyMutator
 where
     S: HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -886,7 +886,7 @@ pub struct BytesSwapMutator {
 impl<I, S> Mutator<I, S> for BytesSwapMutator
 where
     S: HasRand,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -1104,7 +1104,7 @@ impl CrossoverInsertMutator {
         other: &[u8],
     ) -> MutationResult
     where
-        I: HasMutatorResizableBytes,
+        I: HasMutatorBytes,
     {
         input.resize(size + range.len(), 0);
         unsafe {
@@ -1125,7 +1125,7 @@ impl CrossoverInsertMutator {
 
 impl<I, S> Mutator<I, S> for CrossoverInsertMutator
 where
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
     S: HasCorpus<I> + HasRand + HasMaxSize,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
@@ -1205,7 +1205,7 @@ impl CrossoverReplaceMutator {
         other: &[u8],
     ) -> MutationResult
     where
-        I: HasMutatorBytes,
+        I: HasFixedMutatorBytes,
     {
         unsafe {
             buffer_copy(input.bytes_mut(), other, range.start, target, range.len());
@@ -1216,7 +1216,7 @@ impl CrossoverReplaceMutator {
 
 impl<I, S> Mutator<I, S> for CrossoverReplaceMutator
 where
-    I: HasMutatorBytes,
+    I: HasFixedMutatorBytes,
     S: HasCorpus<I> + HasRand,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
@@ -1313,7 +1313,7 @@ impl<F, I, O> MappedCrossoverInsertMutator<F, I, O> {
 impl<S, F, I1, I2, O> Mutator<I2, S> for MappedCrossoverInsertMutator<F, I1, O>
 where
     F: Fn(&I1) -> &O,
-    I2: HasMutatorResizableBytes,
+    I2: HasMutatorBytes,
     O: IntoOptionBytes,
     S: HasCorpus<I1> + HasMaxSize + HasRand,
 {
@@ -1402,7 +1402,7 @@ impl<F, I, O> MappedCrossoverReplaceMutator<F, I, O> {
 impl<S, F, I1, I2, O> Mutator<I2, S> for MappedCrossoverReplaceMutator<F, I1, O>
 where
     F: Fn(&I1) -> &O,
-    I2: HasMutatorBytes,
+    I2: HasFixedMutatorBytes,
     O: IntoOptionBytes,
     S: HasCorpus<I1> + HasMaxSize + HasRand,
 {
@@ -1491,7 +1491,7 @@ pub struct SpliceMutator;
 impl<I, S> Mutator<I, S> for SpliceMutator
 where
     S: HasCorpus<I> + HasRand,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     #[expect(clippy::cast_sign_loss)]
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {

--- a/libafl/src/mutators/scheduled.rs
+++ b/libafl/src/mutators/scheduled.rs
@@ -316,7 +316,7 @@ mod tests {
     use crate::{
         corpus::{Corpus, InMemoryCorpus, Testcase},
         feedbacks::ConstFeedback,
-        inputs::{BytesInput, HasMutatorBytes},
+        inputs::{BytesInput, HasFixedMutatorBytes},
         mutators::{
             havoc_mutations::havoc_mutations, mutations::SpliceMutator,
             scheduled::StdScheduledMutator, Mutator,

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::mutators::str_decode;
 use crate::{
     corpus::{CorpusId, HasCurrentCorpusId},
-    inputs::HasMutatorResizableBytes,
+    inputs::HasMutatorBytes,
     mutators::{
         buffer_self_copy, mutations::buffer_copy, MultiMutator, MutationResult, Mutator, Named,
     },
@@ -306,7 +306,7 @@ pub struct TokenInsert;
 impl<I, S> Mutator<I, S> for TokenInsert
 where
     S: HasMetadata + HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let max_size = state.max_size();
@@ -375,7 +375,7 @@ pub struct TokenReplace;
 impl<I, S> Mutator<I, S> for TokenReplace
 where
     S: HasMetadata + HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
         let size = input.bytes().len();
@@ -435,7 +435,7 @@ pub struct I2SRandReplace;
 impl<I, S> Mutator<I, S> for I2SRandReplace
 where
     S: HasMetadata + HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     #[expect(clippy::too_many_lines)]
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
@@ -636,7 +636,7 @@ where
 impl<I, S> Mutator<I, S> for I2SRandReplaceBinonly
 where
     S: HasMetadata + HasRand + HasMaxSize,
-    I: HasMutatorResizableBytes,
+    I: HasMutatorBytes,
 {
     #[expect(clippy::too_many_lines)]
     fn mutate(&mut self, state: &mut S, input: &mut I) -> Result<MutationResult, Error> {
@@ -1306,7 +1306,7 @@ impl AFLppRedQueen {
 impl<I, S> MultiMutator<I, S> for AFLppRedQueen
 where
     S: HasMetadata + HasRand + HasMaxSize + HasCurrentCorpusId,
-    I: HasMutatorResizableBytes + From<Vec<u8>>,
+    I: HasMutatorBytes + From<Vec<u8>>,
 {
     #[expect(clippy::needless_range_loop, clippy::too_many_lines)]
     fn multi_mutate(

--- a/libafl/src/mutators/unicode/mod.rs
+++ b/libafl/src/mutators/unicode/mod.rs
@@ -11,7 +11,7 @@ use libafl_bolts::{rands::Rand, Error, HasLen, Named};
 
 use crate::{
     corpus::{CorpusId, HasTestcase, Testcase},
-    inputs::{BytesInput, HasMutatorBytes, HasMutatorResizableBytes},
+    inputs::{BytesInput, HasFixedMutatorBytes, HasMutatorBytes},
     mutators::{rand_range, MutationResult, Mutator, Tokens},
     nonzero,
     stages::{
@@ -512,7 +512,7 @@ mod test {
 
     use crate::{
         corpus::NopCorpus,
-        inputs::{BytesInput, HasMutatorBytes},
+        inputs::{BytesInput, HasFixedMutatorBytes},
         mutators::{Mutator, UnicodeCategoryRandMutator, UnicodeSubcategoryRandMutator},
         stages::extract_metadata,
         state::StdState,

--- a/libafl/src/stages/colorization.rs
+++ b/libafl/src/stages/colorization.rs
@@ -18,7 +18,7 @@ use crate::{
     corpus::HasCurrentCorpusId,
     events::EventFirer,
     executors::{Executor, HasObservers},
-    inputs::HasMutatorResizableBytes,
+    inputs::HasMutatorBytes,
     mutators::mutations::buffer_copy,
     nonzero,
     observers::ObserversTuple,
@@ -81,7 +81,7 @@ where
     E: HasObservers + Executor<EM, I, S, Z>,
     S: HasCorpus<I> + HasMetadata + HasRand + HasNamedMetadata + HasCurrentCorpusId,
     E::Observers: ObserversTuple<I, S>,
-    I: HasMutatorResizableBytes + Clone,
+    I: HasMutatorBytes + Clone,
     O: Hash,
     C: AsRef<O> + Named,
 {
@@ -158,7 +158,7 @@ where
     E: HasObservers + Executor<EM, I, S, Z>,
     E::Observers: ObserversTuple<I, S>,
     S: HasCorpus<I> + HasMetadata + HasRand + HasCurrentCorpusId + HasCurrentTestcase<I>,
-    I: HasMutatorResizableBytes + Clone,
+    I: HasMutatorBytes + Clone,
 {
     #[inline]
     fn colorize(

--- a/libafl/src/stages/concolic.rs
+++ b/libafl/src/stages/concolic.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 #[cfg(feature = "concolic_mutation")]
 use crate::{
-    inputs::HasMutatorBytes,
+    inputs::HasFixedMutatorBytes,
     mark_feature_time,
     observers::concolic::{ConcolicMetadata, SymExpr, SymExprRef},
     start_timer, Evaluator,
@@ -377,7 +377,7 @@ impl<I, Z> Named for SimpleConcolicMutationalStage<I, Z> {
 impl<E, EM, I, S, Z> Stage<E, EM, S, Z> for SimpleConcolicMutationalStage<I, Z>
 where
     Z: Evaluator<E, EM, I, S>,
-    I: HasMutatorBytes + Clone,
+    I: HasFixedMutatorBytes + Clone,
     S: HasExecutions
         + HasCorpus<I>
         + HasMetadata

--- a/libafl/src/stages/generalization.rs
+++ b/libafl/src/stages/generalization.rs
@@ -18,8 +18,8 @@ use crate::{
     executors::{Executor, HasObservers},
     feedbacks::map::MapNoveltiesMetadata,
     inputs::{
-        BytesInput, GeneralizedInputMetadata, GeneralizedItem, HasMutatorBytes,
-        HasMutatorResizableBytes,
+        BytesInput, GeneralizedInputMetadata, GeneralizedItem, HasFixedMutatorBytes,
+        HasMutatorBytes,
     },
     mark_feature_time,
     observers::{CanTrack, MapObserver, ObserversTuple},

--- a/libafl_libfuzzer/runtime/src/tmin.rs
+++ b/libafl_libfuzzer/runtime/src/tmin.rs
@@ -8,7 +8,7 @@ use libafl::{
     events::SimpleEventManager,
     executors::{inprocess_fork::InProcessForkExecutor, ExitKind},
     feedbacks::{CrashFeedback, TimeoutFeedback},
-    inputs::{BytesInput, HasMutatorBytes, HasTargetBytes},
+    inputs::{BytesInput, HasFixedMutatorBytes, HasTargetBytes},
     mutators::{havoc_mutations_no_crossover, Mutator, StdScheduledMutator},
     schedulers::QueueScheduler,
     stages::StdTMinMutationalStage,

--- a/libafl_targets/src/libfuzzer/mutators.rs
+++ b/libafl_targets/src/libfuzzer/mutators.rs
@@ -11,7 +11,7 @@ use std::{
 
 use libafl::{
     corpus::Corpus,
-    inputs::{BytesInput, HasMutatorBytes, HasMutatorResizableBytes},
+    inputs::{BytesInput, HasFixedMutatorBytes, HasMutatorBytes},
     mutators::{
         ComposedByMutations, MutationId, MutationResult, Mutator, MutatorsTuple, ScheduledMutator,
     },


### PR DESCRIPTION

As discussed in https://github.com/AFLplusplus/LibAFL/pull/2856#discussion_r1918872555.

Sorry about that!
