### PR TITLE
Use is_multiple_of instead of % == 0

### DIFF
--- a/libafl_intelpt/src/linux.rs
+++ b/libafl_intelpt/src/linux.rs
@@ -724,8 +724,7 @@ impl IntelPTBuilder {
 
     /// Set the size of the perf aux buffer (actual PT traces buffer)
     pub fn perf_aux_buffer_size(mut self, perf_aux_buffer_size: usize) -> Result<Self, Error> {
-        // todo:replace with is_multiple_of once stable
-        if perf_aux_buffer_size % PAGE_SIZE != 0 {
+        if !perf_aux_buffer_size.is_multiple_of(PAGE_SIZE) {
             return Err(Error::illegal_argument(
                 "IntelPT perf_aux_buffer must be page aligned",
             ));


### PR DESCRIPTION
Use is_multiple_of instead of % == 0

## Description

*I was reading the changelog of 1.87 and noticed that it's stable now.
Realised that I saw a todo in the code :)

https://releases.rs/docs/1.87.0/


## Checklist

- [*] I have run `./scripts/precommit.sh` and addressed all comments
