### PR TITLE
Enable building libpng on CI without using GUI

### DIFF
--- a/fuzzers/binary_only/frida_libpng/Justfile
+++ b/fuzzers/binary_only/frida_libpng/Justfile
@@ -25,8 +25,30 @@ harness: lib
     clang++ -O3 harness.o libpng-1.6.37/.libs/libpng16.a -shared -lz -o libpng-harness.so
 
 [windows]
-harness:
-    cl /c harness_win.cpp && link harness_win.obj /dll
+zlib:
+    powershell -Command Invoke-WebRequest -OutFile zlib-1.2.11.tar.gz https://zlib.net/fossils/zlib-1.2.11.tar.gz
+    tar -xvf zlib-1.2.11.tar.gz
+    del /q zlib-1.2.11.tar.gz
+    move zlib-1.2.11 zlib
+
+[windows]
+lib: zlib
+    cd zlib && cmake -A x64 -DCMAKE_CXX_COMPILER=cl . && cmake --build . --config Release
+
+[windows]
+libpng:
+    powershell -Command Invoke-WebRequest -OutFile libpng-1.6.37.tar.gz https://github.com/glennrp/libpng/archive/refs/tags/v1.6.37.tar.gz
+    tar -xvf libpng-1.6.37.tar.gz
+    del /q libpng-1.6.37.tar.gz
+
+[windows]
+lib2: libpng
+    cd libpng-1.6.37 && cmake -A x64 -DCMAKE_CXX_COMPILER=cl -DZLIB_ROOT=..\zlib -DZLIB_LIBRARY=..\zlib\Release\zlib.lib . && cmake --build . --config Release
+
+[windows]
+harness: lib lib2
+    copy libpng-1.6.37\Release\libpng16.lib . && copy libpng-1.6.37\Release\libpng16.dll . && copy zlib\Release\zlib.lib . && copy zlib\Release\zlib.dll . && copy target\release\frida_fuzzer.exe .
+    cl /O2 /c /I .\libpng-1.6.37 harness.cc /Fo:harness.obj && link /DLL /OUT:libpng-harness.dll harness.obj libpng16.lib zlib.lib
 
 [unix]
 [windows]
@@ -39,7 +61,7 @@ run: build harness
 
 [windows]
 run: build harness
-    {{TARGET_DIR}}\{{PROFILE}}\{{FUZZER_NAME_WIN}} -F LLVMFuzzerTestOneInput -H .\harness_win.dll -l .\harness_win.dll --cores=0
+    {{TARGET_DIR}}\{{PROFILE}}\{{FUZZER_NAME_WIN}} -F LLVMFuzzerTestOneInput -H .\libpng-harness.dll -l .\libpng-harness.dll -l .\zlib.dll -l .\libpng16.dll --cores=0
 
 [unix]
 test: build harness
@@ -57,7 +79,7 @@ test: build harness
 [windows]
 [script("cmd.exe", "/c")]
 test: build harness
-    start "" "{{TARGET_DIR}}\{{PROFILE}}\{{FUZZER_NAME_WIN}}" -F LLVMFuzzerTestOneInput -H .\harness_win.dll -l .\harness_win.dll --cores=0
+    start "" "{{TARGET_DIR}}\{{PROFILE}}\{{FUZZER_NAME_WIN}}" -F LLVMFuzzerTestOneInput -H .\libpng-harness.dll -l .\libpng-harness.dll -l .\zlib.dll -l .\libpng16.dll --cores=0
     ping -n 10 127.0.0.1>NUL && taskkill /im frida_fuzzer.exe /F
     dir /a-d corpus_discovered && (echo Files exist) || (exit /b 1337)
 

--- a/fuzzers/binary_only/frida_libpng/harness.cc
+++ b/fuzzers/binary_only/frida_libpng/harness.cc
@@ -85,12 +85,9 @@ extern "C" int afl_libfuzzer_init() {
 
 static char *allocation = NULL;
 
-// Export this symbol
-#ifdef _WIN32
-  #define HARNESS_EXPORTS __declspec(dllexport)
+#ifdef _MSC_VER
   #define NOINLINE __declspec(noinline)
 #else
-  #define HARNESS_EXPORTS
   #define NOINLINE __attribute__((noinline))
 #endif
 
@@ -117,6 +114,13 @@ NOINLINE void func1() {
   // printf("func1\n");
   func2();
 }
+
+// Export this symbol
+#ifdef _WIN32
+  #define HARNESS_EXPORTS __declspec(dllexport)
+#else
+  #define HARNESS_EXPORTS
+#endif
 
 // Entry point for LibFuzzer.
 // Roughly follows the libpng book example:

--- a/fuzzers/binary_only/frida_libpng/harness.cc
+++ b/fuzzers/binary_only/frida_libpng/harness.cc
@@ -85,7 +85,16 @@ extern "C" int afl_libfuzzer_init() {
 
 static char *allocation = NULL;
 
-__attribute__((noinline)) void func3(char *alloc) {
+// Export this symbol
+#ifdef _WIN32
+  #define HARNESS_EXPORTS __declspec(dllexport)
+  #define NOINLINE __declspec(noinline)
+#else
+  #define HARNESS_EXPORTS
+  #define NOINLINE __attribute__((noinline))
+#endif
+
+NOINLINE void func3(char *alloc) {
 // printf("func3\n");
 #ifdef _WIN32
   if ((rand() % 2) == 0) {
@@ -99,27 +108,20 @@ __attribute__((noinline)) void func3(char *alloc) {
   }
 #endif
 }
-__attribute__((noinline)) void func2() {
+NOINLINE void func2() {
   allocation = (char *)malloc(0xff);
   // printf("func2\n");
   func3(allocation);
 }
-__attribute__((noinline)) void func1() {
+NOINLINE void func1() {
   // printf("func1\n");
   func2();
 }
 
-// Export this symbol
-#ifdef _WIN32
-  #define HARNESS_EXPORTS __declspec(dllexport)
-#else
-  #define HARNESS_EXPORTS
-#endif
-
 // Entry point for LibFuzzer.
 // Roughly follows the libpng book example:
 // http://www.libpng.org/pub/png/book/chapter13.html
-HARNESS_EXPORTS extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data,
+extern "C" HARNESS_EXPORTS int LLVMFuzzerTestOneInput(const uint8_t *data,
                                                       size_t         size) {
   if (size >= 8 && *(uint64_t *)data == 0xABCDEFAA8F1324AA) { abort(); }
   if (size < kPngHeaderSize) { return 0; }


### PR DESCRIPTION
## Description

Added windows full build of libpng to Justfile. Enabled harness.cc for cl.exe. Updated README.

Harness changes are minimal and works compiling with clang or cl on windows as well including fuzzing with the harnesses that both compilers generated so should compile fine with clang on linux.

## Checklist

- [x]  I have only tested on windows using `just test`
- [ ] I have run `./scripts/precommit.sh` and addressed all comments
