### PR TITLE
Add back executions to Testcase

### DIFF
--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -407,6 +407,7 @@ impl<I> InMemoryOnDiskCorpus<I> {
             let ondisk_meta = OnDiskMetadata {
                 metadata: testcase.metadata_map(),
                 exec_time: testcase.exec_time(),
+                executions: testcase.executions(),
             };
 
             let mut tmpfile = File::create(&tmpfile_path)?;

--- a/libafl/src/corpus/ondisk.rs
+++ b/libafl/src/corpus/ondisk.rs
@@ -43,6 +43,8 @@ pub struct OnDiskMetadata<'a> {
     pub metadata: &'a SerdeAnyMap,
     /// The exec time for this [`Testcase`]
     pub exec_time: &'a Option<Duration>,
+    /// The executions of this [`Testcase`]
+    pub executions: &'a u64,
 }
 
 /// A corpus able to store [`Testcase`]s to disk, and load them from disk, when they are being used.

--- a/libafl/src/corpus/testcase.rs
+++ b/libafl/src/corpus/testcase.rs
@@ -50,6 +50,8 @@ pub struct Testcase<I> {
     cached_len: Option<usize>,
     /// Number of fuzzing iterations of this particular input updated in `perform_mutational`
     scheduled_count: usize,
+    /// Number of executions done at discovery time
+    executions: u64,
     /// Parent [`CorpusId`], if known
     parent_id: Option<CorpusId>,
     /// If the testcase is "disabled"
@@ -145,6 +147,24 @@ impl<I> Testcase<I> {
         &mut self.metadata_path
     }
 
+    /// Get the executions
+    #[inline]
+    pub fn executions(&self) -> &u64 {
+        &self.executions
+    }
+
+    /// Get the executions (mutable)
+    #[inline]
+    pub fn executions_mut(&mut self) -> &mut u64 {
+        &mut self.executions
+    }
+
+    /// Set the executions
+    #[inline]
+    pub fn set_executions(&mut self, executions: u64) {
+        self.executions = executions;
+    }
+
     /// Get the execution time of the testcase
     #[inline]
     pub fn exec_time(&self) -> &Option<Duration> {
@@ -228,6 +248,7 @@ impl<I> Testcase<I> {
             metadata_path: None,
             exec_time: None,
             cached_len: None,
+            executions: 0,
             scheduled_count: 0,
             parent_id: None,
             disabled: false,
@@ -252,6 +273,7 @@ impl<I> Testcase<I> {
             metadata_path: None,
             exec_time: None,
             cached_len: None,
+            executions: 0,
             scheduled_count: 0,
             parent_id: Some(parent_id),
             disabled: false,
@@ -278,6 +300,7 @@ impl<I> Testcase<I> {
             metadata_path: None,
             exec_time: None,
             cached_len: None,
+            executions: 0,
             scheduled_count: 0,
             parent_id: None,
             disabled: false,
@@ -333,6 +356,7 @@ impl<I> Default for Testcase<I> {
             #[cfg(feature = "std")]
             metadata_path: None,
             disabled: false,
+            executions: 0,
             objectives_found: 0,
             #[cfg(feature = "track_hit_feedbacks")]
             hit_feedbacks: Vec::new(),

--- a/libafl/src/executors/inprocess/mod.rs
+++ b/libafl/src/executors/inprocess/mod.rs
@@ -345,6 +345,7 @@ pub fn run_observers_and_save_state<E, EM, I, OF, S, Z>(
 
     if is_solution {
         let mut new_testcase = Testcase::from(input.clone());
+        new_testcase.set_executions(*state.executions());
         new_testcase.add_metadata(exitkind);
         new_testcase.set_parent_id_optional(*state.corpus().current());
 

--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -677,9 +677,8 @@ where
         let exit_kind = self.execute_input(state, executor, manager, &input)?;
         let observers = executor.observers();
         // Always consider this to be "interesting"
-        let executions = *state.executions();
         let mut testcase = Testcase::from(input.clone());
-        testcase.set_executions(executions);
+        testcase.set_executions(*state.executions());
 
         // Maybe a solution
         #[cfg(not(feature = "introspection"))]

--- a/libafl/src/stages/tmin.rs
+++ b/libafl/src/stages/tmin.rs
@@ -284,6 +284,9 @@ where
                 .feedback_mut()
                 .is_interesting(state, manager, &base, &*observers, &exit_kind)?;
             let mut testcase = Testcase::from(base);
+            testcase.set_executions(*state.executions());
+            testcase.set_parent_id(base_corpus_id);
+
             fuzzer
                 .feedback_mut()
                 .append_metadata(state, manager, &*observers, &mut testcase)?;


### PR DESCRIPTION
## Description

Following #2582, this adds back the `executions` field to `Testcase` and fire an extra event to sync executions metrics, which solves two main issues:

- When a `Event::NewTestcase` is fired, the executions and speed metrics are stale and incorrect.
- Allow users to retrieve the executions of a `Testcase` for post analysis of corpus.

Although the first point can be fixed by fire another `Event::UpdateExecStats`, it is infeasible and not inconvenient to pair such update with new test cases and thus can't fix the second point.

Note that it doesn't add `executions` field to `Event::NewTestcase`.

## Checklist

- [ x ] I have run `./scripts/precommit.sh` and addressed all comments
