### PR TITLE
Fix usage of TracingStage

### DIFF
--- a/fuzzers/binary_only/frida_executable_libpng/src/fuzzer.rs
+++ b/fuzzers/binary_only/frida_executable_libpng/src/fuzzer.rs
@@ -370,7 +370,7 @@ unsafe fn fuzz(
 
                 let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
 
-                let tracing = ShadowTracingStage::new(&mut executor);
+                let tracing = ShadowTracingStage::new();
 
                 // Setup a randomic Input2State stage
                 let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(

--- a/fuzzers/binary_only/frida_libpng/src/fuzzer.rs
+++ b/fuzzers/binary_only/frida_libpng/src/fuzzer.rs
@@ -218,7 +218,7 @@ fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
         let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
 
-        let tracing = ShadowTracingStage::new(&mut executor);
+        let tracing = ShadowTracingStage::new();
 
         // Setup a randomic Input2State stage
         let i2s =

--- a/fuzzers/binary_only/frida_windows_gdiplus/src/fuzzer.rs
+++ b/fuzzers/binary_only/frida_windows_gdiplus/src/fuzzer.rs
@@ -344,7 +344,7 @@ unsafe fn fuzz(options: &FuzzerOptions) -> Result<(), Error> {
 
                 let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
 
-                let tracing = ShadowTracingStage::new(&mut executor);
+                let tracing = ShadowTracingStage::new();
 
                 // Setup a randomic Input2State stage
                 let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(

--- a/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
+++ b/fuzzers/binary_only/fuzzbench_fork_qemu/src/fuzzer.rs
@@ -391,7 +391,7 @@ fn fuzz(
         println!("We imported {} inputs from disk.", state.corpus().count());
     }
 
-    let tracing = ShadowTracingStage::new(&mut executor);
+    let tracing = ShadowTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(calibration, tracing, i2s, power);

--- a/fuzzers/binary_only/fuzzbench_qemu/src/fuzzer.rs
+++ b/fuzzers/binary_only/fuzzbench_qemu/src/fuzzer.rs
@@ -403,7 +403,7 @@ fn fuzz(
         println!("We imported {} input(s) from disk.", state.corpus().count());
     }
 
-    let tracing = ShadowTracingStage::new(&mut executor);
+    let tracing = ShadowTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(calibration, tracing, i2s, power);

--- a/fuzzers/binary_only/qemu_launcher/src/instance.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/instance.rs
@@ -315,7 +315,7 @@ impl<M: Monitor> Instance<'_, M> {
 
             let mut shadow_executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
 
-            let tracing = ShadowTracingStage::new(&mut shadow_executor);
+            let tracing = ShadowTracingStage::new();
 
             // Setup a randomic Input2State stage
             let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(

--- a/fuzzers/full_system/nyx_launcher/src/instance.rs
+++ b/fuzzers/full_system/nyx_launcher/src/instance.rs
@@ -192,7 +192,7 @@ impl<M: Monitor> Instance<'_, M> {
                 I2SRandReplace::new()
             )));
 
-            let tracing = ShadowTracingStage::new(&mut executor);
+            let tracing = ShadowTracingStage::new();
 
             // Setup a MOPT mutator
             let mutator = StdMOptMutator::new(

--- a/fuzzers/full_system/qemu_linux_kernel/src/fuzzer.rs
+++ b/fuzzers/full_system/qemu_linux_kernel/src/fuzzer.rs
@@ -232,7 +232,7 @@ pub fn fuzz() {
         )));
 
         // Setup an havoc mutator with a mutational stage
-        let tracing = ShadowTracingStage::new(&mut executor);
+        let tracing = ShadowTracingStage::new();
         let mutator = StdScheduledMutator::new(havoc_mutations());
         let mut stages = tuple_list!(tracing, i2s, StdMutationalStage::new(mutator),);
 

--- a/fuzzers/full_system/qemu_linux_process/src/fuzzer.rs
+++ b/fuzzers/full_system/qemu_linux_process/src/fuzzer.rs
@@ -240,7 +240,7 @@ pub fn fuzz() {
         )));
 
         // Setup an havoc mutator with a mutational stage
-        let tracing = ShadowTracingStage::new(&mut executor);
+        let tracing = ShadowTracingStage::new();
         let mutator = StdScheduledMutator::new(havoc_mutations());
         let mut stages = tuple_list!(tracing, i2s, StdMutationalStage::new(mutator),);
 

--- a/fuzzers/fuzz_anything/libafl_atheris/src/lib.rs
+++ b/fuzzers/fuzz_anything/libafl_atheris/src/lib.rs
@@ -216,14 +216,9 @@ pub extern "C" fn LLVMFuzzerRunDriver(
             ExitKind::Ok
         };
 
+        let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
         // Setup a tracing stage in which we log comparisons
-        let tracing = TracingStage::new(InProcessExecutor::new(
-            &mut harness,
-            tuple_list!(cmplog_observer),
-            &mut fuzzer,
-            &mut state,
-            &mut mgr,
-        )?);
+        let tracing = ShadowTracingStage::new();
 
         // Setup a randomic Input2State stage
         let i2s =

--- a/fuzzers/fuzz_anything/libafl_atheris/src/lib.rs
+++ b/fuzzers/fuzz_anything/libafl_atheris/src/lib.rs
@@ -28,7 +28,7 @@ use libafl::{
     },
     observers::{CanTrack, HitcountsMapObserver, StdMapObserver, TimeObserver},
     schedulers::{IndexesLenTimeMinimizerScheduler, QueueScheduler},
-    stages::{StdMutationalStage, TracingStage},
+    stages::{ShadowTracingStage, StdMutationalStage, TracingStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
 };

--- a/fuzzers/fuzz_anything/libafl_atheris/src/lib.rs
+++ b/fuzzers/fuzz_anything/libafl_atheris/src/lib.rs
@@ -14,7 +14,7 @@ use clap::{Arg, ArgAction, Command};
 use libafl::{
     corpus::{Corpus, InMemoryCorpus, OnDiskCorpus},
     events::{launcher::Launcher, EventConfig},
-    executors::{inprocess::InProcessExecutor, ExitKind},
+    executors::{inprocess::InProcessExecutor, ExitKind, ShadowExecutor},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback, TimeoutFeedback},
     fuzzer::{Fuzzer, StdFuzzer},

--- a/fuzzers/inprocess/fuzzbench/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench/src/lib.rs
@@ -331,8 +331,6 @@ fn fuzz(
         ExitKind::Ok
     };
 
-    let mut tracing_harness = harness;
-
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
     let mut executor = InProcessExecutor::with_timeout(
         &mut harness,

--- a/fuzzers/inprocess/fuzzbench/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench/src/lib.rs
@@ -260,7 +260,7 @@ fn fuzz(
     let mut feedback = feedback_or!(
         // New maximization map feedback linked to the edges observer and the feedback state
         map_feedback,
-        CrashFeedback::new(),
+        // CrashFeedback::new(),
     );
 
     // A feedback to choose if an input is a solution or not
@@ -382,9 +382,9 @@ fn fuzz(
     #[cfg(unix)]
     {
         let null_fd = file_null.as_raw_fd();
-        // dup2(null_fd, io::stdout().as_raw_fd())?;
+        dup2(null_fd, io::stdout().as_raw_fd())?;
         if std::env::var("LIBAFL_FUZZBENCH_DEBUG").is_err() {
-            // dup2(null_fd, io::stderr().as_raw_fd())?;
+            dup2(null_fd, io::stderr().as_raw_fd())?;
         }
     }
     // reopen file to make sure we're at the end

--- a/fuzzers/inprocess/fuzzbench/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench/src/lib.rs
@@ -343,18 +343,10 @@ fn fuzz(
         timeout,
     )?;
 
+    let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
+
     // Setup a tracing stage in which we log comparisons
-    let tracing = TracingStage::new(
-        InProcessExecutor::with_timeout(
-            &mut tracing_harness,
-            tuple_list!(cmplog_observer),
-            &mut fuzzer,
-            &mut state,
-            &mut mgr,
-            timeout * 10,
-        )?,
-        // Give it more time!
-    );
+    let tracing = ShadownTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(calibration, tracing, i2s, power);

--- a/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
@@ -18,10 +18,7 @@ use clap::{Arg, Command};
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
-    executors::{
-        inprocess::{HookableInProcessExecutor, InProcessExecutor},
-        ExitKind, ShadowExecutor,
-    },
+    executors::{inprocess::HookableInProcessExecutor, ExitKind, ShadowExecutor},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
@@ -343,15 +340,10 @@ fn fuzz(
         ExitKind::Ok
     };
 
-    let mut tracing_harness = harness;
     let ctx_hook = CtxHook::new();
 
-    let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
-    // Setup a tracing stage in which we log comparisons
-    let tracing = ShadowTracingStage::new();
-
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
-    let mut executor = HookableInProcessExecutor::with_timeout_generic(
+    let executor = HookableInProcessExecutor::with_timeout_generic(
         tuple_list!(ctx_hook),
         &mut harness,
         tuple_list!(edges_observer, time_observer),
@@ -360,6 +352,10 @@ fn fuzz(
         &mut mgr,
         timeout,
     )?;
+
+    let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
+    // Setup a tracing stage in which we log comparisons
+    let tracing = ShadowTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(calibration, tracing, i2s, power);

--- a/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
@@ -35,10 +35,7 @@ use libafl::{
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
-    stages::{
-        calibrate::CalibrationStage, power::StdPowerMutationalStage, StdMutationalStage,
-        TracingStage,
-    },
+    stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage, StdMutationalStage},
     state::{HasCorpus, StdState},
     Error, HasMetadata,
 };
@@ -348,7 +345,7 @@ fn fuzz(
 
     let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
     // Setup a tracing stage in which we log comparisons
-    let tracing = ShadownTracingStage::new();
+    let tracing = ShadowTracingStage::new();
 
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
     let mut executor = HookableInProcessExecutor::with_timeout_generic(

--- a/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
@@ -346,18 +346,9 @@ fn fuzz(
     let mut tracing_harness = harness;
     let ctx_hook = CtxHook::new();
 
+    let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
     // Setup a tracing stage in which we log comparisons
-    let tracing = TracingStage::new(
-        InProcessExecutor::with_timeout(
-            &mut tracing_harness,
-            tuple_list!(cmplog_observer),
-            &mut fuzzer,
-            &mut state,
-            &mut mgr,
-            timeout * 10,
-        )?,
-        // Give it more time!
-    );
+    let tracing = ShadownTracingStage::new();
 
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
     let mut executor = HookableInProcessExecutor::with_timeout_generic(

--- a/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
@@ -35,7 +35,10 @@ use libafl::{
     schedulers::{
         powersched::PowerSchedule, IndexesLenTimeMinimizerScheduler, StdWeightedScheduler,
     },
-    stages::{calibrate::CalibrationStage, power::StdPowerMutationalStage, StdMutationalStage},
+    stages::{
+        calibrate::CalibrationStage, power::StdPowerMutationalStage, ShadowTracingStage,
+        StdMutationalStage,
+    },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
 };

--- a/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_ctx/src/lib.rs
@@ -20,7 +20,7 @@ use libafl::{
     events::SimpleRestartingEventManager,
     executors::{
         inprocess::{HookableInProcessExecutor, InProcessExecutor},
-        ExitKind,
+        ExitKind, ShadowExecutor,
     },
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},

--- a/fuzzers/inprocess/fuzzbench_text/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_text/src/lib.rs
@@ -40,7 +40,7 @@ use libafl::{
     },
     stages::{
         calibrate::CalibrationStage, power::StdPowerMutationalStage, GeneralizationStage,
-        StdMutationalStage, TracingStage,
+        StdMutationalStage,
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,
@@ -415,7 +415,7 @@ fn fuzz_binary(
     // Setup a tracing stage in which we log comparisons
     let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
 
-    let tracing = ShadownTracingStage::new();
+    let tracing = ShadowTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(calibration, tracing, i2s, power);
@@ -642,7 +642,7 @@ fn fuzz_text(
     )?;
     // Setup a tracing stage in which we log comparisons
     let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
-    let tracing = ShadownTracingStage::new();
+    let tracing = ShadowTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(generalization, calibration, tracing, i2s, power, grimoire);

--- a/fuzzers/inprocess/fuzzbench_text/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_text/src/lib.rs
@@ -413,14 +413,9 @@ fn fuzz_binary(
     )?;
 
     // Setup a tracing stage in which we log comparisons
-    let tracing = TracingStage::new(InProcessExecutor::with_timeout(
-        &mut tracing_harness,
-        tuple_list!(cmplog_observer),
-        &mut fuzzer,
-        &mut state,
-        &mut mgr,
-        timeout * 10,
-    )?);
+    let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
+
+    let tracing = ShadownTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(calibration, tracing, i2s, power);
@@ -646,15 +641,8 @@ fn fuzz_text(
         timeout,
     )?;
     // Setup a tracing stage in which we log comparisons
-    let tracing = TracingStage::new(InProcessExecutor::with_timeout(
-        &mut tracing_harness,
-        tuple_list!(cmplog_observer),
-        &mut fuzzer,
-        &mut state,
-        &mut mgr,
-        // Give it more time!
-        timeout * 10,
-    )?);
+    let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
+    let tracing = ShadownTracingStage::new();
 
     // The order of the stages matter!
     let mut stages = tuple_list!(generalization, calibration, tracing, i2s, power, grimoire);

--- a/fuzzers/inprocess/fuzzbench_text/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_text/src/lib.rs
@@ -400,8 +400,6 @@ fn fuzz_binary(
         ExitKind::Ok
     };
 
-    let mut tracing_harness = harness;
-
     // Create the executor for an in-process function with one observer for edge coverage and one for the execution time
     let mut executor = InProcessExecutor::with_timeout(
         &mut harness,
@@ -626,8 +624,6 @@ fn fuzz_text(
         }
         ExitKind::Ok
     };
-
-    let mut tracing_harness = harness;
 
     let generalization = GeneralizationStage::new(&edges_observer);
 

--- a/fuzzers/inprocess/fuzzbench_text/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_text/src/lib.rs
@@ -19,7 +19,7 @@ use content_inspector::inspect;
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleRestartingEventManager,
-    executors::{inprocess::InProcessExecutor, ExitKind},
+    executors::{inprocess::InProcessExecutor, ExitKind, ShadowExecutor},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
     fuzzer::{Fuzzer, StdFuzzer},

--- a/fuzzers/inprocess/fuzzbench_text/src/lib.rs
+++ b/fuzzers/inprocess/fuzzbench_text/src/lib.rs
@@ -40,7 +40,7 @@ use libafl::{
     },
     stages::{
         calibrate::CalibrationStage, power::StdPowerMutationalStage, GeneralizationStage,
-        StdMutationalStage,
+        ShadowTracingStage, StdMutationalStage,
     },
     state::{HasCorpus, StdState},
     Error, HasMetadata,

--- a/fuzzers/inprocess/libfuzzer_stb_image/src/main.rs
+++ b/fuzzers/inprocess/libfuzzer_stb_image/src/main.rs
@@ -152,7 +152,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     }
 
     // Setup a tracing stage in which we log comparisons
-    let tracing = ShadowTracingStage::new(&mut executor);
+    let tracing = ShadowTracingStage::new();
 
     // Setup a randomic Input2State stage
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));

--- a/fuzzers/structure_aware/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
+++ b/fuzzers/structure_aware/libfuzzer_stb_image_concolic/fuzzer/src/main.rs
@@ -190,7 +190,7 @@ fn fuzz(
     }
 
     // Setup a tracing stage in which we log comparisons
-    let tracing = ShadowTracingStage::new(&mut executor);
+    let tracing = ShadowTracingStage::new();
 
     // Setup a randomic Input2State stage
     let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(I2SRandReplace::new())));

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -37,7 +37,7 @@ pub use sync::*;
 #[cfg(feature = "std")]
 pub use time_tracker::TimeTrackingStageWrapper;
 pub use tmin::{ObserverEqualityFactory, ObserverEqualityFeedback, StdTMinMutationalStage};
-pub use tracing::{ShadowTracingStage, TracingStage};
+pub use tracing::TracingStage;
 pub use tuneable::*;
 use tuple_list::NonEmptyTuple;
 #[cfg(feature = "unicode")]

--- a/libafl/src/stages/mod.rs
+++ b/libafl/src/stages/mod.rs
@@ -57,6 +57,9 @@ pub mod mutational;
 pub mod push;
 pub mod tmin;
 
+pub mod shadow;
+pub use shadow::*;
+
 pub mod replay;
 pub use replay::*;
 

--- a/libafl/src/stages/shadow.rs
+++ b/libafl/src/stages/shadow.rs
@@ -1,0 +1,107 @@
+//! A stage that runs the shadow executor using also the shadow observers. Unlike tracing stage, this
+//! stage *CAN* be used with inprocess executor.
+
+/// A stage that runs the shadow executor using also the shadow observers
+#[derive(Clone, Debug)]
+pub struct ShadowTracingStage<E, EM, I, SOT, S, Z> {
+    name: Cow<'static, str>,
+    phantom: PhantomData<(E, EM, I, SOT, S, Z)>,
+}
+
+/// The counter for giving this stage unique id
+static mut SHADOW_TRACING_STAGE_ID: usize = 0;
+/// Name for shadow tracing stage
+pub static SHADOW_TRACING_STAGE_NAME: &str = "shadow";
+
+impl<E, EM, I, SOT, S, Z> Named for ShadowTracingStage<E, EM, I, SOT, S, Z> {
+    fn name(&self) -> &Cow<'static, str> {
+        &self.name
+    }
+}
+
+impl<E, EM, I, SOT, S, Z> Stage<ShadowExecutor<E, I, S, SOT>, EM, S, Z>
+    for ShadowTracingStage<E, EM, I, SOT, S, Z>
+where
+    E: Executor<EM, I, S, Z> + HasObservers,
+    E::Observers: ObserversTuple<I, S>,
+    SOT: ObserversTuple<I, S>,
+    S: HasExecutions
+        + HasCorpus<I>
+        + HasNamedMetadata
+        + Debug
+        + HasCurrentTestcase<I>
+        + HasCurrentCorpusId
+        + MaybeHasClientPerfMonitor,
+{
+    #[inline]
+    fn perform(
+        &mut self,
+        fuzzer: &mut Z,
+        executor: &mut ShadowExecutor<E, I, S, SOT>,
+        state: &mut S,
+        manager: &mut EM,
+    ) -> Result<(), Error> {
+        start_timer!(state);
+        let input = state.current_input_cloned()?;
+
+        mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
+
+        start_timer!(state);
+        executor
+            .shadow_observers_mut()
+            .pre_exec_all(state, &input)?;
+        executor.observers_mut().pre_exec_all(state, &input)?;
+        mark_feature_time!(state, PerfFeature::PreExecObservers);
+
+        start_timer!(state);
+        let exit_kind = executor.run_target(fuzzer, state, manager, &input)?;
+        mark_feature_time!(state, PerfFeature::TargetExecution);
+
+        start_timer!(state);
+        executor
+            .shadow_observers_mut()
+            .post_exec_all(state, &input, &exit_kind)?;
+        executor
+            .observers_mut()
+            .post_exec_all(state, &input, &exit_kind)?;
+        mark_feature_time!(state, PerfFeature::PostExecObservers);
+
+        Ok(())
+    }
+}
+
+impl<E, EM, I, SOT, S, Z> Restartable<S> for ShadowTracingStage<E, EM, I, SOT, S, Z>
+where
+    S: HasNamedMetadata + HasCurrentCorpusId,
+{
+    fn should_restart(&mut self, state: &mut S) -> Result<bool, Error> {
+        RetryCountRestartHelper::no_retry(state, &self.name)
+    }
+
+    fn clear_progress(&mut self, state: &mut S) -> Result<(), Error> {
+        RetryCountRestartHelper::clear_progress(state, &self.name)
+    }
+}
+
+impl<E, EM, I, SOT, S, Z> ShadowTracingStage<E, EM, I, SOT, S, Z>
+where
+    E: Executor<EM, I, S, Z> + HasObservers,
+    S: HasExecutions + HasCorpus<I>,
+    SOT: ObserversTuple<I, S>,
+{
+    /// Creates a new default stage
+    pub fn new() -> Self {
+        // unsafe but impossible that you create two threads both instantiating this instance
+        let stage_id = unsafe {
+            let ret = SHADOW_TRACING_STAGE_ID;
+            SHADOW_TRACING_STAGE_ID += 1;
+            ret
+        };
+        Self {
+            name: Cow::Owned(
+                SHADOW_TRACING_STAGE_NAME.to_owned() + ":" + stage_id.to_string().as_str(),
+            ),
+            phantom: PhantomData,
+        }
+    }
+}

--- a/libafl/src/stages/shadow.rs
+++ b/libafl/src/stages/shadow.rs
@@ -1,6 +1,27 @@
 //! A stage that runs the shadow executor using also the shadow observers. Unlike tracing stage, this
 //! stage *CAN* be used with inprocess executor.
 
+use alloc::{
+    borrow::{Cow, ToOwned},
+    string::ToString,
+};
+use core::{fmt::Debug, marker::PhantomData};
+
+use libafl_bolts::Named;
+
+#[cfg(feature = "introspection")]
+use crate::monitors::stats::PerfFeature;
+use crate::{
+    Error, HasNamedMetadata,
+    corpus::HasCurrentCorpusId,
+    executors::{Executor, HasObservers, ShadowExecutor},
+    mark_feature_time,
+    observers::ObserversTuple,
+    stages::{Restartable, RetryCountRestartHelper, Stage},
+    start_timer,
+    state::{HasCorpus, HasCurrentTestcase, HasExecutions, MaybeHasClientPerfMonitor},
+};
+
 /// A stage that runs the shadow executor using also the shadow observers
 #[derive(Clone, Debug)]
 pub struct ShadowTracingStage<E, EM, I, SOT, S, Z> {

--- a/libafl/src/stages/shadow.rs
+++ b/libafl/src/stages/shadow.rs
@@ -29,6 +29,17 @@ pub struct ShadowTracingStage<E, EM, I, SOT, S, Z> {
     phantom: PhantomData<(E, EM, I, SOT, S, Z)>,
 }
 
+impl<E, EM, I, SOT, S, Z> Default for ShadowTracingStage<E, EM, I, SOT, S, Z>
+where
+    E: Executor<EM, I, S, Z> + HasObservers,
+    S: HasExecutions + HasCorpus<I>,
+    SOT: ObserversTuple<I, S>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// The counter for giving this stage unique id
 static mut SHADOW_TRACING_STAGE_ID: usize = 0;
 /// Name for shadow tracing stage

--- a/libafl/src/stages/tracing.rs
+++ b/libafl/src/stages/tracing.rs
@@ -13,7 +13,7 @@ use crate::monitors::stats::PerfFeature;
 use crate::{
     Error, HasNamedMetadata,
     corpus::HasCurrentCorpusId,
-    executors::{Executor, HasObservers, ShadowExecutor},
+    executors::{Executor, HasObservers},
     inputs::Input,
     mark_feature_time,
     observers::ObserversTuple,
@@ -25,7 +25,7 @@ use crate::{
 /// A stage that runs a tracer executor
 /// This should *NOT* be used with inprocess executor
 #[derive(Clone, Debug)]
-pub struct TracerStage<EM, I, TE, S, Z> {
+pub struct TracingStage<EM, I, TE, S, Z> {
     name: Cow<'static, str>,
     tracer_executor: TE,
     phantom: PhantomData<(EM, I, TE, S, Z)>,

--- a/libafl/src/stages/tracing.rs
+++ b/libafl/src/stages/tracing.rs
@@ -23,8 +23,9 @@ use crate::{
 };
 
 /// A stage that runs a tracer executor
+/// This should *NOT* be used with inprocess executor
 #[derive(Clone, Debug)]
-pub struct TracingStage<EM, I, TE, S, Z> {
+pub struct TracerStage<EM, I, TE, S, Z> {
     name: Cow<'static, str>,
     tracer_executor: TE,
     phantom: PhantomData<(EM, I, TE, S, Z)>,
@@ -144,110 +145,5 @@ impl<EM, I, TE, S, Z> TracingStage<EM, I, TE, S, Z> {
     /// Gets the underlying tracer executor (mut)
     pub fn executor_mut(&mut self) -> &mut TE {
         &mut self.tracer_executor
-    }
-}
-
-/// A stage that runs the shadow executor using also the shadow observers
-#[derive(Clone, Debug)]
-pub struct ShadowTracingStage<E, EM, I, SOT, S, Z> {
-    name: Cow<'static, str>,
-    phantom: PhantomData<(E, EM, I, SOT, S, Z)>,
-}
-
-/// The counter for giving this stage unique id
-static mut SHADOW_TRACING_STAGE_ID: usize = 0;
-/// Name for shadow tracing stage
-pub static SHADOW_TRACING_STAGE_NAME: &str = "shadow";
-
-impl<E, EM, I, SOT, S, Z> Named for ShadowTracingStage<E, EM, I, SOT, S, Z> {
-    fn name(&self) -> &Cow<'static, str> {
-        &self.name
-    }
-}
-
-impl<E, EM, I, SOT, S, Z> Stage<ShadowExecutor<E, I, S, SOT>, EM, S, Z>
-    for ShadowTracingStage<E, EM, I, SOT, S, Z>
-where
-    E: Executor<EM, I, S, Z> + HasObservers,
-    E::Observers: ObserversTuple<I, S>,
-    SOT: ObserversTuple<I, S>,
-    S: HasExecutions
-        + HasCorpus<I>
-        + HasNamedMetadata
-        + Debug
-        + HasCurrentTestcase<I>
-        + HasCurrentCorpusId
-        + MaybeHasClientPerfMonitor,
-{
-    #[inline]
-    fn perform(
-        &mut self,
-        fuzzer: &mut Z,
-        executor: &mut ShadowExecutor<E, I, S, SOT>,
-        state: &mut S,
-        manager: &mut EM,
-    ) -> Result<(), Error> {
-        start_timer!(state);
-        let input = state.current_input_cloned()?;
-
-        mark_feature_time!(state, PerfFeature::GetInputFromCorpus);
-
-        start_timer!(state);
-        executor
-            .shadow_observers_mut()
-            .pre_exec_all(state, &input)?;
-        executor.observers_mut().pre_exec_all(state, &input)?;
-        mark_feature_time!(state, PerfFeature::PreExecObservers);
-
-        start_timer!(state);
-        let exit_kind = executor.run_target(fuzzer, state, manager, &input)?;
-        mark_feature_time!(state, PerfFeature::TargetExecution);
-
-        start_timer!(state);
-        executor
-            .shadow_observers_mut()
-            .post_exec_all(state, &input, &exit_kind)?;
-        executor
-            .observers_mut()
-            .post_exec_all(state, &input, &exit_kind)?;
-        mark_feature_time!(state, PerfFeature::PostExecObservers);
-
-        Ok(())
-    }
-}
-
-impl<E, EM, I, SOT, S, Z> Restartable<S> for ShadowTracingStage<E, EM, I, SOT, S, Z>
-where
-    S: HasNamedMetadata + HasCurrentCorpusId,
-{
-    fn should_restart(&mut self, state: &mut S) -> Result<bool, Error> {
-        RetryCountRestartHelper::no_retry(state, &self.name)
-    }
-
-    fn clear_progress(&mut self, state: &mut S) -> Result<(), Error> {
-        RetryCountRestartHelper::clear_progress(state, &self.name)
-    }
-}
-
-impl<E, EM, I, SOT, S, Z> ShadowTracingStage<E, EM, I, SOT, S, Z>
-where
-    E: Executor<EM, I, S, Z> + HasObservers,
-    S: HasExecutions + HasCorpus<I>,
-    SOT: ObserversTuple<I, S>,
-{
-    /// Creates a new default stage
-    pub fn new(_executor: &mut ShadowExecutor<E, I, S, SOT>) -> Self {
-        // unsafe but impossible that you create two threads both instantiating this instance
-        let stage_id = unsafe {
-            let ret = SHADOW_TRACING_STAGE_ID;
-            SHADOW_TRACING_STAGE_ID += 1;
-            ret
-        };
-        Self {
-            name: Cow::Owned(
-                SHADOW_TRACING_STAGE_NAME.to_owned() + ":" + stage_id.to_string().as_str(),
-            ),
-            phantom: PhantomData,
-        }
     }
 }

--- a/libafl_libfuzzer/runtime/src/lib.rs
+++ b/libafl_libfuzzer/runtime/src/lib.rs
@@ -148,7 +148,7 @@ macro_rules! fuzz_with {
         };
         use libafl::{
             corpus::Corpus,
-            executors::{ExitKind, InProcessExecutor},
+            executors::{ExitKind, InProcessExecutor, ShadowExecutor},
             feedback_and_fast, feedback_not, feedback_or, feedback_or_fast,
             feedbacks::{ConstFeedback, CrashFeedback, MaxMapFeedback, NewHashFeedback, TimeFeedback, TimeoutFeedback},
             generators::RandBytesGenerator,
@@ -166,7 +166,7 @@ macro_rules! fuzz_with {
             },
             stages::{
                 CalibrationStage, GeneralizationStage, IfStage, StdMutationalStage,
-                StdPowerMutationalStage, UnicodeIdentificationStage
+                StdPowerMutationalStage, UnicodeIdentificationStage, ShadowTracingStage,
             },
             state::{HasCorpus, StdState},
             StdFuzzer,

--- a/libafl_libfuzzer/runtime/src/lib.rs
+++ b/libafl_libfuzzer/runtime/src/lib.rs
@@ -488,7 +488,7 @@ macro_rules! fuzz_with {
                 }
             }
 
-            let executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
+            let mut executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
             // Setup a tracing stage in which we log comparisons
             let tracing = IfStage::new(|_, _, _, _| Ok(!$options.skip_tracing()), (ShadowTracingStage::new(), ()));
 

--- a/libafl_libfuzzer/runtime/src/lib.rs
+++ b/libafl_libfuzzer/runtime/src/lib.rs
@@ -438,8 +438,6 @@ macro_rules! fuzz_with {
                 }
             };
 
-            let mut tracing_harness = harness;
-
             let add_extra_observer = $extra_obsv;
             let observers = add_extra_observer(
                 tuple_list!(edges_observer, size_edges_observer, time_observer, backtrace_observer, oom_observer),

--- a/libafl_libfuzzer/runtime/src/lib.rs
+++ b/libafl_libfuzzer/runtime/src/lib.rs
@@ -166,7 +166,7 @@ macro_rules! fuzz_with {
             },
             stages::{
                 CalibrationStage, GeneralizationStage, IfStage, StdMutationalStage,
-                StdPowerMutationalStage, UnicodeIdentificationStage, TracingStage,
+                StdPowerMutationalStage, UnicodeIdentificationStage
             },
             state::{HasCorpus, StdState},
             StdFuzzer,
@@ -488,14 +488,9 @@ macro_rules! fuzz_with {
                 }
             }
 
+            let executor = ShadowExecutor::new(executor, tuple_list!(cmplog_observer));
             // Setup a tracing stage in which we log comparisons
-            let tracing = IfStage::new(|_, _, _, _| Ok(!$options.skip_tracing()), (TracingStage::new(InProcessExecutor::new(
-                &mut tracing_harness,
-                tuple_list!(cmplog_observer),
-                &mut fuzzer,
-                &mut state,
-                &mut mgr,
-            )?), ()));
+            let tracing = IfStage::new(|_, _, _, _| Ok(!$options.skip_tracing()), (ShadowTracingStage::new(), ()));
 
             // The order of the stages matter!
             let mut stages = tuple_list!(

--- a/libafl_sugar/src/inmemory.rs
+++ b/libafl_sugar/src/inmemory.rs
@@ -261,7 +261,7 @@ where
             }
 
             // Setup a tracing stage in which we log comparisons
-            let tracing = ShadowTracingStage::new(&mut executor);
+            let tracing = ShadowTracingStage::new();
 
             // Setup a randomic Input2State stage
             let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -299,7 +299,7 @@ where
                 }
 
                 // Setup a tracing stage in which we log comparisons
-                let tracing = ShadowTracingStage::new(&mut executor);
+                let tracing = ShadowTracingStage::new();
 
                 // Setup a randomic Input2State stage
                 let i2s = StdMutationalStage::new(StdScheduledMutator::new(tuple_list!(


### PR DESCRIPTION
## Description

First, separate ShadowTracingStage and TracingStage into different files
These two should be used at very different times.

Essentially in libafl it is not possible to have more than one inprocess executor or its childeren.
So i fixed the misuse of them in fuzzers/*

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
