### PR TITLE
Add global stats cache

### DIFF
--- a/libafl/examples/tui_mock/main.rs
+++ b/libafl/examples/tui_mock/main.rs
@@ -12,11 +12,7 @@ use libafl_bolts::ClientId;
 pub fn main() {
     let mut monitor = TuiMonitor::builder().build();
 
-    let _client_stats = ClientStats {
-        corpus_size: 1024,
-        executions: 512,
-        ..ClientStats::default()
-    };
+    let _client_stats = ClientStats::default();
     let mut client_stats_manager = ClientStatsManager::default();
 
     monitor.display(&mut client_stats_manager, "Test", ClientId(0));

--- a/libafl/src/events/broker_hooks/mod.rs
+++ b/libafl/src/events/broker_hooks/mod.rs
@@ -157,7 +157,7 @@ where
                 client_stats_manager.update_client_stats_for(client_id, |client_stat| {
                     client_stat.update_user_stats(name.clone(), value.clone());
                 });
-                client_stats_manager.aggregate(name);
+                client_stats_manager.aggregate(name.clone());
                 monitor.display(client_stats_manager, event.name(), client_id);
                 Ok(BrokerEventResult::Handled)
             }

--- a/libafl/src/events/simple.rs
+++ b/libafl/src/events/simple.rs
@@ -236,7 +236,7 @@ where
                 client_stats_manager.update_client_stats_for(ClientId(0), |client_stat| {
                     client_stat.update_user_stats(name.clone(), value.clone());
                 });
-                client_stats_manager.aggregate(name);
+                client_stats_manager.aggregate(name.clone());
                 monitor.display(client_stats_manager, event.name(), ClientId(0));
                 Ok(BrokerEventResult::Handled)
             }

--- a/libafl/src/monitors/disk_aggregate.rs
+++ b/libafl/src/monitors/disk_aggregate.rs
@@ -47,13 +47,14 @@ impl Monitor for OnDiskJsonAggregateMonitor {
                 .open(&self.json_path)
                 .expect("Failed to open JSON logging file");
 
+            let global_stats = client_stats_manager.global_stats();
             let mut json_value = json!({
-                "run_time": (cur_time - client_stats_manager.start_time()).as_secs(),
-                "clients": client_stats_manager.client_stats_count(),
-                "corpus": client_stats_manager.corpus_size(),
-                "objectives": client_stats_manager.objective_size(),
-                "executions": client_stats_manager.total_execs(),
-                "exec_sec": client_stats_manager.execs_per_sec(),
+                "run_time": global_stats.run_time.as_secs(),
+                "clients": global_stats.client_stats_count,
+                "corpus": global_stats.corpus_size,
+                "objectives": global_stats.objective_size,
+                "executions": global_stats.total_execs,
+                "exec_sec": global_stats.execs_per_sec,
             });
 
             // Add all aggregated values directly to the root
@@ -62,7 +63,7 @@ impl Monitor for OnDiskJsonAggregateMonitor {
                     client_stats_manager
                         .aggregated()
                         .iter()
-                        .map(|(k, v)| (k.clone(), json!(v))),
+                        .map(|(k, v)| (k.clone().into_owned(), json!(v))),
                 );
             }
 

--- a/libafl/src/monitors/prometheus.rs
+++ b/libafl/src/monitors/prometheus.rs
@@ -37,7 +37,7 @@ use std::{
 
 // using thread in order to start the HTTP server in a separate thread
 use futures::executor::block_on;
-use libafl_bolts::{current_time, format_duration_hms, ClientId};
+use libafl_bolts::{current_time, ClientId};
 // using the official rust client library for Prometheus: https://github.com/prometheus/client_rust
 use prometheus_client::{
     encoding::{text::encode, EncodeLabelSet},
@@ -102,8 +102,9 @@ where
         // require a fair bit of logic to handle "amount to increment given
         // time since last observation"
 
+        let global_stats = client_stats_manager.global_stats();
         // Global (aggregated) metrics
-        let corpus_size = client_stats_manager.corpus_size();
+        let corpus_size = global_stats.corpus_size;
         self.prometheus_global_stats
             .corpus_count
             .get_or_create(&Labels {
@@ -112,7 +113,7 @@ where
             })
             .set(corpus_size.try_into().unwrap());
 
-        let objective_size = client_stats_manager.objective_size();
+        let objective_size = global_stats.objective_size;
         self.prometheus_global_stats
             .objective_count
             .get_or_create(&Labels {
@@ -121,7 +122,7 @@ where
             })
             .set(objective_size.try_into().unwrap());
 
-        let total_execs = client_stats_manager.total_execs();
+        let total_execs = global_stats.total_execs;
         self.prometheus_global_stats
             .executions
             .get_or_create(&Labels {
@@ -130,7 +131,7 @@ where
             })
             .set(total_execs.try_into().unwrap());
 
-        let execs_per_sec = client_stats_manager.execs_per_sec();
+        let execs_per_sec = global_stats.execs_per_sec;
         self.prometheus_global_stats
             .exec_rate
             .get_or_create(&Labels {
@@ -148,10 +149,7 @@ where
             })
             .set(run_time.try_into().unwrap()); // run time in seconds, which can be converted to a time format by Grafana or similar
 
-        let total_clients = client_stats_manager
-            .client_stats_count()
-            .try_into()
-            .unwrap(); // convert usize to u64 (unlikely that # of clients will be > 2^64 -1...)
+        let total_clients = global_stats.client_stats_count.try_into().unwrap(); // convert usize to u64 (unlikely that # of clients will be > 2^64 -1...)
         self.prometheus_global_stats
             .clients_count
             .get_or_create(&Labels {
@@ -164,12 +162,12 @@ where
         let mut global_fmt = format!(
             "[Prometheus] [{} #GLOBAL] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             event_msg,
-            format_duration_hms(&(current_time() - client_stats_manager.start_time())),
-            client_stats_manager.client_stats_count(),
-            client_stats_manager.corpus_size(),
-            client_stats_manager.objective_size(),
-            client_stats_manager.total_execs(),
-            client_stats_manager.execs_per_sec_pretty()
+            global_stats.run_time_pretty,
+            global_stats.client_stats_count,
+            global_stats.corpus_size,
+            global_stats.objective_size,
+            global_stats.total_execs,
+            global_stats.execs_per_sec_pretty
         );
         for (key, val) in client_stats_manager.aggregated() {
             // print global aggregated custom stats
@@ -223,7 +221,7 @@ where
                 client: Cow::from(sender_id.0.to_string()),
                 stat: Cow::from(""),
             })
-            .set(cur_client_clone.corpus_size.try_into().unwrap());
+            .set(cur_client_clone.corpus_size().try_into().unwrap());
 
         self.prometheus_client_stats
             .objective_count
@@ -231,7 +229,7 @@ where
                 client: Cow::from(sender_id.0.to_string()),
                 stat: Cow::from(""),
             })
-            .set(cur_client_clone.objective_size.try_into().unwrap());
+            .set(cur_client_clone.objective_size().try_into().unwrap());
 
         self.prometheus_client_stats
             .executions
@@ -239,7 +237,7 @@ where
                 client: Cow::from(sender_id.0.to_string()),
                 stat: Cow::from(""),
             })
-            .set(cur_client_clone.executions.try_into().unwrap());
+            .set(cur_client_clone.executions().try_into().unwrap());
 
         self.prometheus_client_stats
             .exec_rate
@@ -249,7 +247,7 @@ where
             })
             .set(cur_client_clone.execs_per_sec(current_time()));
 
-        let client_run_time = (current_time() - cur_client_clone.start_time).as_secs();
+        let client_run_time = (current_time() - cur_client_clone.start_time()).as_secs();
         self.prometheus_client_stats
             .runtime
             .get_or_create(&Labels {
@@ -270,13 +268,13 @@ where
             "[Prometheus] [{} #{}] corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
             event_msg,
             sender_id.0,
-            client.corpus_size,
-            client.objective_size,
-            client.executions,
+            client.corpus_size(),
+            client.objective_size(),
+            client.executions(),
             cur_client_clone.execs_per_sec_pretty(current_time())
         );
 
-        for (key, val) in cur_client_clone.user_stats {
+        for (key, val) in cur_client_clone.user_stats() {
             // print the custom stats for each client
             write!(fmt, ", {key}: {val}").unwrap();
             // Update metrics added to the user_stats hashmap by feedback event-fires

--- a/libafl/src/monitors/tui/mod.rs
+++ b/libafl/src/monitors/tui/mod.rs
@@ -3,7 +3,6 @@
 //! It's based on [ratatui](https://ratatui.rs/)
 
 use alloc::{borrow::Cow, boxed::Box, string::ToString};
-use core::cmp;
 use std::{
     collections::VecDeque,
     fmt::Write as _,
@@ -25,7 +24,6 @@ use crossterm::{
 use hashbrown::HashMap;
 use libafl_bolts::{current_time, format_duration_hms, ClientId};
 use ratatui::{backend::CrosstermBackend, Terminal};
-use serde_json::Value;
 use typed_builder::TypedBuilder;
 
 #[cfg(feature = "introspection")]
@@ -33,9 +31,8 @@ use crate::statistics::perf_stats::{ClientPerfStats, PerfFeature};
 use crate::{
     monitors::Monitor,
     statistics::{
-        manager::ClientStatsManager,
-        user_stats::{AggregatorOps, UserStats, UserStatsValue},
-        ClientStats,
+        manager::ClientStatsManager, user_stats::UserStats, ClientStats, ItemGeometry,
+        ProcessTiming,
     },
 };
 
@@ -209,50 +206,6 @@ impl PerfTuiContext {
     }
 }
 
-/// Data struct to process timings
-#[derive(Debug, Default, Clone)]
-pub struct ProcessTiming {
-    /// The start time
-    pub client_start_time: Duration,
-    /// The executions speed
-    pub exec_speed: String,
-    /// Timing of the last new corpus entry
-    pub last_new_entry: Duration,
-    /// Timing of the last new solution
-    pub last_saved_solution: Duration,
-}
-
-impl ProcessTiming {
-    /// Create a new [`ProcessTiming`] struct
-    fn new() -> Self {
-        Self {
-            exec_speed: "0".to_string(),
-            ..Default::default()
-        }
-    }
-}
-
-/// The geometry of a single data point
-#[expect(missing_docs)]
-#[derive(Debug, Default, Clone)]
-pub struct ItemGeometry {
-    pub pending: u64,
-    pub pend_fav: u64,
-    pub own_finds: u64,
-    pub imported: u64,
-    pub stability: String,
-}
-
-impl ItemGeometry {
-    /// Create a new [`ItemGeometry`]
-    fn new() -> Self {
-        Self {
-            stability: "0%".to_string(),
-            ..Default::default()
-        }
-    }
-}
-
 /// The context for a single client tracked in this [`TuiMonitor`]
 #[expect(missing_docs)]
 #[derive(Debug, Default, Clone)]
@@ -272,53 +225,16 @@ pub struct ClientTuiContext {
 
 impl ClientTuiContext {
     /// Grab data for a single client
-    pub fn grab_data(&mut self, client: &ClientStats, exec_sec: String) {
-        self.corpus = client.corpus_size;
-        self.objectives = client.objective_size;
-        self.executions = client.executions;
-        self.process_timing.client_start_time = client.start_time;
-        self.process_timing.last_new_entry = if client.last_corpus_time > client.start_time {
-            client.last_corpus_time - client.start_time
-        } else {
-            Duration::default()
-        };
+    pub fn grab_data(&mut self, client: &mut ClientStats) {
+        self.corpus = client.corpus_size();
+        self.objectives = client.objective_size();
+        self.executions = client.executions();
+        self.process_timing = client.process_timing();
 
-        self.process_timing.last_saved_solution = if client.last_objective_time > client.start_time
-        {
-            client.last_objective_time - client.start_time
-        } else {
-            Duration::default()
-        };
+        self.map_density = client.map_density();
+        self.item_geometry = client.item_geometry();
 
-        self.process_timing.exec_speed = exec_sec;
-
-        self.map_density = client
-            .get_user_stats("edges")
-            .map_or("0%".to_string(), ToString::to_string);
-
-        let default_json = serde_json::json!({
-            "pending": 0,
-            "pend_fav": 0,
-            "imported": 0,
-            "own_finds": 0,
-        });
-        let afl_stats = client
-            .get_user_stats("AflStats")
-            .map_or(default_json.to_string(), ToString::to_string);
-
-        let afl_stats_json: Value =
-            serde_json::from_str(afl_stats.as_str()).unwrap_or(default_json);
-        self.item_geometry.pending = afl_stats_json["pending"].as_u64().unwrap_or_default();
-        self.item_geometry.pend_fav = afl_stats_json["pend_fav"].as_u64().unwrap_or_default();
-        self.item_geometry.imported = afl_stats_json["imported"].as_u64().unwrap_or_default();
-        self.item_geometry.own_finds = afl_stats_json["own_finds"].as_u64().unwrap_or_default();
-
-        let stability = client
-            .get_user_stats("stability")
-            .map_or("0%".to_string(), ToString::to_string);
-        self.item_geometry.stability = stability;
-
-        for (key, val) in &client.user_stats {
+        for (key, val) in client.user_stats() {
             self.user_stats.insert(key.clone(), val.clone());
         }
     }
@@ -412,27 +328,29 @@ impl Monitor for TuiMonitor {
         let cur_time = current_time();
 
         {
+            let global_stats = client_stats_manager.global_stats();
             // TODO implement floating-point support for TimedStat
-            let execsec = client_stats_manager.execs_per_sec() as u64;
-            let totalexec = client_stats_manager.total_execs();
-            let run_time = cur_time - client_stats_manager.start_time();
-            let total_process_timing = get_process_timing(client_stats_manager);
-
+            let execsec = global_stats.execs_per_sec as u64;
+            let totalexec = global_stats.total_execs;
+            let run_time = global_stats.run_time;
+            let exec_per_sec_pretty = global_stats.execs_per_sec_pretty.clone();
             let mut ctx = self.context.write().unwrap();
-            ctx.total_process_timing = total_process_timing;
+            ctx.total_corpus_count = global_stats.corpus_size;
+            ctx.total_solutions = global_stats.objective_size;
             ctx.corpus_size_timed
-                .add(run_time, client_stats_manager.corpus_size());
+                .add(run_time, global_stats.corpus_size);
             ctx.objective_size_timed
-                .add(run_time, client_stats_manager.objective_size());
+                .add(run_time, global_stats.objective_size);
+            let total_process_timing = client_stats_manager.process_timing(exec_per_sec_pretty);
+
+            ctx.total_process_timing = total_process_timing;
             ctx.execs_per_sec_timed.add(run_time, execsec);
             ctx.start_time = client_stats_manager.start_time();
             ctx.total_execs = totalexec;
             ctx.clients_num = client_stats_manager.client_stats().len();
-            ctx.total_map_density = get_map_density(client_stats_manager);
-            ctx.total_solutions = client_stats_manager.objective_size();
+            ctx.total_map_density = client_stats_manager.map_density();
             ctx.total_cycles_done = 0;
-            ctx.total_corpus_count = client_stats_manager.corpus_size();
-            ctx.total_item_geometry = get_item_geometry(client_stats_manager);
+            ctx.total_item_geometry = client_stats_manager.item_geometry();
         }
 
         client_stats_manager.client_stats_insert(sender_id);
@@ -449,9 +367,13 @@ impl Monitor for TuiMonitor {
         let head = format!("{event_msg}{pad} {sender}");
         let mut fmt = format!(
             "[{}] corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
-            head, client.corpus_size, client.objective_size, client.executions, exec_sec
+            head,
+            client.corpus_size(),
+            client.objective_size(),
+            client.executions(),
+            exec_sec
         );
-        for (key, val) in &client.user_stats {
+        for (key, val) in client.user_stats() {
             write!(fmt, ", {key}: {val}").unwrap();
         }
         for (key, val) in client_stats_manager.aggregated() {
@@ -459,12 +381,13 @@ impl Monitor for TuiMonitor {
         }
 
         {
-            let client = &client_stats_manager.client_stats()[sender_id.0 as usize];
             let mut ctx = self.context.write().unwrap();
-            ctx.clients
-                .entry(sender_id.0 as usize)
-                .or_default()
-                .grab_data(client, exec_sec);
+            client_stats_manager.update_client_stats_for(sender_id, |client| {
+                ctx.clients
+                    .entry(sender_id.0 as usize)
+                    .or_default()
+                    .grab_data(client);
+            });
             while ctx.client_logs.len() >= DEFAULT_LOGS_NUMBER {
                 ctx.client_logs.pop_front();
             }
@@ -552,86 +475,6 @@ impl TuiMonitor {
         }
         Self { context }
     }
-}
-
-fn get_process_timing(client_stats_manager: &mut ClientStatsManager) -> ProcessTiming {
-    let mut total_process_timing = ProcessTiming::new();
-    total_process_timing.exec_speed = client_stats_manager.execs_per_sec_pretty();
-    if client_stats_manager.client_stats().len() > 1 {
-        let mut new_path_time = Duration::default();
-        let mut new_objectives_time = Duration::default();
-        for client in client_stats_manager
-            .client_stats()
-            .iter()
-            .filter(|client| client.enabled)
-        {
-            new_path_time = client.last_corpus_time.max(new_path_time);
-            new_objectives_time = client.last_objective_time.max(new_objectives_time);
-        }
-        if new_path_time > client_stats_manager.start_time() {
-            total_process_timing.last_new_entry = new_path_time - client_stats_manager.start_time();
-        }
-        if new_objectives_time > client_stats_manager.start_time() {
-            total_process_timing.last_saved_solution =
-                new_objectives_time - client_stats_manager.start_time();
-        }
-    }
-    total_process_timing
-}
-
-fn get_map_density(client_stats_manager: &ClientStatsManager) -> String {
-    client_stats_manager
-        .client_stats()
-        .iter()
-        .filter(|client| client.enabled)
-        .filter_map(|client| client.get_user_stats("edges"))
-        .map(ToString::to_string)
-        .fold("0%".to_string(), cmp::max)
-}
-
-fn get_item_geometry(client_stats_manager: &ClientStatsManager) -> ItemGeometry {
-    let mut total_item_geometry = ItemGeometry::new();
-    if client_stats_manager.client_stats().len() < 2 {
-        return total_item_geometry;
-    }
-    let mut ratio_a: u64 = 0;
-    let mut ratio_b: u64 = 0;
-    for client in client_stats_manager
-        .client_stats()
-        .iter()
-        .filter(|client| client.enabled)
-    {
-        let afl_stats = client
-            .get_user_stats("AflStats")
-            .map_or("None".to_string(), ToString::to_string);
-        let stability = client.get_user_stats("stability").map_or(
-            UserStats::new(UserStatsValue::Ratio(0, 100), AggregatorOps::Avg),
-            Clone::clone,
-        );
-
-        if afl_stats != "None" {
-            let default_json = serde_json::json!({
-                "pending": 0,
-                "pend_fav": 0,
-                "imported": 0,
-                "own_finds": 0,
-            });
-            let afl_stats_json: Value =
-                serde_json::from_str(afl_stats.as_str()).unwrap_or(default_json);
-            total_item_geometry.pending += afl_stats_json["pending"].as_u64().unwrap_or_default();
-            total_item_geometry.pend_fav += afl_stats_json["pend_fav"].as_u64().unwrap_or_default();
-            total_item_geometry.own_finds +=
-                afl_stats_json["own_finds"].as_u64().unwrap_or_default();
-            total_item_geometry.imported += afl_stats_json["imported"].as_u64().unwrap_or_default();
-        }
-
-        if let UserStatsValue::Ratio(a, b) = stability.value() {
-            ratio_a += a;
-            ratio_b += b;
-        }
-    }
-    total_item_geometry.stability = format!("{}%", ratio_a * 100 / ratio_b);
-    total_item_geometry
 }
 
 fn run_tui_thread<W: Write + Send + Sync + 'static>(

--- a/libafl/src/statistics/manager/global_stats.rs
+++ b/libafl/src/statistics/manager/global_stats.rs
@@ -1,0 +1,173 @@
+//! Global statistics available for Monitors to use
+
+use alloc::string::{String, ToString};
+use core::{cmp, time::Duration};
+
+use libafl_bolts::{current_time, format_duration_hms};
+#[cfg(feature = "std")]
+use serde_json::Value;
+
+use super::ClientStatsManager;
+use crate::statistics::ProcessTiming;
+#[cfg(feature = "std")]
+use crate::statistics::{
+    user_stats::{AggregatorOps, UserStats, UserStatsValue},
+    ItemGeometry,
+};
+
+impl ClientStatsManager {
+    /// Time this fuzzing run stated
+    #[must_use]
+    pub fn start_time(&self) -> Duration {
+        self.start_time
+    }
+
+    /// Time this fuzzing run stated
+    pub fn set_start_time(&mut self, time: Duration) {
+        self.start_time = time;
+    }
+
+    /// Get global stats.
+    ///
+    /// This global stats will be cached until the underlined client stats are modified.
+    pub fn global_stats(&mut self) -> &GlobalStats {
+        let global_stats = self.cached_global_stats.get_or_insert_with(|| GlobalStats {
+            run_time: Duration::ZERO,
+            run_time_pretty: String::new(),
+            client_stats_count: self
+                .client_stats
+                .iter()
+                .filter(|client| client.enabled)
+                .count(),
+            corpus_size: self
+                .client_stats
+                .iter()
+                .fold(0_u64, |acc, x| acc + x.corpus_size),
+            objective_size: self
+                .client_stats
+                .iter()
+                .fold(0_u64, |acc, x| acc + x.objective_size),
+            total_execs: self
+                .client_stats
+                .iter()
+                .fold(0_u64, |acc, x| acc + x.executions),
+            execs_per_sec: 0.0,
+            execs_per_sec_pretty: String::new(),
+        });
+
+        // Time-related data are always re-computed, since it is related with current time.
+        let cur_time = current_time();
+        global_stats.run_time = cur_time - self.start_time;
+        global_stats.run_time_pretty = format_duration_hms(&global_stats.run_time);
+        global_stats.execs_per_sec = self
+            .client_stats
+            .iter_mut()
+            .fold(0.0, |acc, x| acc + x.execs_per_sec(cur_time));
+        global_stats
+            .execs_per_sec_pretty
+            .push_str(&super::super::prettify_float(global_stats.execs_per_sec));
+
+        global_stats
+    }
+
+    /// Get process timing. `execs_per_sec_pretty` could be retrieved from `GlobalStats`.
+    #[must_use]
+    pub fn process_timing(&self, execs_per_sec_pretty: String) -> ProcessTiming {
+        let mut total_process_timing = ProcessTiming::new();
+        total_process_timing.exec_speed = execs_per_sec_pretty;
+        if self.client_stats().len() > 1 {
+            let mut new_path_time = Duration::default();
+            let mut new_objectives_time = Duration::default();
+            for client in self.client_stats().iter().filter(|client| client.enabled()) {
+                new_path_time = client.last_corpus_time().max(new_path_time);
+                new_objectives_time = client.last_objective_time().max(new_objectives_time);
+            }
+            if new_path_time > self.start_time() {
+                total_process_timing.last_new_entry = new_path_time - self.start_time();
+            }
+            if new_objectives_time > self.start_time() {
+                total_process_timing.last_saved_solution = new_objectives_time - self.start_time();
+            }
+        }
+        total_process_timing
+    }
+
+    /// Get map density
+    #[must_use]
+    pub fn map_density(&self) -> String {
+        self.client_stats()
+            .iter()
+            .filter(|client| client.enabled())
+            .filter_map(|client| client.get_user_stats("edges"))
+            .map(ToString::to_string)
+            .fold("0%".to_string(), cmp::max)
+    }
+
+    /// Get item geometry
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn item_geometry(&self) -> ItemGeometry {
+        let mut total_item_geometry = ItemGeometry::new();
+        if self.client_stats().len() < 2 {
+            return total_item_geometry;
+        }
+        let mut ratio_a: u64 = 0;
+        let mut ratio_b: u64 = 0;
+        for client in self.client_stats().iter().filter(|client| client.enabled()) {
+            let afl_stats = client
+                .get_user_stats("AflStats")
+                .map_or("None".to_string(), ToString::to_string);
+            let stability = client.get_user_stats("stability").map_or(
+                UserStats::new(UserStatsValue::Ratio(0, 100), AggregatorOps::Avg),
+                Clone::clone,
+            );
+
+            if afl_stats != "None" {
+                let default_json = serde_json::json!({
+                    "pending": 0,
+                    "pend_fav": 0,
+                    "imported": 0,
+                    "own_finds": 0,
+                });
+                let afl_stats_json: Value =
+                    serde_json::from_str(afl_stats.as_str()).unwrap_or(default_json);
+                total_item_geometry.pending +=
+                    afl_stats_json["pending"].as_u64().unwrap_or_default();
+                total_item_geometry.pend_fav +=
+                    afl_stats_json["pend_fav"].as_u64().unwrap_or_default();
+                total_item_geometry.own_finds +=
+                    afl_stats_json["own_finds"].as_u64().unwrap_or_default();
+                total_item_geometry.imported +=
+                    afl_stats_json["imported"].as_u64().unwrap_or_default();
+            }
+
+            if let UserStatsValue::Ratio(a, b) = stability.value() {
+                ratio_a += a;
+                ratio_b += b;
+            }
+        }
+        total_item_geometry.stability = format!("{}%", ratio_a * 100 / ratio_b);
+        total_item_geometry
+    }
+}
+
+/// Global statistics which aggregates client stats.
+#[derive(Debug)]
+pub struct GlobalStats {
+    /// Run time since started
+    pub run_time: Duration,
+    /// Run time since started
+    pub run_time_pretty: String,
+    /// Count the number of enabled client stats
+    pub client_stats_count: usize,
+    /// Amount of elements in the corpus (combined for all children)
+    pub corpus_size: u64,
+    /// Amount of elements in the objectives (combined for all children)
+    pub objective_size: u64,
+    /// Total executions
+    pub total_execs: u64,
+    /// Executions per second
+    pub execs_per_sec: f64,
+    /// Executions per second
+    pub execs_per_sec_pretty: String,
+}

--- a/libafl/src/statistics/user_stats/mod.rs
+++ b/libafl/src/statistics/user_stats/mod.rs
@@ -1,7 +1,7 @@
 //! User-defined statistics
 
 mod user_stats_value;
-use alloc::string::ToString;
+use alloc::borrow::Cow;
 use core::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -59,11 +59,14 @@ pub enum AggregatorOps {
 }
 
 /// Aggregate user statistics according to their ops
-pub(super) fn aggregate_user_stats(client_stats_manager: &mut ClientStatsManager, name: &str) {
+pub(super) fn aggregate_user_stats(
+    client_stats_manager: &mut ClientStatsManager,
+    name: Cow<'static, str>,
+) {
     let mut gather = client_stats_manager
         .client_stats()
         .iter()
-        .filter_map(|client| client.user_stats.get(name));
+        .filter_map(|client| client.user_stats.get(name.as_ref()));
 
     let gather_count = gather.clone().count();
 
@@ -119,5 +122,5 @@ pub(super) fn aggregate_user_stats(client_stats_manager: &mut ClientStatsManager
 
     client_stats_manager
         .cached_aggregated_user_stats
-        .insert(name.to_string(), init);
+        .insert(name, init);
 }


### PR DESCRIPTION
Previously, each Monitor calculate some aggregated data in each display, so if we combine multiple monitors together, same data will be computed multiple times. 

In this PR, there are following changes:

* A new `GlobalStats` structure is introduced
    Monitors no longer need to call individual functions to get aggregated statistics.
* The new `GlobalStats` are implemented as cached
    Only when the underline statistics are changed, will the `GlobalStats` be updated. If nothing changed, when multiple monitors retrieve the global stats, there will only be one computation.
* Some metrics are collected for all Monitors to use
    TUI monitors previously implemented some individual metrics such as item geometry, process timing and map density. This PR moves those metrics into the `ClientStatsManager`, so that other monitors could potentially use these metrics.