### PR TITLE
Make multi-threading a feature

### DIFF
--- a/libafl_qemu/librasan/asan/Cargo.toml
+++ b/libafl_qemu/librasan/asan/Cargo.toml
@@ -42,6 +42,8 @@ libc = ["dep:libc"]
 linux = ["dep:rustix"]
 ## Enable the `baby_mimalloc` allocator
 mimalloc = ["dep:baby-mimalloc"]
+## Support single-threaded targets by using dummy synchronization primitives
+single-threaded = ["dep:nospin"]
 ##  Disable the magic used to support `no_std` environments for running unit and integration tests
 test = []
 ## Enable support for memory tracking
@@ -59,11 +61,15 @@ log = { version = "0.4.22", default-features = false, features = [
   "release_max_level_info",
 ] }
 libc = { version = "0.2.169", default-features = false, optional = true }
+nospin = { version = "0.2.4", default-features = false, optional = true, features = [
+  "lazy",
+  "mutex",
+  "once",
+] }
 nostd-musl = { version = "0.1.5", default-features = false, features = [
   "optimized-assembly",
 ] }
 nostd-printf = { version = "0.1.4", default-features = false }
-
 readonly = { version = "0.2.12", default-features = false }
 rustix = { version = "1.0.0", default-features = false, features = [
   "fs",

--- a/libafl_qemu/librasan/asan/src/allocator/backend/dlmalloc.rs
+++ b/libafl_qemu/librasan/asan/src/allocator/backend/dlmalloc.rs
@@ -10,6 +10,9 @@ use core::{marker::PhantomData, mem::forget, ptr::null_mut};
 
 use dlmalloc::{Allocator, Dlmalloc};
 use log::debug;
+#[cfg(feature = "single-threaded")]
+use nospin::Mutex;
+#[cfg(not(feature = "single-threaded"))]
 use spin::Mutex;
 
 use crate::mmap::Mmap;

--- a/libafl_qemu/librasan/asan/src/allocator/backend/mimalloc.rs
+++ b/libafl_qemu/librasan/asan/src/allocator/backend/mimalloc.rs
@@ -1,6 +1,9 @@
 use alloc::alloc::{GlobalAlloc, Layout};
 
 use baby_mimalloc::Mimalloc;
+#[cfg(feature = "single-threaded")]
+use nospin::Mutex;
+#[cfg(not(feature = "single-threaded"))]
 use spin::Mutex;
 
 pub struct MimallocBackend<G: GlobalAlloc> {

--- a/libafl_qemu/librasan/asan/src/logger/libc.rs
+++ b/libafl_qemu/librasan/asan/src/logger/libc.rs
@@ -3,6 +3,9 @@ use core::ffi::{CStr, c_int, c_void};
 
 use libc::{STDERR_FILENO, size_t, ssize_t};
 use log::{Level, LevelFilter, Log, Metadata, Record};
+#[cfg(feature = "single-threaded")]
+use nospin::Once;
+#[cfg(not(feature = "single-threaded"))]
 use spin::Once;
 
 use crate::{

--- a/libafl_qemu/librasan/asan/src/logger/linux.rs
+++ b/libafl_qemu/librasan/asan/src/logger/linux.rs
@@ -1,7 +1,10 @@
 use alloc::{boxed::Box, format};
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
+#[cfg(feature = "single-threaded")]
+use nospin::Once;
 use rustix::{io::write, stdio::stderr};
+#[cfg(not(feature = "single-threaded"))]
 use spin::Once;
 
 static ONCE: Once<&'static LinuxLogger> = Once::new();

--- a/libafl_qemu/librasan/asan/src/patch/mod.rs
+++ b/libafl_qemu/librasan/asan/src/patch/mod.rs
@@ -6,6 +6,9 @@ pub mod raw;
 use alloc::fmt::Debug;
 
 use log::trace;
+#[cfg(feature = "single-threaded")]
+use nospin::{Mutex, Once};
+#[cfg(not(feature = "single-threaded"))]
 use spin::{Mutex, Once};
 use thiserror::Error;
 

--- a/libafl_qemu/librasan/asan/src/symbols/atomic_guest_addr/mod.rs
+++ b/libafl_qemu/librasan/asan/src/symbols/atomic_guest_addr/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "single-threaded")]
+pub mod single_threaded;
+
+#[cfg(not(feature = "single-threaded"))]
+pub mod multi_threaded;

--- a/libafl_qemu/librasan/asan/src/symbols/atomic_guest_addr/multi_threaded.rs
+++ b/libafl_qemu/librasan/asan/src/symbols/atomic_guest_addr/multi_threaded.rs
@@ -1,0 +1,65 @@
+use alloc::fmt::Debug;
+use core::{
+    ffi::c_void,
+    ptr::null_mut,
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+use crate::GuestAddr;
+
+pub struct AtomicGuestAddr {
+    addr: AtomicPtr<c_void>,
+}
+
+impl AtomicGuestAddr {
+    pub const fn new() -> Self {
+        AtomicGuestAddr {
+            addr: AtomicPtr::new(null_mut()),
+        }
+    }
+
+    pub fn load(&self) -> Option<GuestAddr> {
+        let addr = self.addr.load(Ordering::SeqCst) as GuestAddr;
+        match addr {
+            GuestAddr::MIN => None,
+            _ => Some(addr),
+        }
+    }
+
+    pub fn store(&self, addr: GuestAddr) {
+        self.addr.store(addr as *mut c_void, Ordering::SeqCst);
+    }
+
+    pub fn get_or_insert_with<F>(&self, f: F) -> GuestAddr
+    where
+        F: FnOnce() -> GuestAddr,
+    {
+        if let Some(addr) = self.load() {
+            addr
+        } else {
+            let addr = f();
+            self.store(addr);
+            addr
+        }
+    }
+
+    pub fn try_get_or_insert_with<F, E>(&self, f: F) -> Result<GuestAddr, E>
+    where
+        F: FnOnce() -> Result<GuestAddr, E>,
+        E: Debug,
+    {
+        if let Some(addr) = self.load() {
+            Ok(addr)
+        } else {
+            let addr = f()?;
+            self.store(addr);
+            Ok(addr)
+        }
+    }
+}
+
+impl Default for AtomicGuestAddr {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libafl_qemu/librasan/asan/src/symbols/atomic_guest_addr/single_threaded.rs
+++ b/libafl_qemu/librasan/asan/src/symbols/atomic_guest_addr/single_threaded.rs
@@ -1,0 +1,63 @@
+use alloc::fmt::Debug;
+use core::cell::UnsafeCell;
+
+use crate::GuestAddr;
+
+pub struct AtomicGuestAddr {
+    addr: UnsafeCell<GuestAddr>,
+}
+
+unsafe impl Sync for AtomicGuestAddr {}
+
+impl AtomicGuestAddr {
+    pub const fn new() -> Self {
+        AtomicGuestAddr {
+            addr: UnsafeCell::new(GuestAddr::MIN),
+        }
+    }
+
+    pub fn load(&self) -> Option<GuestAddr> {
+        let addr = unsafe { *self.addr.get() };
+        match addr {
+            GuestAddr::MIN => None,
+            _ => Some(addr),
+        }
+    }
+
+    pub fn store(&self, addr: GuestAddr) {
+        unsafe { *self.addr.get() = addr };
+    }
+
+    pub fn get_or_insert_with<F>(&self, f: F) -> GuestAddr
+    where
+        F: FnOnce() -> GuestAddr,
+    {
+        if let Some(addr) = self.load() {
+            addr
+        } else {
+            let addr = f();
+            self.store(addr);
+            addr
+        }
+    }
+
+    pub fn try_get_or_insert_with<F, E>(&self, f: F) -> Result<GuestAddr, E>
+    where
+        F: FnOnce() -> Result<GuestAddr, E>,
+        E: Debug,
+    {
+        if let Some(addr) = self.load() {
+            Ok(addr)
+        } else {
+            let addr = f()?;
+            self.store(addr);
+            Ok(addr)
+        }
+    }
+}
+
+impl Default for AtomicGuestAddr {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libafl_qemu/librasan/asan/src/test.rs
+++ b/libafl_qemu/librasan/asan/src/test.rs
@@ -4,6 +4,9 @@ use core::{
 };
 
 use log::{Level, error, trace};
+#[cfg(feature = "single-threaded")]
+use nospin::{Lazy, Mutex};
+#[cfg(not(feature = "single-threaded"))]
 use spin::{Lazy, Mutex};
 
 use crate::{

--- a/libafl_qemu/librasan/gasan/Cargo.toml
+++ b/libafl_qemu/librasan/gasan/Cargo.toml
@@ -8,7 +8,9 @@ rust-version.workspace = true
 crate-type = ["staticlib"]
 
 [features]
-default = []
+default = ["single-threaded"]
+## Support single-threaded targets by using dummy synchronization primitives
+single-threaded = ["dep:nospin", "asan/single-threaded"]
 test = ["asan/test", "dummy_libc/test"]
 
 [dependencies]
@@ -24,6 +26,11 @@ asan = { path = "../asan", default-features = false, features = [
 dummy_libc = { path = "../dummy_libc", default-features = false }
 log = { version = "0.4.22", default-features = false, features = [
   "release_max_level_info",
+] }
+nospin = { version = "0.2.4", default-features = false, optional = true, features = [
+  "lazy",
+  "mutex",
+  "once",
 ] }
 spin = { version = "0.9.8", default-features = false, features = [
   "lazy",

--- a/libafl_qemu/librasan/gasan/src/lib.rs
+++ b/libafl_qemu/librasan/gasan/src/lib.rs
@@ -25,7 +25,10 @@ use asan::{
     tracking::{Tracking, guest_fast::GuestFastTracking},
 };
 use log::{Level, debug, trace};
-use spin::{Lazy, mutex::Mutex};
+#[cfg(feature = "single-threaded")]
+use nospin::{Lazy, Mutex};
+#[cfg(not(feature = "single-threaded"))]
+use spin::{Lazy, Mutex};
 
 type Syms = DlSymSymbols<LookupTypeNext>;
 

--- a/libafl_qemu/librasan/qasan/Cargo.toml
+++ b/libafl_qemu/librasan/qasan/Cargo.toml
@@ -8,7 +8,9 @@ rust-version.workspace = true
 crate-type = ["staticlib"]
 
 [features]
-default = []
+default = ["single-threaded"]
+## Support single-threaded targets by using dummy synchronization primitives
+single-threaded = ["dep:nospin", "asan/single-threaded"]
 test = ["asan/test", "dummy_libc/test"]
 
 [dependencies]
@@ -25,6 +27,11 @@ dummy_libc = { path = "../dummy_libc", default-features = false }
 libc = { version = "0.2.169", default-features = false }
 log = { version = "0.4.22", default-features = false, features = [
   "release_max_level_info",
+] }
+nospin = { version = "0.2.4", default-features = false, optional = true, features = [
+  "lazy",
+  "mutex",
+  "once",
 ] }
 spin = { version = "0.9.8", default-features = false, features = [
   "lazy",

--- a/libafl_qemu/librasan/qasan/src/lib.rs
+++ b/libafl_qemu/librasan/qasan/src/lib.rs
@@ -23,6 +23,9 @@ use asan::{
     tracking::{Tracking, host::HostTracking},
 };
 use log::{Level, trace};
+#[cfg(feature = "single-threaded")]
+use nospin::{Lazy, Mutex};
+#[cfg(not(feature = "single-threaded"))]
 use spin::{Lazy, Mutex};
 
 type Syms = DlSymSymbols<LookupTypeNext>;

--- a/libafl_qemu/librasan/zasan/Cargo.toml
+++ b/libafl_qemu/librasan/zasan/Cargo.toml
@@ -8,7 +8,9 @@ rust-version.workspace = true
 crate-type = ["staticlib"]
 
 [features]
-default = []
+default = ["single-threaded"]
+## Support single-threaded targets by using dummy synchronization primitives
+single-threaded = ["dep:nospin", "asan/single-threaded"]
 test = ["asan/test"]
 
 [dependencies]
@@ -19,10 +21,16 @@ asan = { path = "../asan", default-features = false, features = [
   "hooks",
   "host",
   "linux",
+  "single-threaded",
   "tracking",
 ] }
 log = { version = "0.4.22", default-features = false, features = [
   "release_max_level_info",
+] }
+nospin = { version = "0.2.4", default-features = false, optional = true, features = [
+  "lazy",
+  "mutex",
+  "once",
 ] }
 spin = { version = "0.9.8", default-features = false, features = [
   "lazy",

--- a/libafl_qemu/librasan/zasan/src/lib.rs
+++ b/libafl_qemu/librasan/zasan/src/lib.rs
@@ -19,6 +19,9 @@ use asan::{
     tracking::{Tracking, guest_fast::GuestFastTracking},
 };
 use log::{Level, trace};
+#[cfg(feature = "single-threaded")]
+use nospin::{Lazy, Mutex};
+#[cfg(not(feature = "single-threaded"))]
 use spin::{Lazy, Mutex};
 
 pub type ZasanFrontend = DefaultFrontend<


### PR DESCRIPTION
## Description

Add `single-threaded` and `multi-threaded` configuration options to `librasan` to switch out the use of the `spin` crate for synchronization for the newly created [`nospin`](https://crates.io/crates/nospin) crate (which doesn't provide any thread safety).

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
