### PR TITLE
ensure Nyx command handler support is more CPU agnostic (#3153)

### DIFF
--- a/libafl_qemu/src/command/nyx.rs
+++ b/libafl_qemu/src/command/nyx.rs
@@ -109,8 +109,8 @@ macro_rules! define_nyx_command_manager {
                 #[deny(unreachable_patterns)]
                 fn parse(&self, qemu: Qemu) -> Result<Self::Commands, CommandError> {
                     let arch_regs_map: &'static EnumMap<ExitArgs, Regs> = get_exit_arch_regs();
-                    let nyx_backdoor = qemu.read_reg(Regs::Rax)? as c_uint;
-                    let cmd_id = qemu.read_reg(Regs::Rbx)? as c_uint;
+                    let nyx_backdoor = qemu.read_reg(arch_regs_map[ExitArgs::Ret])? as c_uint;
+                    let cmd_id = qemu.read_reg(arch_regs_map[ExitArgs::Cmd])? as c_uint;
 
                     // Check nyx backdoor correctness
                     debug_assert_eq!(nyx_backdoor, 0x1f);


### PR DESCRIPTION
## Description

Straightforward fix ensuring the Nyx command handler uses the local `arch_regs_map` via `get_exit_arch_regs()`. This is to determine the correct `Ret` and `Cmd` CPU registers for the guest architecture, respectively.

No build errors after overriding the guest CPU architecture in `Cargo.toml`, as described (`i386`). Same build result when reverting back to `arm`. Still, must test to be sure.

## Checklist
- [x] I have run `./scripts/precommit.sh` and addressed all comments
- [ ] Test Nyx support for `i386` QEMU guest
