### PR TITLE
Use `Arc<()>` to ref-counting `InpuFile` 

### DIFF
--- a/libafl_bolts/src/fs.rs
+++ b/libafl_bolts/src/fs.rs
@@ -1,19 +1,18 @@
 //! `LibAFL` functionality for filesystem interaction
 
-#[cfg(feature = "std")]
-use alloc::{borrow::ToOwned, vec::Vec};
-use alloc::{rc::Rc, string::String};
-use core::cell::RefCell;
-#[cfg(feature = "std")]
-use core::time::Duration;
+use alloc::string::String;
+
 #[cfg(unix)]
 use std::os::unix::prelude::{AsRawFd, RawFd};
-#[cfg(feature = "std")]
-use std::time::SystemTime;
+
 use std::{
+    borrow::ToOwned,
     fs::{self, File, OpenOptions, remove_file},
     io::{Seek, Write},
     path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, SystemTime},
+    vec::Vec,
 };
 
 use crate::Error;
@@ -62,7 +61,6 @@ where
 
 /// An [`InputFile`] to write fuzzer input to.
 /// The target/forkserver will read from this file.
-#[cfg(feature = "std")]
 #[derive(Debug)]
 pub struct InputFile {
     /// The filename/path too this [`InputFile`]
@@ -71,7 +69,7 @@ pub struct InputFile {
     pub file: File,
     /// The ref count for this [`InputFile`].
     /// Once it reaches 0, the underlying [`File`] will be removed.
-    pub rc: Rc<RefCell<usize>>,
+    pub rc: Arc<()>,
 }
 
 impl Eq for InputFile {}
@@ -84,11 +82,6 @@ impl PartialEq for InputFile {
 
 impl Clone for InputFile {
     fn clone(&self) -> Self {
-        {
-            let mut rc = self.rc.borrow_mut();
-            assert_ne!(*rc, usize::MAX, "InputFile rc overflow");
-            *rc += 1;
-        }
         Self {
             path: self.path.clone(),
             file: self.file.try_clone().unwrap(),
@@ -113,7 +106,7 @@ impl InputFile {
         Ok(Self {
             path: filename.as_ref().to_owned(),
             file: f,
-            rc: Rc::new(RefCell::new(1)),
+            rc: Arc::new(()),
         })
     }
 
@@ -147,7 +140,6 @@ impl InputFile {
 /// Finds new files in the given directory, taking the last time we looked at this path as parameter.
 /// This method works recursively.
 /// If `last` is `None`, it'll load all file.
-#[cfg(feature = "std")]
 pub fn find_new_files_rec<P: AsRef<Path>>(
     dir: P,
     last_check: &Option<Duration>,
@@ -182,13 +174,9 @@ pub fn find_new_files_rec<P: AsRef<Path>>(
     Ok(new_files)
 }
 
-#[cfg(feature = "std")]
 impl Drop for InputFile {
     fn drop(&mut self) {
-        let mut rc = self.rc.borrow_mut();
-        assert_ne!(*rc, 0, "InputFile rc should never be 0");
-        *rc -= 1;
-        if *rc == 0 {
+        if Arc::try_unwrap(std::mem::take(&mut self.rc)).is_ok() {
             // try to remove the file, but ignore errors
             drop(remove_file(&self.path));
         }

--- a/libafl_bolts/src/fs.rs
+++ b/libafl_bolts/src/fs.rs
@@ -1,21 +1,20 @@
 //! `LibAFL` functionality for filesystem interaction
 
-use alloc::string::String;
-
 #[cfg(unix)]
 use std::os::unix::prelude::{AsRawFd, RawFd};
 
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::{borrow::ToOwned, vec::Vec};
+use core::time::Duration;
+
+use crate::Error;
+use std::time::SystemTime;
 use std::{
-    borrow::ToOwned,
     fs::{self, File, OpenOptions, remove_file},
     io::{Seek, Write},
     path::{Path, PathBuf},
-    sync::Arc,
-    time::{Duration, SystemTime},
-    vec::Vec,
 };
-
-use crate::Error;
 
 /// The default filename to use to deliver testcases to the target
 pub const INPUTFILE_STD: &str = ".cur_input";
@@ -176,7 +175,7 @@ pub fn find_new_files_rec<P: AsRef<Path>>(
 
 impl Drop for InputFile {
     fn drop(&mut self) {
-        if Arc::try_unwrap(std::mem::take(&mut self.rc)).is_ok() {
+        if Arc::try_unwrap(core::mem::take(&mut self.rc)).is_ok() {
             // try to remove the file, but ignore errors
             drop(remove_file(&self.path));
         }

--- a/libafl_bolts/src/fs.rs
+++ b/libafl_bolts/src/fs.rs
@@ -175,7 +175,7 @@ pub fn find_new_files_rec<P: AsRef<Path>>(
 
 impl Drop for InputFile {
     fn drop(&mut self) {
-        if Arc::try_unwrap(core::mem::take(&mut self.rc)).is_ok() {
+        if Arc::into_inner(core::mem::take(&mut self.rc)).is_some() {
             // try to remove the file, but ignore errors
             drop(remove_file(&self.path));
         }


### PR DESCRIPTION
## Description

From `Arc::try_unwrap`:

```
Returns the inner value, if the Arc has exactly one strong reference.

Otherwise, [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None) is returned and the Arc is dropped.

This will succeed even if there are outstanding weak references.

If Arc::into_inner is called on every clone of this Arc, it is guaranteed that exactly one of the calls returns the inner value. This means in particular that the inner value is not dropped.
```

This exactly serves the original purpose. Using `Arc` here means I'm making a `Forkserver` to `Send`, as part of efforts to make the whole `ForkserverExecutor` to be `Send`. This is important so that we can spin up all fork servers and send them to standalone threads. Otherwise, we have to spin up threads first and then do fork, which is considered bad practice.

Since this `Arc` doesn't impact any hot path and only is probably used when constructing fork servers, the overhead should be negligible.  I also clean a few unnecessary std gates because the whole `fs` module is already `std`.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
