### PR TITLE
Add x86_64 architecture to QEMU in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,11 +87,13 @@ RUN wget https://download.qemu.org/qemu-${QEMU_VER}.tar.xz && \
       i386-linux-user,\
       ppc-linux-user,\
       mips-linux-user,\
+      x86_64-linux-user,\
       arm-softmmu,\
       aarch64-softmmu,\
       i386-softmmu,\
       ppc-softmmu,\
-      mips-softmmu" && \
+      mips-softmmu,\
+      x86_64-softmmu" && \
     make -j && \
     make install && \
     cd /root && \


### PR DESCRIPTION
## Description

Add x86_64 architecture to QEMU in Dockerfile

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
