### PR TITLE
Remove spurious logs

### DIFF
--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -396,12 +396,6 @@ impl Forkserver {
             ));
         };
 
-        if env::var(AFL_MAP_SIZE_ENV_VAR).is_err() {
-            log::warn!(
-                "{AFL_MAP_SIZE_ENV_VAR} not set. If it is unset, the forkserver may fail to start up"
-            );
-        }
-
         if env::var(SHM_ENV_VAR).is_err() {
             return Err(Error::unknown("__AFL_SHM_ID not set. It is necessary to set this env, otherwise the forkserver cannot communicate with the fuzzer".to_string()));
         }


### PR DESCRIPTION
## Description

Trivial patch.

The logs here seem useless and always triggered:

- If we do not pass in the coverage size to the builder, we return an error before printing it.
- If we pass in the coverage size to the builder, it logs anyway and we immediately overwrite the size.
- If we set `AFL_MAP_SIZE` environment variable, the builder won't take it from the environment variable.

Therefore, the check on the env seems useless and the log is not necessary at all.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
