### PR TITLE
Remove bindgen float16 workaround

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/bindings.rs
+++ b/libafl_qemu/libafl_qemu_build/src/bindings.rs
@@ -6,10 +6,6 @@ use crate::store_generated_content_if_different;
 
 const WRAPPER_HEADER: &str = r#"
 
-// https://github.com/rust-lang/rust-bindgen/issues/2500
-#define __AVX512VLFP16INTRIN_H
-#define __AVX512FP16INTRIN_H
-
 // QEMU_BUILD_BUG* cause an infinite recursion in bindgen when target is arm
 #include "qemu/compiler.h"
 


### PR DESCRIPTION
## Description

This PR removes two lines from `libafl_qemu_build/src/bindings.rs` that define the existence of libclang headers `avx512vlfp16intrin.h` and `avx512fp16intrin.h`.

This used to be a workaround for bindgen not working well with specific types defined in Clang's `mmintrin.h`, see https://github.com/rust-lang/rust-bindgen/issues/2500#issuecomment-1640545912.

This seems to have been resolved in https://github.com/rust-lang/rust-bindgen/pull/2667, pushed to bindgen `v0.69.3`, rendering the workaround unnecessary.

With the old workaround, I was not able to compile libafl_qemu on clang-19 and later. See the build error below.
I tested this PR, and libafl_qemu compiles properly with clang-13, clang-15, and clang-19 to clang-21.

<details>

<summary>Clang 21 error message</summary>

```
  --- stderr
  DEBUG:mkvenv:/home/user/LibAFL/target/debug/qemu-libafl-bridge/python/scripts/mkvenv.py: make_venv(env_dir=pyvenv, system_site_packages=True, clear=True, symlinks=None, with_pip=True)
  DEBUG:mkvenv:QemuEnvBuilder.__init__(...)
  mkvenv: Creating non-isolated virtual environment at 'pyvenv'
  DEBUG:mkvenv:Invoking builder.create()
  DEBUG:mkvenv:create(env_dir=pyvenv)
  DEBUG:mkvenv:ensure_directories(env_dir=/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv)
  DEBUG:mkvenv:post_venv_setup()
  DEBUG:mkvenv:generate_console_scripts(packages=['pip'], python_path=/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/python3, bin_path=/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin)
  INFO:distlib.util:changing mode of /home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/pip to 755
  DEBUG:mkvenv:wrote console_script '/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/pip'
  INFO:distlib.util:changing mode of /home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/pip3 to 755
  DEBUG:mkvenv:wrote console_script '/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/pip3'
  DEBUG:mkvenv:mkvenv.py post_init: exiting
  DEBUG:mkvenv:builder.create() finished
  DEBUG:mkvenv:mkvenv.py create: exiting
  mkvenv: checking for meson>=1.5.0
  INFO:mkvenv:found meson 1.7.2
  mkvenv: checking for pycotap>=1.1.0
  DEBUG:mkvenv:generate_console_scripts(packages=['meson'], python_path=/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/python3, bin_path=/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin)
  INFO:distlib.util:changing mode of /home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/meson to 755
  DEBUG:mkvenv:wrote console_script '/home/user/LibAFL/target/debug/qemu-libafl-bridge/build/pyvenv/bin/meson'
  mkvenv: installing pycotap==1.3.1
  DEBUG:mkvenv:mkvenv.py ensuregroup: exiting
/home/user/LibAFL/target/debug/qemu-libafl-bridge/include/exec/cpu-all.h:160:47: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
  /home/user/LibAFL/target/debug/qemu-libafl-bridge/include/exec/cpu-all.h:160:47: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
  /usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:252:19: error: unknown type name '__m512h'
  /usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:254:10: error: returning '__attribute__((__vector_size__(32 * sizeof(_Float16)))) _Float16' (vector of 32 '_Float16' values) from a function with incompatible result type 'int'
  /usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:257:19: error: unknown type name '__m512h'
  /usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:259:10: error: returning '__attribute__((__vector_size__(32 * sizeof(_Float16)))) _Float16' (vector of 32 '_Float16' values) from a function with incompatible result type 'int'
  /usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:340:8: error: unknown type name '__m512h'
  /usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:359:8: error: unknown type name '__m512h'
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:61:33: error: invalid conversion between vector type '__v8hf' (vector of 8 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:147:33: error: invalid conversion between vector type '__v8hf' (vector of 8 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:181:33: error: invalid conversion between vector type '__v16hf' (vector of 16 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:267:33: error: invalid conversion between vector type '__v16hf' (vector of 16 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2120:29: error: invalid conversion between vector type '__m128h' (vector of 8 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2192:29: error: invalid conversion between vector type '__m128h' (vector of 8 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2217:30: error: invalid conversion between vector type '__m256h' (vector of 16 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2289:30: error: invalid conversion between vector type '__m256h' (vector of 16 '_Float16' values) and integer type 'int' of different size
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3091:10: error: returning 'int' from a function with incompatible result type '__m128h' (vector of 8 '_Float16' values)
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3125:10: error: returning 'int' from a function with incompatible result type '__m128h' (vector of 8 '_Float16' values)
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3158:10: error: returning 'int' from a function with incompatible result type '__m128h' (vector of 8 '_Float16' values)
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3180:10: error: returning 'int' from a function with incompatible result type '__m256h' (vector of 16 '_Float16' values)
  /usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3214:10: error: returning 'int' from a function with incompatible result type '__m256h' (vector of 16 '_Float16' values)
  fatal error: too many errors emitted, stopping now [-ferror-limit=]
  clang diag: /home/user/LibAFL/target/debug/qemu-libafl-bridge/include/exec/cpu-all.h:160:47: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
  clang diag: /home/user/LibAFL/target/debug/qemu-libafl-bridge/include/exec/cpu-all.h:160:47: warning: shifting a negative signed value is undefined [-Wshift-negative-value]

  thread 'main' panicked at libafl_qemu/libafl_qemu_build/src/lib.rs:81:10:
  Failed to generate the bindings: ClangDiagnostic("/usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:252:19: error: unknown type name '__m512h'\n/usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:254:10: error: returning '__attribute__((__vector_size__(32 * sizeof(_Float16)))) _Float16' (vector of 32 '_Float16' values) from a function with incompatible result type 'int'\n/usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:257:19: error: unknown type name '__m512h'\n/usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:259:10: error: returning '__attribute__((__vector_size__(32 * sizeof(_Float16)))) _Float16' (vector of 32 '_Float16' values) from a function with incompatible result type 'int'\n/usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:340:8: error: unknown type name '__m512h'\n/usr/lib/llvm-21/lib/clang/21/include/amxavx512intrin.h:359:8: error: unknown type name '__m512h'\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:61:33: error: invalid conversion between vector type '__v8hf' (vector of 8 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:147:33: error: invalid conversion between vector type '__v8hf' (vector of 8 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:181:33: error: invalid conversion between vector type '__v16hf' (vector of 16 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:267:33: error: invalid conversion between vector type '__v16hf' (vector of 16 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2120:29: error: invalid conversion between vector type '__m128h' (vector of 8 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2192:29: error: invalid conversion between vector type '__m128h' (vector of 8 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2217:30: error: invalid conversion between vector type '__m256h' (vector of 16 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:2289:30: error: invalid conversion between vector type '__m256h' (vector of 16 '_Float16' values) and integer type 'int' of different size\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3091:10: error: returning 'int' from a function with incompatible result type '__m128h' (vector of 8 '_Float16' values)\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3125:10: error: returning 'int' from a function with incompatible result type '__m128h' (vector of 8 '_Float16' values)\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3158:10: error: returning 'int' from a function with incompatible result type '__m128h' (vector of 8 '_Float16' values)\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3180:10: error: returning 'int' from a function with incompatible result type '__m256h' (vector of 16 '_Float16' values)\n/usr/lib/llvm-21/lib/clang/21/include/avx10_2convertintrin.h:3214:10: error: returning 'int' from a function with incompatible result type '__m256h' (vector of 16 '_Float16' values)\nfatal error: too many errors emitted, stopping now [-ferror-limit=]\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

</details>

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
