### PR TITLE
Remove aarch64, arm, i386, ppc tests from CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -378,10 +378,11 @@ jobs:
           - ./fuzzers/binary_only/qemu_coverage
           - ./fuzzers/binary_only/qemu_launcher
         arch:
-          - aarch64
-          - arm
-          - i386
-          - ppc
+          # unless somebody pays us for the servers.
+          # - aarch64
+          # - arm
+          # - i386
+          # - ppc
           - x86_64
 
     runs-on: [ self-hosted, qemu ]


### PR DESCRIPTION
## Description

We don't have enough machines for these 2nd-tier architecures.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
