### PR TITLE
Make cmplog exported functions more consistent

### DIFF
--- a/libafl/Cargo.toml
+++ b/libafl/Cargo.toml
@@ -239,7 +239,7 @@ ahash = { workspace = true } # The hash function already used in hashbrown
 meminterval = { workspace = true, features = ["serde"] }
 backtrace = { workspace = true, optional = true } # Used to get the stacktrace in StacktraceObserver
 typed-builder = { workspace = true, optional = true } # Implement the builder pattern at compiletime
-send_wrapper = { version="0.6.0", optional = true } # To move data between threads
+send_wrapper = { version = "0.6.0", optional = true } # To move data between threads
 
 serde_json = { workspace = true, optional = true, default-features = false, features = [
   "alloc",

--- a/libafl_targets/src/cmplog.c
+++ b/libafl_targets/src/cmplog.c
@@ -105,7 +105,7 @@ void __libafl_targets_cmplog_instructions(uintptr_t k, uint8_t shape,
 // Very generic afl++ style cmplog instructions callback
 void __libafl_targets_cmplog_instructions_extended(uintptr_t k, uint8_t shape,
   uint64_t arg1, uint64_t arg2) {
-  cmplog_instructions_extended_checked(k, shape, arg1, arg2, 0);
+  cmplog_instructions_checked_extended(k, shape, arg1, arg2, 0);
 }
 
 // Very generic cmplog routines callback
@@ -179,7 +179,7 @@ void __cmplog_ins_hook1_extended(uint8_t arg1, uint8_t arg2, uint8_t attr) {
   k = (k >> 4) ^ (k << 8);
   k &= CMPLOG_MAP_W - 1;
 
-  cmplog_instructions_extended_checked(k, 0, arg1, arg2, attr);
+  cmplog_instructions_checked_extended(k, 0, arg1, arg2, attr);
 }
 void __cmplog_ins_hook1(uint8_t arg1, uint8_t arg2) {
   uintptr_t k = RETADDR;
@@ -194,7 +194,7 @@ void __cmplog_ins_hook2_extended(uint16_t arg1, uint16_t arg2, uint8_t attr) {
   k = (k >> 4) ^ (k << 8);
   k &= CMPLOG_MAP_W - 1;
 
-  cmplog_instructions_extended_checked(k, 1, arg1, arg2, attr);
+  cmplog_instructions_checked_extended(k, 1, arg1, arg2, attr);
 }
 void __cmplog_ins_hook2(uint16_t arg1, uint16_t arg2) {
   uintptr_t k = RETADDR;
@@ -209,7 +209,7 @@ void __cmplog_ins_hook4_extended(uint32_t arg1, uint32_t arg2, uint8_t attr) {
   k = (k >> 4) ^ (k << 8);
   k &= CMPLOG_MAP_W - 1;
 
-  cmplog_instructions_extended_checked(k, 3, arg1, arg2, attr);
+  cmplog_instructions_checked_extended(k, 3, arg1, arg2, attr);
 }
 void __cmplog_ins_hook4(uint32_t arg1, uint32_t arg2) {
   uintptr_t k = RETADDR;
@@ -224,7 +224,7 @@ void __cmplog_ins_hook8_extended(uint64_t arg1, uint64_t arg2, uint8_t attr) {
   k = (k >> 4) ^ (k << 8);
   k &= CMPLOG_MAP_W - 1;
 
-  cmplog_instructions_extended_checked(k, 7, arg1, arg2, attr);
+  cmplog_instructions_checked_extended(k, 7, arg1, arg2, attr);
 }
 void __cmplog_ins_hook8(uint64_t arg1, uint64_t arg2) {
   uintptr_t k = RETADDR;
@@ -241,7 +241,7 @@ void __cmplog_ins_hook16_extended(uint128_t arg1, uint128_t arg2,
   k = (k >> 4) ^ (k << 8);
   k &= CMPLOG_MAP_W - 1;
 
-  cmplog_instructions_extended_checked(k, 15, arg1, arg2, attr);
+  cmplog_instructions_checked_extended(k, 15, arg1, arg2, attr);
 }
 void __cmplog_ins_hook16(uint128_t arg1, uint128_t arg2) {
   uintptr_t k = RETADDR;
@@ -257,7 +257,7 @@ void __cmplog_ins_hookN_extended(uint128_t arg1, uint128_t arg2, uint8_t attr,
   k = (k >> 4) ^ (k << 8);
   k &= CMPLOG_MAP_W - 1;
 
-  cmplog_instructions_extended_checked(k, size - 1, arg1, arg2, attr);
+  cmplog_instructions_checked_extended(k, size - 1, arg1, arg2, attr);
 }
 void __cmplog_ins_hookN(uint128_t arg1, uint128_t arg2, uint8_t size) {
   uintptr_t k = RETADDR;

--- a/libafl_targets/src/cmplog.c
+++ b/libafl_targets/src/cmplog.c
@@ -133,8 +133,43 @@ void __libafl_targets_cmplog_routines_len(uintptr_t k, const uint8_t *ptr1,
     return;
   }
 
+  if (len >= CMPLOG_RTN_LEN) {
+    len = CMPLOG_RTN_LEN - 1;
+  }
+
   cmplog_routines_checked(k, ptr1, ptr2, len);
 }
+
+void __libafl_targets_cmplog_routines_extended(uintptr_t k, const uint8_t *ptr1,
+                                               const uint8_t *ptr2) {
+  if (!libafl_cmplog_enabled) { return; }
+
+  int l1, l2;
+  if ((l1 = area_is_valid(ptr1, CMPLOG_RTN_LEN)) <= 0 ||
+      (l2 = area_is_valid(ptr2, CMPLOG_RTN_LEN)) <= 0) {
+    return;
+  }
+  int len = MIN(l1, l2);
+
+  cmplog_routines_checked_extended(k, ptr1, ptr2, len);
+}
+
+void __libafl_targets_cmplog_routines_extended_len(uintptr_t k, const uint8_t *ptr1,
+                                                   const uint8_t *ptr2, size_t len) {
+  if (!libafl_cmplog_enabled) { return; }
+
+  if ((area_is_valid(ptr1, CMPLOG_RTN_LEN)) <= 0 ||
+      (area_is_valid(ptr2, CMPLOG_RTN_LEN)) <= 0) {
+    return;
+  }
+
+  if (len >= CMPLOG_RTN_LEN) {
+    len = CMPLOG_RTN_LEN - 1;
+  }
+
+  cmplog_routines_checked_extended(k, ptr1, ptr2, len);
+}
+
 /*
   CMPLOG Callback for instructions
 */

--- a/libafl_targets/src/cmplog.h
+++ b/libafl_targets/src/cmplog.h
@@ -102,7 +102,7 @@ extern uint8_t libafl_cmplog_enabled;
 
 // 5 of CMPLOG inner APIs, we static inline everything
 // area_is_valid, cmplog_instructions_checked,
-// cmplog_instructions_extended_checked,
+// cmplog_instructions_checked_extended,
 // cmplog_routines_checked,
 // cmplog_routines_checked_extended
 
@@ -132,7 +132,7 @@ static inline void cmplog_instructions_checked(uintptr_t k, uint8_t shape,
   libafl_cmplog_enabled = true;
 }
 
-static inline void cmplog_instructions_extended_checked(
+static inline void cmplog_instructions_checked_extended(
     uintptr_t k, uint8_t shape, uint64_t arg1, uint64_t arg2, uint8_t attr) {
 #ifdef CMPLOG_EXTENDED
   if (!libafl_cmplog_enabled) { return; }

--- a/libafl_targets/src/cmps/mod.rs
+++ b/libafl_targets/src/cmps/mod.rs
@@ -45,7 +45,7 @@ pub const CMPLOG_KIND_RTN: u8 = 1;
 
 // EXTERNS, GLOBALS
 
-#[cfg(any(feature = "cmplog", feature = "sancov_cmplog"))]
+#[cfg(any(feature = "cmplog", feature = "sancov_cmplog", feature = "sancov_value_profile"))]
 // void __libafl_targets_cmplog_instructions(uintptr_t k, uint8_t shape, uint64_t arg1, uint64_t arg2)
 unsafe extern "C" {
     /// Logs an instruction for feedback during fuzzing

--- a/libafl_targets/src/cmps/mod.rs
+++ b/libafl_targets/src/cmps/mod.rs
@@ -57,11 +57,22 @@ unsafe extern "C" {
     /// Logs a routine for feedback during fuzzing
     pub fn __libafl_targets_cmplog_routines(k: usize, ptr1: *const u8, ptr2: *const u8);
 
+    /// Cmplog routines but with len specified.
+    pub fn __libafl_targets_cmplog_routines_len(k: usize, ptr1: *const u8, ptr2: *const u8, len: usize);
+
     /// Pointer to the `CmpLog` map
     pub static mut libafl_cmplog_map_ptr: *mut CmpLogMap;
 
     /// Pointer to the extended `CmpLog` map
     pub static mut libafl_cmplog_map_extended_ptr: *mut CmpLogMap;
+}
+
+#[cfg(feature = "cmplog_extended_instrumentation")]
+unsafe extern "C" {
+    /// Logs an AFL++ style routine for feedback during fuzzing
+    pub fn __libafl_targets_cmplog_routines_extended(k: usize, ptr1: *const u8, ptr2: *const u8);
+    /// Extended cmplog routines but with len specified.
+    pub fn __libafl_targets_cmplog_routines_extended_len(k: usize, ptr1: *const u8, ptr2: *const u8, len: usize);
 }
 
 #[cfg(feature = "cmplog_extended_instrumentation")]

--- a/libafl_targets/src/cmps/mod.rs
+++ b/libafl_targets/src/cmps/mod.rs
@@ -45,7 +45,7 @@ pub const CMPLOG_KIND_RTN: u8 = 1;
 
 // EXTERNS, GLOBALS
 
-#[cfg(feature = "cmplog")]
+#[cfg(any(feature = "cmplog", feature = "sancov_cmplog"))]
 // void __libafl_targets_cmplog_instructions(uintptr_t k, uint8_t shape, uint64_t arg1, uint64_t arg2)
 unsafe extern "C" {
     /// Logs an instruction for feedback during fuzzing

--- a/libafl_targets/src/sancov_cmp.rs
+++ b/libafl_targets/src/sancov_cmp.rs
@@ -30,9 +30,6 @@ unsafe extern "C" {
 
     /// Trace a switch statement
     pub fn __sanitizer_cov_trace_switch(val: u64, cases: *const u64);
-
-    /// cmplog internal api
-    pub fn __libafl_targets_cmplog_routines_len(k: usize, s1: *const u8, s2: *const u8, len: usize);
 }
 
 /// overriding `__sanitizer_weak_hook_memcmp`
@@ -51,7 +48,7 @@ pub unsafe extern "C" fn __sanitizer_weak_hook_memcmp(
             let k: usize = called_pc as usize;
             let k = (k >> 4) ^ (k << 8);
             let k = k & (CMPLOG_MAP_W - 1);
-            __libafl_targets_cmplog_routines_len(
+            crate::__libafl_targets_cmplog_routines_len(
                 k,
                 s1 as *const u8,
                 s2 as *const u8,
@@ -89,7 +86,7 @@ pub unsafe extern "C" fn __sanitizer_weak_hook_strncmp(
                 }
                 actual_len += 1;
             }
-            __libafl_targets_cmplog_routines_len(k, s1 as *const u8, s2 as *const u8, actual_len);
+            crate::__libafl_targets_cmplog_routines_len(k, s1 as *const u8, s2 as *const u8, actual_len);
         }
     }
 }
@@ -135,7 +132,7 @@ pub unsafe extern "C" fn __sanitizer_weak_hook_strcmp(
                 }
                 actual_len += 1;
             }
-            __libafl_targets_cmplog_routines_len(k, s1 as *const u8, s2 as *const u8, actual_len);
+            crate::__libafl_targets_cmplog_routines_len(k, s1 as *const u8, s2 as *const u8, actual_len);
         }
     }
 }


### PR DESCRIPTION
## Description

Previously, we have exported:

* Cmplog for instructions
* Extended Cmplog for instructions
* Cmplog for routines
* Cmplog for routines with len (but exported in sancov_cmp.rs)

Now we can make it more consistent for others to use:

* Cmplog for instructions
* Extended Cmplog for instructions
* Cmplog for routines
* Cmplog for routines with len
* Extended cmplog for routines
* Extended cmplog for routines with len

BTW, [this TODO](https://github.com/AFLplusplus/LibAFL/blob/00e494b31f1577c918c79ca3e205e16136a185a8/libafl_targets/src/cmplog.h#L185) seems to be made in [this commit](https://github.com/AFLplusplus/LibAFL/commit/75fcd470443a2bcd540f9c1be2f2ae1240a3707b). In AFL++, it seems to be `len - 1` ([this code](https://github.com/AFLplusplus/AFLplusplus/blob/16cc444ae576da9c8c7ef45f55984507b3cf6004/instrumentation/afl-compiler-rt.o.c#L2544)). I am not fully aware of how cmplog is implemented. Is this intentional? If it should be adjusted to `len - 1`, I'm willing to add this in my PR.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
