### PR TITLE
librasan: Support patching Thumb functions

### DIFF
--- a/libafl_qemu/librasan/asan/src/patch/raw.rs
+++ b/libafl_qemu/librasan/asan/src/patch/raw.rs
@@ -71,11 +71,11 @@ impl RawPatch {
     #[cfg(target_arch = "arm")]
     fn get_patch(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
         // ldr ip, [pc]
-        // mov pc, ip
+        // bx ip
         // .long 0xdeadface
         let insns = [
             [0x00, 0xc0, 0x9f, 0xe5].to_vec(),
-            [0x0c, 0xf0, 0xa0, 0xe1].to_vec(),
+            [0x1c, 0xff, 0x2f, 0xe1].to_vec(),
             [0xce, 0xfa, 0xad, 0xde].to_vec(),
         ];
         let addr = destination.to_ne_bytes().to_vec();

--- a/libafl_qemu/librasan/asan/src/patch/raw.rs
+++ b/libafl_qemu/librasan/asan/src/patch/raw.rs
@@ -14,35 +14,18 @@ pub struct RawPatch;
 
 impl Patch for RawPatch {
     type Error = RawPatchError;
-
-    #[cfg(not(target_arch = "arm"))]
     fn patch(target: GuestAddr, destination: GuestAddr) -> Result<(), Self::Error> {
         debug!("patch - addr: {:#x}, target: {:#x}", target, destination);
         if target == destination {
             Err(RawPatchError::IdentityPatch(target))?;
         }
-        let patch = Self::get_patch(destination)?;
-        trace!("patch: {:02x?}", patch);
-        let dest = unsafe { from_raw_parts_mut(target as *mut u8, patch.len()) };
-        dest.copy_from_slice(&patch);
-        Ok(())
-    }
+        let patch = Self::get_patch(target, destination)?;
 
-    #[cfg(target_arch = "arm")]
-    fn patch(target: GuestAddr, destination: GuestAddr) -> Result<(), Self::Error> {
-        debug!("patch - addr: {:#x}, target: {:#x}", target, destination);
-        if target == destination {
-            Err(RawPatchError::IdentityPatch(target))?;
-        }
-
-        let patch = if target & 1 == 1 {
-            Self::get_patch_thumb(destination)?
-        } else {
-            Self::get_patch_arm(destination)?
-        };
-
-        trace!("patch: {:02x?}", patch);
+        // Mask the thumb mode indicator bit
+        #[cfg(target_arch = "arm")]
         let target = target & !1;
+
+        trace!("patch: {:02x?}", patch);
         let dest = unsafe { from_raw_parts_mut(target as *mut u8, patch.len()) };
         dest.copy_from_slice(&patch);
         Ok(())
@@ -51,7 +34,7 @@ impl Patch for RawPatch {
 
 impl RawPatch {
     #[cfg(target_arch = "x86_64")]
-    fn get_patch(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
+    fn get_patch(_target: GuestAddr, destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
         // mov rax, 0xdeadfacef00dd00d
         // jmp rax
         let insns = [
@@ -77,7 +60,7 @@ impl RawPatch {
     }
 
     #[cfg(target_arch = "x86")]
-    fn get_patch(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
+    fn get_patch(_target: GuestAddr, destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
         // mov eax, 0xdeadface
         // jmp eax
         let insns = [
@@ -91,37 +74,37 @@ impl RawPatch {
     }
 
     #[cfg(target_arch = "arm")]
-    fn get_patch_arm(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
-        // ldr ip, [pc]
-        // bx ip
-        // .long 0xdeadface
-        let insns = [
-            [0x00, 0xc0, 0x9f, 0xe5].to_vec(),
-            [0x1c, 0xff, 0x2f, 0xe1].to_vec(),
-            [0xce, 0xfa, 0xad, 0xde].to_vec(),
-        ];
-        let addr = destination.to_ne_bytes().to_vec();
-        let insns_mod = [&insns[0], &insns[1], &addr];
-        Ok(insns_mod.into_iter().flatten().cloned().collect())
-    }
-
-    #[cfg(target_arch = "arm")]
-    fn get_patch_thumb(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
-        // ldr ip, [pc, #2]
-        // bx ip
-        // .long 0xdeadface
-        let insns = [
-            [0xdf, 0xf8, 0x02, 0xc0].to_vec(),
-            [0x60, 0x47].to_vec(),
-            [0xce, 0xfa, 0xad, 0xde].to_vec(),
-        ];
-        let addr = destination.to_ne_bytes().to_vec();
-        let insns_mod = [&insns[0], &insns[1], &addr];
-        Ok(insns_mod.into_iter().flatten().cloned().collect())
+    fn get_patch(target: GuestAddr, destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
+        // If our target is in thumb mode
+        if target & 1 == 1 {
+            // ldr ip, [pc, #2]
+            // bx ip
+            // .long 0xdeadface
+            let insns = [
+                [0xdf, 0xf8, 0x02, 0xc0].to_vec(),
+                [0x60, 0x47].to_vec(),
+                [0xce, 0xfa, 0xad, 0xde].to_vec(),
+            ];
+            let addr = destination.to_ne_bytes().to_vec();
+            let insns_mod = [&insns[0], &insns[1], &addr];
+            Ok(insns_mod.into_iter().flatten().cloned().collect())
+        } else {
+            // ldr ip, [pc]
+            // bx ip
+            // .long 0xdeadface
+            let insns = [
+                [0x00, 0xc0, 0x9f, 0xe5].to_vec(),
+                [0x1c, 0xff, 0x2f, 0xe1].to_vec(),
+                [0xce, 0xfa, 0xad, 0xde].to_vec(),
+            ];
+            let addr = destination.to_ne_bytes().to_vec();
+            let insns_mod = [&insns[0], &insns[1], &addr];
+            Ok(insns_mod.into_iter().flatten().cloned().collect())
+        }
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn get_patch(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
+    fn get_patch(_target: GuestAddr, destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
         // ldr x16, #8
         // br  x16
         // .quad 0xdeadfacef00dd00d
@@ -137,7 +120,7 @@ impl RawPatch {
     }
 
     #[cfg(target_arch = "powerpc")]
-    fn get_patch(destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
+    fn get_patch(_target: GuestAddr, destination: GuestAddr) -> Result<Vec<u8>, RawPatchError> {
         // lis 12, 0xdead
         // ori 12, 12, 0xface
         // mtctr 12

--- a/libafl_qemu/librasan/asan/tests/patch_raw.rs
+++ b/libafl_qemu/librasan/asan/tests/patch_raw.rs
@@ -148,50 +148,50 @@ mod tests {
         };
     }
 
-    define_test_function!(test_arm1, 0xdeadface);
-    define_test_function!(test_arm2, 0xd00df00d);
-    define_test_function!(test_arm3, 0xfeeddeaf);
+    define_test_function!(arm_patch_target, 0xdeadface);
+    define_test_function!(patched_arm_to_arm, 0xd00df00d);
+    define_test_function!(patched_arm_to_thumb, 0xfeeddeaf);
     define_test_function!(
         target_feature(enable = "thumb-mode"),
-        test_thumb1,
+        thumb_patch_target,
         0xcafebabe
     );
     define_test_function!(
         target_feature(enable = "thumb-mode"),
-        test_thumb2,
+        patched_thumb_to_thumb,
         0xbeeffade
     );
     define_test_function!(
         target_feature(enable = "thumb-mode"),
-        test_thumb3,
+        patched_thumb_to_arm,
         0xdeedcede
     );
 
     define_test!(
         test_patch_arm_to_arm,
-        test_arm2,
-        test_arm1,
+        patched_arm_to_arm,
+        arm_patch_target,
         0xd00df00d,
         0xdeadface
     );
     define_test!(
         test_patch_arm_to_thumb,
-        test_arm3,
-        test_thumb1,
+        patched_arm_to_thumb,
+        thumb_patch_target,
         0xfeeddeaf,
         0xcafebabe
     );
     define_test!(
         test_patch_thumb_to_arm,
-        test_thumb3,
-        test_arm1,
+        patched_thumb_to_arm,
+        arm_patch_target,
         0xdeedcede,
         0xdeadface
     );
     define_test!(
         test_patch_thumb_to_thumb,
-        test_thumb2,
-        test_thumb1,
+        patched_thumb_to_thumb,
+        thumb_patch_target,
         0xbeeffade,
         0xcafebabe
     );

--- a/libafl_qemu/librasan/asan/tests/patch_raw.rs
+++ b/libafl_qemu/librasan/asan/tests/patch_raw.rs
@@ -1,5 +1,8 @@
+#![cfg_attr(target_arch = "arm", feature(arm_target_feature))]
+
 #[cfg(test)]
 #[cfg(feature = "libc")]
+#[cfg(not(target_arch = "arm"))]
 mod tests {
     use asan::{
         GuestAddr,
@@ -54,4 +57,133 @@ mod tests {
         let ret = test1(1, 2, 3, 4, 5, 6);
         assert_eq!(ret, 0xd00df00d);
     }
+}
+
+#[cfg(test)]
+#[cfg(feature = "libc")]
+#[cfg(target_arch = "arm")]
+mod tests {
+    use asan::{
+        GuestAddr,
+        mmap::{Mmap, MmapProt, linux::LinuxMmap},
+        patch::{Patch, raw::RawPatch},
+    };
+    use log::info;
+
+    macro_rules! define_test_function {
+        ($fn_name:ident, $ret_val:expr) => {
+            define_test_function!([], $fn_name, $ret_val);
+        };
+
+        ($attr:meta, $fn_name:ident, $ret_val:expr) => {
+            define_test_function!([$attr], $fn_name, $ret_val);
+        };
+
+        ([$($attr:meta)*], $fn_name:ident, $ret_val:expr) => {
+            #[unsafe(no_mangle)]
+            $(#[$attr])*
+            extern "C" fn $fn_name(
+                a1: usize,
+                a2: usize,
+                a3: usize,
+                a4: usize,
+                a5: usize,
+                a6: usize,
+            ) -> usize {
+                assert_eq!(a1, 1);
+                assert_eq!(a2, 2);
+                assert_eq!(a3, 3);
+                assert_eq!(a4, 4);
+                assert_eq!(a5, 5);
+                assert_eq!(a6, 6);
+                return $ret_val;
+            }
+        };
+    }
+
+    macro_rules! define_test {
+        (
+            $fn_name:ident,
+            $test_fn1:ident,
+            $test_fn2:ident,
+            $test_ret_val1:expr,
+            $test_ret_val2:expr
+        ) => {
+            #[test]
+            fn $fn_name() {
+                #[allow(unused_unsafe)]
+                unsafe {
+                    let ret1 = $test_fn1(1, 2, 3, 4, 5, 6);
+                    assert_eq!(ret1, $test_ret_val1);
+
+                    let ret2 = $test_fn2(1, 2, 3, 4, 5, 6);
+                    assert_eq!(ret2, $test_ret_val2);
+
+                    let ptest1 = $test_fn1 as *const () as GuestAddr;
+                    let ptest2 = $test_fn2 as *const () as GuestAddr;
+                    info!("pfn: {:#x}", ptest1);
+                    let aligned_pfn = ptest1 & !0xfff;
+                    info!("aligned_pfn: {:#x}", aligned_pfn);
+                    LinuxMmap::protect(
+                        aligned_pfn,
+                        0x4096,
+                        MmapProt::READ | MmapProt::WRITE | MmapProt::EXEC,
+                    )
+                    .unwrap();
+
+                    RawPatch::patch(ptest1, ptest2).unwrap();
+                    let ret = $test_fn1(1, 2, 3, 4, 5, 6);
+                    assert_eq!(ret, $test_ret_val2);
+                }
+            }
+        };
+    }
+
+    define_test_function!(test_arm1, 0xdeadface);
+    define_test_function!(test_arm2, 0xd00df00d);
+    define_test_function!(test_arm3, 0xfeeddeaf);
+    define_test_function!(
+        target_feature(enable = "thumb-mode"),
+        test_thumb1,
+        0xcafebabe
+    );
+    define_test_function!(
+        target_feature(enable = "thumb-mode"),
+        test_thumb2,
+        0xbeeffade
+    );
+    define_test_function!(
+        target_feature(enable = "thumb-mode"),
+        test_thumb3,
+        0xdeedcede
+    );
+
+    define_test!(
+        test_patch_arm_to_arm,
+        test_arm2,
+        test_arm1,
+        0xd00df00d,
+        0xdeadface
+    );
+    define_test!(
+        test_patch_arm_to_thumb,
+        test_arm3,
+        test_thumb1,
+        0xfeeddeaf,
+        0xcafebabe
+    );
+    define_test!(
+        test_patch_thumb_to_arm,
+        test_thumb3,
+        test_arm1,
+        0xdeedcede,
+        0xdeadface
+    );
+    define_test!(
+        test_patch_thumb_to_thumb,
+        test_thumb2,
+        test_thumb1,
+        0xbeeffade,
+        0xcafebabe
+    );
 }


### PR DESCRIPTION
## Description

ARMv7 has two instruction sets: Thumb2 and ARM. ARM CPUs switch to Thumb state when they jump to a target address if the least significant bit of the address is set to 1. While `libc` can be compiled with ARM or Thumb instructions entirely, mixed instruction sets are also possible. This can happen when `libc` is compiled for ARM but has some handwritten Thumb assembly implementations for certain functions for performance reasons.

The following command shows a `libc.so.6` where two symbols have an address with the least significant bit set to 1.
```
$ readelf --syms --wide libc.so.6 | awk '$2~/.*[13579bde]$/'
Symbol table '.dynsym' contains 2208 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
   523: 0007bb21   156 FUNC    GLOBAL DEFAULT   12 memchr@@GLIBC_2.4
   769: 0007a641   220 FUNC    GLOBAL DEFAULT   12 strlen@@GLIBC_2.4
```

This poses a problem with the current live-patching implementation, which assumes that all `libc` functions are always ARM functions. In the current situation, the live patcher writes the assembly trampoline consisting of ARM instructions into a function where Thumb instructions are expected, offset by a single byte. This obviously leads to incorrect behavior once such a function is called.

This PR fixes that by checking whether the target address points to a Thumb functions and generates a Thumb trampoline which it writes to the correct address (i.e. address - 1).

The ARMv7-A manual also says the following.
> A processor in ARM state executes ARM instructions, and a processor in Thumb state executes Thumb instructions. A processor in Thumb state can enter ARM state by executing any of the following instructions: `BX`, `BLX`, or an `LDR` or `LDM` that loads the PC.
>
> A processor in ARM state can enter Thumb state by executing any of the same instructions.
>
> In ARMv7, a processor in ARM state can also enter Thumb state by executing an `ADC`, `ADD`, `AND`, `ASR`, `BIC`, `EOR`, `LSL`, `LSR`, `MOV`, `MVN`, `ORR`, `ROR`, `RRX`, `RSB`, `RSC`, `SBC`, or `SUB` instruction that has the PC as destination register and does not set the condition flags
>
> This permits calls and returns between ARM code written for ARMv4 processors and Thumb code running on ARMv7 processors to function correctly. ARM recommends that new software uses `BX` or `BLX` instructions instead. In particular, ARM recommends that software uses `BX LR` to return from a procedure, not `MOV PC, LR`.

Which means we have to use `bx ip` instead of `mov pc, ip` in Thumb state. For consistency and following the recommendation, I've also changed the ARM trampoline to use `bx ip`.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
