### PR TITLE
Fix issue with const_map_observer

### DIFF
--- a/libafl_qemu/src/modules/edges/helpers.rs
+++ b/libafl_qemu/src/modules/edges/helpers.rs
@@ -68,7 +68,7 @@ mod generators {
         if IS_CONST_MAP {
             const {
                 assert!(
-                    MAP_SIZE > 0,
+                    !IS_CONST_MAP || MAP_SIZE > 0,
                     "The size of a const map should be bigger than 0."
                 );
                 MAP_SIZE.overflowing_sub(1).0

--- a/libafl_qemu/src/modules/edges/helpers.rs
+++ b/libafl_qemu/src/modules/edges/helpers.rs
@@ -68,7 +68,7 @@ mod generators {
         if IS_CONST_MAP {
             const {
                 assert!(
-                    !IS_CONST_MAP || MAP_SIZE > 0,
+                    MAP_SIZE > 0,
                     "The size of a const map should be bigger than 0."
                 );
                 MAP_SIZE.overflowing_sub(1).0
@@ -107,7 +107,9 @@ mod generators {
             emulator_modules.get::<EdgeCoverageModule<AF, PF, V, IS_CONST_MAP, MAP_SIZE>>()
         {
             unsafe {
-                assert!(LIBAFL_QEMU_EDGES_MAP_MASK_MAX > 0);
+                if !IS_CONST_MAP {
+                    assert!(LIBAFL_QEMU_EDGES_MAP_MASK_MAX > 0);
+                }
                 let edges_map_size_ptr = &raw const LIBAFL_QEMU_EDGES_MAP_SIZE_PTR;
                 assert_ne!(*edges_map_size_ptr, ptr::null_mut());
             }

--- a/libafl_qemu/src/modules/edges/mod.rs
+++ b/libafl_qemu/src/modules/edges/mod.rs
@@ -194,11 +194,17 @@ impl<AF, PF, V, const IS_INITIALIZED: bool, const IS_CONST_MAP: bool, const MAP_
     #[must_use]
     pub fn const_map_observer<O, const NEW_MAP_SIZE: usize>(
         self,
-        _const_map_observer: &mut O,
+        const_map_observer: &mut O,
     ) -> EdgeCoverageModuleBuilder<AF, PF, V, true, true, NEW_MAP_SIZE>
     where
         O: ConstLenMapObserver<NEW_MAP_SIZE>,
     {
+        let map_ptr = const_map_observer.map_slice_mut().as_mut_ptr() as *mut u8;
+
+        unsafe {
+            LIBAFL_QEMU_EDGES_MAP_PTR = map_ptr;
+        }
+
         EdgeCoverageModuleBuilder::<AF, PF, V, true, true, NEW_MAP_SIZE>::new(
             self.variant,
             self.address_filter,


### PR DESCRIPTION
- Set `LIBAFL_QEMU_EDGES_MAP_PTR` in `const_map_observer` to fix issue #2925 (result of qemu_cmin is "Imported 4 seeds from disk." with this patch).
- Avoid assertion failure in `gen_unique_edge_ids` when a const map is used.