### PR TITLE
Remove unnecessary copy in mutation

### DIFF
--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -934,9 +934,7 @@ impl BytesCopyMutator {
 
 /// Bytes insert and self copy mutation for inputs with a bytes vector
 #[derive(Debug, Default)]
-pub struct BytesInsertCopyMutator {
-    tmp_buf: Vec<u8>,
-}
+pub struct BytesInsertCopyMutator;
 
 impl<I, S> Mutator<I, S> for BytesInsertCopyMutator
 where
@@ -965,26 +963,16 @@ where
         let range = rand_range(state, size, max_insert_len);
 
         input.resize(size + range.len(), 0);
-        self.tmp_buf.resize(range.len(), 0);
         unsafe {
-            buffer_copy(
-                &mut self.tmp_buf,
-                input.mutator_bytes(),
-                range.start,
-                0,
-                range.len(),
-            );
-
             buffer_self_copy(
                 input.mutator_bytes_mut(),
                 target,
                 target + range.len(),
                 size - target,
             );
-            buffer_copy(
+            buffer_self_copy(
                 input.mutator_bytes_mut(),
-                &self.tmp_buf,
-                0,
+                target + range.len(),
                 target,
                 range.len(),
             );

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -1000,7 +1000,7 @@ impl BytesInsertCopyMutator {
     /// Creates a new [`BytesInsertCopyMutator`].
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }
 

--- a/libafl/src/mutators/mutations.rs
+++ b/libafl/src/mutators/mutations.rs
@@ -970,12 +970,6 @@ where
                 target + range.len(),
                 size - target,
             );
-            buffer_self_copy(
-                input.mutator_bytes_mut(),
-                target + range.len(),
-                target,
-                range.len(),
-            );
         }
         Ok(MutationResult::Mutated)
     }


### PR DESCRIPTION
## Description

I'm not sure why `BytesInsertCopyMutator` uses a temp buffer to do its thing, seems like this just adds an unnecessary allocation and two buffer copy operations.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
