### PR TITLE
Fix incorrect autotokens check on macos

### DIFF
--- a/libafl_targets/src/coverage.rs
+++ b/libafl_targets/src/coverage.rs
@@ -73,11 +73,11 @@ pub fn autotokens() -> Result<Tokens, Error> {
     // All values are checked before dereferencing.
 
     unsafe {
-        if !has_autotokens() {
-            Ok(Tokens::default())
-        } else {
+        if has_autotokens() {
             // we can safely unwrap
             Tokens::from_mut_ptrs(__token_start, __token_stop)
+        } else {
+            Ok(Tokens::default())
         }
     }
 }

--- a/libafl_targets/src/forkserver.rs
+++ b/libafl_targets/src/forkserver.rs
@@ -127,7 +127,7 @@ fn map_shared_memory_common<SHM: ShMemProvider>(
     } else {
         map_size_default_fallback
     };
-    log::trace!("id_str: {}, size: {}", id_str, map_size);
+
     let shmem = shmem_provider.shmem_from_id_and_size(ShMemId::from_string(&id_str), map_size)?;
 
     Ok(shmem_into_raw(shmem))


### PR DESCRIPTION
## Description

On macOS, the `__token_start` and `__token_end` are defined as:

```
#elif defined(__APPLE__)
extern uint8_t __start_libafl_token __asm(
    "section$start$__DATA$__libafl_token");
extern uint8_t __stop_libafl_token __asm("section$end$__DATA$__libafl_token");
#endif

#if defined(__linux__) || defined(__APPLE__)
// Expose the start of libafl_token section as C symbols
uint8_t *__token_start = &__start_libafl_token;
uint8_t *__token_stop = &__stop_libafl_token;

#endif
```

This gives both pointers a non-null value and then:

```
    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
    if autotokens_on {
        #[expect(clippy::cast_sign_loss)]
        let tokens_len = unsafe { __token_stop.offset_from(__token_start) } as u32;
        write_u32_to_forkserver(tokens_len).inspect_err(|_| {
            log::error!("Error: could not send autotokens len");
        })?;
        write_all_to_forkserver(unsafe {
            core::slice::from_raw_parts(__token_start, tokens_len as usize)
        })
        .inspect_err(|_| {
            log::error!("could not send autotokens");
        })?;
    }
```

Previous check will set `autotokens_on` to `true` and thus `AFL++` will reject this forkserver as it is sending 0 length dictionary like:

```
[-] PROGRAM ABORT : Dictionary has an illegal size: 0
         Location : afl_fsrv_start(), src/afl-forkserver.c:1291
```
This PR fixes this by also checking dictionary length.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
