### PR TITLE
Forbid overwriting MapIndexesMetadata

### DIFF
--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -472,7 +472,7 @@ where
                 indices.push(i);
             }
             let meta = MapIndexesMetadata::new(indices);
-            testcase.add_metadata(meta);
+            testcase.try_add_metadata(meta)?;
         } else {
             for (i, value) in observer
                 .as_iter()


### PR DESCRIPTION
## Description

Fix https://github.com/AFLplusplus/LibAFL/issues/2006
Here instead of making this metadata named. I just make it forbidden to overwrite this metadata.
This means that users are responsible for setting the `tracking` correctly for the corresponding observers attached to each mapfeedback

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
