### PR TITLE
Make sure EM and Z remain consistent using traits (alternative to #2873)

### DIFF
--- a/libafl/src/executors/inprocess/mod.rs
+++ b/libafl/src/executors/inprocess/mod.rs
@@ -12,6 +12,7 @@ use core::{
     time::Duration,
 };
 
+use inner::EnterLeaveTarget;
 use libafl_bolts::tuples::{tuple_list, RefIndexable};
 
 #[cfg(any(unix, feature = "std"))]

--- a/libafl/src/executors/inprocess/stateful.rs
+++ b/libafl/src/executors/inprocess/stateful.rs
@@ -10,6 +10,7 @@ use core::{
 
 use libafl_bolts::tuples::{tuple_list, RefIndexable};
 
+use super::inner::EnterLeaveTarget;
 use crate::{
     events::{EventFirer, EventRestarter},
     executors::{
@@ -32,14 +33,14 @@ pub type StatefulInProcessExecutor<'a, ES, H, I, OT, S> =
 
 /// The process executor simply calls a target function, as boxed `FnMut` trait object
 /// The internal state of the executor is made available to the harness.
-pub type OwnedInProcessExecutor<I, OT, S, ES> = StatefulGenericInProcessExecutor<
+pub type OwnedInProcessExecutor<ES, I, OT, S> = StatefulGenericInProcessExecutor<
+    ES,
     dyn FnMut(&mut ES, &I) -> ExitKind,
     Box<dyn FnMut(&mut ES, &I) -> ExitKind>,
     (),
     I,
     OT,
     S,
-    ES,
 >;
 
 /// The inmem executor simply calls a target function, then returns afterwards.
@@ -54,7 +55,7 @@ pub struct StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S> {
     phantom: PhantomData<(ES, *const H)>,
 }
 
-impl<H, HB, HT, I, OT, S, ES> Debug for StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
+impl<ES, H, HB, HT, I, OT, S> Debug for StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
 where
     OT: Debug,
 {
@@ -66,7 +67,7 @@ where
     }
 }
 
-impl<EM, H, HB, HT, I, OT, S, Z, ES> Executor<EM, I, S, Z>
+impl<EM, ES, H, HB, HT, I, OT, S, Z> Executor<EM, I, S, Z>
     for StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
 where
     H: FnMut(&mut ES, &mut S, &I) -> ExitKind + Sized,
@@ -98,7 +99,7 @@ where
     }
 }
 
-impl<H, HB, HT, I, OT, S, ES> HasObservers
+impl<ES, H, HB, HT, I, OT, S> HasObservers
     for StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
 where
     H: FnMut(&mut ES, &mut S, &I) -> ExitKind + Sized,
@@ -118,7 +119,7 @@ where
     }
 }
 
-impl<'a, H, I, OT, S, ES> StatefulInProcessExecutor<'a, ES, H, I, OT, S>
+impl<'a, ES, H, I, OT, S> StatefulInProcessExecutor<'a, ES, H, I, OT, S>
 where
     H: FnMut(&mut ES, &mut S, &I) -> ExitKind + Sized,
     OT: ObserversTuple<I, S>,
@@ -224,7 +225,7 @@ where
     }
 }
 
-impl<H, HB, HT, I, OT, S, ES> StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S> {
+impl<ES, H, HB, HT, I, OT, S> StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S> {
     /// The executor state given to the harness
     pub fn exposed_executor_state(&self) -> &ES {
         &self.exposed_executor_state
@@ -236,7 +237,7 @@ impl<H, HB, HT, I, OT, S, ES> StatefulGenericInProcessExecutor<ES, H, HB, HT, I,
     }
 }
 
-impl<H, HB, HT, I, OT, S, ES> StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
+impl<ES, H, HB, HT, I, OT, S> StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
 where
     H: FnMut(&mut ES, &mut S, &I) -> ExitKind + Sized,
     HB: BorrowMut<H>,
@@ -363,7 +364,7 @@ where
     }
 }
 
-impl<H, HB, HT, I, OT, S, ES> HasInProcessHooks<I, S>
+impl<ES, H, HB, HT, I, OT, S> HasInProcessHooks<I, S>
     for StatefulGenericInProcessExecutor<ES, H, HB, HT, I, OT, S>
 {
     /// the timeout handler

--- a/libafl/src/executors/inprocess_fork/stateful.rs
+++ b/libafl/src/executors/inprocess_fork/stateful.rs
@@ -27,7 +27,7 @@ use crate::{
 pub type StatefulInProcessForkExecutor<'a, EM, ES, H, I, OT, S, SP, Z> =
     StatefulGenericInProcessForkExecutor<'a, EM, ES, H, (), I, OT, S, SP, Z>;
 
-impl<'a, H, I, OT, S, SP, ES, EM, Z> StatefulInProcessForkExecutor<'a, EM, ES, H, I, OT, S, SP, Z>
+impl<'a, EM, ES, H, I, OT, S, SP, Z> StatefulInProcessForkExecutor<'a, EM, ES, H, I, OT, S, SP, Z>
 where
     OT: ObserversTuple<I, S>,
     SP: ShMemProvider,
@@ -68,7 +68,7 @@ pub struct StatefulGenericInProcessForkExecutor<'a, EM, ES, H, HT, I, OT, S, SP,
     pub inner: GenericInProcessForkExecutorInner<EM, HT, I, OT, S, SP, Z>,
 }
 
-impl<H, HT, I, OT, S, SP, ES, EM, Z> Debug
+impl<EM, ES, H, HT, I, OT, S, SP, Z> Debug
     for StatefulGenericInProcessForkExecutor<'_, EM, ES, H, HT, I, OT, S, SP, Z>
 where
     HT: Debug,
@@ -92,7 +92,7 @@ where
     }
 }
 
-impl<EM, H, HT, I, OT, S, SP, Z, ES> Executor<EM, I, S, Z>
+impl<EM, ES, H, HT, I, OT, S, SP, Z> Executor<EM, I, S, Z>
     for StatefulGenericInProcessForkExecutor<'_, EM, ES, H, HT, I, OT, S, SP, Z>
 where
     H: FnMut(&mut ES, &I) -> ExitKind + Sized,
@@ -131,7 +131,7 @@ where
     }
 }
 
-impl<'a, H, HT, I, OT, S, SP, ES, EM, Z>
+impl<'a, H, HT, I, OT, S, SP, EM, ES, Z>
     StatefulGenericInProcessForkExecutor<'a, EM, ES, H, HT, I, OT, S, SP, Z>
 where
     HT: ExecutorHooksTuple<I, S>,
@@ -178,7 +178,7 @@ where
     }
 }
 
-impl<H, HT, I, OT, S, SP, ES, EM, Z> HasObservers
+impl<H, HT, I, OT, S, SP, EM, ES, Z> HasObservers
     for StatefulGenericInProcessForkExecutor<'_, EM, ES, H, HT, I, OT, S, SP, Z>
 {
     type Observers = OT;


### PR DESCRIPTION
Another option how to fix #2872. If it works then it'd be better. But maybe ppl could still call the methods using different instances of the trait?

What do you think @addisoncrump