### PR TITLE
Allow `InputLocation::Stdin` to specify a file name

### DIFF
--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -262,7 +262,7 @@ where
                             self.args[*argnum] = cstring_input;
                         }
                     }
-                    InputLocation::StdIn => {
+                    InputLocation::StdIn { out_file: _ } => {
                         let (pipe_read, pipe_write) = pipe().unwrap();
                         write(pipe_write, &input.target_bytes()).unwrap();
                         dup2(pipe_read.as_raw_fd(), STDIN_FILENO).unwrap();

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -164,7 +164,7 @@ where
                 }
                 Ok(cmd.spawn()?)
             }
-            InputLocation::StdIn { out_file: _ } => {
+            InputLocation::StdIn { input_file: _ } => {
                 let mut handle = self.command.stdin(Stdio::piped()).spawn()?;
                 let mut stdin = handle.stdin.take().unwrap();
                 match stdin.write_all(input.target_bytes().as_slice()) {
@@ -590,7 +590,9 @@ impl CommandExecutorBuilder {
 
         let mut command = Command::new(program);
         match &self.target_inner.input_location {
-            InputLocation::StdIn { out_file } => {
+            InputLocation::StdIn {
+                input_file: out_file,
+            } => {
                 if out_file.is_some() {
                     return Err(Error::illegal_argument(
                         "Setting filename for CommandExecutor is not supported!",

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -262,7 +262,7 @@ where
                             self.args[*argnum] = cstring_input;
                         }
                     }
-                    InputLocation::StdIn { out_file: _ } => {
+                    InputLocation::StdIn { input_file: _ } => {
                         let (pipe_read, pipe_write) = pipe().unwrap();
                         write(pipe_write, &input.target_bytes()).unwrap();
                         dup2(pipe_read.as_raw_fd(), STDIN_FILENO).unwrap();

--- a/libafl/src/executors/command.rs
+++ b/libafl/src/executors/command.rs
@@ -164,7 +164,7 @@ where
                 }
                 Ok(cmd.spawn()?)
             }
-            InputLocation::StdIn => {
+            InputLocation::StdIn { out_file: _ } => {
                 let mut handle = self.command.stdin(Stdio::piped()).spawn()?;
                 let mut stdin = handle.stdin.take().unwrap();
                 match stdin.write_all(input.target_bytes().as_slice()) {
@@ -590,7 +590,12 @@ impl CommandExecutorBuilder {
 
         let mut command = Command::new(program);
         match &self.target_inner.input_location {
-            InputLocation::StdIn => {
+            InputLocation::StdIn { out_file } => {
+                if out_file.is_some() {
+                    return Err(Error::illegal_argument(
+                        "Setting filename for CommandExecutor is not supported!",
+                    ));
+                }
                 command.stdin(Stdio::piped());
             }
             InputLocation::File { .. } | InputLocation::Arg { .. } => {

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -1031,7 +1031,10 @@ where
         OT: ObserversTuple<I, S>,
     {
         let input_file = match &self.target_inner.input_location {
-            InputLocation::StdIn => InputFile::create(OsString::from(get_unique_std_input_file()))?,
+            InputLocation::StdIn { out_file } => match out_file {
+                Some(out_file) => out_file.clone(),
+                None => InputFile::create(OsString::from(get_unique_std_input_file()))?,
+            },
             InputLocation::Arg { argnum: _ } => {
                 return Err(Error::illegal_argument(
                     "forkserver doesn't support argument mutation",

--- a/libafl/src/executors/forkserver.rs
+++ b/libafl/src/executors/forkserver.rs
@@ -1031,7 +1031,9 @@ where
         OT: ObserversTuple<I, S>,
     {
         let input_file = match &self.target_inner.input_location {
-            InputLocation::StdIn { out_file } => match out_file {
+            InputLocation::StdIn {
+                input_file: out_file,
+            } => match out_file {
                 Some(out_file) => out_file.clone(),
                 None => InputFile::create(OsString::from(get_unique_std_input_file()))?,
             },

--- a/libafl_bolts/src/target_args.rs
+++ b/libafl_bolts/src/target_args.rs
@@ -125,7 +125,7 @@ pub trait StdTargetArgs: Sized {
         assert!(
             match &moved.inner().input_location {
                 InputLocation::File { out_file } => out_file.path.as_path() == path.as_ref(),
-                InputLocation::StdIn { input_file } => out_file
+                InputLocation::StdIn { input_file } => input_file
                     .as_ref()
                     .is_none_or(|of| of.path.as_path() == path.as_ref()),
                 InputLocation::Arg { argnum: _ } => false,

--- a/libafl_bolts/src/target_args.rs
+++ b/libafl_bolts/src/target_args.rs
@@ -90,10 +90,7 @@ pub trait StdTargetArgs: Sized {
     /// If use stdin
     #[must_use]
     fn use_stdin(&self) -> bool {
-        match &self.inner().input_location {
-            InputLocation::StdIn { out_file: _ } => true,
-            _ => false,
-        }
+        matches!(&self.inner().input_location, InputLocation::StdIn { out_file: _ })
     }
 
     /// Set input
@@ -127,8 +124,7 @@ pub trait StdTargetArgs: Sized {
                 InputLocation::File { out_file } => out_file.path.as_path() == path.as_ref(),
                 InputLocation::StdIn { out_file } => out_file
                     .as_ref()
-                    .map(|of| of.path.as_path() == path.as_ref())
-                    .unwrap_or(true),
+                    .is_none_or(|of| of.path.as_path() == path.as_ref()),
                 InputLocation::Arg { argnum: _ } => false,
             },
             "Already specified an input file under a different name. This is not supported"

--- a/libafl_bolts/src/target_args.rs
+++ b/libafl_bolts/src/target_args.rs
@@ -90,7 +90,10 @@ pub trait StdTargetArgs: Sized {
     /// If use stdin
     #[must_use]
     fn use_stdin(&self) -> bool {
-        matches!(&self.inner().input_location, InputLocation::StdIn { out_file: _ })
+        matches!(
+            &self.inner().input_location,
+            InputLocation::StdIn { out_file: _ }
+        )
     }
 
     /// Set input

--- a/libafl_bolts/src/target_args.rs
+++ b/libafl_bolts/src/target_args.rs
@@ -21,7 +21,7 @@ pub enum InputLocation {
     /// Deliver input via `StdIn`
     StdIn {
         /// The alternative input file
-        out_file: Option<InputFile>,
+        input_file: Option<InputFile>,
     },
     /// Deliver the input via the specified [`InputFile`]
     /// You can use specify [`InputFile::create(INPUTFILE_STD)`] to use a default filename.
@@ -33,7 +33,7 @@ pub enum InputLocation {
 
 impl Default for InputLocation {
     fn default() -> Self {
-        Self::StdIn { out_file: None }
+        Self::StdIn { input_file: None }
     }
 }
 
@@ -92,7 +92,7 @@ pub trait StdTargetArgs: Sized {
     fn use_stdin(&self) -> bool {
         matches!(
             &self.inner().input_location,
-            InputLocation::StdIn { out_file: _ }
+            InputLocation::StdIn { input_file: _ }
         )
     }
 
@@ -125,7 +125,7 @@ pub trait StdTargetArgs: Sized {
         assert!(
             match &moved.inner().input_location {
                 InputLocation::File { out_file } => out_file.path.as_path() == path.as_ref(),
-                InputLocation::StdIn { out_file } => out_file
+                InputLocation::StdIn { input_file } => out_file
                     .as_ref()
                     .is_none_or(|of| of.path.as_path() == path.as_ref()),
                 InputLocation::Arg { argnum: _ } => false,


### PR DESCRIPTION
## Description

As title, this allows `InputLocation::Stdin` to have a filename specified instead of using the auto-generated ones.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
