### PR TITLE
scripts/test_fuzzer.sh: correct working directory

### DIFF
--- a/scripts/test_fuzzer.sh
+++ b/scripts/test_fuzzer.sh
@@ -43,30 +43,32 @@ do
         continue
     fi
 
-    cd "$fuzzer" || exit 1
-    # Clippy checks
-    if [ "$1" != "--no-clippy" ]; then
-        echo "[*] Running clippy for $fuzzer"
-        cargo clippy || exit 1
-    else
-        echo "[+] Skipping fmt and clippy for $fuzzer (--no-clippy specified)"
-    fi
-    
-    if [ -e ./Makefile.toml ] && grep -qF "skip_core_tasks = true" Makefile.toml; then
-        echo "[*] Building $fuzzer (running tests is not supported in this context)"
-        just build || exit 1
-        echo "[+] Done building $fuzzer"
-    elif [ -e ./Makefile.toml ]; then
-        echo "[*] Testing $fuzzer"
-        just test || exit 1
-        echo "[+] Done testing $fuzzer"
-    elif [ -e ./Justfile ]; then
-        echo "[*] Testing $fuzzer"
-        just test || exit 1
-        echo "[+] Done testing $fuzzer"
-    else
-        echo "[*] Building $fuzzer"
-        cargo build || exit 1
-        echo "[+] Done building $fuzzer"
-    fi
+    (
+        cd "$fuzzer" || exit 1
+        # Clippy checks
+        if [ "$1" != "--no-clippy" ]; then
+            echo "[*] Running clippy for $fuzzer"
+            cargo clippy || exit 1
+        else
+            echo "[+] Skipping fmt and clippy for $fuzzer (--no-clippy specified)"
+        fi
+
+        if [ -e ./Makefile.toml ] && grep -qF "skip_core_tasks = true" Makefile.toml; then
+            echo "[*] Building $fuzzer (running tests is not supported in this context)"
+            just build || exit 1
+            echo "[+] Done building $fuzzer"
+        elif [ -e ./Makefile.toml ]; then
+            echo "[*] Testing $fuzzer"
+            just test || exit 1
+            echo "[+] Done testing $fuzzer"
+        elif [ -e ./Justfile ]; then
+            echo "[*] Testing $fuzzer"
+            just test || exit 1
+            echo "[+] Done testing $fuzzer"
+        else
+            echo "[*] Building $fuzzer"
+            cargo build || exit 1
+            echo "[+] Done building $fuzzer"
+        fi
+    )
 done


### PR DESCRIPTION
## Small fix in test_fuzzer.sh

Calling test_fuzzer.sh without parameters will by default try to test all fuzzers. This will not work, as the working directory is changed in the first iteration from LibAFL to LibAFL/fuzzers/.

Solution is quite simple: Create a subshell with parentheses to keep same base working directory for every fuzzer in the list.

### Reproducer

Run test_fuzzer.sh from LibAFL directory without parameters:

`/LibAFL# ./scripts/test_fuzzer.sh`

### Error message:

> [+] Done building ./fuzzers/inprocess
./scripts/test_fuzzer.sh: line 46: cd: ./fuzzers/fuzz_anything: No such file or directory

## Checklist

- [ x] I have run `./scripts/precommit.sh` and addressed all comments
