### PR TITLE
CI: try to speedup by avoiding unnecessary installs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y lsb-release wget software-properties-common gnupg ninja-build python3-dev python3-pip python3-venv libz3-dev
+        run: sudo apt-get update && sudo apt-get install -y lsb-release wget software-properties-common gnupg libz3-dev
       - name: Install maturin
         run: cargo install --locked maturin
       - uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -171,8 +171,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: ubuntu
     steps:
-      - name: Install curl
-        run: sudo apt-get update && sudo apt-get install clang
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -610,8 +608,6 @@ jobs:
   android:
     runs-on: ubuntu-24.04
     steps:
-      - name: Install curl
-        run: sudo apt-get update && sudo apt-get install clang
       - uses: dtolnay/rust-toolchain@stable
       - uses: nttld/setup-ndk@v1
         with:

--- a/.github/workflows/qemu-fuzzer-tester-prepare/action.yml
+++ b/.github/workflows/qemu-fuzzer-tester-prepare/action.yml
@@ -5,7 +5,10 @@ runs:
   steps:
     - name: Install QEMU deps
       shell: bash
-      run: apt-get update && apt-get install -y qemu-utils sudo python3-msgpack python3-jinja2 curl python3-dev
+      run: |
+        apt-get update 
+        apt-get install -y qemu-utils sudo python3-msgpack python3-jinja2 curl python3-dev gcc-arm-none-eabi \
+          gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
     - uses: dtolnay/rust-toolchain@stable
     - name: enable mult-thread for `make`
       shell: bash

--- a/.github/workflows/ubuntu-prepare/action.yml
+++ b/.github/workflows/ubuntu-prepare/action.yml
@@ -21,16 +21,6 @@ runs:
     - name: Add nightly clippy
       shell: bash
       run: rustup toolchain install nightly --component clippy --allow-downgrade
-    - name: Remove existing clang and LLVM
-      shell: bash
-      run: |
-        for version in {15..30}; do
-          if [ "${{ env.MAIN_LLVM_VERSION }}" != "$version" ]; then
-            if dpkg-query -W -f='${Status}\n' "*llvm-${version}*" 2>/dev/null | grep "install ok installed"; then
-              sudo apt-get purge -y *llvm-${version}* *clang-${version}* lld-${version}* lldb-${version}*
-            fi
-          fi
-        done
     - name: Install cargo-hack
       shell: bash
       run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin

--- a/.github/workflows/ubuntu-prepare/action.yml
+++ b/.github/workflows/ubuntu-prepare/action.yml
@@ -36,6 +36,7 @@ runs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh ${{env.MAIN_LLVM_VERSION}} all
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{env.MAIN_LLVM_VERSION}} 200
     - name: Symlink Headers
       shell: bash
       run: sudo ln -s /usr/include/asm-generic /usr/include/asm

--- a/.github/workflows/ubuntu-prepare/action.yml
+++ b/.github/workflows/ubuntu-prepare/action.yml
@@ -8,8 +8,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y curl lsb-release wget software-properties-common gnupg shellcheck pax-utils \
-          nasm libsqlite3-dev libc6-dev libgtk-3-dev gcc g++ gcc-arm-none-eabi gcc-arm-linux-gnueabi \
-          g++-arm-linux-gnueabi libslirp-dev libz3-dev build-essential \
+          nasm libsqlite3-dev libc6-dev libgtk-3-dev gcc g++ libslirp-dev libz3-dev build-essential \
     - uses: dtolnay/rust-toolchain@stable
     - name: install just
       uses: extractions/setup-just@v2

--- a/.github/workflows/ubuntu-prepare/action.yml
+++ b/.github/workflows/ubuntu-prepare/action.yml
@@ -30,14 +30,12 @@ runs:
     - name: Default to nightly
       shell: bash
       run: rustup default nightly
-    - name: Add LLVM in sources list
+    - name: Install LLVM
       shell: bash
       run: |
-        llvm-config-${{env.MAIN_LLVM_VERSION}} --version || (
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{env.MAIN_LLVM_VERSION}} all
-        )
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh ${{env.MAIN_LLVM_VERSION}} all
     - name: Symlink Headers
       shell: bash
       run: sudo ln -s /usr/include/asm-generic /usr/include/asm

--- a/.github/workflows/ubuntu-prepare/action.yml
+++ b/.github/workflows/ubuntu-prepare/action.yml
@@ -10,6 +10,7 @@ runs:
         sudo apt-get install -y curl lsb-release wget software-properties-common gnupg shellcheck pax-utils \
           nasm libsqlite3-dev libc6-dev libgtk-3-dev gcc g++ gcc-arm-none-eabi gcc-arm-linux-gnueabi \
           g++-arm-linux-gnueabi libslirp-dev libz3-dev build-essential \
+    - uses: dtolnay/rust-toolchain@stable
     - name: install just
       uses: extractions/setup-just@v2
       with:
@@ -22,7 +23,14 @@ runs:
       run: rustup toolchain install nightly --component clippy --allow-downgrade
     - name: Remove existing clang and LLVM
       shell: bash
-      run: sudo apt-get purge -y *llvm* *clang* lld* lldb* opt*
+      run: |
+        for version in {15..30}; do
+          if [ "${{ env.MAIN_LLVM_VERSION }}" != "$version" ]; then
+            if dpkg-query -W -f='${Status}\n' "*llvm-${version}*" 2>/dev/null | grep "install ok installed"; then
+              sudo apt-get purge -y *llvm-${version}* *clang-${version}* lld-${version}* lldb-${version}*
+            fi
+          fi
+        done
     - name: Install cargo-hack
       shell: bash
       run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
@@ -35,9 +43,11 @@ runs:
     - name: Add LLVM in sources list
       shell: bash
       run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh ${{env.MAIN_LLVM_VERSION}} all
+        llvm-config-${{env.MAIN_LLVM_VERSION}} --version || (
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{env.MAIN_LLVM_VERSION}} all
+        )
     - name: Symlink Headers
       shell: bash
       run: sudo ln -s /usr/include/asm-generic /usr/include/asm

--- a/.github/workflows/ubuntu-prepare/action.yml
+++ b/.github/workflows/ubuntu-prepare/action.yml
@@ -5,8 +5,11 @@ runs:
   steps:
     - name: Install and cache deps
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y curl lsb-release wget software-properties-common gnupg ninja-build shellcheck pax-utils nasm libsqlite3-dev libc6-dev libgtk-3-dev gcc g++ gcc-arm-none-eabi gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libslirp-dev libz3-dev build-essential
-    - uses: dtolnay/rust-toolchain@stable
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y curl lsb-release wget software-properties-common gnupg shellcheck pax-utils \
+          nasm libsqlite3-dev libc6-dev libgtk-3-dev gcc g++ gcc-arm-none-eabi gcc-arm-linux-gnueabi \
+          g++-arm-linux-gnueabi libslirp-dev libz3-dev build-essential \
     - name: install just
       uses: extractions/setup-just@v2
       with:


### PR DESCRIPTION
## Description

- GH images come with baked-in software that doesn't come from apt, getting the apt version will just slow down CI since the baked in version will be used anyway.
- Move ARM build chains as suggested by @tokatoka 
- Do not uninstall installed Clang, just set the desired one as default (is quicker)

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
