### PR TITLE
use `libafl_wide`

### DIFF
--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -121,7 +121,7 @@ llmp_small_maps = ["alloc"]
 #! ### Stable SIMD features
 
 ## Use the best SIMD implementation by our benchmark.
-simd = ["alloc", "libafl_wide"]
+simd = ["alloc", "wide"]
 
 [build-dependencies]
 rustversion = { workspace = true }
@@ -178,7 +178,7 @@ serial_test = { workspace = true, optional = true, default-features = false, fea
 ] }
 
 # optional stable simd, pin to a commit due to `u8x32` not released yet. Switch to `wide` as long as next release is out!
-libafl_wide = { version = "0.7.33", optional = true, package = "wide" }
+wide = { version = "0.7.33", optional = true, package = "libafl_wide" }
 rustversion = { workspace = true }
 
 # Document all features of this crate (for `cargo doc`)

--- a/libafl_bolts/Cargo.toml
+++ b/libafl_bolts/Cargo.toml
@@ -121,7 +121,7 @@ llmp_small_maps = ["alloc"]
 #! ### Stable SIMD features
 
 ## Use the best SIMD implementation by our benchmark.
-simd = ["alloc", "wide"]
+simd = ["alloc", "libafl_wide"]
 
 [build-dependencies]
 rustversion = { workspace = true }
@@ -177,8 +177,8 @@ serial_test = { workspace = true, optional = true, default-features = false, fea
   "logging",
 ] }
 
-# optional stable simd, pin to a commit due to `u8x32` not released yet. Switch as long as next release is out!
-wide = { git = "https://github.com/Lokathor/wide", rev = "71b5df0b2620da753836fafce5f99076181a49fe", optional = true }
+# optional stable simd, pin to a commit due to `u8x32` not released yet. Switch to `wide` as long as next release is out!
+libafl_wide = { version = "0.7.33", optional = true, package = "wide" }
 rustversion = { workspace = true }
 
 # Document all features of this crate (for `cargo doc`)


### PR DESCRIPTION
## Description

`wide` seems not so active and let's release one for us temporarily.

https://crates.io/crates/libafl_wide

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
