### PR TITLE
allow building python bindings for aarch64

### DIFF
--- a/libafl_qemu/src/arch/aarch64.rs
+++ b/libafl_qemu/src/arch/aarch64.rs
@@ -4,6 +4,7 @@ use capstone::arch::BuildsCapstone;
 use enum_map::{EnumMap, enum_map};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[cfg(feature = "python")]
+#[allow(unused)]
 use pyo3::prelude::*;
 pub use strum_macros::EnumIter;
 pub use syscall_numbers::aarch64::*;


### PR DESCRIPTION
## Description

The bindings are failing to build because `#[must_use]` is placed on some code. Adding `#[allow(unused)]` here bypass the requirement and the bindings are compiling.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
