### PR TITLE
Support binding to a single core for `ForkserverExecutor`

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -653,6 +653,10 @@ impl CommandExecutorBuilder {
             command.stderr(Stdio::piped());
         }
 
+        if let Some(core) = self.child_env_inner.core {
+            command.bind(core);
+        }
+
         let configurator = StdCommandConfigurator {
             debug_child: self.child_env_inner.debug_child,
             stdout_cap,

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -658,9 +658,10 @@ impl CommandExecutorBuilder {
             command.bind(core);
 
             #[cfg(not(feature = "fork"))]
-            return Err(Error::illegal_argument(
-                "Your host doesn't support fork and thus libafl can not bind to a core right after children get spawned",
-            ));
+            return Err(Error::illegal_argument(format!(
+                "Your host doesn't support fork and thus libafl can not bind to core {:?} right after children get spawned",
+                core
+            )));
         }
 
         let configurator = StdCommandConfigurator {

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -654,7 +654,13 @@ impl CommandExecutorBuilder {
         }
 
         if let Some(core) = self.child_env_inner.core {
+            #[cfg(feature = "fork")]
             command.bind(core);
+
+            #[cfg(not(feature = "fork"))]
+            return Err(Error::illegal_argument(
+                "Your host doesn't support fork and thus libafl can not bind to a core right after children get spawned",
+            ));
         }
 
         let configurator = StdCommandConfigurator {

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -442,7 +442,6 @@ impl Forkserver {
             command.bind(core);
         }
 
-        command.env("AFL_MAP_SIZE", format!("{coverage_map_size}"));
         command.env(AFL_MAP_SIZE_ENV_VAR, format!("{coverage_map_size}"));
 
         // Persistent, deferred forkserver

--- a/libafl/src/executors/mod.rs
+++ b/libafl/src/executors/mod.rs
@@ -16,9 +16,9 @@ pub use inprocess::InProcessExecutor;
 pub use inprocess_fork::InProcessForkExecutor;
 #[cfg(unix)]
 use libafl_bolts::os::unix_signals::Signal;
-#[cfg(feature = "std")]
-use libafl_bolts::tuples::Handle;
 use libafl_bolts::tuples::RefIndexable;
+#[cfg(feature = "std")]
+use libafl_bolts::{core_affinity::CoreId, tuples::Handle};
 use serde::{Deserialize, Serialize};
 pub use shadow::ShadowExecutor;
 pub use with_observers::WithObservers;
@@ -247,6 +247,8 @@ pub struct StdChildArgsInner {
     pub current_directory: Option<PathBuf>,
     /// Whether debug child by inheriting stdout/stderr
     pub debug_child: bool,
+    /// Core to bind for the children
+    pub core: Option<CoreId>,
 }
 
 #[cfg(feature = "std")]
@@ -258,6 +260,7 @@ impl Default for StdChildArgsInner {
             stdout_observer: None,
             current_directory: None,
             debug_child: false,
+            core: None,
         }
     }
 }
@@ -310,6 +313,13 @@ pub trait StdChildArgs: Sized {
             );
         }
         self.inner_mut().debug_child = debug_child;
+        self
+    }
+
+    #[must_use]
+    /// Set the core to bind for the children
+    fn core(mut self, core: CoreId) -> Self {
+        self.inner_mut().core = Some(core);
         self
     }
 }


### PR DESCRIPTION
## Description

As title, this PR allows `ForkserverExecutorBuilder` to accept an optional `CoreId` so that it can bind forkserver (and children) to a specific core. This is particularly useful for differential fuzzing where parallel forkservers are executed at the same time.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
