### PR TITLE
Implement `HasBytesConverter` for `NopFuzzer`

### DIFF
--- a/libafl/src/fuzzer/mod.rs
+++ b/libafl/src/fuzzer/mod.rs
@@ -1150,19 +1150,34 @@ where
 
 /// A [`NopFuzzer`] that does nothing
 #[derive(Clone, Debug)]
-pub struct NopFuzzer {}
+pub struct NopFuzzer {
+    converter: NopBytesConverter,
+}
 
 impl NopFuzzer {
     /// Creates a new [`NopFuzzer`]
     #[must_use]
     pub fn new() -> Self {
-        Self {}
+        Self {
+            converter: NopBytesConverter::default(),
+        }
     }
 }
 
 impl Default for NopFuzzer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl HasBytesConverter for NopFuzzer {
+    type Converter = NopBytesConverter;
+    fn converter(&self) -> &Self::Converter {
+        &self.converter
+    }
+
+    fn converter_mut(&mut self) -> &mut Self::Converter {
+        &mut self.converter
     }
 }
 

--- a/libafl/src/inputs/mod.rs
+++ b/libafl/src/inputs/mod.rs
@@ -298,7 +298,7 @@ impl ResizableMutator<u8> for &mut Vec<u8> {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 /// Basic `NopBytesConverter` with just one type that is not converting
 pub struct NopBytesConverter {}
 


### PR DESCRIPTION
## Description

I use `NopFuzzer` to drive `ForkserverExecutor`, which doesn't really need anything from the fuzzer itself, except the trivial input converter.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
