### PR TITLE
Better type_eq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,52 +1,52 @@
 [workspace]
 resolver = "2"
 members = [
-    "libafl",
-    "libafl_bolts",
-    "libafl_cc",
-    "libafl_concolic/symcc_runtime",
-    "libafl_concolic/symcc_libafl",
-    "libafl_derive",
-    "libafl_frida",
-    "libafl_intelpt",
-    "libafl_libfuzzer",
-    "libafl_nyx",
-    "libafl_targets",
-    "libafl_tinyinst",
-    "libafl_qemu",
-    "libafl_qemu/libafl_qemu_build",
-    "libafl_qemu/libafl_qemu_sys",
-    "libafl_sugar",
-    "libafl_concolic/test/dump_constraints",
-    "libafl_concolic/test/runtime_test",
-    "utils/build_and_test_fuzzers",
-    "utils/deexit",
-    "utils/drcov_utils",
-    "utils/gramatron/construct_automata",
-    "utils/libafl_benches",
-    "utils/libafl_jumper",
+  "libafl",
+  "libafl_bolts",
+  "libafl_cc",
+  "libafl_concolic/symcc_runtime",
+  "libafl_concolic/symcc_libafl",
+  "libafl_derive",
+  "libafl_frida",
+  "libafl_intelpt",
+  "libafl_libfuzzer",
+  "libafl_nyx",
+  "libafl_targets",
+  "libafl_tinyinst",
+  "libafl_qemu",
+  "libafl_qemu/libafl_qemu_build",
+  "libafl_qemu/libafl_qemu_sys",
+  "libafl_sugar",
+  "libafl_concolic/test/dump_constraints",
+  "libafl_concolic/test/runtime_test",
+  "utils/build_and_test_fuzzers",
+  "utils/deexit",
+  "utils/drcov_utils",
+  "utils/gramatron/construct_automata",
+  "utils/libafl_benches",
+  "utils/libafl_jumper",
 ]
 
 default-members = [
-    "libafl",
-    "libafl_bolts",
-    "libafl_cc",
-    "libafl_derive",
-    "libafl_targets",
+  "libafl",
+  "libafl_bolts",
+  "libafl_cc",
+  "libafl_derive",
+  "libafl_targets",
 ]
 
 exclude = [
-    "bindings/pylibafl",
-    "fuzzers",
-    "libafl_libfuzzer_runtime",
-    "utils/noaslr",
-    "utils/gdb_qemu",
-    "utils/libafl_fmt",
-    "utils/desyscall",
-    "utils/multi_machine_generator",
-    "scripts",
-    # additional crates
-    "libafl_concolic/test/symcc/util/symcc_fuzzing_helper",
+  "bindings/pylibafl",
+  "fuzzers",
+  "libafl_libfuzzer_runtime",
+  "utils/noaslr",
+  "utils/gdb_qemu",
+  "utils/libafl_fmt",
+  "utils/desyscall",
+  "utils/multi_machine_generator",
+  "scripts",
+  # additional crates
+  "libafl_concolic/test/symcc/util/symcc_fuzzing_helper",
 ]
 
 [workspace.package]
@@ -104,7 +104,7 @@ num_enum = { version = "0.7.3", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.0.10", features = [
-    "alloc",
+  "alloc",
 ], default-features = false } # no_std compatible serde serialization format
 pyo3 = "0.23.2"
 pyo3-build-config = "0.23.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ strum = "0.26.3"
 strum_macros = "0.26.4"
 toml = "0.8.19" # For parsing the injections toml file
 typed-builder = "0.20.0" # Implement the builder pattern at compiletime
-typeid = "1" # Safe type_eq that doesn't rely on std specialization
+typeid = "1.0.0" # Safe type_eq that doesn't rely on std specialization
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 which = "6.0.3"
 windows = "0.59.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,52 +1,52 @@
 [workspace]
 resolver = "2"
 members = [
-  "libafl",
-  "libafl_bolts",
-  "libafl_cc",
-  "libafl_concolic/symcc_runtime",
-  "libafl_concolic/symcc_libafl",
-  "libafl_derive",
-  "libafl_frida",
-  "libafl_intelpt",
-  "libafl_libfuzzer",
-  "libafl_nyx",
-  "libafl_targets",
-  "libafl_tinyinst",
-  "libafl_qemu",
-  "libafl_qemu/libafl_qemu_build",
-  "libafl_qemu/libafl_qemu_sys",
-  "libafl_sugar",
-  "libafl_concolic/test/dump_constraints",
-  "libafl_concolic/test/runtime_test",
-  "utils/build_and_test_fuzzers",
-  "utils/deexit",
-  "utils/drcov_utils",
-  "utils/gramatron/construct_automata",
-  "utils/libafl_benches",
-  "utils/libafl_jumper",
+    "libafl",
+    "libafl_bolts",
+    "libafl_cc",
+    "libafl_concolic/symcc_runtime",
+    "libafl_concolic/symcc_libafl",
+    "libafl_derive",
+    "libafl_frida",
+    "libafl_intelpt",
+    "libafl_libfuzzer",
+    "libafl_nyx",
+    "libafl_targets",
+    "libafl_tinyinst",
+    "libafl_qemu",
+    "libafl_qemu/libafl_qemu_build",
+    "libafl_qemu/libafl_qemu_sys",
+    "libafl_sugar",
+    "libafl_concolic/test/dump_constraints",
+    "libafl_concolic/test/runtime_test",
+    "utils/build_and_test_fuzzers",
+    "utils/deexit",
+    "utils/drcov_utils",
+    "utils/gramatron/construct_automata",
+    "utils/libafl_benches",
+    "utils/libafl_jumper",
 ]
 
 default-members = [
-  "libafl",
-  "libafl_bolts",
-  "libafl_cc",
-  "libafl_derive",
-  "libafl_targets",
+    "libafl",
+    "libafl_bolts",
+    "libafl_cc",
+    "libafl_derive",
+    "libafl_targets",
 ]
 
 exclude = [
-  "bindings/pylibafl",
-  "fuzzers",
-  "libafl_libfuzzer_runtime",
-  "utils/noaslr",
-  "utils/gdb_qemu",
-  "utils/libafl_fmt",
-  "utils/desyscall",
-  "utils/multi_machine_generator",
-  "scripts",
-  # additional crates
-  "libafl_concolic/test/symcc/util/symcc_fuzzing_helper",
+    "bindings/pylibafl",
+    "fuzzers",
+    "libafl_libfuzzer_runtime",
+    "utils/noaslr",
+    "utils/gdb_qemu",
+    "utils/libafl_fmt",
+    "utils/desyscall",
+    "utils/multi_machine_generator",
+    "scripts",
+    # additional crates
+    "libafl_concolic/test/symcc/util/symcc_fuzzing_helper",
 ]
 
 [workspace.package]
@@ -104,7 +104,7 @@ num_enum = { version = "0.7.3", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.0.10", features = [
-  "alloc",
+    "alloc",
 ], default-features = false } # no_std compatible serde serialization format
 pyo3 = "0.23.2"
 pyo3-build-config = "0.23.2"
@@ -120,6 +120,7 @@ strum = "0.26.3"
 strum_macros = "0.26.4"
 toml = "0.8.19" # For parsing the injections toml file
 typed-builder = "0.20.0" # Implement the builder pattern at compiletime
+typeid = "1" # Safe type_eq that doesn't rely on std specialization
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 which = "6.0.3"
 windows = "0.59.0"

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -2,8 +2,8 @@
 name = "libafl_bolts"
 version.workspace = true
 authors = [
-    "Andrea Fioraldi <andreafioraldi@gmail.com>",
-    "Dominik Maier <domenukk@gmail.com>",
+  "Andrea Fioraldi <andreafioraldi@gmail.com>",
+  "Dominik Maier <domenukk@gmail.com>",
 ]
 description = "Low-level bolts to create fuzzers and so much more"
 documentation = "https://docs.rs/libafl"
@@ -14,11 +14,11 @@ keywords = ["fuzzing", "testing", "security"]
 edition = "2021"
 rust-version = "1.82"
 categories = [
-    "development-tools::testing",
-    "emulators",
-    "embedded",
-    "os",
-    "no-std",
+  "development-tools::testing",
+  "emulators",
+  "embedded",
+  "os",
+  "no-std",
 ]
 
 [package.metadata.docs.rs]
@@ -27,15 +27,15 @@ all-features = true
 
 [features]
 default = [
-    "std",
-    "derive",
-    "llmp_compression",
-    "llmp_small_maps",
-    "rand_trait",
-    "gzip",
-    "serdeany_autoreg",
-    "alloc",
-    "xxh3",
+  "std",
+  "derive",
+  "llmp_compression",
+  "llmp_small_maps",
+  "rand_trait",
+  "gzip",
+  "serdeany_autoreg",
+  "alloc",
+  "xxh3",
 ]
 document-features = ["dep:document-features"]
 
@@ -44,14 +44,14 @@ document-features = ["dep:document-features"]
 
 ## Enables features that need rust's `std` lib to work, like print, env, ... support
 std = [
-    "hostname",
-    "nix",
-    "serde/std",
-    "uuid",
-    "backtrace",
-    "uds",
-    "serial_test",
-    "alloc",
+  "hostname",
+  "nix",
+  "serde/std",
+  "uuid",
+  "backtrace",
+  "uds",
+  "serial_test",
+  "alloc",
 ]
 
 ## Enables all features that allocate in `no_std`
@@ -126,14 +126,14 @@ typeid = { workspace = true }
 
 tuple_list = { version = "0.1.3" }
 hashbrown = { workspace = true, features = [
-    "serde",
-    "ahash",
+  "serde",
+  "ahash",
 ], default-features = false, optional = true } # A faster hashmap, nostd compatible
 xxhash-rust = { version = "0.8.12", features = [
-    "xxh3",
+  "xxh3",
 ], optional = true } # xxh3 hashing for rust
 serde = { workspace = true, default-features = false, features = [
-    "derive",
+  "derive",
 ] } # serialization lib
 erased-serde = { version = "0.4.5", default-features = false, optional = true } # erased serde
 postcard = { workspace = true, optional = true } # no_std compatible serde serialization format
@@ -146,22 +146,22 @@ miniz_oxide = { version = "0.8.0", optional = true }
 hostname = { version = "0.4.0", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.9.0", optional = true }
 nix = { workspace = true, optional = true, default-features = false, features = [
-    "fs",
-    "signal",
-    "socket",
-    "poll",
+  "fs",
+  "signal",
+  "socket",
+  "poll",
 ] }
 uuid = { workspace = true, optional = true, features = ["serde", "v4"] }
 clap = { workspace = true, features = [
-    "derive",
-    "wrap_help",
+  "derive",
+  "wrap_help",
 ], optional = true } # CLI parsing, for libafl_bolts::cli / the `cli` feature
 log = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["serde", "macros"] }
 
 # optional-dev deps (change when target.'cfg(accessible(::std))'.test-dependencies will be stable)
 serial_test = { workspace = true, optional = true, default-features = false, features = [
-    "logging",
+  "logging",
 ] }
 
 # Document all features of this crate (for `cargo doc`)
@@ -176,14 +176,14 @@ uds = { version = "0.4.2", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, features = [
-    "Win32_Foundation",
-    "Win32_System_Threading",
-    "Win32_System_Diagnostics_Debug",
-    "Win32_System_Kernel",
-    "Win32_System_Memory",
-    "Win32_Security",
-    "Win32_System_SystemInformation",
-    "Win32_System_Console",
+  "Win32_Foundation",
+  "Win32_System_Threading",
+  "Win32_System_Diagnostics_Debug",
+  "Win32_System_Kernel",
+  "Win32_System_Memory",
+  "Win32_Security",
+  "Win32_System_SystemInformation",
+  "Win32_System_Console",
 ] }
 windows-result = "0.3.0"
 

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -2,8 +2,8 @@
 name = "libafl_bolts"
 version.workspace = true
 authors = [
-  "Andrea Fioraldi <andreafioraldi@gmail.com>",
-  "Dominik Maier <domenukk@gmail.com>",
+    "Andrea Fioraldi <andreafioraldi@gmail.com>",
+    "Dominik Maier <domenukk@gmail.com>",
 ]
 description = "Low-level bolts to create fuzzers and so much more"
 documentation = "https://docs.rs/libafl"
@@ -14,11 +14,11 @@ keywords = ["fuzzing", "testing", "security"]
 edition = "2021"
 rust-version = "1.82"
 categories = [
-  "development-tools::testing",
-  "emulators",
-  "embedded",
-  "os",
-  "no-std",
+    "development-tools::testing",
+    "emulators",
+    "embedded",
+    "os",
+    "no-std",
 ]
 
 [package.metadata.docs.rs]
@@ -27,15 +27,15 @@ all-features = true
 
 [features]
 default = [
-  "std",
-  "derive",
-  "llmp_compression",
-  "llmp_small_maps",
-  "rand_trait",
-  "gzip",
-  "serdeany_autoreg",
-  "alloc",
-  "xxh3",
+    "std",
+    "derive",
+    "llmp_compression",
+    "llmp_small_maps",
+    "rand_trait",
+    "gzip",
+    "serdeany_autoreg",
+    "alloc",
+    "xxh3",
 ]
 document-features = ["dep:document-features"]
 
@@ -44,14 +44,14 @@ document-features = ["dep:document-features"]
 
 ## Enables features that need rust's `std` lib to work, like print, env, ... support
 std = [
-  "hostname",
-  "nix",
-  "serde/std",
-  "uuid",
-  "backtrace",
-  "uds",
-  "serial_test",
-  "alloc",
+    "hostname",
+    "nix",
+    "serde/std",
+    "uuid",
+    "backtrace",
+    "uds",
+    "serial_test",
+    "alloc",
 ]
 
 ## Enables all features that allocate in `no_std`
@@ -122,17 +122,18 @@ rustversion = { workspace = true }
 [dependencies]
 libafl_derive = { workspace = true, default-features = true, optional = true }
 static_assertions = { workspace = true }
+typeid = { workspace = true }
 
 tuple_list = { version = "0.1.3" }
 hashbrown = { workspace = true, features = [
-  "serde",
-  "ahash",
+    "serde",
+    "ahash",
 ], default-features = false, optional = true } # A faster hashmap, nostd compatible
 xxhash-rust = { version = "0.8.12", features = [
-  "xxh3",
+    "xxh3",
 ], optional = true } # xxh3 hashing for rust
 serde = { workspace = true, default-features = false, features = [
-  "derive",
+    "derive",
 ] } # serialization lib
 erased-serde = { version = "0.4.5", default-features = false, optional = true } # erased serde
 postcard = { workspace = true, optional = true } # no_std compatible serde serialization format
@@ -145,22 +146,22 @@ miniz_oxide = { version = "0.8.0", optional = true }
 hostname = { version = "0.4.0", optional = true } # Is there really no gethostname in the stdlib?
 rand_core = { version = "0.9.0", optional = true }
 nix = { workspace = true, optional = true, default-features = false, features = [
-  "fs",
-  "signal",
-  "socket",
-  "poll",
+    "fs",
+    "signal",
+    "socket",
+    "poll",
 ] }
 uuid = { workspace = true, optional = true, features = ["serde", "v4"] }
 clap = { workspace = true, features = [
-  "derive",
-  "wrap_help",
+    "derive",
+    "wrap_help",
 ], optional = true } # CLI parsing, for libafl_bolts::cli / the `cli` feature
 log = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["serde", "macros"] }
 
 # optional-dev deps (change when target.'cfg(accessible(::std))'.test-dependencies will be stable)
 serial_test = { workspace = true, optional = true, default-features = false, features = [
-  "logging",
+    "logging",
 ] }
 
 # Document all features of this crate (for `cargo doc`)
@@ -175,14 +176,14 @@ uds = { version = "0.4.2", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, features = [
-  "Win32_Foundation",
-  "Win32_System_Threading",
-  "Win32_System_Diagnostics_Debug",
-  "Win32_System_Kernel",
-  "Win32_System_Memory",
-  "Win32_Security",
-  "Win32_System_SystemInformation",
-  "Win32_System_Console",
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Kernel",
+    "Win32_System_Memory",
+    "Win32_Security",
+    "Win32_System_SystemInformation",
+    "Win32_System_Console",
 ] }
 windows-result = "0.3.0"
 

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -8,7 +8,7 @@ use core::{
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut, Index, IndexMut},
 };
-use core::{any::TypeId, cell::Cell, marker::PhantomData, mem::transmute};
+use core::{any::TypeId, marker::PhantomData, mem::transmute};
 
 #[cfg(feature = "alloc")]
 use serde::{Deserialize, Serialize};
@@ -21,36 +21,9 @@ use crate::HasLen;
 use crate::Named;
 
 /// Returns if the type `T` is equal to `U`, ignoring lifetimes.
-#[inline] // this entire call gets optimized away :)
 #[must_use]
-pub fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
-    // decider struct: hold a cell (which we will update if the types are unequal) and some
-    // phantom data using a function pointer to allow for Copy to be implemented
-    struct W<'a, T: ?Sized, U: ?Sized>(&'a Cell<bool>, PhantomData<fn() -> (&'a T, &'a U)>);
-
-    // default implementation: if the types are unequal, we will use the clone implementation
-    impl<T: ?Sized, U: ?Sized> Clone for W<'_, T, U> {
-        #[inline]
-        fn clone(&self) -> Self {
-            // indicate that the types are unequal
-            // unfortunately, use of interior mutability (Cell) makes this not const-compatible
-            // not really possible to get around at this time
-            self.0.set(false);
-            W(self.0, self.1)
-        }
-    }
-
-    // specialized implementation: Copy is only implemented if the types are the same
-    #[expect(clippy::mismatching_type_param_order)]
-    impl<T: ?Sized> Copy for W<'_, T, T> {}
-
-    let detected = Cell::new(true);
-    // [].clone() is *specialized* in core.
-    // Types which implement copy will have their copy implementations used, falling back to clone.
-    // If the types are the same, then our clone implementation (which sets our Cell to false)
-    // will never be called, meaning that our Cell's content remains true.
-    let res = [W::<T, U>(&detected, PhantomData)].clone();
-    res[0].0.get()
+pub const fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
+    typeid::of::<T>() == typeid::of::<U>()
 }
 
 /// Borrow each member of the tuple
@@ -955,7 +928,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "alloc")]
     #[expect(unused_qualifications)] // for type name tests
     fn test_type_eq() {
         // An alias for equality testing
@@ -976,15 +948,6 @@ mod test {
         // test weirder lifetime things
         assert!(type_eq::<OwnedMutSlice<u8>, OwnedMutSlice<u8>>());
         assert!(!type_eq::<OwnedMutSlice<u8>, OwnedMutSlice<u32>>());
-
-        assert!(type_eq::<
-            OwnedMutSlice<u8>,
-            crate::ownedref::OwnedMutSlice<u8>,
-        >());
-        assert!(!type_eq::<
-            OwnedMutSlice<u8>,
-            crate::ownedref::OwnedMutSlice<u32>,
-        >());
     }
 
     #[test]

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -22,7 +22,7 @@ use crate::Named;
 
 /// Returns if the type `T` is equal to `U`, ignoring lifetimes.
 #[must_use]
-pub const fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
+pub fn type_eq<T: ?Sized, U: ?Sized>() -> bool {
     typeid::of::<T>() == typeid::of::<U>()
 }
 
@@ -928,7 +928,6 @@ mod test {
     }
 
     #[test]
-    #[expect(unused_qualifications)] // for type name tests
     fn test_type_eq() {
         // An alias for equality testing
         type OwnedMutSliceAlias<'a> = OwnedMutSlice<'a, u8>;

--- a/libafl_bolts/src/tuples.rs
+++ b/libafl_bolts/src/tuples.rs
@@ -6,9 +6,10 @@ use alloc::{borrow::Cow, vec::Vec};
 use core::{
     any::type_name,
     fmt::{Debug, Formatter},
+    marker::PhantomData,
     ops::{Deref, DerefMut, Index, IndexMut},
 };
-use core::{any::TypeId, marker::PhantomData, mem::transmute};
+use core::{any::TypeId, mem::transmute};
 
 #[cfg(feature = "alloc")]
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Avoid dependence on std specialization. Fixes #2945.