### PR TITLE
Expose AFL++ style extended cmplog for unicornafl

### DIFF
--- a/libafl_cc/src/no-link-rt.c
+++ b/libafl_cc/src/no-link-rt.c
@@ -16,6 +16,15 @@ void __libafl_targets_cmplog_instructions(uintptr_t k, uint8_t shape,
   (void)arg2;
 }
 
+void __libafl_targets_cmplog_instructions_extended(uintptr_t k, uint8_t shape,
+                                                   uint64_t arg1,
+                                                   uint64_t arg2) {
+  (void)k;
+  (void)shape;
+  (void)arg1;
+  (void)arg2;
+}
+
 void __cmplog_ins_hook1_extended(uint8_t arg1, uint8_t arg2, uint8_t attr) {
   (void)arg1;
   (void)arg2;

--- a/libafl_targets/Cargo.toml
+++ b/libafl_targets/Cargo.toml
@@ -67,6 +67,7 @@ forkserver = [
 windows_asan = ["common"] # Compile C code for ASAN on Windows
 whole_archive = [] # use +whole-archive to ensure the presence of weak symbols
 cmplog_extended_instrumentation = [
+  "cmplog", # without `cmplog`, extended instrumentation won't compile
 ] # support for aflpp cmplog map, we will remove this once aflpp and libafl cmplog shares the same LLVM passes.
 function-logging = ["common"]
 track_hit_feedbacks = ["libafl/track_hit_feedbacks"]

--- a/libafl_targets/src/cmplog.c
+++ b/libafl_targets/src/cmplog.c
@@ -102,6 +102,12 @@ void __libafl_targets_cmplog_instructions(uintptr_t k, uint8_t shape,
   cmplog_instructions_checked(k, shape, arg1, arg2, 0);
 }
 
+// Very generic afl++ style cmplog instructions callback
+void __libafl_targets_cmplog_instructions_extended(uintptr_t k, uint8_t shape,
+  uint64_t arg1, uint64_t arg2) {
+  cmplog_instructions_extended_checked(k, shape, arg1, arg2, 0);
+}
+
 // Very generic cmplog routines callback
 void __libafl_targets_cmplog_routines(uintptr_t k, const uint8_t *ptr1,
                                       const uint8_t *ptr2) {

--- a/libafl_targets/src/cmplog.h
+++ b/libafl_targets/src/cmplog.h
@@ -234,7 +234,8 @@ static inline void cmplog_routines_checked_extended(uintptr_t      k,
 
 void __libafl_targets_cmplog_instructions(uintptr_t k, uint8_t shape,
                                           uint64_t arg1, uint64_t arg2);
-
+void __libafl_targets_cmplog_instructions_extended(uintptr_t k, uint8_t shape,
+                                          uint64_t arg1, uint64_t arg2);
 void __libafl_targets_cmplog_routines(uintptr_t k, const uint8_t *ptr1,
                                       const uint8_t *ptr2);
 

--- a/libafl_targets/src/cmps/mod.rs
+++ b/libafl_targets/src/cmps/mod.rs
@@ -61,13 +61,13 @@ unsafe extern "C" {
     pub static mut libafl_cmplog_map_ptr: *mut CmpLogMap;
 
     /// Pointer to the extended `CmpLog` map
-    pub static mut libafl_cmplog_map_extended: *mut CmpLogMap;
+    pub static mut libafl_cmplog_map_extended_ptr: *mut CmpLogMap;
 }
 
 #[cfg(feature = "cmplog")]
 pub use libafl_cmplog_map_ptr as CMPLOG_MAP_PTR;
 #[cfg(feature = "cmplog_extended_instrumentation")]
-pub use libafl_cmplog_map_extended as EXTENDED_CMPLOG_MAP_PTR;
+pub use libafl_cmplog_map_extended_ptr as EXTENDED_CMPLOG_MAP_PTR;
 
 /// Value indicating if cmplog is enabled.
 #[unsafe(no_mangle)]

--- a/libafl_targets/src/cmps/mod.rs
+++ b/libafl_targets/src/cmps/mod.rs
@@ -59,10 +59,15 @@ unsafe extern "C" {
 
     /// Pointer to the `CmpLog` map
     pub static mut libafl_cmplog_map_ptr: *mut CmpLogMap;
+
+    /// Pointer to the extended `CmpLog` map
+    pub static mut libafl_cmplog_map_extended: *mut CmpLogMap;
 }
 
 #[cfg(feature = "cmplog")]
 pub use libafl_cmplog_map_ptr as CMPLOG_MAP_PTR;
+#[cfg(feature = "cmplog_extended_instrumentation")]
+pub use libafl_cmplog_map_extended as EXTENDED_CMPLOG_MAP_PTR;
 
 /// Value indicating if cmplog is enabled.
 #[unsafe(no_mangle)]

--- a/libafl_targets/src/cmps/mod.rs
+++ b/libafl_targets/src/cmps/mod.rs
@@ -51,6 +51,9 @@ unsafe extern "C" {
     /// Logs an instruction for feedback during fuzzing
     pub fn __libafl_targets_cmplog_instructions(k: usize, shape: u8, arg1: u64, arg2: u64);
 
+    /// Logs an AFL++ style instruction for feedback during fuzzing
+    pub fn __libafl_targets_cmplog_instructions_extended(k: usize, shape: u8, arg1: u64, arg2: u64);
+
     /// Logs a routine for feedback during fuzzing
     pub fn __libafl_targets_cmplog_routines(k: usize, ptr1: *const u8, ptr2: *const u8);
 

--- a/libafl_targets/src/forkserver.rs
+++ b/libafl_targets/src/forkserver.rs
@@ -201,6 +201,10 @@ fn map_cmplog_shared_memory_internal() -> Result<(), Error> {
     unsafe {
         CMPLOG_MAP_PTR = map.cast();
     }
+    #[cfg(feature = "cmplog_extended_instrumentation")]
+    unsafe {
+        EXTENDED_CMPLOG_MAP_PTR = map.cast();
+    }
     Ok(())
 }
 

--- a/libafl_targets/src/forkserver.rs
+++ b/libafl_targets/src/forkserver.rs
@@ -22,6 +22,9 @@ use nix::{
 
 #[cfg(feature = "cmplog")]
 use crate::cmps::CMPLOG_MAP_PTR;
+#[cfg(feature = "cmplog_extended_instrumentation")]
+use crate::cmps::EXTENDED_CMPLOG_MAP_PTR;
+
 use crate::coverage::{__afl_map_size, EDGES_MAP_PTR, INPUT_LENGTH_PTR, INPUT_PTR, SHM_FUZZING};
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use crate::coverage::{__token_start, __token_stop};


### PR DESCRIPTION
This uses `cmplog_instructions_extended_checked` for the correct headers to communicate with AFL++.

cc @Evian-Zhang 

