### PR TITLE
Fix clippy

### DIFF
--- a/libafl_qemu/src/modules/usermode/asan.rs
+++ b/libafl_qemu/src/modules/usermode/asan.rs
@@ -5,7 +5,7 @@ use core::{fmt, slice};
 use std::{
     borrow::Cow,
     env,
-    fmt::{Debug, Display},
+    fmt::{Debug, Display, Write},
     fs,
     path::PathBuf,
     pin::Pin,
@@ -1641,11 +1641,11 @@ pub unsafe fn asan_report(rt: &AsanGiovese, qemu: Qemu, pc: GuestAddr, err: &Asa
                         info += &line.to_string();
                     }
                 } else {
-                    info += &format!(" ({}+{raddr:#x})", images[*idx].0);
+                    let _ = write!(&mut info, " ({}+{raddr:#x})", images[*idx].0);
                 }
             }
             if info.is_empty() {
-                info += &format!(" ({}+{raddr:#x})", images[*idx].0);
+                let _ = write!(&mut info, " ({}+{raddr:#x})", images[*idx].0);
             }
         }
         info

--- a/libafl_qemu/src/qemu/mod.rs
+++ b/libafl_qemu/src/qemu/mod.rs
@@ -9,7 +9,7 @@ use core::{
 };
 use std::{
     ffi::{c_void, CString},
-    fmt::{Display, Formatter},
+    fmt::{Display, Formatter, Write},
     mem::{transmute, MaybeUninit},
     ops::Range,
     pin::Pin,
@@ -456,7 +456,7 @@ impl CPU {
         for (i, r) in Regs::iter().enumerate() {
             let v: GuestAddr = self.read_reg(r).unwrap();
             let sr = format!("{r:#?}");
-            display += &format!("{sr:>maxl$}: {v:#016x} ");
+            let _ = write!(&mut display, "{sr:>maxl$}: {v:#016x} ");
             if (i + 1) % 4 == 0 {
                 display += "\n";
             }


### PR DESCRIPTION
Since nightly clippy has added the rule [format_push_string](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string). This fix is modified as suggested in that webpage.