### PR TITLE
Add cmplog shared memory mapping method for forkserver

### DIFF
--- a/fuzzers/forkserver/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver/src/main.rs
@@ -11,7 +11,7 @@ use clap::{Arg, ArgAction, Command};
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleEventManager,
-    executors::forkserver::ForkserverExecutor,
+    executors::forkserver::{ForkserverExecutor, SHM_CMPLOG_ENV_VAR},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
@@ -351,7 +351,7 @@ fn fuzz(
         let mut cmplog_shmem = shmem_provider.uninit_on_shmem::<AFLppCmpLogMap>().unwrap();
         // let the forkserver know the shmid
         unsafe {
-            cmplog_shmem.write_to_env("__AFL_CMPLOG_SHM_ID").unwrap();
+            cmplog_shmem.write_to_env(SHM_CMPLOG_ENV_VAR).unwrap();
         }
         let cmpmap = unsafe { OwnedRefMut::<AFLppCmpLogMap>::from_shmem(&mut cmplog_shmem) };
 

--- a/fuzzers/forkserver/fuzzbench_forkserver_cmplog/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver_cmplog/src/main.rs
@@ -11,7 +11,7 @@ use clap::{Arg, ArgAction, Command};
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleEventManager,
-    executors::forkserver::ForkserverExecutor,
+    executors::forkserver::{ForkserverExecutor, SHM_CMPLOG_ENV_VAR},
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
@@ -354,7 +354,7 @@ fn fuzz(
         let mut cmplog_shmem = shmem_provider.uninit_on_shmem::<AFLppCmpLogMap>().unwrap();
         // let the forkserver know the shmid
         unsafe {
-            cmplog_shmem.write_to_env("__AFL_CMPLOG_SHM_ID").unwrap();
+            cmplog_shmem.write_to_env(SHM_CMPLOG_ENV_VAR).unwrap();
         }
         let cmpmap = unsafe { OwnedRefMut::from_shmem(&mut cmplog_shmem) };
 

--- a/fuzzers/forkserver/fuzzbench_forkserver_sand/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver_sand/src/main.rs
@@ -11,7 +11,10 @@ use clap::{Arg, ArgAction, Command};
 use libafl::{
     corpus::{Corpus, InMemoryOnDiskCorpus, OnDiskCorpus},
     events::SimpleEventManager,
-    executors::{forkserver::ForkserverExecutor, sand::SANDExecutor},
+    executors::{
+        forkserver::{ForkserverExecutor, SHM_CMPLOG_ENV_VAR},
+        sand::SANDExecutor,
+    },
     feedback_or,
     feedbacks::{CrashFeedback, MaxMapFeedback, TimeFeedback},
     fuzzer::{Fuzzer, StdFuzzer},
@@ -398,7 +401,7 @@ fn fuzz(
         let mut cmplog_shmem = shmem_provider.uninit_on_shmem::<AFLppCmpLogMap>().unwrap();
         // let the forkserver know the shmid
         unsafe {
-            cmplog_shmem.write_to_env("__AFL_CMPLOG_SHM_ID").unwrap();
+            cmplog_shmem.write_to_env(SHM_CMPLOG_ENV_VAR).unwrap();
         }
         let cmpmap = unsafe { OwnedRefMut::<AFLppCmpLogMap>::from_shmem(&mut cmplog_shmem) };
 

--- a/fuzzers/forkserver/libafl-fuzz/src/fuzzer.rs
+++ b/fuzzers/forkserver/libafl-fuzz/src/fuzzer.rs
@@ -16,7 +16,7 @@ use libafl::monitors::SimpleMonitor;
 use libafl::{
     corpus::{CachedOnDiskCorpus, Corpus, OnDiskCorpus},
     events::ProgressReporter,
-    executors::forkserver::{ForkserverExecutor, ForkserverExecutorBuilder},
+    executors::forkserver::{ForkserverExecutor, ForkserverExecutorBuilder, SHM_CMPLOG_ENV_VAR},
     feedback_and, feedback_or, feedback_or_fast,
     feedbacks::{
         CaptureTimeoutFeedback, ConstFeedback, CrashFeedback, MaxMapFeedback, TimeFeedback,
@@ -476,7 +476,7 @@ define_run_client!(state, mgr, fuzzer_dir, core_id, opt, is_main_node, {
 
         // Let the Forkserver know the CmpLog shared memory map ID.
         unsafe {
-            cmplog_shmem.write_to_env("__AFL_CMPLOG_SHM_ID").unwrap();
+            cmplog_shmem.write_to_env(SHM_CMPLOG_ENV_VAR).unwrap();
         }
         let cmpmap = unsafe { OwnedRefMut::from_shmem(&mut cmplog_shmem) };
 

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -147,6 +147,8 @@ const MIN_INPUT_SIZE_DEFAULT: usize = 1;
 pub const SHM_FUZZ_ENV_VAR: &str = "__AFL_SHM_FUZZ_ID";
 /// Environment variable key for shared memory id for edge map
 pub const SHM_ENV_VAR: &str = "__AFL_SHM_ID";
+/// Environment variable key for shared memory id for cmplog map
+pub const SHM_CMPLOG_ENV_VAR: &str = "__AFL_CMPLOG_SHM_ID";
 
 /// The default signal to use to kill child processes
 const KILL_SIGNAL_DEFAULT: Signal = Signal::SIGTERM;


### PR DESCRIPTION
## Description

Previously we already have methods to map `__AFL_SHM_ID` and `__AFL_SHM_FUZZZ_ID`. Now add the method to map `__AFL_CMPLOG_SHM_ID`.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
