### PR TITLE
fix fuzzbench cmplog fuzzer and rtn_extend_encoding buffer overflow

### DIFF
--- a/fuzzers/forkserver/fuzzbench_forkserver/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver/src/main.rs
@@ -365,6 +365,7 @@ fn fuzz(
             .debug_child(debug_child)
             .shmem_provider(&mut shmem_provider)
             .parse_afl_cmdline(arguments)
+            .coverage_map_size(MAP_SIZE)
             .is_persistent(true)
             .timeout(timeout * 10)
             .kill_signal(signal)

--- a/fuzzers/forkserver/fuzzbench_forkserver_cmplog/src/main.rs
+++ b/fuzzers/forkserver/fuzzbench_forkserver_cmplog/src/main.rs
@@ -369,6 +369,7 @@ fn fuzz(
             .debug_child(debug_child)
             .shmem_provider(&mut shmem_provider)
             .parse_afl_cmdline(arguments)
+            .coverage_map_size(MAP_SIZE)
             .is_persistent(true)
             // increase timeouts for cmplog
             .timeout(timeout * 10)

--- a/libafl/src/mutators/token_mutations.rs
+++ b/libafl/src/mutators/token_mutations.rs
@@ -1301,9 +1301,11 @@ impl AflppRedQueen {
         if copy_len > 0 {
             unsafe {
                 for l in 1..=copy_len {
-                    let mut cloned = buf.to_vec();
-                    buffer_copy(&mut cloned, repl, 0, buf_idx, l);
-                    vec.push(cloned);
+                    if l <= repl.len() {
+                        let mut cloned = buf.to_vec();
+                        buffer_copy(&mut cloned, repl, 0, buf_idx, l);
+                        vec.push(cloned);
+                    }
                 }
                 // vec.push(cloned);
             }


### PR DESCRIPTION
## Problem Description

### 1. Forkserver Configuration Panic
When executing the fuzzbench cmplog fuzzer, we encountered a panic in Forkserver initialization:
```
thread 'main' panicked at src/main.rs:373:14:
called `Result::unwrap()` on an `Err` value: Unknown("Coverage map size unknown. Use coverage_map_size() to tell the forkserver about the map size.", ErrorBacktrace)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Root cause: Missing mandatory coverage_map_size() configuration during executor builder setup.

### 2. Token Mutation Buffer Overflow
After fixing the first issue, subsequent runs exposed a buffer overflow in token mutations:
```
thread 'main' panicked at /home/test/fork_libafl/LibAFL/libafl/src/mutators/mutations.rs:45:5:
assertion failed: from + len <= src.len()
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:75:14
   2: core::panicking::panic
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:145:5
   3: libafl::mutators::mutations::buffer_copy
             at /home/test/fork_libafl/LibAFL/libafl/src/mutators/mutations.rs:45:5
   4: libafl::mutators::token_mutations::AflppRedQueen::rtn_extend_encoding
             at /home/test/fork_libafl/LibAFL/libafl/src/mutators/token_mutations.rs:1305:21
```
Root cause: Incorrect offset calculation in token mutation logic causing invalid memory access.
