### PR TITLE
Fix python bindings

### DIFF
--- a/libafl_qemu/src/arch/arm.rs
+++ b/libafl_qemu/src/arch/arm.rs
@@ -4,6 +4,7 @@ use capstone::arch::BuildsCapstone;
 use enum_map::{EnumMap, enum_map};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[cfg(feature = "python")]
+#[allow(unused)]
 use pyo3::prelude::*;
 pub use strum_macros::EnumIter;
 pub use syscall_numbers::arm::*;

--- a/libafl_qemu/src/qemu/usermode.rs
+++ b/libafl_qemu/src/qemu/usermode.rs
@@ -494,14 +494,14 @@ pub mod pybind {
     extern "C" fn py_syscall_hook_wrapper(
         _data: u64,
         sys_num: i32,
-        a0: u64,
-        a1: u64,
-        a2: u64,
-        a3: u64,
-        a4: u64,
-        a5: u64,
-        a6: u64,
-        a7: u64,
+        a0: GuestAddr,
+        a1: GuestAddr,
+        a2: GuestAddr,
+        a3: GuestAddr,
+        a4: GuestAddr,
+        a5: GuestAddr,
+        a6: GuestAddr,
+        a7: GuestAddr,
     ) -> hooks::SyscallHookResult {
         unsafe { (&raw const PY_SYSCALL_HOOK).read() }.map_or_else(
             || hooks::SyscallHookResult::Run,

--- a/libafl_targets/src/libfuzzer/mutators.rs
+++ b/libafl_targets/src/libfuzzer/mutators.rs
@@ -5,10 +5,10 @@ use alloc::{
     vec::Vec,
 };
 use core::{cell::RefCell, marker::PhantomData, ops::Deref};
-use libafl::corpus::CorpusId;
+
 use libafl::{
     Error,
-    corpus::Corpus,
+    corpus::{Corpus, CorpusId},
     inputs::{BytesInput, HasMutatorBytes, ResizableMutator},
     mutators::{
         ComposedByMutations, MutationId, MutationResult, Mutator, MutatorsTuple, ScheduledMutator,
@@ -304,7 +304,10 @@ where
     }
     #[inline]
     fn post_exec(&mut self, state: &mut S, new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
-        self.mutator.deref().borrow_mut().post_exec(state, new_corpus_id)
+        self.mutator
+            .deref()
+            .borrow_mut()
+            .post_exec(state, new_corpus_id)
     }
 }
 
@@ -387,7 +390,10 @@ where
     }
     #[inline]
     fn post_exec(&mut self, state: &mut S, new_corpus_id: Option<CorpusId>) -> Result<(), Error> {
-        self.mutator.deref().borrow_mut().post_exec(state, new_corpus_id)
+        self.mutator
+            .deref()
+            .borrow_mut()
+            .post_exec(state, new_corpus_id)
     }
 }
 


### PR DESCRIPTION
## Description

When compiling the python bindings with `CPU_TARGET=arm maturin develop` I got an error because of a type mismatch in `py_syscall_hook_wrapper` (`libafl_qemu/src/qemu/usermode.rs`) and some unused functions in `libafl_qemu/src/arch/arm.rs`.

This fixes those issues.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments

I ran `./scripts/precommit.sh` but compilation for libafl_nyx failed so it only partially applied.