### PR TITLE
Fix build for libfuzzer_libpng in ubuntu 24

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -319,7 +319,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/fuzzer-tester-prepare
-      - uses: lhotari/action-upterm@v1
       - name: Build and run example fuzzers (Linux)
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -319,6 +319,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/fuzzer-tester-prepare
+      - uses: lhotari/action-upterm@v1
       - name: Build and run example fuzzers (Linux)
         if: runner.os == 'Linux'
         shell: bash

--- a/fuzzers/inprocess/libfuzzer_libpng/Justfile
+++ b/fuzzers/inprocess/libfuzzer_libpng/Justfile
@@ -2,24 +2,20 @@ import "../../../just/libafl-cc-libpng.just"
 
 FUZZER_NAME := 'fuzzer_libpng'
 
-alias cc := cxx
+[unix]
+cc feat:
+    cargo build --profile {{PROFILE}} --features="{{feat}}"
 
 [unix]
-cxx:
-    cargo build --profile {{PROFILE}}
+cxx feat:
+    cargo build --profile {{PROFILE}} --features="{{feat}}"
 
 [unix]
-crash_cxx:
-    cargo build --profile {{PROFILE}} --features=crash
+lib feat: (libpng feat) (cxx feat)
 
+# Feat is either nothing or "crash"
 [unix]
-lib: libpng cxx
-
-[unix]
-crash_lib: libpng crash_cxx
-
-[unix]
-fuzzer: lib cxx
+fuzzer feat="": (lib feat) (cxx feat)
     {{LIBAFL_CXX}} {{PROJECT_DIR}}/harness.cc \
         "{{LIBPNG_BUILD}}/.libs/libpng16.a" \
         "{{ZLIB_BUILD}}/libz.a" \
@@ -30,28 +26,9 @@ fuzzer: lib cxx
         -o {{FUZZER_NAME}} \
         -lm -lz
 
+# Feat is either nothing or "crash"
 [unix]
-crash_fuzzer: crash_lib crash_cxx
-    {{LIBAFL_CXX}} {{PROJECT_DIR}}/harness.cc \
-        "{{LIBPNG_BUILD}}/.libs/libpng16.a" \
-        "{{ZLIB_BUILD}}/libz.a" \
-        -I"{{LIBPNG_INCLUDE}}" \
-        -I"{{LIBPNG_BUILD}}" \
-        -I"{{ZLIB_INCLUDE}}" \
-        -L"{{ZLIB_LIB}}" \
-        -o {{FUZZER_NAME}} \
-        -lm -lz
-
-
-[unix]
-run: fuzzer
-    #!/bin/bash
-    ./{{FUZZER_NAME}} &
-    sleep 0.2
-    ./{{FUZZER_NAME}} 2>/dev/null
-
-[unix]
-crash: crash_fuzzer
+run feat="": (fuzzer feat)
     #!/bin/bash
     ./{{FUZZER_NAME}} &
     sleep 0.2

--- a/fuzzers/inprocess/libfuzzer_libpng/Justfile
+++ b/fuzzers/inprocess/libfuzzer_libpng/Justfile
@@ -1,117 +1,63 @@
-FUZZER_NAME := 'fuzzer_libpng'
-PROJECT_DIR := absolute_path(".")
-PROFILE := env("PROFILE", "release")
-PROFILE_DIR := if PROFILE == "release" { "release" } else if PROFILE == "dev" { "debug" } else { "debug" }
-CARGO_TARGET_DIR := env("CARGO_TARGET_DIR", "target")
-FUZZER := PROJECT_DIR / CARGO_TARGET_DIR / PROFILE_DIR / FUZZER_NAME
-LIBAFL_CC := PROJECT_DIR / CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"
-LIBAFL_CXX := PROJECT_DIR / CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cxx"
+import "../../../just/libafl-cc-libpng.just"
 
+FUZZER_NAME := 'fuzzer_libpng'
 
 alias cc := cxx
 
-[linux]
-[macos]
-libpng:
-    #!/bin/bash
-    if [ ! -f v1.6.37.tar.gz ]; then
-        wget https://github.com/glennrp/libpng/archive/refs/tags/v1.6.37.tar.gz
-    fi
-    tar -xvf v1.6.37.tar.gz
-
-[windows]
-libpng:
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 cxx:
     cargo build --profile {{PROFILE}}
 
-[windows]
-cxx:
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 crash_cxx:
     cargo build --profile {{PROFILE}} --features=crash
 
-[windows]
-crash_cxx:
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 lib: libpng cxx
-    #!/bin/bash
-    cd libpng-1.6.37 && ./configure --enable-shared=no --with-pic=yes --enable-hardware-optimizations=yes
-    cd {{PROJECT_DIR}}
-    make -C libpng-1.6.37 CC="{{LIBAFL_CC}}" CXX="{{LIBAFL_CXX}}"
 
-[windows]
-lib:
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 crash_lib: libpng crash_cxx
-    #!/bin/bash
-    cd libpng-1.6.37 && ./configure --enable-shared=no --with-pic=yes --enable-hardware-optimizations=yes
-    cd {{PROJECT_DIR}}
-    make -C libpng-1.6.37 CC="{{LIBAFL_CC}}" CXX="{{LIBAFL_CXX}}"
 
-[windows]
-crash_lib:
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 fuzzer: lib cxx
-    pwd
-    {{LIBAFL_CXX}} {{PROJECT_DIR}}/harness.cc {{PROJECT_DIR}}/libpng-1.6.37/.libs/libpng16.a -I {{PROJECT_DIR}}/libpng-1.6.37/ -o {{FUZZER_NAME}} -lm -lz
+    {{LIBAFL_CXX}} {{PROJECT_DIR}}/harness.cc \
+        "{{LIBPNG_BUILD}}/.libs/libpng16.a" \
+        "{{ZLIB_BUILD}}/libz.a" \
+        -I"{{LIBPNG_INCLUDE}}" \
+        -I"{{LIBPNG_BUILD}}" \
+        -I"{{ZLIB_INCLUDE}}" \
+        -L"{{ZLIB_LIB}}" \
+        -o {{FUZZER_NAME}} \
+        -lm -lz
 
-[windows]
-fuzzer:
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 crash_fuzzer: crash_lib crash_cxx
-    {{LIBAFL_CXX}} {{PROJECT_DIR}}/harness.cc {{PROJECT_DIR}}/libpng-1.6.37/.libs/libpng16.a -I {{PROJECT_DIR}}/libpng-1.6.37/ -o {{FUZZER_NAME}} -lm -lz
+    {{LIBAFL_CXX}} {{PROJECT_DIR}}/harness.cc \
+        "{{LIBPNG_BUILD}}/.libs/libpng16.a" \
+        "{{ZLIB_BUILD}}/libz.a" \
+        -I"{{LIBPNG_INCLUDE}}" \
+        -I"{{LIBPNG_BUILD}}" \
+        -I"{{ZLIB_INCLUDE}}" \
+        -L"{{ZLIB_LIB}}" \
+        -o {{FUZZER_NAME}} \
+        -lm -lz
 
-[windows]
-crash_fuzzer:
-    echo "Unsupported on this platform"
 
-
-[linux]
-[macos]
+[unix]
 run: fuzzer
     #!/bin/bash
     ./{{FUZZER_NAME}} &
     sleep 0.2
     ./{{FUZZER_NAME}} 2>/dev/null
 
-[windows]
-run: fuzzer
-    echo "Unsupported on this platform"
-
-[linux]
-[macos]
+[unix]
 crash: crash_fuzzer
     #!/bin/bash
     ./{{FUZZER_NAME}} &
     sleep 0.2
     ./{{FUZZER_NAME}} 2>/dev/null
 
-[windows]
-crash: fuzzer
-    echo "Unsupported on this platform"
-
-
-[linux]
-[macos]
+[unix]
 test: fuzzer
     #!/bin/bash
     rm -rf libafl_unix_shmem_server || true
@@ -125,12 +71,7 @@ test: fuzzer
         exit 1
     fi
 
-[windows]
-test: fuzzer
-    echo "Unsupported on this platform"
-
 clean:
     rm -rf {{FUZZER_NAME}}
     make -C libpng-1.6.37 clean || true
     cargo clean
-

--- a/just/libafl-cc-libpng.just
+++ b/just/libafl-cc-libpng.just
@@ -23,45 +23,30 @@ deps_dir:
 
 [unix]
 zlib_wget: deps_dir
-    #!/bin/bash
+    wget -O "{{ DEPS_DIR }}/zlib-1.2.13.tar.gz" https://zlib.net/fossils/zlib-1.2.13.tar.gz
 
-    wget \
-        -O "{{ DEPS_DIR }}/zlib-1.2.13.tar.gz" \
-        https://zlib.net/fossils/zlib-1.2.13.tar.gz
-
-    tar \
-        zxvf {{ DEPS_DIR }}/zlib-1.2.13.tar.gz \
-        -C {{ DEPS_DIR }}
+    tar zxvf {{ DEPS_DIR }}/zlib-1.2.13.tar.gz -C {{ DEPS_DIR }}
 
 [unix]
-zlib: zlib_wget
-    #!/bin/bash
-
+zlib feat: zlib_wget (cc feat)
     rm -rf {{ ZLIB_BUILD }}
     mkdir {{ ZLIB_BUILD }}
 
-    cd {{ ZLIB_BUILD }} && \
-        CC={{LIBAFL_CC}} \
-        {{ ZLIB_ROOT }}/configure \
-            --prefix=./zlib
+    cd {{ ZLIB_BUILD }} && CC={{ LIBAFL_CC }} {{ ZLIB_ROOT }}/configure --prefix=./zlib
 
-    make -j install
+    make -j -C {{ ZLIB_BUILD }} install
 
 [unix]
 libpng_wget: deps_dir
-    wget \
-        -O "{{ DEPS_DIR }}/v1.6.37.tar.gz" \
-        https://github.com/glennrp/libpng/archive/refs/tags/v1.6.37.tar.gz
+    wget -O "{{ DEPS_DIR }}/v1.6.37.tar.gz" https://github.com/glennrp/libpng/archive/refs/tags/v1.6.37.tar.gz
 
-    tar \
-        -xvf "{{ DEPS_DIR }}/v1.6.37.tar.gz" \
-        -C {{ DEPS_DIR }}
+    tar -xvf "{{ DEPS_DIR }}/v1.6.37.tar.gz" -C {{ DEPS_DIR }}
 
     rm -rf {{ LIBPNG_BUILD }}
     mkdir {{ LIBPNG_BUILD }}
 
 [unix]
-libpng: zlib libpng_wget
+libpng feat: (zlib feat) libpng_wget (cc feat)
     cd {{ LIBPNG_BUILD }}/ && \
         CC="{{LIBAFL_CC}}" \
         CFLAGS="-I{{ ZLIB_INCLUDE }}" \
@@ -72,4 +57,4 @@ libpng: zlib libpng_wget
             --with-pic=yes \
             --enable-hardware-optimizations={{ OPTIMIZATIONS }}
 
-    make -j -C {{ TARGET_DIR }}/build-png/
+    make -j -C {{ LIBPNG_BUILD }}

--- a/just/libafl-cc-libpng.just
+++ b/just/libafl-cc-libpng.just
@@ -1,0 +1,75 @@
+import "libafl-cc.just"
+
+OPTIMIZATIONS := env("OPTIMIZATIONS", "yes")
+
+LIBPNG_ROOT :=  DEPS_DIR / "libpng-1.6.37"
+LIBPNG_BUILD := TARGET_DIR / "build-png"
+LIBPNG_INCLUDE := LIBPNG_ROOT
+
+ZLIB_ROOT := DEPS_DIR / "zlib-1.2.13"
+ZLIB_BUILD := TARGET_DIR / "build-zlib"
+ZLIB_INCLUDE := ZLIB_BUILD / "zlib" / "include"
+ZLIB_LIB := ZLIB_BUILD / "zlib" / "lib"
+
+DEPS_DIR := TARGET_DIR / "deps"
+
+[unix]
+target_dir:
+    mkdir -p {{ TARGET_DIR }}
+
+[unix]
+deps_dir:
+    mkdir -p {{ DEPS_DIR }}
+
+[unix]
+zlib_wget: deps_dir
+    #!/bin/bash
+
+    wget \
+        -O "{{ DEPS_DIR }}/zlib-1.2.13.tar.gz" \
+        https://zlib.net/fossils/zlib-1.2.13.tar.gz
+
+    tar \
+        zxvf {{ DEPS_DIR }}/zlib-1.2.13.tar.gz \
+        -C {{ DEPS_DIR }}
+
+[unix]
+zlib: zlib_wget
+    #!/bin/bash
+
+    rm -rf {{ ZLIB_BUILD }}
+    mkdir {{ ZLIB_BUILD }}
+
+    cd {{ ZLIB_BUILD }} && \
+        CC={{LIBAFL_CC}} \
+        {{ ZLIB_ROOT }}/configure \
+            --prefix=./zlib
+
+    make -j install
+
+[unix]
+libpng_wget: deps_dir
+    wget \
+        -O "{{ DEPS_DIR }}/v1.6.37.tar.gz" \
+        https://github.com/glennrp/libpng/archive/refs/tags/v1.6.37.tar.gz
+
+    tar \
+        -xvf "{{ DEPS_DIR }}/v1.6.37.tar.gz" \
+        -C {{ DEPS_DIR }}
+
+    rm -rf {{ LIBPNG_BUILD }}
+    mkdir {{ LIBPNG_BUILD }}
+
+[unix]
+libpng: zlib libpng_wget
+    cd {{ LIBPNG_BUILD }}/ && \
+        CC="{{LIBAFL_CC}}" \
+        CFLAGS="-I{{ ZLIB_INCLUDE }}" \
+        CPPFLAGS="-I{{ ZLIB_INCLUDE }}" \
+        LDFLAGS="-L{{ ZLIB_LIB }}" \
+        {{ DEPS_DIR }}/libpng-1.6.37/configure \
+            --enable-shared=no \
+            --with-pic=yes \
+            --enable-hardware-optimizations={{ OPTIMIZATIONS }}
+
+    make -j -C {{ TARGET_DIR }}/build-png/

--- a/just/libafl-cc.just
+++ b/just/libafl-cc.just
@@ -1,0 +1,4 @@
+import "libafl.just"
+
+LIBAFL_CC := BUILD_DIR / "libafl_cc"
+LIBAFL_CXX := BUILD_DIR / "libafl_cxx"

--- a/just/libafl-qemu-libpng.just
+++ b/just/libafl-qemu-libpng.just
@@ -73,7 +73,7 @@ libpng: arch_dir zlib libpng_wget
 
     cd {{ TARGET_DIR }}/build-png/ && \
         CC=$CROSS_CC \
-        CFLAGS="$CROSS_CFLAGS -I"{{ TARGET_DIR }}/build-zlib/zlib/include"" \
+        CFLAGS="$CROSS_CFLAGS -I"{{ TARGET_DIR }}/build-zlib/zlib/lib"" \
         LDFLAGS=-L"{{ TARGET_DIR }}/build-zlib/zlib/lib" \
         {{ DEPS_DIR }}/libpng-1.6.37/configure \
             --enable-shared=no \

--- a/just/libafl-qemu-libpng.just
+++ b/just/libafl-qemu-libpng.just
@@ -73,12 +73,12 @@ libpng: arch_dir zlib libpng_wget
 
     cd {{ TARGET_DIR }}/build-png/ && \
         CC=$CROSS_CC \
-        CFLAGS="$CROSS_CFLAGS -I"{{ TARGET_DIR }}/build-zlib/zlib/lib"" \
+        CFLAGS="$CROSS_CFLAGS -I"{{ TARGET_DIR }}/build-zlib/zlib/include"" \
         LDFLAGS=-L"{{ TARGET_DIR }}/build-zlib/zlib/lib" \
         {{ DEPS_DIR }}/libpng-1.6.37/configure \
             --enable-shared=no \
             --with-pic=yes \
             --enable-hardware-optimizations={{ OPTIMIZATIONS }} \
-            --host={{ ARCH }} \
+            --host={{ ARCH }}
 
     make -j -C {{ TARGET_DIR }}/build-png/

--- a/just/libafl.just
+++ b/just/libafl.just
@@ -12,11 +12,13 @@
 #   - `FUZZER`: Executable path.
 
 PROFILE := env("PROFILE", "release")
+FUZZER_EXTENSION := if os_family() == "windows" { ".exe" } else { "" }
+FUZZER := BUILD_DIR / FUZZER_NAME + FUZZER_EXTENSION
+
+PROJECT_DIR := absolute_path(".")
 PROFILE_DIR := if PROFILE == "dev" { "debug" } else { "release" }
 TARGET_DIR := absolute_path(env("TARGET_DIR", "target"))
 BUILD_DIR := TARGET_DIR / PROFILE_DIR
-FUZZER_EXTENSION := if os_family() == "windows" { ".exe" } else { "" }
-FUZZER := BUILD_DIR / FUZZER_NAME + FUZZER_EXTENSION
 
 JUSTHASHES := ".justhashes"
 

--- a/libafl_targets/src/forkserver.c
+++ b/libafl_targets/src/forkserver.c
@@ -272,8 +272,7 @@ void __afl_start_forkserver(void) {
     uint32_t len = (__token_stop - __token_start), offset = 0;
 
     if (write(FORKSRV_FD + 1, &len, 4) != 4) {
-      write(2, "Error: could not send autotokens len\n",
-            strlen("Error: could not send autotokens len\n"));
+      fprintf(stderr, "Error: could not send autotokens len\n");
       _exit(1);
     }
 


### PR DESCRIPTION
also did the migration to library-style justile.
next step is to migrate other libpng fuzzers