### PR TITLE
Allow passing Qemu object to QemuBytesCoverageSugar

### DIFF
--- a/fuzzers/binary_only/python_qemu/fuzzer.py
+++ b/fuzzers/binary_only/python_qemu/fuzzer.py
@@ -6,7 +6,7 @@ import lief
 MAX_SIZE = 0x100
 BINARY_PATH = "./a.out"
 
-emu = qemu.Qemu(["qemu-x86_64", BINARY_PATH], [])
+emu = qemu.Qemu(["qemu-x86_64", BINARY_PATH])
 
 elf = lief.parse(BINARY_PATH)
 test_one_input = elf.get_function_address("LLVMFuzzerTestOneInput")
@@ -41,5 +41,6 @@ def harness(b):
     emu.run()
 
 
-fuzz = sugar.QemuBytesCoverageSugar(["./in"], "./out", 3456, [0, 1, 2, 3])
-fuzz.run(emu, harness)
+fuzz = sugar.QemuBytesCoverageSugar(["./in"], "./out", 3456, [0])
+#fuzz.run_with_qemu(emu, harness)
+fuzz.run(["qemu-x86_64", BINARY_PATH], harness)

--- a/fuzzers/binary_only/python_qemu/fuzzer.py
+++ b/fuzzers/binary_only/python_qemu/fuzzer.py
@@ -41,6 +41,11 @@ def harness(b):
     emu.run()
 
 
-fuzz = sugar.QemuBytesCoverageSugar(["./in"], "./out", 3456, [0])
-#fuzz.run_with_qemu(emu, harness)
-fuzz.run(["qemu-x86_64", BINARY_PATH], harness)
+# Create a fuzzer using the launcher
+# with 4 instances bounds to cores 0-3
+# LLMP uses port 3456 to synchronize
+# stdout from the target is NOT redirected to /dev/null
+fuzz = sugar.QemuBytesCoverageSugar(
+    ["./in"], "./out", 3456, [0, 1, 2, 3], enable_stdout=True
+)
+fuzz.run(emu, harness)

--- a/libafl_qemu/src/emu/builder.rs
+++ b/libafl_qemu/src/emu/builder.rs
@@ -176,13 +176,13 @@ where
         let emulator_modules = unsafe { super::EmulatorModules::new(emulator_hooks, self.modules) };
 
         unsafe {
-            Emulator::new_with_qemu(
+            Ok(Emulator::new_with_qemu(
                 qemu,
                 emulator_modules,
                 self.driver,
                 self.snapshot_manager,
                 self.command_manager,
-            )
+            ))
         }
     }
 }

--- a/libafl_qemu/src/emu/builder.rs
+++ b/libafl_qemu/src/emu/builder.rs
@@ -6,8 +6,8 @@ use libafl_bolts::tuples::{Append, Prepend, tuple_list};
 #[cfg(feature = "systemmode")]
 use crate::FastSnapshotManager;
 use crate::{
-    Emulator, NopEmulatorDriver, NopSnapshotManager, QemuInitError, QemuParams, StdEmulatorDriver,
-    StdSnapshotManager,
+    Emulator, NopEmulatorDriver, NopSnapshotManager, Qemu, QemuInitError, QemuParams,
+    StdEmulatorDriver, StdSnapshotManager,
     command::{NopCommandManager, StdCommandManager},
     config::QemuConfigBuilder,
     modules::{EmulatorModule, EmulatorModuleTuple},
@@ -159,6 +159,31 @@ where
             self.snapshot_manager,
             self.command_manager,
         )
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn build_with_qemu(
+        self,
+        qemu: Qemu,
+    ) -> Result<Emulator<C, CM, ED, ET, I, S, SM>, QemuInitError>
+    where
+        ET: EmulatorModuleTuple<I, S>,
+    {
+        // The logic from Emulator::new needs to be duplicated here because of type mismatch on modules
+        //  between Emulator::new and Emulator::new_wit_qemu
+        let emulator_hooks =
+            unsafe { super::EmulatorHooks::new(crate::QemuHooks::get_unchecked()) };
+        let emulator_modules = unsafe { super::EmulatorModules::new(emulator_hooks, self.modules) };
+
+        unsafe {
+            Emulator::new_with_qemu(
+                qemu,
+                emulator_modules,
+                self.driver,
+                self.snapshot_manager,
+                self.command_manager,
+            )
+        }
     }
 }
 

--- a/libafl_qemu/src/emu/mod.rs
+++ b/libafl_qemu/src/emu/mod.rs
@@ -371,13 +371,13 @@ where
         // # Safety
         // Pre-init hooks have been called above.
         unsafe {
-            Ok(Self::new_with_qemu(
+            Self::new_with_qemu(
                 qemu,
                 emulator_modules,
                 driver,
                 snapshot_manager,
                 command_manager,
-            ))
+            )
         }
     }
 
@@ -393,7 +393,7 @@ where
         driver: ED,
         snapshot_manager: SM,
         command_manager: CM,
-    ) -> Self {
+    ) -> Result<Self, QemuInitError> {
         let mut emulator = Emulator {
             modules: emulator_modules,
             command_manager,
@@ -406,7 +406,7 @@ where
 
         emulator.modules.post_qemu_init_all(qemu);
 
-        emulator
+        Ok(emulator)
     }
 }
 

--- a/libafl_qemu/src/emu/mod.rs
+++ b/libafl_qemu/src/emu/mod.rs
@@ -371,13 +371,13 @@ where
         // # Safety
         // Pre-init hooks have been called above.
         unsafe {
-            Self::new_with_qemu(
+            Ok(Self::new_with_qemu(
                 qemu,
                 emulator_modules,
                 driver,
                 snapshot_manager,
                 command_manager,
-            )
+            ))
         }
     }
 
@@ -393,7 +393,7 @@ where
         driver: ED,
         snapshot_manager: SM,
         command_manager: CM,
-    ) -> Result<Self, QemuInitError> {
+    ) -> Self {
         let mut emulator = Emulator {
             modules: emulator_modules,
             command_manager,
@@ -406,7 +406,7 @@ where
 
         emulator.modules.post_qemu_init_all(qemu);
 
-        Ok(emulator)
+        emulator
     }
 }
 

--- a/libafl_sugar/src/qemu.rs
+++ b/libafl_sugar/src/qemu.rs
@@ -116,7 +116,7 @@ where
 }
 
 /// Enum to allow passing either qemu cli parameters or a running qemu instance
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum QemuSugarParameter<'a> {
     /// Argument list to pass to initialize Qemu
     QemuCli(&'a [String]),


### PR DESCRIPTION
## Description

Linked to #3260 , I wanted to bring back passing a Qemu object to the QemuBytesCoverageSugar::run function of the python bindings. 
To (attempt to) avoid breaking anything I created a new functionQemuBytesCoverageSugar::run_with_qemu 
It introduces a `QemuSugarParameter` enum (the name is not great) to differentiate between cli argument and already running Qemu instance. In a way it brings back the `QemuBuilder` enum which was removed in #2707 

## Checklist

- [X] I have run `./scripts/precommit.sh` and addressed all comments

Note: It failed at building libafl_nyx