### PR TITLE
Allow QEMU location and version to be specified in environment

### DIFF
--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -9,7 +9,7 @@ use which::which;
 
 use crate::cargo_add_rpath;
 
-pub const LIBAFL_QEMU_GIT_REMOTE: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
+pub const LIBAFL_QEMU_GIT_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
 pub const LIBAFL_QEMU_DIRNAME: &str = "qemu-libafl-bridge";
 pub const LIBAFL_QEMU_GIT_REV: &str = "0bea78a122b249cbffafdb130af04cc7331c9aee";
 
@@ -278,8 +278,8 @@ pub fn build(
         env::var_os("LIBAFL_QEMU_CLONE_DIR").map(|x| x.to_string_lossy().to_string());
     let libafl_qemu_force_configure = env::var("LIBAFL_QEMU_FORCE_CONFIGURE").is_ok();
     let libafl_qemu_no_build = env::var("LIBAFL_QEMU_NO_BUILD").is_ok();
-    let libafl_qemu_git_remote =
-        env::var_os("LIBAFL_QEMU_GIT_REMOTE").map(|x| x.to_string_lossy().to_string());
+    let libafl_qemu_git_url =
+        env::var_os("LIBAFL_QEMU_GIT_URL").map(|x| x.to_string_lossy().to_string());
     let libafl_qemu_git_rev =
         env::var_os("LIBAFL_QEMU_GIT_REV").map(|x| x.to_string_lossy().to_string());
 
@@ -288,7 +288,7 @@ pub fn build(
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_FORCE_BUILD");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_FORCE_CONFIGURE");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_NO_BUILD");
-    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_GIT_REMOTE");
+    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_GIT_URL");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_GIT_REV");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
@@ -311,8 +311,8 @@ pub fn build(
         );
 
         assert!(
-            libafl_qemu_git_remote.is_none(),
-            "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_GIT_REMOTE are both set."
+            libafl_qemu_git_url.is_none(),
+            "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_GIT_URL are both set."
         );
 
         assert!(
@@ -328,9 +328,9 @@ pub fn build(
             target_dir.join(LIBAFL_QEMU_DIRNAME)
         };
 
-        let qemu_git_remote = libafl_qemu_git_remote
+        let qemu_git_url = libafl_qemu_git_url
             .as_deref()
-            .unwrap_or(LIBAFL_QEMU_GIT_REMOTE);
+            .unwrap_or(LIBAFL_QEMU_GIT_URL);
         let qemu_git_rev = libafl_qemu_git_rev
             .as_deref()
             .unwrap_or(LIBAFL_QEMU_GIT_REV);
@@ -359,7 +359,7 @@ pub fn build(
                     .arg("remote")
                     .arg("add")
                     .arg("origin")
-                    .arg(qemu_git_remote)
+                    .arg(qemu_git_url)
                     .status()
                     .unwrap()
                     .success()

--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -278,12 +278,17 @@ pub fn build(
         env::var_os("LIBAFL_QEMU_CLONE_DIR").map(|x| x.to_string_lossy().to_string());
     let libafl_qemu_force_configure = env::var("LIBAFL_QEMU_FORCE_CONFIGURE").is_ok();
     let libafl_qemu_no_build = env::var("LIBAFL_QEMU_NO_BUILD").is_ok();
+    let libafl_qemu_url = env::var_os("LIBAFL_QEMU_URL").map(|x| x.to_string_lossy().to_string());
+    let libafl_qemu_revision =
+        env::var_os("LIBAFL_QEMU_REVISION").map(|x| x.to_string_lossy().to_string());
 
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_DIR");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_CLONE_DIR");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_FORCE_BUILD");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_FORCE_CONFIGURE");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_NO_BUILD");
+    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_URL");
+    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_REVISION");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_dir = out_dir.to_string_lossy().to_string();
@@ -305,6 +310,18 @@ pub fn build(
             );
         }
 
+        if libafl_qemu_url.is_some() {
+            println!(
+                "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_URL are both set. LIBAFL_QEMU_DIR will be considered in priority"
+            );
+        }
+
+        if libafl_qemu_revision.is_some() {
+            println!(
+                "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_REVISION are both set. LIBAFL_QEMU_DIR will be considered in priority"
+            );
+        }
+
         Path::new(&qemu_dir).to_path_buf()
     } else {
         let qemu_path = if let Some(clone_dir) = &libafl_qemu_clone_dir {
@@ -313,15 +330,18 @@ pub fn build(
             target_dir.join(QEMU_DIRNAME)
         };
 
+        let qemu_url = libafl_qemu_url.as_deref().unwrap_or(QEMU_URL);
+        let qemu_revision = libafl_qemu_revision.as_deref().unwrap_or(QEMU_REVISION);
+
         let qemu_rev = target_dir.join("QEMU_REVISION");
         if qemu_rev.exists()
-            && fs::read_to_string(&qemu_rev).expect("Failed to read QEMU_REVISION") != QEMU_REVISION
+            && fs::read_to_string(&qemu_rev).expect("Failed to read QEMU_REVISION") != qemu_revision
         {
             drop(fs::remove_dir_all(&qemu_path));
         }
 
         if !qemu_path.is_dir() {
-            println!("cargo:warning=Qemu not found, cloning with git ({QEMU_REVISION})...");
+            println!("cargo:warning=Qemu not found, cloning with git ({qemu_revision})...");
             fs::create_dir_all(&qemu_path).unwrap();
             assert!(
                 Command::new("git")
@@ -337,7 +357,7 @@ pub fn build(
                     .arg("remote")
                     .arg("add")
                     .arg("origin")
-                    .arg(QEMU_URL)
+                    .arg(qemu_url)
                     .status()
                     .unwrap()
                     .success()
@@ -349,7 +369,7 @@ pub fn build(
                     .arg("--depth")
                     .arg("1")
                     .arg("origin")
-                    .arg(QEMU_REVISION)
+                    .arg(qemu_revision)
                     .status()
                     .unwrap()
                     .success()
@@ -363,7 +383,7 @@ pub fn build(
                     .unwrap()
                     .success()
             );
-            fs::write(&qemu_rev, QEMU_REVISION).unwrap();
+            fs::write(&qemu_rev, qemu_revision).unwrap();
         }
 
         qemu_path

--- a/libafl_qemu/libafl_qemu_build/src/build.rs
+++ b/libafl_qemu/libafl_qemu_build/src/build.rs
@@ -9,9 +9,9 @@ use which::which;
 
 use crate::cargo_add_rpath;
 
-pub const QEMU_URL: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
-pub const QEMU_DIRNAME: &str = "qemu-libafl-bridge";
-pub const QEMU_REVISION: &str = "0bea78a122b249cbffafdb130af04cc7331c9aee";
+pub const LIBAFL_QEMU_GIT_REMOTE: &str = "https://github.com/AFLplusplus/qemu-libafl-bridge";
+pub const LIBAFL_QEMU_DIRNAME: &str = "qemu-libafl-bridge";
+pub const LIBAFL_QEMU_GIT_REV: &str = "0bea78a122b249cbffafdb130af04cc7331c9aee";
 
 pub struct BuildResult {
     pub qemu_path: PathBuf,
@@ -278,17 +278,18 @@ pub fn build(
         env::var_os("LIBAFL_QEMU_CLONE_DIR").map(|x| x.to_string_lossy().to_string());
     let libafl_qemu_force_configure = env::var("LIBAFL_QEMU_FORCE_CONFIGURE").is_ok();
     let libafl_qemu_no_build = env::var("LIBAFL_QEMU_NO_BUILD").is_ok();
-    let libafl_qemu_url = env::var_os("LIBAFL_QEMU_URL").map(|x| x.to_string_lossy().to_string());
-    let libafl_qemu_revision =
-        env::var_os("LIBAFL_QEMU_REVISION").map(|x| x.to_string_lossy().to_string());
+    let libafl_qemu_git_remote =
+        env::var_os("LIBAFL_QEMU_GIT_REMOTE").map(|x| x.to_string_lossy().to_string());
+    let libafl_qemu_git_rev =
+        env::var_os("LIBAFL_QEMU_GIT_REV").map(|x| x.to_string_lossy().to_string());
 
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_DIR");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_CLONE_DIR");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_FORCE_BUILD");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_FORCE_CONFIGURE");
     println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_NO_BUILD");
-    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_URL");
-    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_REVISION");
+    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_GIT_REMOTE");
+    println!("cargo:rerun-if-env-changed=LIBAFL_QEMU_GIT_REV");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_dir = out_dir.to_string_lossy().to_string();
@@ -304,44 +305,45 @@ pub fn build(
     let cpp_compiler = cc::Build::new().cpp(true).get_compiler();
 
     let libafl_qemu_dir = if let Some(qemu_dir) = libafl_qemu_dir.as_ref() {
-        if libafl_qemu_clone_dir.is_some() {
-            println!(
-                "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_CLONE_DIR are both set. LIBAFL_QEMU_DIR will be considered in priority"
-            );
-        }
+        assert!(
+            libafl_qemu_clone_dir.is_none(),
+            "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_CLONE_DIR are both set."
+        );
 
-        if libafl_qemu_url.is_some() {
-            println!(
-                "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_URL are both set. LIBAFL_QEMU_DIR will be considered in priority"
-            );
-        }
+        assert!(
+            libafl_qemu_git_remote.is_none(),
+            "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_GIT_REMOTE are both set."
+        );
 
-        if libafl_qemu_revision.is_some() {
-            println!(
-                "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_REVISION are both set. LIBAFL_QEMU_DIR will be considered in priority"
-            );
-        }
+        assert!(
+            libafl_qemu_git_rev.is_none(),
+            "cargo:warning=LIBAFL_QEMU_DIR and LIBAFL_QEMU_GIT_REV are both set."
+        );
 
         Path::new(&qemu_dir).to_path_buf()
     } else {
         let qemu_path = if let Some(clone_dir) = &libafl_qemu_clone_dir {
             PathBuf::from(clone_dir)
         } else {
-            target_dir.join(QEMU_DIRNAME)
+            target_dir.join(LIBAFL_QEMU_DIRNAME)
         };
 
-        let qemu_url = libafl_qemu_url.as_deref().unwrap_or(QEMU_URL);
-        let qemu_revision = libafl_qemu_revision.as_deref().unwrap_or(QEMU_REVISION);
+        let qemu_git_remote = libafl_qemu_git_remote
+            .as_deref()
+            .unwrap_or(LIBAFL_QEMU_GIT_REMOTE);
+        let qemu_git_rev = libafl_qemu_git_rev
+            .as_deref()
+            .unwrap_or(LIBAFL_QEMU_GIT_REV);
 
         let qemu_rev = target_dir.join("QEMU_REVISION");
         if qemu_rev.exists()
-            && fs::read_to_string(&qemu_rev).expect("Failed to read QEMU_REVISION") != qemu_revision
+            && fs::read_to_string(&qemu_rev).expect("Failed to read QEMU_REVISION") != qemu_git_rev
         {
             drop(fs::remove_dir_all(&qemu_path));
         }
 
         if !qemu_path.is_dir() {
-            println!("cargo:warning=Qemu not found, cloning with git ({qemu_revision})...");
+            println!("cargo:warning=Qemu not found, cloning with git ({qemu_git_rev})...");
             fs::create_dir_all(&qemu_path).unwrap();
             assert!(
                 Command::new("git")
@@ -357,7 +359,7 @@ pub fn build(
                     .arg("remote")
                     .arg("add")
                     .arg("origin")
-                    .arg(qemu_url)
+                    .arg(qemu_git_remote)
                     .status()
                     .unwrap()
                     .success()
@@ -369,7 +371,7 @@ pub fn build(
                     .arg("--depth")
                     .arg("1")
                     .arg("origin")
-                    .arg(qemu_revision)
+                    .arg(qemu_git_rev)
                     .status()
                     .unwrap()
                     .success()
@@ -383,7 +385,7 @@ pub fn build(
                     .unwrap()
                     .success()
             );
-            fs::write(&qemu_rev, qemu_revision).unwrap();
+            fs::write(&qemu_rev, qemu_git_rev).unwrap();
         }
 
         qemu_path

--- a/libafl_qemu/libafl_qemu_build/src/lib.rs
+++ b/libafl_qemu/libafl_qemu_build/src/lib.rs
@@ -24,7 +24,7 @@ mod build;
 pub use build::build;
 
 #[rustversion::nightly]
-use crate::build::QEMU_REVISION;
+use crate::build::LIBAFL_QEMU_GIT_REV;
 
 const LLVM_VERSION_MAX: i32 = 33;
 
@@ -421,7 +421,7 @@ pub fn maybe_generate_stub_bindings(
             None,
             vec![
                 header.as_str(),
-                format!("/* qemu git hash: {QEMU_REVISION} */").as_str(),
+                format!("/* qemu git hash: {LIBAFL_QEMU_GIT_REV} */").as_str(),
             ],
             false,
         );


### PR DESCRIPTION
## Description

Allow the URL and REVISION for QEMU to be overriden using environment variables.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
