### PR TITLE
librasan: Fix errno_location function name

### DIFF
--- a/libafl_qemu/librasan/asan/src/maps/libc.rs
+++ b/libafl_qemu/librasan/asan/src/maps/libc.rs
@@ -45,7 +45,7 @@ struct FunctionErrnoLocation;
 
 impl Function for FunctionErrnoLocation {
     type Func = unsafe extern "C" fn() -> *mut c_int;
-    const NAME: &'static CStr = c"errno_location";
+    const NAME: &'static CStr = c"__errno_location";
 }
 
 static OPEN_ADDR: AtomicGuestAddr = AtomicGuestAddr::new();

--- a/libafl_qemu/librasan/asan/src/mmap/libc.rs
+++ b/libafl_qemu/librasan/asan/src/mmap/libc.rs
@@ -55,7 +55,7 @@ struct FunctionErrnoLocation;
 
 impl Function for FunctionErrnoLocation {
     type Func = unsafe extern "C" fn() -> *mut c_int;
-    const NAME: &'static CStr = c"errno_location";
+    const NAME: &'static CStr = c"__errno_location";
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Description

The `errno` C macro should point to `__errno_location` on Linux.

http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---errno-location.html

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
