### PR TITLE
Fix Observer State Restoration Footgun (Issue - #925)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ feel free to add an AST-based input for structured fuzzing, and more.
 - `QEMU` user-mode and system mode, including hooks for emulation, in [libafl_qemu](./crates/libafl_qemu)
 - `TinyInst`, in [libafl_tinyinst](./crates/libafl_tinyinst) by [elbiazo](https://github.com/elbiazo)
 
+## ⚠️ Note on Observer Configuration and Restarts
+
+If you modify observer configuration/state at runtime (for example, the initial value of a MapObserver), you **must** ensure this state is stored in the fuzzer state (as metadata) and restored after a restart. Otherwise, changes will be lost when using restarting event managers. See the documentation for the [`Observer` trait](./crates/libafl/src/observers/mod.rs) and the [Observer core concept](./docs/src/core_concepts/observer.md#observer-state-restoration-and-restarts) for details and examples.
+
 ## Building and installing
 
 #### Install the Dependencies

--- a/crates/libafl/src/executors/differential.rs
+++ b/crates/libafl/src/executors/differential.rs
@@ -176,6 +176,10 @@ where
         self.differential
             .post_exec_child_all(state, input, exit_kind)
     }
+
+    fn on_state_restore_all(&mut self, state: &S) {
+        self.differential.on_state_restore_all(state);
+    }
 }
 
 impl<A, B, DOT> Deref for ProxyObserversTuple<A, B, DOT> {

--- a/docs/src/core_concepts/observer.md
+++ b/docs/src/core_concepts/observer.md
@@ -12,3 +12,36 @@ In terms of code, in the library this entity is described by the [`Observer`](ht
 In addition to holding the volatile data connected with the last execution of the target, the structures implementing this trait can define some execution hooks that are executed before and after each fuzz case. In these hooks, the observer can modify the fuzzer's state.
 
 The fuzzer will act based on these observers through a [`Feedback`](./feedback.md), that reduces the observation to the choice if a testcase is `interesting` for the fuzzer, or not.
+
+## Observer State Restoration and Restarts
+
+**Important:** If your observer has configuration or state that must persist across fuzzer restarts (for example, when using an EventRestarter), you **must** store this information in the fuzzer state (typically as metadata), and restore it in the `on_state_restore` method of your observer. Otherwise, any changes made to the observer's configuration at runtime will be lost after a restart.
+
+LibAFL provides:
+- The `Observer::on_state_restore(&self, state: &S)` method, which you can override to re-sync your observer's configuration from the fuzzer state after a restart.
+- The `notify_observers_on_state_restore` utility function, which calls `on_state_restore_all` for all observers in a tuple.
+
+**Example:**
+
+```rust
+// After restoring the state (e.g., from a restarting event manager):
+let (mut state, mut mgr) = setup_restarting_mgr_std(...)?;
+let mut observers = ...; // your observers tuple
+libafl::observers::notify_observers_on_state_restore(&mut observers, &state);
+```
+
+If your observer needs to restore configuration:
+
+```rust
+impl<I, S> Observer<I, S> for MyObserver {
+    // ...
+    fn on_state_restore(&mut self, state: &S) {
+        // Restore configuration from state metadata
+        if let Some(meta) = state.metadata::<MyObserverConfig>() {
+            self.config = meta.clone();
+        }
+    }
+}
+```
+
+See also the documentation in the `Observer` trait for more details.


### PR DESCRIPTION
Observers (especially MapObservers) can have configuration/state (like the initial value) that is mutated at runtime. When a fuzzer is restarted via an EventRestarter, only the corpus/state is restored, not the runtime configuration of observers. This leads to subtle bugs where observer configuration changes made during fuzzing are lost after a restart.

Solution
1. Added on_state_restore method to Observer trait: Observers can now implement this method to restore their configuration from the fuzzer state after a restart.
2. Extended ObserversTuple trait: Added on_state_restore_all method to notify all observers in a tuple when state is restored.
3. Added utility function: notify_observers_on_state_restore provides a convenient way to call the restoration method on observer tuples.
4. Updated documentation:
 - Added comprehensive documentation in the Observer core concept explaining the footgun and how to avoid it
 - Added warning in README about observer configuration persistence
 - Included code examples showing correct usage patterns
5. Fixed missing implementation: Added on_state_restore_all to ProxyObserversTuple in differential executor.