### PR TITLE
Revert "Set rust-analyzer.cargo.allTargets to False in setings.json.default"

### DIFF
--- a/.vscode/settings.json.default
+++ b/.vscode/settings.json.default
@@ -8,6 +8,5 @@
         "cargo",
         "check",
         "--message-format=json",
-    ],
-    "rust-analyzer.cargo.allTargets": false,
+    ]
 }


### PR DESCRIPTION
Reverts AFLplusplus/LibAFL#2864


-> I need tests to be rust analyzered