### PR TITLE
Fix Lehmer64 implementation of `next`.

### DIFF
--- a/libafl_bolts/src/rands/mod.rs
+++ b/libafl_bolts/src/rands/mod.rs
@@ -371,7 +371,7 @@ impl Rand for Lehmer64Rand {
     #[inline]
     #[expect(clippy::unreadable_literal)]
     fn next(&mut self) -> u64 {
-        self.s *= 0xda942042e4dd58b5;
+        self.s = self.s.wrapping_mul(0xda942042e4dd58b5);
         (self.s >> 64) as u64
     }
 }


### PR DESCRIPTION

The implementation of [`Lehmer64Rand::next`] performs a mul on `u128`, which
is not checked against overflows. It leads to panic in debug mode.


[`Lehmer64Rand`]: https://github.com/AFLplusplus/LibAFL/blob/fd6271fa356f3addda6db33f37db7e42a2c99bbc/libafl_bolts/src/rands/mod.rs#L373-L376
