### PR TITLE
Proposed fix for #3094, issue with trace-cmp

### DIFF
--- a/libafl_targets/src/windows_asan.rs
+++ b/libafl_targets/src/windows_asan.rs
@@ -29,11 +29,8 @@ unsafe extern "C" {
 ///
 /// # Safety
 /// Calls the unsafe `__sanitizer_set_death_callback` symbol, but should be safe to call otherwise.
-pub unsafe fn setup_asan_callback<E, EM, I, OF, S, Z>(
-    _executor: &E,
-    _event_mgr: &EM,
-    _fuzzer: &Z,
-) where
+pub unsafe fn setup_asan_callback<E, EM, I, OF, S, Z>(_executor: &E, _event_mgr: &EM, _fuzzer: &Z)
+where
     E: Executor<EM, I, S, Z> + HasObservers,
     E::Observers: ObserversTuple<I, S>,
     EM: EventFirer<I, S> + EventRestarter<S>,


### PR DESCRIPTION
## Description

There is an issue with one of the macros for generating `__libafl_targets_value_profileX` calls, which resulted in all instances calling `__libafl_targets_value_profile1` - meaning that only 1 byte of the conditional check got passed through.

@ammaraskar: you said that you found the bug due to some unexpected results (not being able to break through magic numbers); any chance you can rerun your setup and see if this fixes it?

Also: not sure if the formatter setup has changed or what - let me know if you'd prefer I remove the whitespace changes from this PR and create a new one after. Only `libafl_targets/src/sancov_cmp.c:17` has changed semantically.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
