### PR TITLE
Allow setting custom initial value for map observers via with_initial

### DIFF
--- a/libafl/src/observers/map/mod.rs
+++ b/libafl/src/observers/map/mod.rs
@@ -668,6 +668,7 @@ where
     }
 
     /// Sets a custom initial value for the map observer
+    #[must_use]
     pub fn with_initial(mut self, initial: T) -> Self {
         self.initial = initial;
         self

--- a/libafl/src/observers/map/mod.rs
+++ b/libafl/src/observers/map/mod.rs
@@ -666,6 +666,12 @@ where
     pub fn map_mut(&mut self) -> &mut OwnedMutSlice<'a, T> {
         &mut self.map
     }
+
+    /// Sets a custom initial value for the map observer
+    pub fn with_initial(mut self, initial: T) -> Self {
+        self.initial = initial;
+        self
+    }
 }
 
 impl<'a, T> StdMapObserver<'a, T, false>


### PR DESCRIPTION
Fixes #2447

As discussed here(https://github.com/AFLplusplus/LibAFL/issues/2447#issuecomment-2566105911) with @addisoncrump.