### PR TITLE
Add support for `AFL_LLVM/GCC_ONLY_FSRV`

### DIFF
--- a/fuzzers/forkserver/fuzzbench_forkserver_sand/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver_sand/src/main.rs
@@ -388,6 +388,7 @@ fn fuzz(
             .shmem_provider(&mut shmem_provider)
             .parse_afl_cmdline(arguments)
             .coverage_map_size(MAP_SIZE)
+            .fsrv_only(true)
             .timeout(timeout)
             .kill_signal(signal)
             .is_persistent(true)

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -835,6 +835,7 @@ where
 
 /// The builder for `ForkserverExecutor`
 #[derive(Debug)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct ForkserverExecutorBuilder<'a, SP> {
     target_inner: StdTargetArgsInner,
     child_env_inner: StdChildArgsInner,


### PR DESCRIPTION
## Description

Following https://github.com/AFLplusplus/AFLplusplus/pull/2421, this PR adds support for `AFL_LLVM/GCC_ONLY_FSRV` so that the normal sanitizer-enabled and pc instrumented binaries (built without `AFL_LLVM/GCC_ONLY_FSRV`) [can be used with `SandExecutor`](https://github.com/AFLplusplus/AFLplusplus/pull/2421/files#diff-ab30967d7af99ca9228e908b516bfe8778681594c6b37360605f020daad07719R51).  Another potential usage is executing cmplog binaries in this mode and that support will be added to LibAFL once I get it working with AFL++.

There is no need to patch `libafl_targets` since it is trivial to implement this on forkserver side, e.g. just skip the call to `map_shared_memory` or so.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
