### PR TITLE
Revert "Update hashbrown requirement from 0.14.5 to 0.15.3"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ cc = "1.1.21"
 cmake = "0.1.51"
 document-features = "0.2.10"
 fastbloom = { version = "0.9.0", default-features = false }
-hashbrown = { version = "0.15.3", default-features = false } # A faster hashmap, nostd compatible
+hashbrown = { version = "0.14.5", default-features = false } # A faster hashmap, nostd compatible
 just = "1.40.0"
 libc = "0.2.159" # For (*nix) libc
 libipt = "0.3.0"


### PR DESCRIPTION
Reverts AFLplusplus/LibAFL#3184

this is clearly not mergeable as it is, it breaks the whole ci.