### PR TITLE
chore: adds check for riscv64 and riscv32 archs

### DIFF
--- a/libafl_qemu/runtime/libafl_qemu_arch.h
+++ b/libafl_qemu/runtime/libafl_qemu_arch.h
@@ -30,12 +30,12 @@
       // Linux kernel
       #include <asm-generic/int-ll64.h>
 
-      #if defined(__x86_64__) || defined(__aarch64__)
+      #if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
         typedef __u64 libafl_word;
         #define LIBAFL_CALLING_CONVENTION __attribute__(())
       #endif
 
-      #ifdef __arm__
+      #if defined(__arm__) || (defined(__riscv) && __riscv_xlen == 32)
         typedef __u32 libafl_word;
         #define LIBAFL_CALLING_CONVENTION __attribute__(())
       #endif
@@ -47,12 +47,12 @@
 
       #define noinline __attribute__((noinline))
 
-      #if defined(__x86_64__) || defined(__aarch64__)
+      #if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
         typedef uint64_t libafl_word;
         #define LIBAFL_CALLING_CONVENTION __attribute__(())
       #endif
 
-      #ifdef __arm__
+      #if defined(__arm__) || (defined(__riscv) && __riscv_xlen == 32)
         typedef uint32_t libafl_word;
         #define LIBAFL_CALLING_CONVENTION __attribute__(())
       #endif
@@ -66,12 +66,12 @@
 
     #define noinline __attribute__((noinline))
 
-    #if defined(__x86_64__) || defined(__aarch64__)
+    #if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
       typedef uint64_t libafl_word;
       #define LIBAFL_CALLING_CONVENTION __attribute__(())
     #endif
 
-    #ifdef __arm__
+    #if defined(__arm__) || (defined(__riscv) && __riscv_xlen == 32)
       typedef uint32_t libafl_word;
       #define LIBAFL_CALLING_CONVENTION __attribute__(())
     #endif


### PR DESCRIPTION
This PR fixes riscv target compilation that use qemu calls, by adding checks for riscv compiler macros (64 and 32).

Current issue: on riscv targets `libafl_word` and `LIBAFL_CALLING_CONVENTION` would not get defined.

Fixed: `libafl_word` and `LIBAFL_CALLING_CONVENTION` are defined for riscv targets
