### PR TITLE
Ignore downloaded Nyx folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,8 @@ __pycache__
 **/corpus_discovered
 **/libxml2-*.tar.gz
 
-libafl_nyx/QEMU-Nyx
-libafl_nyx/packer
+**/libafl_nyx/QEMU-Nyx
+**/libafl_nyx/packer
 
 .z3-trace
 


### PR DESCRIPTION
## Description

`git` lists `crates/libafl_nyx/QEMU-Nyx` and `crates/libafl_nyx/packer` as untracked files after `libafl_nyx` is moved to `crates`. This PR updates `.gitignore` to fix the above problem.