### PR TITLE
Fix git pager (needs less, not cat, for expected behaviour).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && \
     gdb-multiarch \
     git \
     gnupg \
+    less \
     libc6-dev:i386 \
     libclang-dev \
     libgcc-12-dev:i386 \
@@ -71,8 +72,6 @@ RUN set -ex &&\
 RUN apt-get update && \
   apt-get install -y \
   clang-format-${LLVM_VERSION}
-
-RUN git config --global core.pager cat
 
 # Install a modern version of QEMU
 WORKDIR /root


### PR DESCRIPTION
## Description

A previous commit added git config `core.pager=cat` to the devcontainer, presumably because the pager bevahiour was sub-standard. A better solution is to install less.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
