### PR TITLE
Fix 0/0 stability feedback for libafl_nyx

### DIFF
--- a/libafl/src/stages/calibrate.rs
+++ b/libafl/src/stages/calibrate.rs
@@ -254,7 +254,7 @@ where
                 metadata.unstable_entries.insert(item); // Insert newly found items
             }
             metadata.filled_entries_count = map_first_filled_count;
-        } else if !state.has_metadata::<UnstableEntriesMetadata>() {
+        } else if !state.has_metadata::<UnstableEntriesMetadata>() && map_first_filled_count > 0 {
             send_default_stability = true;
             state.add_metadata(UnstableEntriesMetadata::new());
         }


### PR DESCRIPTION
## Description

When the first `map_first_filled_count` returned from a fuzzer is equal to 0, stability will be initialized to a value of 0/0 and not updated as the map becomes filled _until_ the first instance of stability. For runs that are 100% stable, this means that the output will always report 0% stability.

This PR adds a check to ensure the stability metric isn't initialized until the first _non-zero_ map fill count.

Resolves #3161

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
