### PR TITLE
Add combined monitor

### DIFF
--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -1319,11 +1319,14 @@ pub struct CombinedMonitor<A, B> {
 
 impl<A: Monitor, B: Monitor> CombinedMonitor<A, B> {
     /// Create a new combined monitor
-    pub fn new(first: A, second: B) -> Self {
+    pub fn new(mut first: A, mut second: B) -> Self {
+        let start_time = current_time();
+        first.set_start_time(start_time);
+        second.set_start_time(start_time);
         Self {
             first,
             second,
-            start_time: current_time(),
+            start_time,
             client_stats: vec![],
         }
     }

--- a/libafl/src/monitors/mod.rs
+++ b/libafl/src/monitors/mod.rs
@@ -1352,9 +1352,11 @@ impl<A: Monitor, B: Monitor> Monitor for CombinedMonitor<A, B> {
     }
 
     fn display(&mut self, event_msg: &str, sender_id: ClientId) {
-        *self.first.client_stats_mut() = self.client_stats.clone();
+        self.first.client_stats_mut().clone_from(&self.client_stats);
         self.first.display(event_msg, sender_id);
-        *self.second.client_stats_mut() = self.client_stats.clone();
+        self.second
+            .client_stats_mut()
+            .clone_from(&self.client_stats);
         self.second.display(event_msg, sender_id);
     }
 


### PR DESCRIPTION
Related to issue #2895. Now we can create multiple monitors for one fuzzer instance.

Currently, the API of Monitor is not good enough to implement a zero-cost combined monitor, the client stats need to be synced to underline monitors in the right time (I choose to sync before each display call), which incurs some runtime overhead.