### PR TITLE
Remove unnecessary trait bounds in NautilusSpliceMutator

### DIFF
--- a/libafl/src/mutators/nautilus.rs
+++ b/libafl/src/mutators/nautilus.rs
@@ -178,7 +178,7 @@ impl Debug for NautilusSpliceMutator<'_> {
 
 impl<S> Mutator<NautilusInput, S> for NautilusSpliceMutator<'_>
 where
-    S: HasCorpus<NautilusInput> + HasMetadata + HasRand,
+    S: HasMetadata + HasRand,
 {
     fn mutate(
         &mut self,

--- a/libafl/src/mutators/nautilus.rs
+++ b/libafl/src/mutators/nautilus.rs
@@ -19,7 +19,7 @@ use crate::{
     generators::nautilus::NautilusContext,
     inputs::nautilus::NautilusInput,
     mutators::{MutationResult, Mutator},
-    state::{HasCorpus, HasRand},
+    state::HasRand,
 };
 
 /// The randomic mutator for `Nautilus` grammar.


### PR DESCRIPTION
## Description

The implementation of NautilusSpliceMutator does not need S: HasCorpus<NautilusInput> at all.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments

Clippy complains at somewhere I did not modify.
