### PR TITLE
Implement enters target for guarding execution from double-mutability

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -49,7 +49,7 @@ use super::HasTimeout;
 #[cfg(target_os = "linux")]
 use crate::executors::hooks::ExecutorHooksTuple;
 use crate::{
-    executors::{Executor, ExitKind, HasObservers},
+    executors::{hooks::InitableExecutorHooksTuple, Executor, ExitKind, HasObservers},
     inputs::HasTargetBytes,
     observers::{ObserversTuple, StdErrObserver, StdOutObserver},
     state::HasExecutions,
@@ -425,6 +425,7 @@ where
     OT: MatchName + ObserversTuple<I, S>,
     S: HasExecutions,
     T: CommandConfigurator<I, Pid> + Debug,
+    HT: InitableExecutorHooksTuple<S>,
 {
     /// Linux specific low level implementation, to directly handle `fork`, `exec` and use linux
     /// `ptrace`

--- a/libafl/src/executors/hooks/inprocess_fork.rs
+++ b/libafl/src/executors/hooks/inprocess_fork.rs
@@ -35,9 +35,6 @@ pub struct InChildProcessHooks<I, S> {
 }
 
 impl<I, S> ExecutorHook<I, S> for InChildProcessHooks<I, S> {
-    /// Init this hook
-    fn init(&mut self, _state: &mut S) {}
-
     /// Call before running a target.
     fn pre_exec(&mut self, _state: &mut S, _input: &I) {
         unsafe {

--- a/libafl/src/executors/hooks/mod.rs
+++ b/libafl/src/executors/hooks/mod.rs
@@ -24,30 +24,50 @@ pub mod timer;
 #[cfg(all(feature = "intel_pt", target_os = "linux"))]
 pub mod intel_pt;
 
-/// The hook that runs before and after the executor runs the target
-pub trait ExecutorHook<I, S> {
+pub trait InitableExecutorHook<S> {
     /// Init this hook
     fn init(&mut self, state: &mut S);
+}
+
+/// The hook that runs before and after the executor runs the target
+pub trait ExecutorHook<I, S> {
     /// The hook that runs before runs the target
     fn pre_exec(&mut self, state: &mut S, input: &I);
     /// The hook that runs before runs the target
     fn post_exec(&mut self, state: &mut S, input: &I);
 }
 
-/// The hook that runs before and after the executor runs the target
-pub trait ExecutorHooksTuple<I, S> {
+pub trait InitableExecutorHooksTuple<S> {
     /// Init these hooks
     fn init_all(&mut self, state: &mut S);
+}
+
+/// The hook that runs before and after the executor runs the target
+pub trait ExecutorHooksTuple<I, S> {
     /// The hooks that runs before runs the target
     fn pre_exec_all(&mut self, state: &mut S, input: &I);
     /// The hooks that runs after runs the target
     fn post_exec_all(&mut self, state: &mut S, input: &I);
 }
 
-impl<I, S> ExecutorHooksTuple<I, S> for () {
+impl<S> InitableExecutorHooksTuple<S> for () {
     fn init_all(&mut self, _state: &mut S) {}
+}
+
+impl<I, S> ExecutorHooksTuple<I, S> for () {
     fn pre_exec_all(&mut self, _state: &mut S, _input: &I) {}
     fn post_exec_all(&mut self, _state: &mut S, _input: &I) {}
+}
+
+impl<Head, Tail, S> InitableExecutorHooksTuple<S> for (Head, Tail)
+where
+    Head: InitableExecutorHook<S>,
+    Tail: InitableExecutorHooksTuple<S>,
+{
+    fn init_all(&mut self, state: &mut S) {
+        self.0.init(state);
+        self.1.init_all(state);
+    }
 }
 
 impl<Head, Tail, I, S> ExecutorHooksTuple<I, S> for (Head, Tail)
@@ -55,11 +75,6 @@ where
     Head: ExecutorHook<I, S>,
     Tail: ExecutorHooksTuple<I, S>,
 {
-    fn init_all(&mut self, state: &mut S) {
-        self.0.init(state);
-        self.1.init_all(state);
-    }
-
     fn pre_exec_all(&mut self, state: &mut S, input: &I) {
         self.0.pre_exec(state, input);
         self.1.pre_exec_all(state, input);

--- a/libafl/src/executors/hooks/timer.rs
+++ b/libafl/src/executors/hooks/timer.rs
@@ -70,6 +70,7 @@ extern "C" {
 /// The strcut about all the internals of the timer.
 /// This struct absorb all platform specific differences about timer.
 #[expect(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct TimerStruct {
     // timeout time (windows)
     #[cfg(windows)]

--- a/libafl/src/executors/hooks/timer.rs
+++ b/libafl/src/executors/hooks/timer.rs
@@ -62,7 +62,7 @@ pub(crate) struct Itimerval {
 extern "C" {
     pub(crate) fn setitimer(
         which: libc::c_int,
-        new_value: *mut Itimerval,
+        new_value: *const Itimerval,
         old_value: *mut Itimerval,
     ) -> libc::c_int;
 }

--- a/libafl/src/executors/inprocess/inner.rs
+++ b/libafl/src/executors/inprocess/inner.rs
@@ -1,47 +1,43 @@
 use core::{
     ffi::c_void,
     fmt::{self, Debug, Formatter},
+    marker::PhantomData,
     ptr::{self, null, write_volatile},
     sync::atomic::{compiler_fence, Ordering},
     time::Duration,
 };
-use std::marker::PhantomData;
 
-use libafl_bolts::tuples::{tuple_list, Merge, RefIndexable};
+use libafl_bolts::tuples::RefIndexable;
 #[cfg(windows)]
 use windows::Win32::System::Threading::SetThreadStackGuarantee;
 
-#[cfg(all(feature = "std", target_os = "linux"))]
-use crate::executors::hooks::inprocess::HasTimeout;
 #[cfg(all(windows, feature = "std"))]
 use crate::executors::hooks::inprocess::HasTimeout;
 use crate::{
     events::{EventFirer, EventRestarter},
     executors::{
         hooks::{
-            inprocess::{InProcessHooks, GLOBAL_STATE},
-            ExecutorHooksTuple,
+            inprocess::GLOBAL_STATE, timer::TimerStruct, unix::unix_signal_handler,
+            InitableExecutorHooksTuple,
         },
-        inprocess::HasInProcessHooks,
         EntersTarget, Executor, HasObservers,
     },
     feedbacks::Feedback,
-    fuzzer::HasObjective,
     inputs::Input,
     observers::ObserversTuple,
     state::{HasCurrentTestcase, HasExecutions, HasSolutions},
-    Error,
+    Error, HasObjective,
 };
 
 /// The internal state of `GenericInProcessExecutor`.
-pub struct GenericInProcessExecutorInner<HT, I, OT, S> {
+pub struct GenericInProcessExecutorInner<HT, OT> {
     /// The observers, observing each run
     pub(super) observers: OT,
     // Crash and timeout hah
-    pub(super) hooks: (InProcessHooks<I, S>, HT),
+    pub(super) hooks: HT,
 }
 
-impl<HT, I, OT, S> Debug for GenericInProcessExecutorInner<HT, I, OT, S>
+impl<HT, OT> Debug for GenericInProcessExecutorInner<HT, OT>
 where
     OT: Debug,
 {
@@ -52,7 +48,7 @@ where
     }
 }
 
-impl<HT, I, OT, S> HasObservers for GenericInProcessExecutorInner<HT, I, OT, S> {
+impl<HT, OT> HasObservers for GenericInProcessExecutorInner<HT, OT> {
     type Observers = OT;
 
     #[inline]
@@ -77,14 +73,24 @@ impl Drop for InProcessGuard<'_> {
         unsafe {
             let data = &raw mut GLOBAL_STATE;
 
+            write_volatile(&raw mut (*data).timeout_handler, null());
+            write_volatile(&raw mut (*data).crash_handler, null());
             write_volatile(&raw mut (*data).current_input_ptr, null());
+
             compiler_fence(Ordering::SeqCst);
         }
     }
 }
 
-impl<E, EM, HT, I, OT, S, Z> EntersTarget<E, EM, I, S, Z>
-    for GenericInProcessExecutorInner<HT, I, OT, S>
+impl<E, EM, HT, I, OT, S, Z> EntersTarget<E, EM, I, S, Z> for GenericInProcessExecutorInner<HT, OT>
+where
+    E: Executor<EM, I, S, Z> + HasObservers,
+    E::Observers: ObserversTuple<I, S>,
+    EM: EventFirer<I, S> + EventRestarter<S>,
+    S: HasExecutions + HasSolutions<I> + HasCurrentTestcase<I>,
+    Z: HasObjective,
+    Z::Objective: Feedback<EM, I, E::Observers, S>,
+    I: Input + Clone,
 {
     type Guard<'a>
         = InProcessGuard<'a>
@@ -132,6 +138,21 @@ impl<E, EM, HT, I, OT, S, Z> EntersTarget<E, EM, I, S, Z>
                 &raw mut (*data).fuzzer_ptr,
                 ptr::from_mut(fuzzer) as *mut c_void,
             );
+            write_volatile(
+                &raw mut (*data).crash_handler,
+                unix_signal_handler::inproc_crash_handler::<E, EM, I, S, Z> as *mut c_void,
+            );
+            write_volatile(
+                &raw mut (*data).timeout_handler,
+                unix_signal_handler::inproc_timeout_handler::<E, EM, I, S, Z> as *mut c_void,
+            );
+
+            // TODO should this be not(any(...))? Why would we only not run with miri on apple?
+            #[cfg(all(feature = "std", not(all(miri, target_vendor = "apple"))))]
+            if let Some(timer) = (*data).timer.as_mut() {
+                timer.set_timer();
+            }
+
             compiler_fence(Ordering::SeqCst);
         }
         InProcessGuard {
@@ -140,14 +161,9 @@ impl<E, EM, HT, I, OT, S, Z> EntersTarget<E, EM, I, S, Z>
     }
 }
 
-impl<HT, I, OT, S> GenericInProcessExecutorInner<HT, I, OT, S>
-where
-    HT: ExecutorHooksTuple<I, S>,
-    OT: ObserversTuple<I, S>,
-    S: HasExecutions + HasSolutions<I>,
-{
+impl<HT, OT> GenericInProcessExecutorInner<HT, OT> {
     /// Create a new in mem executor with the default timeout (5 sec)
-    pub fn generic<E, EM, OF, Z>(
+    pub fn generic<E, EM, S, Z>(
         user_hooks: HT,
         observers: OT,
         fuzzer: &mut Z,
@@ -155,15 +171,9 @@ where
         event_mgr: &mut EM,
     ) -> Result<Self, Error>
     where
-        E: Executor<EM, I, S, Z> + HasObservers + HasInProcessHooks<I, S>,
-        E::Observers: ObserversTuple<I, S>,
-        EM: EventFirer<I, S> + EventRestarter<S>,
-        I: Input + Clone,
-        OF: Feedback<EM, I, E::Observers, S>,
-        S: HasCurrentTestcase<I> + HasSolutions<I>,
-        Z: HasObjective<Objective = OF>,
+        HT: InitableExecutorHooksTuple<S>,
     {
-        Self::with_timeout_generic::<E, EM, OF, Z>(
+        Self::with_timeout_generic::<E, EM, S, Z>(
             user_hooks,
             observers,
             fuzzer,
@@ -175,7 +185,7 @@ where
 
     /// Create a new in mem executor with the default timeout and use batch mode(5 sec)
     #[cfg(all(feature = "std", target_os = "linux"))]
-    pub fn batched_timeout_generic<E, EM, OF, Z>(
+    pub fn batched_timeout_generic<E, EM, S, Z>(
         user_hooks: HT,
         observers: OT,
         fuzzer: &mut Z,
@@ -184,18 +194,17 @@ where
         exec_tmout: Duration,
     ) -> Result<Self, Error>
     where
-        E: Executor<EM, I, S, Z> + HasObservers + HasInProcessHooks<I, S>,
-        E::Observers: ObserversTuple<I, S>,
-        EM: EventFirer<I, S> + EventRestarter<S>,
-        I: Input + Clone,
-        OF: Feedback<EM, I, E::Observers, S>,
-        S: HasCurrentTestcase<I> + HasSolutions<I>,
-        Z: HasObjective<Objective = OF>,
+        HT: InitableExecutorHooksTuple<S>,
     {
-        let mut me = Self::with_timeout_generic::<E, EM, OF, Z>(
+        let me = Self::with_timeout_generic::<E, EM, S, Z>(
             user_hooks, observers, fuzzer, state, event_mgr, exec_tmout,
         )?;
-        me.hooks_mut().0.timer_mut().batch_mode = true;
+        unsafe {
+            let data = &raw mut GLOBAL_STATE;
+            (*data).timer.as_mut().unwrap().batch_mode = true;
+        }
+        compiler_fence(Ordering::SeqCst);
+
         Ok(me)
     }
 
@@ -207,8 +216,8 @@ where
     /// * `observers` - the observers observing the target during execution
     ///
     /// This may return an error on unix, if signal handler setup fails
-    pub fn with_timeout_generic<E, EM, OF, Z>(
-        user_hooks: HT,
+    pub fn with_timeout_generic<E, EM, S, Z>(
+        mut hooks: HT,
         observers: OT,
         _fuzzer: &mut Z,
         state: &mut S,
@@ -216,16 +225,27 @@ where
         timeout: Duration,
     ) -> Result<Self, Error>
     where
-        E: Executor<EM, I, S, Z> + HasObservers + HasInProcessHooks<I, S>,
-        E::Observers: ObserversTuple<I, S>,
-        EM: EventFirer<I, S> + EventRestarter<S>,
-        OF: Feedback<EM, I, E::Observers, S>,
-        S: HasCurrentTestcase<I> + HasSolutions<I>,
-        Z: HasObjective<Objective = OF>,
-        I: Input + Clone,
+        HT: InitableExecutorHooksTuple<S>,
     {
-        let default = InProcessHooks::new::<E, EM, OF, Z>(timeout)?;
-        let mut hooks = tuple_list!(default).merge(user_hooks);
+        // # Safety
+        // We get a pointer to `GLOBAL_STATE` that will be initialized at this point in time.
+        // This unsafe is needed in stable but not in nightly. Remove in the future(?)
+        #[expect(unused_unsafe)]
+        #[cfg(all(not(miri), unix, feature = "std"))]
+        let data = unsafe { &raw mut GLOBAL_STATE };
+        // # Safety
+        // Setting up the signal handlers with a pointer to the `GLOBAL_STATE` which should not be NULL at this point.
+        // We are the sole users of `GLOBAL_STATE` right now, and only dereference it in case of Segfault/Panic.
+        // In that case we get the mutable borrow. Otherwise we don't use it.
+        #[cfg(all(not(miri), unix, feature = "std"))]
+        unsafe {
+            libafl_bolts::os::unix_signals::setup_signal_handler(data)?;
+            (*data).timer = Some(TimerStruct::new(timeout));
+        }
+        compiler_fence(Ordering::SeqCst);
+
+        #[cfg(feature = "std")]
+        unix_signal_handler::setup_panic_hook();
         hooks.init_all(state);
 
         #[cfg(windows)]
@@ -256,27 +276,13 @@ where
 
     /// The inprocess handlers
     #[inline]
-    pub fn hooks(&self) -> &(InProcessHooks<I, S>, HT) {
+    pub fn hooks(&self) -> &HT {
         &self.hooks
     }
 
     /// The inprocess handlers (mutable)
     #[inline]
-    pub fn hooks_mut(&mut self) -> &mut (InProcessHooks<I, S>, HT) {
+    pub fn hooks_mut(&mut self) -> &mut HT {
         &mut self.hooks
-    }
-}
-
-impl<HT, I, OT, S> HasInProcessHooks<I, S> for GenericInProcessExecutorInner<HT, I, OT, S> {
-    /// the timeout handler
-    #[inline]
-    fn inprocess_hooks(&self) -> &InProcessHooks<I, S> {
-        &self.hooks.0
-    }
-
-    /// the timeout handler
-    #[inline]
-    fn inprocess_hooks_mut(&mut self) -> &mut InProcessHooks<I, S> {
-        &mut self.hooks.0
     }
 }

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -67,6 +67,30 @@ pub enum ExitKind {
     // Custom(Box<dyn SerdeAny>),
 }
 
+/// Trait which enters and exits the target. When entering the target, the corresponding fuzzer,
+/// state, event manager, and input are held in a guard until it is dropped, at which point these
+/// references may once again be used.
+pub trait EntersTarget<E, EM, I, S, Z> {
+    /// Holds the references to the fuzzer components until it is dropped.
+    type Guard<'a>
+    where
+        E: 'a,
+        EM: 'a,
+        I: 'a,
+        S: 'a,
+        Z: 'a;
+
+    /// Enter the target. Until the guard is dropped, these references may not otherwise be used.
+    #[must_use]
+    fn enter_target<'a>(
+        executor: &'a mut E,
+        fuzzer: &'a mut Z,
+        state: &'a mut S,
+        event_mgr: &'a mut EM,
+        input: &'a I,
+    ) -> Self::Guard<'a>;
+}
+
 /// How one of the diffing executions finished.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(


### PR DESCRIPTION
This will almost guaranteed break QEMU, because it was doing something necessarily unsound (double-mutable access of state). This needs to be resolved before this is merged.