### PR TITLE
Add weak symbol for forkserver

### DIFF
--- a/libafl_targets/src/coverage.c
+++ b/libafl_targets/src/coverage.c
@@ -16,7 +16,9 @@ uint32_t       *__afl_acc_memop_ptr = __afl_acc_memop_ptr_local;
 
 // Set by this macro
 // https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-cc.c#L993
+#if !defined(_WIN32)
 EXT_VAR(__afl_sharedmem_fuzzing, int);
+#endif
 
 // Weak symbols, LLVM Passes overwrites them if we really use it
 #if defined(__linux__)

--- a/libafl_targets/src/coverage.c
+++ b/libafl_targets/src/coverage.c
@@ -14,6 +14,10 @@ uint8_t       *__afl_area_ptr = __afl_area_ptr_local;
 extern uint32_t __afl_acc_memop_ptr_local[ACCOUNTING_MAP_SIZE];
 uint32_t       *__afl_acc_memop_ptr = __afl_acc_memop_ptr_local;
 
+// Set by this macro
+// https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-cc.c#L993
+extern EXT_VAR(__afl_sharedmem_fuzzing, int);
+
 // Weak symbols, LLVM Passes overwrites them if we really use it
 #if defined(__linux__)
 extern EXT_VAR(__start_libafl_token, uint8_t);

--- a/libafl_targets/src/coverage.c
+++ b/libafl_targets/src/coverage.c
@@ -16,7 +16,7 @@ uint32_t       *__afl_acc_memop_ptr = __afl_acc_memop_ptr_local;
 
 // Set by this macro
 // https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-cc.c#L993
-int __afl_sharedmem_fuzzing __attribute__((weak));
+EXT_VAR(__afl_sharedmem_fuzzing, int);
 
 // Weak symbols, LLVM Passes overwrites them if we really use it
 #if defined(__linux__)

--- a/libafl_targets/src/coverage.c
+++ b/libafl_targets/src/coverage.c
@@ -16,7 +16,7 @@ uint32_t       *__afl_acc_memop_ptr = __afl_acc_memop_ptr_local;
 
 // Set by this macro
 // https://github.com/AFLplusplus/AFLplusplus/blob/stable/src/afl-cc.c#L993
-extern EXT_VAR(__afl_sharedmem_fuzzing, int);
+int __afl_sharedmem_fuzzing __attribute__((weak));
 
 // Weak symbols, LLVM Passes overwrites them if we really use it
 #if defined(__linux__)


### PR DESCRIPTION
## Description

#3183 removes a weak symbol `__afl_sharedmem_fuzzing`, which is only defined in `afl-cc`. Add it back for other modes that use forkserver.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
