### PR TITLE
Default to use SIMD acceleration map feedbacks

### DIFF
--- a/fuzzers/inprocess/libfuzzer_libmozjpeg/src/lib.rs
+++ b/fuzzers/inprocess/libfuzzer_libmozjpeg/src/lib.rs
@@ -11,7 +11,7 @@ use libafl::{
     events::{setup_restarting_mgr_std, EventConfig},
     executors::{inprocess::InProcessExecutor, ExitKind},
     feedback_or,
-    feedbacks::{CrashFeedback, MaxMapFeedback},
+    feedbacks::{CrashFeedback, DifferentIsNovel, MapFeedback, MaxMapFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
     inputs::{BytesInput, HasTargetBytes},
     monitors::SimpleMonitor,
@@ -28,6 +28,7 @@ use libafl::{
 };
 use libafl_bolts::{
     rands::StdRand,
+    simd::MaxReducer,
     tuples::{tuple_list, Merge},
     AsSlice,
 };
@@ -101,7 +102,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     let mut feedback = feedback_or!(
         MaxMapFeedback::new(&edges_observer),
         MaxMapFeedback::new(&cmps_observer),
-        MaxMapFeedback::new(&allocs_observer)
+        MapFeedback::<_, DifferentIsNovel, _, MaxReducer>::new(&allocs_observer)
     );
 
     // A feedback to choose if an input is a solution or not

--- a/fuzzers/inprocess/libfuzzer_libpng/src/lib.rs
+++ b/fuzzers/inprocess/libfuzzer_libpng/src/lib.rs
@@ -62,8 +62,6 @@ pub extern "C" fn libafl_main() {
 #[cfg(not(test))]
 fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Result<(), Error> {
     // 'While the stats are state, they are usually used in the broker - which is likely never restarted
-
-    use libafl::feedbacks::simd::{SimdImplmentation, SimdMapFeedback};
     let monitor = MultiMonitor::new(|s| println!("{s}"));
 
     // The restarting state will spawn the same process again as child, then restarted it each time it crashes.
@@ -95,7 +93,7 @@ fn fuzz(corpus_dirs: &[PathBuf], objective_dir: PathBuf, broker_port: u16) -> Re
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
-    let map_feedback = SimdMapFeedback::new(MaxMapFeedback::new(&edges_observer));
+    let map_feedback = MaxMapFeedback::new(&edges_observer);
     let calibration = CalibrationStage::new(&map_feedback);
 
     // Feedback to rate the interestingness of an input

--- a/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.lock
+++ b/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.lock
@@ -193,6 +193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +211,25 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.0.5",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -266,6 +293,36 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -335,7 +392,7 @@ checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
  "getrandom",
  "siphasher",
- "wide",
+ "wide 0.7.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -468,7 +525,7 @@ dependencies = [
  "bitbybit",
  "const_format",
  "const_panic",
- "crossterm",
+ "crossterm 0.29.0",
  "fastbloom",
  "fs2",
  "hashbrown 0.14.5",
@@ -523,6 +580,7 @@ dependencies = [
  "typeid",
  "uds",
  "uuid",
+ "wide 0.7.32 (git+https://github.com/Lokathor/wide?rev=71b5df0b2620da753836fafce5f99076181a49fe)",
  "winapi",
  "windows 0.59.0",
  "windows-result",
@@ -555,6 +613,18 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -773,7 +843,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools",
@@ -838,8 +908,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1154,6 +1237,15 @@ name = "wide"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "git+https://github.com/Lokathor/wide?rev=71b5df0b2620da753836fafce5f99076181a49fe#71b5df0b2620da753836fafce5f99076181a49fe"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.lock
+++ b/fuzzers/structure_aware/baby_fuzzer_multi/Cargo.lock
@@ -193,15 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,25 +202,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "derive_more",
- "document-features",
- "mio",
- "parking_lot",
- "rustix 1.0.5",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -293,36 +266,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -392,7 +335,7 @@ checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
  "getrandom",
  "siphasher",
- "wide 0.7.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wide",
 ]
 
 [[package]]
@@ -525,7 +468,7 @@ dependencies = [
  "bitbybit",
  "const_format",
  "const_panic",
- "crossterm 0.29.0",
+ "crossterm",
  "fastbloom",
  "fs2",
  "hashbrown 0.14.5",
@@ -580,7 +523,6 @@ dependencies = [
  "typeid",
  "uds",
  "uuid",
- "wide 0.7.32 (git+https://github.com/Lokathor/wide?rev=71b5df0b2620da753836fafce5f99076181a49fe)",
  "winapi",
  "windows 0.59.0",
  "windows-result",
@@ -613,18 +555,6 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -843,7 +773,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
- "crossterm 0.28.1",
+ "crossterm",
  "indoc",
  "instability",
  "itertools",
@@ -908,21 +838,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1237,15 +1154,6 @@ name = "wide"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.32"
-source = "git+https://github.com/Lokathor/wide?rev=71b5df0b2620da753836fafce5f99076181a49fe#71b5df0b2620da753836fafce5f99076181a49fe"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/fuzzers/structure_aware/baby_fuzzer_multi/src/main.rs
+++ b/fuzzers/structure_aware/baby_fuzzer_multi/src/main.rs
@@ -21,7 +21,9 @@ use libafl::{
     state::StdState,
     Evaluator,
 };
-use libafl_bolts::{nonnull_raw_mut, rands::StdRand, simd::MinReducer, tuples::tuple_list, AsSlice};
+use libafl_bolts::{
+    nonnull_raw_mut, rands::StdRand, simd::MinReducer, tuples::tuple_list, AsSlice,
+};
 
 /// Coverage map with explicit assignments due to the lack of instrumentation
 static mut SIGNALS: [u8; 128] = [0; 128];

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -196,8 +196,8 @@ nautilus = [
   "regex",
 ]
 
-## Use the best SIMD implementation by our [benchmark](https://github.com/wtdcode/libafl_simd_bench)
-stable_simd = ["libafl_bolts/stable_simd"]
+## Use the best SIMD implementation by our benchmark
+simd = ["libafl_bolts/simd"]
 
 [[example]]
 name = "tui_mock"

--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -39,7 +39,7 @@ default = [
   "regex",
   "serdeany_autoreg",
   "libafl_bolts/xxh3",
-  "stable_simd",
+  "simd",
 ]
 document-features = ["dep:document-features"]
 

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -23,7 +23,6 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 #[cfg(feature = "simd")]
 use super::simd::SimdMapFeedback;
-
 #[cfg(feature = "track_hit_feedbacks")]
 use crate::feedbacks::premature_last_result_err;
 use crate::{

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -39,24 +39,30 @@ use crate::{
     state::HasExecutions,
 };
 
-/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
 #[cfg(feature = "simd")]
+/// A [`SimdMapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
 pub type AflMapFeedback<C, O> = SimdMapFeedback<C, O, SimdOrReducer, u8x32>;
 #[cfg(not(feature = "simd"))]
+/// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
 pub type AflMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, OrReducer>;
 
-/// A [`MapFeedback`] that strives to maximize the map contents.
+
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+/// A [`SimdMapFeedback`] that strives to maximize the map contents.
 pub type MaxMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMaxReducer, u8x16>;
 #[cfg(all(feature = "simd", not(target_arch = "x86_64")))]
+/// A [`SimdMapFeedback`] that strives to maximize the map contents.
 pub type MaxMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMaxReducer, u8x32>;
 #[cfg(not(feature = "simd"))]
+/// A [`MapFeedback`] that strives to maximize the map contents.
 pub type MaxMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, MaxReducer>;
 
-/// A [`MapFeedback`] that strives to minimize the map contents.
+
 #[cfg(feature = "simd")]
+/// A [`SimdMapFeedback`] that strives to minimize the map contents.
 pub type MinMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMinReducer, u8x32>;
 #[cfg(not(feature = "simd"))]
+/// A [`MapFeedback`] that strives to minimize the map contents.
 pub type MinMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, MinReducer>;
 
 /// A [`MapFeedback`] that always returns `true` for `is_interesting`. Useful for tracing all executions.

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -9,6 +9,8 @@ use core::{
 
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 use libafl_bolts::simd::vector::u8x16;
+#[cfg(not(feature = "simd"))]
+use libafl_bolts::simd::{MinReducer, OrReducer};
 #[cfg(feature = "simd")]
 use libafl_bolts::simd::{SimdMaxReducer, SimdMinReducer, SimdOrReducer, vector::u8x32};
 use libafl_bolts::{
@@ -16,8 +18,6 @@ use libafl_bolts::{
     simd::{MaxReducer, NopReducer, Reducer},
     tuples::{Handle, Handled, MatchName, MatchNameRef},
 };
-#[cfg(not(feature = "simd"))]
-use libafl_bolts::simd::{MinReducer, OrReducer};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -21,7 +21,9 @@ use libafl_bolts::{MinReducer, OrReducer, Reducer};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+#[cfg(feature = "simd")]
 use super::simd::SimdMapFeedback;
+
 #[cfg(feature = "track_hit_feedbacks")]
 use crate::feedbacks::premature_last_result_err;
 use crate::{

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 #[cfg(feature = "simd")]
-/// A [`SimdMapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
+/// A [`SimdMapFeedback`] that implements the AFL algorithm using an [`SimdOrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
 pub type AflMapFeedback<C, O> = SimdMapFeedback<C, O, SimdOrReducer, u8x32>;
 #[cfg(not(feature = "simd"))]
 /// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -682,7 +682,7 @@ where
     O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
     C: CanTrack + AsRef<O>,
 {
-    #[allow(dead_code)] // this is true on stable wihout "stable_simd"
+    #[allow(dead_code)] // this is true on stable wihout "simd"
     pub(crate) fn is_interesting_u8_simd_optimized<S, OT, F>(
         &mut self,
         state: &mut S,

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -17,7 +17,7 @@ use libafl_bolts::{
     tuples::{Handle, Handled, MatchName, MatchNameRef},
 };
 #[cfg(not(feature = "simd"))]
-use libafl_bolts::{MinReducer, OrReducer, Reducer};
+use libafl_bolts::simd::{MinReducer, OrReducer};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -10,8 +10,11 @@ use core::{
 #[cfg(feature = "simd")]
 use libafl_bolts::simd::{
     SimdMaxReducer, SimdMinReducer, SimdOrReducer,
-    vector::{u8x16, u8x32},
+    vector::u8x32,
 };
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+use libafl_bolts::simd::vector::u8x16;
+
 use libafl_bolts::{
     AsIter, HasRefCnt, Named,
     simd::{MaxReducer, NopReducer, Reducer},

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -310,7 +310,7 @@ pub struct MapFeedback<C, N, O, R> {
     stats_name: Cow<'static, str>,
     // The previous run's result of [`Self::is_interesting`]
     #[cfg(feature = "track_hit_feedbacks")]
-    last_result: Option<bool>,
+    pub(crate) last_result: Option<bool>,
     /// Phantom Data of Reducer
     #[expect(clippy::type_complexity)]
     phantom: PhantomData<fn() -> (N, O, R)>,

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -7,14 +7,10 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-#[cfg(feature = "simd")]
-use libafl_bolts::simd::{
-    SimdMaxReducer, SimdMinReducer, SimdOrReducer,
-    vector::u8x32,
-};
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 use libafl_bolts::simd::vector::u8x16;
-
+#[cfg(feature = "simd")]
+use libafl_bolts::simd::{SimdMaxReducer, SimdMinReducer, SimdOrReducer, vector::u8x32};
 use libafl_bolts::{
     AsIter, HasRefCnt, Named,
     simd::{MaxReducer, NopReducer, Reducer},
@@ -46,7 +42,6 @@ pub type AflMapFeedback<C, O> = SimdMapFeedback<C, O, SimdOrReducer, u8x32>;
 /// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
 pub type AflMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, OrReducer>;
 
-
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 /// A [`SimdMapFeedback`] that strives to maximize the map contents.
 pub type MaxMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMaxReducer, u8x16>;
@@ -56,7 +51,6 @@ pub type MaxMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMaxReducer, u8x32>;
 #[cfg(not(feature = "simd"))]
 /// A [`MapFeedback`] that strives to maximize the map contents.
 pub type MaxMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, MaxReducer>;
-
 
 #[cfg(feature = "simd")]
 /// A [`SimdMapFeedback`] that strives to minimize the map contents.

--- a/libafl/src/feedbacks/map.rs
+++ b/libafl/src/feedbacks/map.rs
@@ -4,18 +4,25 @@ use alloc::{borrow::Cow, vec::Vec};
 use core::{
     fmt::Debug,
     marker::PhantomData,
-    ops::{BitAnd, BitOr, Deref, DerefMut},
+    ops::{Deref, DerefMut},
 };
 
-#[rustversion::nightly]
-use libafl_bolts::simd::std_covmap_is_interesting;
+#[cfg(feature = "simd")]
+use libafl_bolts::simd::{
+    SimdMaxReducer, SimdMinReducer, SimdOrReducer,
+    vector::{u8x16, u8x32},
+};
 use libafl_bolts::{
-    AsIter, AsSlice, HasRefCnt, Named,
+    AsIter, HasRefCnt, Named,
+    simd::{MaxReducer, NopReducer, Reducer},
     tuples::{Handle, Handled, MatchName, MatchNameRef},
 };
+#[cfg(not(feature = "simd"))]
+use libafl_bolts::{MinReducer, OrReducer, Reducer};
 use num_traits::PrimInt;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+use super::simd::SimdMapFeedback;
 #[cfg(feature = "track_hit_feedbacks")]
 use crate::feedbacks::premature_last_result_err;
 use crate::{
@@ -30,11 +37,23 @@ use crate::{
 };
 
 /// A [`MapFeedback`] that implements the AFL algorithm using an [`OrReducer`] combining the bits for the history map and the bit from (`HitcountsMapObserver`)[`crate::observers::HitcountsMapObserver`].
+#[cfg(feature = "simd")]
+pub type AflMapFeedback<C, O> = SimdMapFeedback<C, O, SimdOrReducer, u8x32>;
+#[cfg(not(feature = "simd"))]
 pub type AflMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, OrReducer>;
 
 /// A [`MapFeedback`] that strives to maximize the map contents.
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+pub type MaxMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMaxReducer, u8x16>;
+#[cfg(all(feature = "simd", not(target_arch = "x86_64")))]
+pub type MaxMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMaxReducer, u8x32>;
+#[cfg(not(feature = "simd"))]
 pub type MaxMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, MaxReducer>;
+
 /// A [`MapFeedback`] that strives to minimize the map contents.
+#[cfg(feature = "simd")]
+pub type MinMapFeedback<C, O> = SimdMapFeedback<C, O, SimdMinReducer, u8x32>;
+#[cfg(not(feature = "simd"))]
 pub type MinMapFeedback<C, O> = MapFeedback<C, DifferentIsNovel, O, MinReducer>;
 
 /// A [`MapFeedback`] that always returns `true` for `is_interesting`. Useful for tracing all executions.
@@ -46,79 +65,6 @@ pub type MaxMapPow2Feedback<C, O> = MapFeedback<C, NextPow2IsNovel, O, MaxReduce
 /// A [`MapFeedback`] that strives to maximize the map contents,
 /// but only, if a value is either `T::one()` or `T::max_value()`.
 pub type MaxMapOneOrFilledFeedback<C, O> = MapFeedback<C, OneOrFilledIsNovel, O, MaxReducer>;
-
-/// A `Reducer` function is used to aggregate values for the novelty search
-pub trait Reducer<T> {
-    /// Reduce two values to one value, with the current [`Reducer`].
-    fn reduce(first: T, second: T) -> T;
-}
-
-/// A [`OrReducer`] reduces the values returning the bitwise OR with the old value
-#[derive(Clone, Debug)]
-pub struct OrReducer {}
-
-impl<T> Reducer<T> for OrReducer
-where
-    T: BitOr<Output = T>,
-{
-    #[inline]
-    fn reduce(history: T, new: T) -> T {
-        history | new
-    }
-}
-
-/// A [`AndReducer`] reduces the values returning the bitwise AND with the old value
-#[derive(Clone, Debug)]
-pub struct AndReducer {}
-
-impl<T> Reducer<T> for AndReducer
-where
-    T: BitAnd<Output = T>,
-{
-    #[inline]
-    fn reduce(history: T, new: T) -> T {
-        history & new
-    }
-}
-
-/// A [`NopReducer`] does nothing, and just "reduces" to the second/`new` value.
-#[derive(Clone, Debug)]
-pub struct NopReducer {}
-
-impl<T> Reducer<T> for NopReducer {
-    #[inline]
-    fn reduce(_history: T, new: T) -> T {
-        new
-    }
-}
-
-/// A [`MaxReducer`] reduces int values and returns their maximum.
-#[derive(Clone, Debug)]
-pub struct MaxReducer {}
-
-impl<T> Reducer<T> for MaxReducer
-where
-    T: PartialOrd,
-{
-    #[inline]
-    fn reduce(first: T, second: T) -> T {
-        if first > second { first } else { second }
-    }
-}
-
-/// A [`MinReducer`] reduces int values and returns their minimum.
-#[derive(Clone, Debug)]
-pub struct MinReducer {}
-
-impl<T> Reducer<T> for MinReducer
-where
-    T: PartialOrd,
-{
-    #[inline]
-    fn reduce(first: T, second: T) -> T {
-        if first < second { first } else { second }
-    }
-}
 
 /// A `IsNovel` function is used to discriminate if a reduced value is considered novel.
 pub trait IsNovel<T> {
@@ -351,7 +297,7 @@ where
 #[derive(Clone, Debug)]
 pub struct MapFeedback<C, N, O, R> {
     /// New indexes observed in the last observation
-    novelties: Option<Vec<usize>>,
+    pub(crate) novelties: Option<Vec<usize>>,
     /// Name identifier of this instance
     name: Cow<'static, str>,
     /// Name identifier of the observer
@@ -391,24 +337,6 @@ where
     R: Reducer<O::Entry>,
     S: HasNamedMetadata + HasExecutions,
 {
-    #[rustversion::nightly]
-    default fn is_interesting(
-        &mut self,
-        state: &mut S,
-        _manager: &mut EM,
-        _input: &I,
-        observers: &OT,
-        _exit_kind: &ExitKind,
-    ) -> Result<bool, Error> {
-        let res = self.is_interesting_default(state, observers);
-        #[cfg(feature = "track_hit_feedbacks")]
-        {
-            self.last_result = Some(res);
-        }
-        Ok(res)
-    }
-
-    #[rustversion::not(nightly)]
     fn is_interesting(
         &mut self,
         state: &mut S,
@@ -525,28 +453,6 @@ where
         )?;
 
         Ok(())
-    }
-}
-
-/// Specialize for the common coverage map size, maximization of u8s
-#[rustversion::nightly]
-impl<C, O, EM, I, OT, S> Feedback<EM, I, OT, S> for MapFeedback<C, DifferentIsNovel, O, MaxReducer>
-where
-    C: CanTrack + AsRef<O>,
-    EM: EventFirer<I, S>,
-    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
-    OT: MatchName,
-    S: HasNamedMetadata + HasExecutions,
-{
-    fn is_interesting(
-        &mut self,
-        state: &mut S,
-        _manager: &mut EM,
-        _input: &I,
-        observers: &OT,
-        _exit_kind: &ExitKind,
-    ) -> Result<bool, Error> {
-        Ok(self.is_interesting_u8_simd_optimized(state, observers, std_covmap_is_interesting))
     }
 }
 
@@ -672,67 +578,6 @@ where
             }
         }
 
-        interesting
-    }
-}
-
-/// Specialize for the common coverage map size, maximization of u8s
-impl<C, O> MapFeedback<C, DifferentIsNovel, O, MaxReducer>
-where
-    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
-    C: CanTrack + AsRef<O>,
-{
-    #[allow(dead_code)] // this is true on stable wihout "simd"
-    pub(crate) fn is_interesting_u8_simd_optimized<S, OT, F>(
-        &mut self,
-        state: &mut S,
-        observers: &OT,
-        simd: F,
-    ) -> bool
-    where
-        S: HasNamedMetadata,
-        OT: MatchName,
-        F: FnOnce(&[u8], &[u8], bool) -> (bool, Vec<usize>),
-    {
-        // TODO Replace with match_name_type when stable
-        let observer = observers.get(&self.map_ref).expect("MapObserver not found. This is likely because you entered the crash handler with the wrong executor/observer").as_ref();
-
-        let map_state = state
-            .named_metadata_map_mut()
-            .get_mut::<MapFeedbackMetadata<u8>>(&self.name)
-            .unwrap();
-        let size = observer.usable_count();
-        let len = observer.len();
-        if map_state.history_map.len() < len {
-            map_state.history_map.resize(len, u8::default());
-        }
-
-        let map = observer.as_slice();
-        debug_assert!(map.len() >= size);
-
-        let history_map = map_state.history_map.as_slice();
-
-        // Non vector implementation for reference
-        /*for (i, history) in history_map.iter_mut().enumerate() {
-            let item = map[i];
-            let reduced = MaxReducer::reduce(*history, item);
-            if DifferentIsNovel::is_novel(*history, reduced) {
-                *history = reduced;
-                interesting = true;
-                if self.novelties.is_some() {
-                    self.novelties.as_mut().unwrap().push(i);
-                }
-            }
-        }*/
-
-        let (interesting, novelties) = simd(history_map, &map, self.novelties.is_some());
-        if let Some(nov) = self.novelties.as_mut() {
-            *nov = novelties;
-        }
-        #[cfg(feature = "track_hit_feedbacks")]
-        {
-            self.last_result = Some(interesting);
-        }
         interesting
     }
 }

--- a/libafl/src/feedbacks/mod.rs
+++ b/libafl/src/feedbacks/mod.rs
@@ -46,7 +46,7 @@ pub mod map;
 pub mod nautilus;
 #[cfg(feature = "std")]
 pub mod new_hash_feedback;
-#[cfg(feature = "stable_simd")]
+#[cfg(feature = "simd")]
 pub mod simd;
 #[cfg(feature = "std")]
 pub mod stdio;

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -1,24 +1,20 @@
 //! SIMD accelerated map feedback with stable Rust.
 
-use alloc::{borrow::Cow, vec::Vec};
+use alloc::borrow::Cow;
 use core::{
     fmt::Debug,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
 use libafl_bolts::{
     AsIter, AsSlice, Error, Named,
-    simd::{
-        covmap_is_interesting_naive, covmap_is_interesting_u8x16, covmap_is_interesting_u8x32,
-        std_covmap_is_interesting,
-    },
-    tuples::{Handle, MatchName},
+    simd::{Reducer, SimdReducer, VectorType, covmap_is_interesting_simd},
+    tuples::{Handle, MatchName, MatchNameRef},
 };
 use serde::{Serialize, de::DeserializeOwned};
 
-use super::{
-    DifferentIsNovel, Feedback, HasObserverHandle, MapFeedback, MaxReducer, StateInitializer,
-};
+use super::{DifferentIsNovel, Feedback, HasObserverHandle, MapFeedback, StateInitializer};
 #[cfg(feature = "introspection")]
 use crate::state::HasClientPerfMonitor;
 use crate::{
@@ -26,93 +22,142 @@ use crate::{
     corpus::Testcase,
     events::EventFirer,
     executors::ExitKind,
+    feedbacks::MapFeedbackMetadata,
     observers::{CanTrack, MapObserver},
     state::HasExecutions,
 };
 
-/// The coverage map SIMD acceleration to use.
-/// Benchmark is available at [`libafl_bolts`]
-#[derive(Debug, Clone, Default, Copy)]
-pub enum SimdImplmentation {
-    /// The u8x16 implementation from wide, usually the fastest
-    #[default]
-    WideU8x16,
-    /// The u8x32 implementation from wide, slightly slower than u8x16 (~1%)
-    WideU8x32,
-    /// Naive implementation, reference only
-    Naive,
-}
-
-impl SimdImplmentation {
-    fn dispatch_simd(self) -> CoverageMapFunPtr {
-        match self {
-            SimdImplmentation::WideU8x16 => covmap_is_interesting_u8x16,
-            SimdImplmentation::WideU8x32 => covmap_is_interesting_u8x32,
-            SimdImplmentation::Naive => covmap_is_interesting_naive,
-        }
-    }
-}
-
-type CoverageMapFunPtr = fn(&[u8], &[u8], bool) -> (bool, Vec<usize>);
-
 /// Stable Rust wrapper for SIMD accelerated map feedback. Unfortunately, we have to
 /// keep this until specialization is stablized (not yet since 2016).
 #[derive(Debug, Clone)]
-pub struct SimdMapFeedback<C, O> {
-    map: MapFeedback<C, DifferentIsNovel, O, MaxReducer>,
-    simd: CoverageMapFunPtr,
+pub struct SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+{
+    map: MapFeedback<C, DifferentIsNovel, O, R::PrimitiveReducer>,
+    _ph: PhantomData<V>,
 }
 
-impl<C, O> SimdMapFeedback<C, O> {
+impl<C, O, R, V> SimdMapFeedback<C, O, R, V>
+where
+    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
+    C: CanTrack + AsRef<O>,
+    R: SimdReducer<V>,
+    V: VectorType + Copy + Eq,
+{
+    fn is_interesting_u8_simd_optimized<S, OT>(&mut self, state: &mut S, observers: &OT) -> bool
+    where
+        S: HasNamedMetadata,
+        OT: MatchName,
+    {
+        // TODO Replace with match_name_type when stable
+        let observer = observers.get(self.map.observer_handle()).expect("MapObserver not found. This is likely because you entered the crash handler with the wrong executor/observer").as_ref();
+
+        let map_state = state
+            .named_metadata_map_mut()
+            .get_mut::<MapFeedbackMetadata<u8>>(&self.map.name())
+            .unwrap();
+        let size = observer.usable_count();
+        let len = observer.len();
+        if map_state.history_map.len() < len {
+            map_state.history_map.resize(len, u8::default());
+        }
+
+        let map = observer.as_slice();
+        debug_assert!(map.len() >= size);
+
+        let history_map = map_state.history_map.as_slice();
+
+        let (interesting, novelties) =
+            covmap_is_interesting_simd::<R, V>(history_map, &map, self.map.novelties.is_some());
+        if let Some(nov) = self.map.novelties.as_mut() {
+            *nov = novelties;
+        }
+        #[cfg(feature = "track_hit_feedbacks")]
+        {
+            self.last_result = Some(interesting);
+        }
+        interesting
+    }
+}
+
+impl<C, O, R, V> SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+{
     /// Wraps an existing map and enable SIMD acceleration. This will use standard SIMD
     /// implementation, which might vary based on target architecture according to our
     /// benchmark.
     #[must_use]
-    pub fn new(map: MapFeedback<C, DifferentIsNovel, O, MaxReducer>) -> Self {
+    pub fn wrap(map: MapFeedback<C, DifferentIsNovel, O, R::PrimitiveReducer>) -> Self {
         Self {
             map,
-            simd: std_covmap_is_interesting,
-        }
-    }
-
-    /// Wraps an existing map and enable SIMD acceleration according to arguments.
-    #[must_use]
-    pub fn with_simd(
-        map: MapFeedback<C, DifferentIsNovel, O, MaxReducer>,
-        simd: SimdImplmentation,
-    ) -> Self {
-        Self {
-            map,
-            simd: simd.dispatch_simd(),
+            _ph: PhantomData,
         }
     }
 }
 
-impl<C, O> Deref for SimdMapFeedback<C, O> {
-    type Target = MapFeedback<C, DifferentIsNovel, O, MaxReducer>;
+impl<C, O, R, V> SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+    C: CanTrack + AsRef<O> + Named,
+{
+    /// Mock [`MapFeedback::new`]
+    #[must_use]
+    pub fn new(map_observer: &C) -> Self {
+        let map = MapFeedback::new(map_observer);
+        Self {
+            map: map,
+            _ph: PhantomData,
+        }
+    }
+
+    /// Mock [`MapFeedback::with_name`]
+    #[must_use]
+    pub fn with_name(name: &'static str, map_observer: &C) -> Self {
+        let map = MapFeedback::with_name(name, map_observer);
+        Self {
+            map: map,
+            _ph: PhantomData,
+        }
+    }
+}
+
+impl<C, O, R, V> Deref for SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+{
+    type Target = MapFeedback<C, DifferentIsNovel, O, R::PrimitiveReducer>;
     fn deref(&self) -> &Self::Target {
         &self.map
     }
 }
 
-impl<C, O> DerefMut for SimdMapFeedback<C, O> {
+impl<C, O, R, V> DerefMut for SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.map
     }
 }
 
-impl<C, O, S> StateInitializer<S> for SimdMapFeedback<C, O>
+impl<C, O, S, R, V> StateInitializer<S> for SimdMapFeedback<C, O, R, V>
 where
     O: MapObserver,
     O::Entry: 'static + Default + Debug + DeserializeOwned + Serialize,
     S: HasNamedMetadata,
+    R: SimdReducer<V>,
 {
     fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
         self.map.init_state(state)
     }
 }
 
-impl<C, O> HasObserverHandle for SimdMapFeedback<C, O> {
+impl<C, O, R, V> HasObserverHandle for SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+{
     type Observer = C;
 
     #[inline]
@@ -121,7 +166,10 @@ impl<C, O> HasObserverHandle for SimdMapFeedback<C, O> {
     }
 }
 
-impl<C, O> Named for SimdMapFeedback<C, O> {
+impl<C, O, R, V> Named for SimdMapFeedback<C, O, R, V>
+where
+    R: SimdReducer<V>,
+{
     #[inline]
     fn name(&self) -> &Cow<'static, str> {
         self.map.name()
@@ -129,13 +177,16 @@ impl<C, O> Named for SimdMapFeedback<C, O> {
 }
 
 // Delegate implementations to inner mapping except is_interesting
-impl<C, O, EM, I, OT, S> Feedback<EM, I, OT, S> for SimdMapFeedback<C, O>
+impl<C, O, EM, I, OT, S, R, V> Feedback<EM, I, OT, S> for SimdMapFeedback<C, O, R, V>
 where
     C: CanTrack + AsRef<O>,
     EM: EventFirer<I, S>,
     O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
     OT: MatchName,
     S: HasNamedMetadata + HasExecutions,
+    R: SimdReducer<V>,
+    V: VectorType + Copy + Eq,
+    R::PrimitiveReducer: Reducer<u8>,
 {
     fn is_interesting(
         &mut self,
@@ -145,9 +196,7 @@ where
         observers: &OT,
         _exit_kind: &ExitKind,
     ) -> Result<bool, Error> {
-        let res = self
-            .map
-            .is_interesting_u8_simd_optimized(state, observers, self.simd);
+        let res = self.is_interesting_u8_simd_optimized(state, observers);
         Ok(res)
     }
 

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -107,7 +107,7 @@ impl<C, O, R, V> SimdMapFeedback<C, O, R, V>
 where
     R: SimdReducer<V>,
     C: CanTrack + AsRef<O> + Named,
-    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>
+    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>,
 {
     /// Mock [`MapFeedback::new`]. If you are getting bound errors, your entry is probably not
     /// `u8` and you should use [`MapFeedback`] instead.

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -219,15 +219,13 @@ where
     #[cfg(feature = "track_hit_feedbacks")]
     fn last_result(&self) -> Result<bool, Error> {
         // cargo +nightly doc asks so
-        <MapFeedback<C, DifferentIsNovel, O, MaxReducer> as Feedback<EM, I, OT, S>>::last_result(
-            &self.map,
-        )
+        self.map.last_result()
     }
 
     #[cfg(feature = "track_hit_feedbacks")]
     fn append_hit_feedbacks(&self, list: &mut Vec<Cow<'static, str>>) -> Result<(), Error> {
         // cargo +nightly doc asks so
-        <MapFeedback<C, DifferentIsNovel, O, MaxReducer> as Feedback<EM, I, OT, S>>::append_hit_feedbacks(&self.map, list)
+        self.map.append_hit_feedbacks(list)
     }
 
     #[inline]

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -99,12 +99,18 @@ where
     }
 }
 
+/// Implementation that mocks [`MapFeedback`], note the bound of O is intentionally stricter
+/// than we we need to hint users when their entry is not `u8`. Without this bound, there
+/// would be bound related errors in [`crate::fuzzer::StdFuzzer`], which is super confusing
+/// and misleading.
 impl<C, O, R, V> SimdMapFeedback<C, O, R, V>
 where
     R: SimdReducer<V>,
     C: CanTrack + AsRef<O> + Named,
+    O: MapObserver<Entry = u8> + for<'a> AsSlice<'a, Entry = u8> + for<'a> AsIter<'a, Item = u8>
 {
-    /// Mock [`MapFeedback::new`]
+    /// Mock [`MapFeedback::new`]. If you are getting bound errors, your entry is probably not
+    /// `u8` and you should use [`MapFeedback`] instead.
     #[must_use]
     pub fn new(map_observer: &C) -> Self {
         let map = MapFeedback::new(map_observer);
@@ -114,7 +120,8 @@ where
         }
     }
 
-    /// Mock [`MapFeedback::with_name`]
+    /// Mock [`MapFeedback::with_name`] If you are getting bound errors, your entry is probably not
+    /// `u8` and you should use [`MapFeedback`] instead.
     #[must_use]
     pub fn with_name(name: &'static str, map_observer: &C) -> Self {
         let map = MapFeedback::with_name(name, map_observer);

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -1,6 +1,8 @@
 //! SIMD accelerated map feedback with stable Rust.
 
 use alloc::borrow::Cow;
+#[cfg(feature = "track_hit_feedbacks")]
+use alloc::vec::Vec;
 use core::{
     fmt::Debug,
     marker::PhantomData,
@@ -219,13 +221,23 @@ where
     #[cfg(feature = "track_hit_feedbacks")]
     fn last_result(&self) -> Result<bool, Error> {
         // cargo +nightly doc asks so
-        self.map.last_result()
+        <MapFeedback<C, DifferentIsNovel, O, <R as SimdReducer<V>>::PrimitiveReducer> as Feedback<
+            EM,
+            I,
+            OT,
+            S,
+        >>::last_result(&self.map)
     }
 
     #[cfg(feature = "track_hit_feedbacks")]
     fn append_hit_feedbacks(&self, list: &mut Vec<Cow<'static, str>>) -> Result<(), Error> {
         // cargo +nightly doc asks so
-        self.map.append_hit_feedbacks(list)
+        <MapFeedback<C, DifferentIsNovel, O, <R as SimdReducer<V>>::PrimitiveReducer> as Feedback<
+            EM,
+            I,
+            OT,
+            S,
+        >>::append_hit_feedbacks(&self.map, list)
     }
 
     #[inline]

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 /// The coverage map SIMD acceleration to use.
-/// Benchmark is available at <https://github.com/wtdcode/libafl_simd_bench>
+/// Benchmark is available at [`libafl_bolts`]
 #[derive(Debug, Clone, Default, Copy)]
 pub enum SimdImplmentation {
     /// The u8x16 implementation from wide, usually the fastest

--- a/libafl/src/feedbacks/simd.rs
+++ b/libafl/src/feedbacks/simd.rs
@@ -55,7 +55,7 @@ where
 
         let map_state = state
             .named_metadata_map_mut()
-            .get_mut::<MapFeedbackMetadata<u8>>(&self.map.name())
+            .get_mut::<MapFeedbackMetadata<u8>>(self.map.name())
             .unwrap();
         let size = observer.usable_count();
         let len = observer.len();
@@ -107,7 +107,7 @@ where
     pub fn new(map_observer: &C) -> Self {
         let map = MapFeedback::new(map_observer);
         Self {
-            map: map,
+            map,
             _ph: PhantomData,
         }
     }
@@ -117,7 +117,7 @@ where
     pub fn with_name(name: &'static str, map_observer: &C) -> Self {
         let map = MapFeedback::with_name(name, map_observer);
         Self {
-            map: map,
+            map,
             _ph: PhantomData,
         }
     }

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -120,8 +120,8 @@ llmp_small_maps = ["alloc"]
 
 #! ### Stable SIMD features
 
-## Use the best SIMD implementation by our [benchmark](https://github.com/wtdcode/libafl_simd_bench)
-stable_simd = ["alloc", "wide"]
+## Use the best SIMD implementation by our benchmark.
+simd = ["alloc", "wide"]
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -52,7 +52,7 @@ std = [
   "uds",
   "serial_test",
   "alloc",
-  "stable_simd",
+  "simd",
 ]
 
 ## Enables all features that allocate in `no_std`
@@ -235,4 +235,4 @@ name = "simd"
 path = "./examples/simd/simd.rs"
 bench = true
 harness = false
-required-features = ["std", "stable_simd"]
+required-features = ["std", "simd"]

--- a/libafl_bolts/examples/simd/simd.rs
+++ b/libafl_bolts/examples/simd/simd.rs
@@ -2,7 +2,9 @@ use chrono::Utc;
 use clap::Parser;
 use itertools::Itertools;
 use libafl_bolts::simd::{
-    covmap_is_interesting_naive, covmap_is_interesting_simd, simplify_map_naive, simplify_map_u8x16, simplify_map_u8x32, AndReducer, MaxReducer, MinReducer, OrReducer, Reducer, SimdAndReducer, SimdMaxReducer, SimdMinReducer, SimdOrReducer, SimdReducer, VectorType
+    AndReducer, MaxReducer, MinReducer, OrReducer, Reducer, SimdAndReducer, SimdMaxReducer,
+    SimdMinReducer, SimdOrReducer, SimdReducer, VectorType, covmap_is_interesting_naive,
+    covmap_is_interesting_simd, simplify_map_naive, simplify_map_u8x16, simplify_map_u8x32,
 };
 use rand::{RngCore, rngs::ThreadRng};
 
@@ -100,7 +102,11 @@ struct CovInput {
 }
 
 impl CovInput {
-    fn from_cli_simd<T: VectorType + Eq + Copy, R: SimdReducer<T>>(name: &str, cli: &Cli, rng: &ThreadRng) -> Self {
+    fn from_cli_simd<T: VectorType + Eq + Copy, R: SimdReducer<T>>(
+        name: &str,
+        cli: &Cli,
+        rng: &ThreadRng,
+    ) -> Self {
         CovInput {
             name: name.to_string(),
             func: covmap_is_interesting_simd::<R, T>,
@@ -145,7 +151,8 @@ impl CovInput {
 
                 assert!(
                     canonical_interesting == interesting && novelties == canonical_novelties,
-                    "Incorrect {} impl. {canonical_interesting} vs {interesting}, {canonical_novelties:?} vs\n{novelties:?}", self.name
+                    "Incorrect {} impl. {canonical_interesting} vs {interesting}, {canonical_novelties:?} vs\n{novelties:?}",
+                    self.name
                 );
             }
             let after = Utc::now();
@@ -213,7 +220,7 @@ fn main() {
         CovInput::from_cli_simd::<wide::u8x32, SimdAndReducer>("u8x32 and cov", &cli, &rng),
         CovInput::from_cli_naive::<OrReducer>("naive or cov", &cli, &rng),
         CovInput::from_cli_simd::<wide::u8x16, SimdOrReducer>("u8x16 or cov", &cli, &rng),
-        CovInput::from_cli_simd::<wide::u8x32, SimdOrReducer>("u8x32 or cov", &cli, &rng)
+        CovInput::from_cli_simd::<wide::u8x32, SimdOrReducer>("u8x32 or cov", &cli, &rng),
     ];
 
     for bench in benches {

--- a/libafl_bolts/examples/simd/simd.rs
+++ b/libafl_bolts/examples/simd/simd.rs
@@ -2,8 +2,7 @@ use chrono::Utc;
 use clap::Parser;
 use itertools::Itertools;
 use libafl_bolts::simd::{
-    covmap_is_interesting_naive, covmap_is_interesting_u8x16, covmap_is_interesting_u8x32,
-    simplify_map_naive, simplify_map_u8x16, simplify_map_u8x32,
+    covmap_is_interesting_naive, covmap_is_interesting_simd, simplify_map_naive, simplify_map_u8x16, simplify_map_u8x32, AndReducer, MaxReducer, MinReducer, OrReducer, Reducer, SimdAndReducer, SimdMaxReducer, SimdMinReducer, SimdOrReducer, SimdReducer, VectorType
 };
 use rand::{RngCore, rngs::ThreadRng};
 
@@ -92,6 +91,7 @@ type CovFuncPtr = fn(&[u8], &[u8], bool) -> (bool, Vec<usize>);
 struct CovInput {
     name: String,
     func: CovFuncPtr,
+    naive: CovFuncPtr,
     hist: Vec<u8>,
     map: Vec<u8>,
     rounds: usize,
@@ -100,10 +100,11 @@ struct CovInput {
 }
 
 impl CovInput {
-    fn from_cli(name: &str, f: CovFuncPtr, cli: &Cli, rng: &ThreadRng) -> Self {
+    fn from_cli_simd<T: VectorType + Eq + Copy, R: SimdReducer<T>>(name: &str, cli: &Cli, rng: &ThreadRng) -> Self {
         CovInput {
             name: name.to_string(),
-            func: f,
+            func: covmap_is_interesting_simd::<R, T>,
+            naive: covmap_is_interesting_naive::<R::PrimitiveReducer>,
             hist: vec![0; cli.map],
             map: vec![0; cli.map],
             rng: rng.clone(),
@@ -111,6 +112,20 @@ impl CovInput {
             validate: cli.validate,
         }
     }
+
+    fn from_cli_naive<R: Reducer<u8>>(name: &str, cli: &Cli, rng: &ThreadRng) -> Self {
+        CovInput {
+            name: name.to_string(),
+            func: covmap_is_interesting_naive::<R>,
+            naive: covmap_is_interesting_naive::<R>,
+            hist: vec![0; cli.map],
+            map: vec![0; cli.map],
+            rng: rng.clone(),
+            rounds: cli.rounds,
+            validate: cli.validate,
+        }
+    }
+
     fn measure_cov(mut self) -> Vec<chrono::TimeDelta> {
         println!("Running {}", &self.name);
         let mut outs = vec![];
@@ -126,11 +141,11 @@ impl CovInput {
             let (interesting, novelties) = (self.func)(&self.hist, &self.map, true);
             if self.validate {
                 let (canonical_interesting, canonical_novelties) =
-                    covmap_is_interesting_naive(&self.hist, &self.map, true);
+                    (self.naive)(&self.hist, &self.map, true);
 
                 assert!(
                     canonical_interesting == interesting && novelties == canonical_novelties,
-                    "Incorrect covmap impl. {canonical_interesting} vs {interesting}, {canonical_novelties:?} vs\n{novelties:?}"
+                    "Incorrect {} impl. {canonical_interesting} vs {interesting}, {canonical_novelties:?} vs\n{novelties:?}", self.name
                 );
             }
             let after = Utc::now();
@@ -187,9 +202,18 @@ fn main() {
     }
 
     let benches = [
-        CovInput::from_cli("naive cov", covmap_is_interesting_naive, &cli, &rng),
-        CovInput::from_cli("u8x16 cov", covmap_is_interesting_u8x16, &cli, &rng),
-        CovInput::from_cli("u8x32 cov", covmap_is_interesting_u8x32, &cli, &rng),
+        CovInput::from_cli_naive::<MaxReducer>("naive max cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x16, SimdMaxReducer>("u8x16 max cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x32, SimdMaxReducer>("u8x32 max cov", &cli, &rng),
+        CovInput::from_cli_naive::<MinReducer>("naive min cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x16, SimdMinReducer>("u8x16 min cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x32, SimdMinReducer>("u8x32 min cov", &cli, &rng),
+        CovInput::from_cli_naive::<AndReducer>("naive and cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x16, SimdAndReducer>("u8x16 and cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x32, SimdAndReducer>("u8x32 and cov", &cli, &rng),
+        CovInput::from_cli_naive::<OrReducer>("naive or cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x16, SimdOrReducer>("u8x16 or cov", &cli, &rng),
+        CovInput::from_cli_simd::<wide::u8x32, SimdOrReducer>("u8x32 or cov", &cli, &rng)
     ];
 
     for bench in benches {

--- a/libafl_bolts/examples/simd/simd.rs
+++ b/libafl_bolts/examples/simd/simd.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use libafl_bolts::simd::{
     AndReducer, MaxReducer, MinReducer, OrReducer, Reducer, SimdAndReducer, SimdMaxReducer,
     SimdMinReducer, SimdOrReducer, SimdReducer, VectorType, covmap_is_interesting_naive,
-    covmap_is_interesting_simd, simplify_map_naive, simplify_map_u8x16, simplify_map_u8x32,
+    covmap_is_interesting_simd, simplify_map_naive, simplify_map_simd,
 };
 use rand::{RngCore, rngs::ThreadRng};
 
@@ -198,8 +198,18 @@ fn main() {
 
     let simpls = [
         SimplifyMapInput::from_cli("naive simplify_map", simplify_map_naive, &cli, &rng),
-        SimplifyMapInput::from_cli("u8x16 simplify_map", simplify_map_u8x16, &cli, &rng),
-        SimplifyMapInput::from_cli("u8x32 simplify_map", simplify_map_u8x32, &cli, &rng),
+        SimplifyMapInput::from_cli(
+            "u8x16 simplify_map",
+            simplify_map_simd::<wide::u8x16>,
+            &cli,
+            &rng,
+        ),
+        SimplifyMapInput::from_cli(
+            "u8x32 simplify_map",
+            simplify_map_simd::<wide::u8x32>,
+            &cli,
+            &rng,
+        ),
     ];
 
     for bench in simpls {

--- a/libafl_bolts/src/simd.rs
+++ b/libafl_bolts/src/simd.rs
@@ -1,7 +1,206 @@
 //! Module for SIMD assisted methods.
 
+use core::ops::{BitAnd, BitOr};
+
 #[cfg(feature = "alloc")]
 use alloc::{vec, vec::Vec};
+
+/// The SIMD based reducer implementation
+#[cfg(feature = "wide")]
+pub trait SimdReducer<T>: Reducer<T> {
+    /// The associated primitive reducer
+    type PrimitiveReducer: Reducer<u8>;
+}
+
+/// A `Reducer` function is used to aggregate values for the novelty search
+pub trait Reducer<T> {
+    /// Reduce two values to one value, with the current [`Reducer`].
+    fn reduce(first: T, second: T) -> T;
+}
+
+#[cfg(feature = "wide")]
+trait HasMax: Sized {
+    fn max_(self, rhs: Self) -> Self;
+}
+
+#[cfg(feature = "wide")]
+impl HasMax for wide::u8x16 {
+    fn max_(self, rhs: Self) -> Self {
+        self.max(rhs)
+    }
+}
+
+#[cfg(feature = "wide")]
+impl HasMax for wide::u8x32 {
+    fn max_(self, rhs: Self) -> Self {
+        self.max(rhs)
+    }
+}
+
+#[cfg(feature = "wide")]
+trait HasMin: Sized {
+    fn min_(self, rhs: Self) -> Self;
+}
+
+#[cfg(feature = "wide")]
+impl HasMin for wide::u8x16 {
+    fn min_(self, rhs: Self) -> Self {
+        self.min(rhs)
+    }
+}
+
+#[cfg(feature = "wide")]
+impl HasMin for wide::u8x32 {
+    fn min_(self, rhs: Self) -> Self {
+        self.min(rhs)
+    }
+}
+
+
+/// A [`MaxReducer`] reduces int values and returns their maximum.
+#[derive(Clone, Debug)]
+pub struct MaxReducer {}
+
+impl<T> Reducer<T> for MaxReducer
+where
+    T: PartialOrd,
+{
+    #[inline]
+    fn reduce(first: T, second: T) -> T {
+        if first > second { first } else { second }
+    }
+}
+
+/// Unforunately we have to keep this type due to [`wide::*`] might not PartialOrd
+#[cfg(feature = "wide")]
+#[derive(Debug)]
+pub struct SimdMaxReducer;
+
+#[cfg(feature = "wide")]
+impl<T> Reducer<T> for SimdMaxReducer 
+where 
+    T: HasMax
+{
+    fn reduce(first: T, second: T) -> T {
+        first.max_(second)
+    }
+}
+
+#[cfg(feature = "wide")]
+impl<T> SimdReducer<T> for SimdMaxReducer 
+where
+    T: HasMax
+{
+    type PrimitiveReducer = MaxReducer;
+}
+
+/// A [`NopReducer`] does nothing, and just "reduces" to the second/`new` value.
+#[derive(Clone, Debug)]
+pub struct NopReducer {}
+
+impl<T> Reducer<T> for NopReducer {
+    #[inline]
+    fn reduce(_history: T, new: T) -> T {
+        new
+    }
+}
+
+#[cfg(feature = "wide")]
+impl<T> SimdReducer<T> for NopReducer {
+    type PrimitiveReducer = NopReducer;
+}
+
+
+/// A [`MinReducer`] reduces int values and returns their minimum.
+#[derive(Clone, Debug)]
+pub struct MinReducer {}
+
+impl<T> Reducer<T> for MinReducer
+where
+    T: PartialOrd,
+{
+    #[inline]
+    fn reduce(first: T, second: T) -> T {
+        if first < second { first } else { second }
+    }
+}
+
+/// Unforunately we have to keep this type due to [`wide::*`] might not PartialOrd
+#[cfg(feature = "wide")]
+#[derive(Debug)]
+pub struct SimdMinReducer;
+
+#[cfg(feature = "wide")]
+impl<T> Reducer<T> for SimdMinReducer 
+where 
+    T: HasMin
+{
+    fn reduce(first: T, second: T) -> T {
+        first.min_(second)
+    }
+}
+
+#[cfg(feature = "wide")]
+impl<T> SimdReducer<T> for SimdMinReducer
+where 
+    T: HasMin
+{
+    type PrimitiveReducer = MinReducer;
+}
+
+
+/// A [`OrReducer`] reduces the values returning the bitwise OR with the old value
+#[derive(Clone, Debug)]
+pub struct OrReducer {}
+
+impl<T> Reducer<T> for OrReducer
+where
+    T: BitOr<Output = T>,
+{
+    #[inline]
+    fn reduce(history: T, new: T) -> T {
+        history | new
+    }
+}
+
+#[cfg(feature = "wide")]
+impl<T> SimdReducer<T> for OrReducer 
+where 
+    T: BitOr<Output = T>
+{
+    type PrimitiveReducer = OrReducer;
+}
+
+/// SIMD based OrReducer, alias for consistency
+#[cfg(feature = "wide")]
+pub type SimdOrReducer = OrReducer;
+
+/// A [`AndReducer`] reduces the values returning the bitwise AND with the old value
+#[derive(Clone, Debug)]
+pub struct AndReducer {}
+
+impl<T> Reducer<T> for AndReducer
+where
+    T: BitAnd<Output = T>,
+{
+    #[inline]
+    fn reduce(history: T, new: T) -> T {
+        history & new
+    }
+}
+
+#[cfg(feature = "wide")]
+impl<T> SimdReducer<T> for AndReducer 
+where 
+    T: BitAnd<Output = T>
+{
+    type PrimitiveReducer = AndReducer;
+}
+
+/// SIMD based AndReducer, alias for consistency
+#[cfg(feature = "wide")]
+pub type SimdAndReducer = AndReducer;
+
 
 /// `simplify_map` naive implementaion. In most cases, this can be auto-vectorized.
 pub fn simplify_map_naive(map: &mut [u8]) {
@@ -79,45 +278,105 @@ pub fn std_simplify_map(map: &mut [u8]) {
     simplify_map_u8x32(map);
 }
 
+
+/// The vector type that can be used with coverage map
+pub trait VectorType {
+    /// Number of bytes
+    const N: usize;
+
+    /// Construct vector from slice
+    fn from_array(arr: &[u8]) -> Self;
+    
+    /// Collect novelties. We pass in base to avoid redo calculate for novelties indice.
+    fn novelties(hist: &[u8], map: &[u8], base: usize, novelties: &mut Vec<usize>);
+}
+
+impl VectorType for wide::u8x16 {
+    const N: usize = Self::LANES as usize;
+
+    fn from_array(arr: &[u8]) -> Self {
+        Self::new(arr[0..Self::N].try_into().unwrap())
+    }
+
+    fn novelties(hist: &[u8], map: &[u8], base: usize, novelties: &mut Vec<usize>) {
+        unsafe {
+            for j in base..(base + Self::N) {
+                let item = *map.get_unchecked(j);
+                if item > *hist.get_unchecked(j) {
+                    novelties.push(j);
+                }
+            }
+        }
+    }
+}
+
+impl VectorType for wide::u8x32 {
+    const N: usize = Self::LANES as usize;
+
+    fn from_array(arr: &[u8]) -> Self {
+        Self::new(arr[0..Self::N].try_into().unwrap())
+    }
+
+    fn novelties(hist: &[u8], map: &[u8], base: usize, novelties: &mut Vec<usize>) {
+        unsafe {
+            // Break into two loops so that LLVM will vectorize both loops.
+            // Or LLVM won't vectorize them and is super slow. We need a few
+            // extra intrinsic to wide and safe_arch to vectorize this manually.
+            for j in base..(base + Self::N / 2) {
+                let item = *map.get_unchecked(j);
+                if item > *hist.get_unchecked(j) {
+                    novelties.push(j);
+                }
+            }
+
+            for j in (base + Self::N / 2)..(base + Self::N) {
+                let item = *map.get_unchecked(j);
+                if item > *hist.get_unchecked(j) {
+                    novelties.push(j);
+                }
+            }
+        }
+    }
+}
+
 /// Coverage map insteresting implementation by u8x16. Slightly faster than nightly simd.
 #[cfg(all(feature = "alloc", feature = "wide"))]
 #[must_use]
-pub fn covmap_is_interesting_u8x16(
+pub fn covmap_is_interesting_simd<R, V>(
     hist: &[u8],
     map: &[u8],
     collect_novelties: bool,
-) -> (bool, Vec<usize>) {
-    type VectorType = wide::u8x16;
+) -> (bool, Vec<usize>)
+where 
+    V: VectorType + Eq + Copy,
+    R: SimdReducer<V>
+{
     let mut novelties = vec![];
     let mut interesting = false;
     let size = map.len();
-    let steps = size / VectorType::LANES as usize;
-    let left = size % VectorType::LANES as usize;
+    let steps = size / V::N;
+    let left = size % V::N;
 
     if collect_novelties {
         for step in 0..steps {
-            let i = step * VectorType::LANES as usize;
+            let i = step * V::N;
             let history =
-                VectorType::new(hist[i..i + VectorType::LANES as usize].try_into().unwrap());
-            let items = VectorType::new(map[i..i + VectorType::LANES as usize].try_into().unwrap());
+                V::from_array(&hist[i..]);
+            let items = V::from_array(&map[i..]);
 
-            if items.max(history) != history {
+            let out= R::reduce(history, items);
+            if out != history {
                 interesting = true;
-                unsafe {
-                    for j in i..(i + VectorType::LANES as usize) {
-                        let item = *map.get_unchecked(j);
-                        if item > *hist.get_unchecked(j) {
-                            novelties.push(j);
-                        }
-                    }
-                }
+                V::novelties(hist, map, i, &mut novelties);
             }
         }
 
         for j in (size - left)..size {
             unsafe {
                 let item = *map.get_unchecked(j);
-                if item > *hist.get_unchecked(j) {
+                let history = *hist.get_unchecked(j);
+                let out = R::PrimitiveReducer::reduce(item, history);
+                if out != history {
                     interesting = true;
                     novelties.push(j);
                 }
@@ -125,12 +384,13 @@ pub fn covmap_is_interesting_u8x16(
         }
     } else {
         for step in 0..steps {
-            let i = step * VectorType::LANES as usize;
+            let i = step * V::N;
             let history =
-                VectorType::new(hist[i..i + VectorType::LANES as usize].try_into().unwrap());
-            let items = VectorType::new(map[i..i + VectorType::LANES as usize].try_into().unwrap());
+                V::from_array(&hist[i..]);
+            let items = V::from_array(&map[i..]);
 
-            if items.max(history) != history {
+            let out= R::reduce(history, items);
+            if out != history {
                 interesting = true;
                 break;
             }
@@ -140,7 +400,9 @@ pub fn covmap_is_interesting_u8x16(
             for j in (size - left)..size {
                 unsafe {
                     let item = *map.get_unchecked(j);
-                    if item > *hist.get_unchecked(j) {
+                    let history = *hist.get_unchecked(j);
+                    let out = R::PrimitiveReducer::reduce(item, history);
+                    if out != history {
                         interesting = true;
                         break;
                     }
@@ -152,104 +414,25 @@ pub fn covmap_is_interesting_u8x16(
     (interesting, novelties)
 }
 
-/// Coverage map insteresting implementation by u8x32. Slightly faster than nightly simd but slightly
-/// slower than u8x16 version.
-#[cfg(all(feature = "alloc", feature = "wide"))]
-#[must_use]
-pub fn covmap_is_interesting_u8x32(
-    hist: &[u8],
-    map: &[u8],
-    collect_novelties: bool,
-) -> (bool, Vec<usize>) {
-    type VectorType = wide::u8x32;
-    const N: usize = VectorType::LANES as usize;
-    let mut novelties = vec![];
-    let mut interesting = false;
-    let size = map.len();
-    let steps = size / N;
-    let left = size % N;
-
-    if collect_novelties {
-        for step in 0..steps {
-            let i = step * N;
-            let history = VectorType::new(hist[i..i + N].try_into().unwrap());
-            let items = VectorType::new(map[i..i + N].try_into().unwrap());
-
-            if items.max(history) != history {
-                interesting = true;
-                unsafe {
-                    // Break into two loops so that LLVM will vectorize both loops.
-                    // Or LLVM won't vectorize them and is super slow. We need a few
-                    // extra intrinsic to wide and safe_arch to vectorize this manually.
-                    for j in i..(i + N / 2) {
-                        let item = *map.get_unchecked(j);
-                        if item > *hist.get_unchecked(j) {
-                            novelties.push(j);
-                        }
-                    }
-
-                    for j in (i + N / 2)..(i + N) {
-                        let item = *map.get_unchecked(j);
-                        if item > *hist.get_unchecked(j) {
-                            novelties.push(j);
-                        }
-                    }
-                }
-            }
-        }
-
-        for j in (size - left)..size {
-            unsafe {
-                let item = *map.get_unchecked(j);
-                if item > *hist.get_unchecked(j) {
-                    interesting = true;
-                    novelties.push(j);
-                }
-            }
-        }
-    } else {
-        for step in 0..steps {
-            let i = step * N;
-            let history = VectorType::new(hist[i..i + N].try_into().unwrap());
-            let items = VectorType::new(map[i..i + N].try_into().unwrap());
-
-            if items.max(history) != history {
-                interesting = true;
-                break;
-            }
-        }
-
-        if !interesting {
-            for j in (size - left)..size {
-                unsafe {
-                    let item = *map.get_unchecked(j);
-                    if item > *hist.get_unchecked(j) {
-                        interesting = true;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    (interesting, novelties)
-}
 
 /// Coverage map insteresting naive implementation. Do not use it unless you have strong reasons to do.
 #[cfg(feature = "alloc")]
 #[must_use]
-pub fn covmap_is_interesting_naive(
+pub fn covmap_is_interesting_naive<R>(
     hist: &[u8],
     map: &[u8],
     collect_novelties: bool,
-) -> (bool, Vec<usize>) {
+) -> (bool, Vec<usize>) 
+where 
+    R: Reducer<u8>
+{
     let mut novelties = vec![];
     let mut interesting = false;
     let initial = 0;
     if collect_novelties {
         for (i, item) in map.iter().enumerate().filter(|(_, item)| **item != initial) {
             let existing = unsafe { *hist.get_unchecked(i) };
-            let reduced = existing.max(*item);
+            let reduced = R::reduce(existing, *item);
             if existing != reduced {
                 interesting = true;
                 novelties.push(i);
@@ -258,7 +441,7 @@ pub fn covmap_is_interesting_naive(
     } else {
         for (i, item) in map.iter().enumerate().filter(|(_, item)| **item != initial) {
             let existing = unsafe { *hist.get_unchecked(i) };
-            let reduced = existing.max(*item);
+            let reduced = R::reduce(existing, *item);
             if existing != reduced {
                 interesting = true;
                 break;
@@ -269,17 +452,18 @@ pub fn covmap_is_interesting_naive(
     (interesting, novelties)
 }
 
-/// Standard coverage map instereting implementation. Use the available fastest implementation by default.
+
+/// Standard max coverage map instereting implementation. Use the available fastest implementation by default.
 #[cfg(feature = "alloc")]
 #[allow(unused_variables)] // or we fail cargo doc
 #[must_use]
-pub fn std_covmap_is_interesting(
+pub fn std_max_covmap_is_interesting(
     hist: &[u8],
     map: &[u8],
     collect_novelties: bool,
 ) -> (bool, Vec<usize>) {
     #[cfg(not(feature = "wide"))]
-    return covmap_is_interesting_naive(hist, map, collect_novelties);
+    return covmap_is_interesting_naive::<MaxReducer>(hist, map, collect_novelties);
 
     #[cfg(feature = "wide")]
     {
@@ -287,9 +471,9 @@ pub fn std_covmap_is_interesting(
         // - on aarch64, u8x32 is 15% faster than u8x16
         // - on amd64, u8x16 is 10% faster compared to the u8x32
         #[cfg(target_arch = "aarch64")]
-        return covmap_is_interesting_u8x32(hist, map, collect_novelties);
+        return covmap_is_interesting_simd::<SimdMaxReducer, wide::u8x32>(hist, map, collect_novelties);
 
         #[cfg(not(target_arch = "aarch64"))]
-        return covmap_is_interesting_u8x16(hist, map, collect_novelties);
+        return covmap_is_interesting_simd::<SimdMaxReducer, wide::u8x16>(hist, map, collect_novelties);
     }
 }

--- a/libafl_bolts/src/simd.rs
+++ b/libafl_bolts/src/simd.rs
@@ -75,7 +75,7 @@ where
     }
 }
 
-/// Unforunately we have to keep this type due to [`wide::*`] might not `PartialOrd``
+/// Unforunately we have to keep this type due to [`wide::*`] might not `PartialOrd`
 #[cfg(feature = "wide")]
 #[derive(Debug)]
 pub struct SimdMaxReducer;

--- a/libafl_bolts/src/simd.rs
+++ b/libafl_bolts/src/simd.rs
@@ -78,7 +78,7 @@ where
     }
 }
 
-/// Unforunately we have to keep this type due to [`wide::*`] might not `PartialOrd`
+/// Unforunately we have to keep this type due to [`wide`] might not `PartialOrd`
 #[cfg(feature = "wide")]
 #[derive(Debug)]
 pub struct SimdMaxReducer;
@@ -131,7 +131,7 @@ where
     }
 }
 
-/// Unforunately we have to keep this type due to [`wide::*`] might not `PartialOrd`
+/// Unforunately we have to keep this type due to [`wide`] might not `PartialOrd`
 #[cfg(feature = "wide")]
 #[derive(Debug)]
 pub struct SimdMinReducer;
@@ -228,7 +228,7 @@ pub trait VectorType {
     #[must_use]
     fn blend(self, lhs: Self, rhs: Self) -> Self;
 
-    /// Can't reuse [`crate::AsSlice`] due to [`wide::*`] might implement `Deref`
+    /// Can't reuse [`crate::AsSlice`] due to [`wide`] might implement `Deref`
     fn as_slice(&self) -> &[u8];
 }
 

--- a/libafl_bolts/src/simd.rs
+++ b/libafl_bolts/src/simd.rs
@@ -75,7 +75,7 @@ where
     }
 }
 
-/// Unforunately we have to keep this type due to [`wide::*`] might not PartialOrd
+/// Unforunately we have to keep this type due to [`wide::*`] might not `PartialOrd``
 #[cfg(feature = "wide")]
 #[derive(Debug)]
 pub struct SimdMaxReducer;
@@ -128,7 +128,7 @@ where
     }
 }
 
-/// Unforunately we have to keep this type due to [`wide::*`] might not PartialOrd
+/// Unforunately we have to keep this type due to [`wide::*`] might not `PartialOrd`
 #[cfg(feature = "wide")]
 #[derive(Debug)]
 pub struct SimdMinReducer;
@@ -173,7 +173,7 @@ where
     type PrimitiveReducer = OrReducer;
 }
 
-/// SIMD based OrReducer, alias for consistency
+/// SIMD based [`OrReducer`], alias for consistency
 #[cfg(feature = "wide")]
 pub type SimdOrReducer = OrReducer;
 
@@ -199,7 +199,7 @@ where
     type PrimitiveReducer = AndReducer;
 }
 
-/// SIMD based AndReducer, alias for consistency
+/// SIMD based [`AndReducer`], alias for consistency
 #[cfg(feature = "wide")]
 pub type SimdAndReducer = AndReducer;
 

--- a/libafl_bolts/src/simd.rs
+++ b/libafl_bolts/src/simd.rs
@@ -225,9 +225,10 @@ pub trait VectorType {
     fn novelties(hist: &[u8], map: &[u8], base: usize, novelties: &mut Vec<usize>);
 
     /// Do blending
+    #[must_use]
     fn blend(self, lhs: Self, rhs: Self) -> Self;
 
-    /// Can't reuse AsSlice due to [`wide::*`] might implement `Deref`
+    /// Can't reuse [`crate::AsSlice`] due to [`wide::*`] might implement `Deref`
     fn as_slice(&self) -> &[u8];
 }
 
@@ -332,6 +333,7 @@ where
         map[i..i + V::N].copy_from_slice(out.as_slice());
     }
 
+    #[allow(clippy::needless_range_loop)]
     for j in (size - left)..size {
         map[j] = if map[j] == 0 { 0x1 } else { 0x80 }
     }


### PR DESCRIPTION
## Description

As title. This PR does:

- Rename `stable_simd` to `simd`
- No longer rely on `nightly` for `std::simd` since `wide` is slightly faster and stable
- Support SIMD for `MaxReducer`, `OrReducer`, `AndReducer`, `MinReducer`
- Move `Reducer` to `libafl_bolts` to live with`SimdReducer`
- Benchmarked these SIMD operations and choose defaults for them
- Generalized SIMD vector support.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
