### PR TITLE
libafl: fix lockfile ctr serialization

### DIFF
--- a/crates/libafl/src/corpus/inmemory_ondisk.rs
+++ b/crates/libafl/src/corpus/inmemory_ondisk.rs
@@ -490,7 +490,7 @@ impl<I> InMemoryOnDiskCorpus<I> {
                     drop(fs::remove_file(lockfile_path));
                 } else {
                     lockfile.seek(SeekFrom::Start(0))?;
-                    lockfile.write_all(&(ctr.parse::<u32>()? - 1).to_le_bytes())?;
+                    lockfile.write_all((ctr.parse::<u32>()? - 1).to_string().as_bytes())?;
                     return Ok(());
                 }
             }


### PR DESCRIPTION
I'm not entirely sure what the purpose of the lockfiles is but I ran into the following crash with my fuzzer:

```
called `Result::unwrap()` on an `Err` value: Unknown("Failed to parse Int: ParseIntError { kind: InvalidDigit }",    0: <libafl_bolts::Error as core::convert::From<core::num::error::ParseIntError>>::from
   1: libafl::corpus::inmemory_ondisk::InMemoryOnDiskCorpus<I>::save_testcase
   2: <libafl::corpus::inmemory_ondisk::InMemoryOnDiskCorpus<I> as libafl::corpus::Corpus<I>>::add
   3: <libafl::fuzzer::StdFuzzer<CS,F,IF,OF> as libafl::fuzzer::ExecutionProcessor<EM,I,OT,S>>::evaluate_execution
   4: <libafl::fuzzer::StdFuzzer<CS,F,IF,OF> as libafl::fuzzer::Fuzzer<E,EM,I,S,ST>>::fuzz_one
```

After looking at how data is written to and read from the lockfile, it appears to expect an integer as a string when reading but in `InMemoryOnDiskCorpus<I>::remove_testcase` it writes the raw bytes of the integer to the file. See the commit message for further explanation.