### PR TITLE
fix ForkserverBytesCoverageSugar

### DIFF
--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -147,7 +147,7 @@ impl ForkserverBytesCoverageSugar<'_> {
             };
 
             // New maximization map feedback linked to the edges observer and the feedback state
-            let map_feedback = MaxMapFeedback::new(&edges_observer);
+            let map_feedback = MaxMapFeedback::with_name("map_feedback", &edges_observer);
             // Extra MapFeedback to deduplicate finds according to the cov map
             let map_objective = MaxMapFeedback::with_name("map_objective", &edges_observer);
 
@@ -157,7 +157,7 @@ impl ForkserverBytesCoverageSugar<'_> {
             // This one is composed by two Feedbacks in OR
             let mut feedback = feedback_or!(
                 // New maximization map feedback linked to the edges observer and the feedback state
-                MaxMapFeedback::new(&edges_observer),
+                map_feedback,
                 // Time feedback, this one does not need a feedback state
                 TimeFeedback::new(&time_observer)
             );

--- a/libafl_sugar/src/forkserver.rs
+++ b/libafl_sugar/src/forkserver.rs
@@ -115,7 +115,7 @@ impl ForkserverBytesCoverageSugar<'_> {
         let shmem_provider = UnixShMemProvider::new().expect("Failed to init shared memory");
         let mut shmem_provider_client = shmem_provider.clone();
 
-        let monitor = MultiMonitor::new(|s| log::info!("{s}"));
+        let monitor = MultiMonitor::new(|s| println!("{s}"));
 
         // Create an observation channel to keep track of the execution time
         let time_observer = TimeObserver::new("time");
@@ -147,7 +147,7 @@ impl ForkserverBytesCoverageSugar<'_> {
             };
 
             // New maximization map feedback linked to the edges observer and the feedback state
-            let map_feedback = MaxMapFeedback::with_name("map_feedback", &edges_observer);
+            let map_feedback = MaxMapFeedback::new(&edges_observer);
             // Extra MapFeedback to deduplicate finds according to the cov map
             let map_objective = MaxMapFeedback::with_name("map_objective", &edges_observer);
 

--- a/libafl_sugar/src/inprocess.rs
+++ b/libafl_sugar/src/inprocess.rs
@@ -337,7 +337,7 @@ where
                         fuzzer.fuzz_loop(&mut stages, &mut executor, &mut state, &mut mgr)?;
                     }
                 } else {
-                    let mut stages = tuple_list!(mutational);
+                    let mut stages = tuple_list!(calibration, mutational);
                     if let Some(iters) = self.iterations {
                         fuzzer.fuzz_loop_for(
                             &mut stages,


### PR DESCRIPTION
## Description

The `ForkserverBytesCoverageSugar` panic in the calibration stage when retrieving the map state (https://github.com/AFLplusplus/LibAFL/blob/main/libafl/src/stages/calibrate.rs#L218). Changing to a non named map fixes the issue

CC @domenukk

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
