### PR TITLE
Added heap feature

### DIFF
--- a/libafl_qemu/librasan/asan/Cargo.toml
+++ b/libafl_qemu/librasan/asan/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 default = [
   "dlmalloc",
   "guest",
+  "heap",
   "hooks",
   "host",
   "libc",
@@ -21,6 +22,7 @@ default = [
 ]
 dlmalloc = ["dep:dlmalloc"]
 guest = []
+heap = []
 hooks = []
 host = ["dep:syscalls"]
 libc = ["dep:libc"]

--- a/libafl_qemu/librasan/asan/src/mem.rs
+++ b/libafl_qemu/librasan/asan/src/mem.rs
@@ -3,10 +3,10 @@ use core::{
     slice::{from_raw_parts, from_raw_parts_mut},
 };
 
-#[cfg(feature = "dlmalloc")]
+#[cfg(all(feature = "heap", feature = "dlmalloc"))]
 use crate::allocator::backend::dlmalloc::DlmallocBackend;
 
-#[cfg(all(feature = "linux", not(feature = "libc")))]
+#[cfg(all(feature = "heap", feature = "linux", not(feature = "libc")))]
 type Mmap = crate::mmap::linux::LinuxMmap;
 
 #[cfg(feature = "libc")]
@@ -14,14 +14,15 @@ type Mmap = crate::mmap::libc::LibcMmap<
     crate::symbols::dlsym::DlSymSymbols<crate::symbols::dlsym::LookupTypeNext>,
 >;
 
+#[cfg(all(feature = "heap"))]
 const PAGE_SIZE: usize = 4096;
 
 #[global_allocator]
-#[cfg(all(feature = "dlmalloc", not(feature = "mimalloc")))]
+#[cfg(all(feature = "heap", feature = "dlmalloc", not(feature = "mimalloc")))]
 static GLOBAL_ALLOCATOR: DlmallocBackend<Mmap> = DlmallocBackend::new(PAGE_SIZE);
 
 #[global_allocator]
-#[cfg(all(feature = "dlmalloc", feature = "mimalloc"))]
+#[cfg(all(feature = "heap", feature = "dlmalloc", feature = "mimalloc"))]
 static GLOBAL_ALLOCATOR: baby_mimalloc::MimallocMutexWrapper<DlmallocBackend<Mmap>> =
     baby_mimalloc::MimallocMutexWrapper::with_os_allocator(DlmallocBackend::new(PAGE_SIZE));
 

--- a/libafl_qemu/librasan/gasan/Cargo.toml
+++ b/libafl_qemu/librasan/gasan/Cargo.toml
@@ -15,6 +15,7 @@ test = ["asan/test", "dummy_libc/test"]
 asan = { path = "../asan", default-features = false, features = [
   "dlmalloc",
   "guest",
+  "heap",
   "hooks",
   "libc",
   "mimalloc",

--- a/libafl_qemu/librasan/qasan/Cargo.toml
+++ b/libafl_qemu/librasan/qasan/Cargo.toml
@@ -14,6 +14,7 @@ test = ["asan/test", "dummy_libc/test"]
 [dependencies]
 asan = { path = "../asan", default-features = false, features = [
   "dlmalloc",
+  "heap",
   "hooks",
   "host",
   "libc",

--- a/libafl_qemu/librasan/zasan/Cargo.toml
+++ b/libafl_qemu/librasan/zasan/Cargo.toml
@@ -15,6 +15,7 @@ test = ["asan/test"]
 asan = { path = "../asan", default-features = false, features = [
   "dlmalloc",
   "guest",
+  "heap",
   "hooks",
   "host",
   "linux",


### PR DESCRIPTION
## Description

Make the inclusion of a `#[global_allocator]` option when using `librasan` by configuration of the `heap` feature

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
