### PR TITLE
Add `add_metadata_checked` method

### DIFF
--- a/libafl/src/common/mod.rs
+++ b/libafl/src/common/mod.rs
@@ -26,6 +26,23 @@ pub trait HasMetadata {
         self.metadata_map_mut().insert(meta);
     }
 
+    /// Add a metadata to the metadata map
+    /// Returns error if the metadata is already there
+    #[inline]
+    fn add_metadata_checked<M>(&mut self, meta: M) -> Result<(), Error>
+    where
+        M: SerdeAny,
+    {
+        if self.has_metadata::<M>() {
+            return Err(Error::illegal_argument(format!(
+                "Tried to add a metadata of {}. But this will overwrite the existing metadata",
+                type_name::<M>()
+            )));
+        }
+        self.metadata_map_mut().insert(meta);
+        Ok(())
+    }
+
     /// Gets metadata, or inserts it using the given construction function `default`
     fn metadata_or_insert_with<M>(&mut self, default: impl FnOnce() -> M) -> &mut M
     where
@@ -92,6 +109,20 @@ pub trait HasNamedMetadata {
         M: SerdeAny,
     {
         self.named_metadata_map_mut().insert(name, meta);
+    }
+
+    /// Add a metadata to the metadata map
+    /// Return an error if there already is the metadata with the same name
+    #[inline]
+    fn add_named_metadata_checked<M>(&mut self, name: &str, meta: M) -> Result<(), Error>
+    where
+        M: SerdeAny,
+    {
+        if self.has_named_metadata::<M>(name) {
+            return Err(Error::illegal_argument(format!("Tried to add a metadata of {} named {}. But this will overwrite the existing metadata", type_name::<M>(), name)));
+        }
+        self.named_metadata_map_mut().insert(name, meta);
+        Ok(())
     }
 
     /// Add a metadata to the metadata map

--- a/libafl/src/feedbacks/list.rs
+++ b/libafl/src/feedbacks/list.rs
@@ -118,7 +118,7 @@ where
     T: Debug + Eq + Hash + for<'a> Deserialize<'a> + Serialize + Default + Copy + 'static,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
-        state.add_named_metadata(self.name(), ListFeedbackMetadata::<T>::default());
+        state.add_named_metadata_checked(self.name(), ListFeedbackMetadata::<T>::default())?;
         Ok(())
     }
 }

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -386,7 +386,7 @@ where
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
         // Initialize `MapFeedbackMetadata` with an empty vector and add it to the state.
         // The `MapFeedbackMetadata` would be resized on-demand in `is_interesting`
-        state.add_named_metadata(&self.name, MapFeedbackMetadata::<O::Entry>::default());
+        state.add_named_metadata_checked(&self.name, MapFeedbackMetadata::<O::Entry>::default())?;
         Ok(())
     }
 }

--- a/libafl/src/feedbacks/new_hash_feedback.rs
+++ b/libafl/src/feedbacks/new_hash_feedback.rs
@@ -141,10 +141,10 @@ where
     S: HasNamedMetadata,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
-        state.add_named_metadata(
+        state.add_named_metadata_checked(
             &self.name,
             NewHashFeedbackMetadata::with_capacity(self.capacity),
-        );
+        )?;
         Ok(())
     }
 }

--- a/libafl/src/observers/map/mod.rs
+++ b/libafl/src/observers/map/mod.rs
@@ -68,7 +68,6 @@ pub use owned_map::*;
 /// // inform the feedback to track indices (required by IndexesLenTimeMinimizerScheduler), but not novelties
 /// // this *MUST* be done before it is passed to MaxMapFeedback!
 /// let edges_observer = edges_observer.track_indices();
-///
 /// // init the feedback
 /// let mut feedback = MaxMapFeedback::new(&edges_observer);
 /// #
@@ -80,9 +79,6 @@ pub use owned_map::*;
 /// #     &mut feedback,
 /// #     &mut (),
 /// # ).unwrap();
-///
-/// # feedback.init_state(&mut state).unwrap();
-///
 /// let scheduler = IndexesLenTimeMinimizerScheduler::new(&edges_observer, QueueScheduler::new());
 /// # scheduler.cull(&state).unwrap();
 /// ```


### PR DESCRIPTION
## Pull Request Checklist

Please make sure you've completed the following steps before submitting:

- [x] I have run `./script/fmt_all.sh` to format the code
- [x] I have run `./script/clippy.sh` and fixed all errors/warnings

In this PR. I added `add_metadata_checked` and `add_namedmetadata_checked`. 
This is for checking the metadata or named metadata is already existent and return error if so.
This way we can avoid bugs like when you use same mapmetadata for objectives and feedbacks such as this: https://github.com/AFLplusplus/LibAFL/pull/2983#discussion_r1957105585