### PR TITLE
Fix the python binding configuration

### DIFF
--- a/bindings/pylibafl/pyproject.toml
+++ b/bindings/pylibafl/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin[patchelf]>=0.14.10,<0.15"]
+requires = ["maturin[patchelf]>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -20,7 +20,7 @@ classifiers = [
 repository = "https://github.com/AFLplusplus/LibAFL.git"
 
 [tool.maturin]
-bindings = "pylibafl"
+bindings = "pyo3"
 manifest-path = "Cargo.toml"
-python-source = "python"
+python-source = "src"
 all-features = true


### PR DESCRIPTION
According to `maturin`'s documentation: https://www.maturin.rs/config.html
`python-source` should point to the source directory containing python sources.
In `LibAFL` case, it does not exist. However, `maturin` will panic if that directory does not exist in development.
So better point to `src`.
For bindings, only `pyo3`, `Py_LIMITED_API/abi3`, `cffi`, `uniffi` options are available.
In `LibAFL` case, it should be `pyo3`.