### PR TITLE
[WIP?] QemuSugar Snapshot support (+ OptionalModule)

### DIFF
--- a/crates/libafl/src/common/nautilus/README.md
+++ b/crates/libafl/src/common/nautilus/README.md
@@ -1,4 +1,4 @@
-# Nautilus 2.0 LibAFL Mutator
+# Nautilus 2.0 `LibAFL` Mutator
 
 Nautilus is a coverage guided, grammar-based mutator. You can use it to improve your test coverage and find more bugs. By specifying the grammar of semi-valid inputs, Nautilus is able to perform complex mutation and to uncover more interesting test cases. Many of the ideas behind the original fuzzer are documented in a paper published at NDSS 2019.
 
@@ -7,7 +7,7 @@ Nautilus is a coverage guided, grammar-based mutator. You can use it to improve 
 </p>
 
 Version 2.0 has added many improvements to this early prototype.
-Features from version 2.0 we support in LibAFL:
+Features from version 2.0 we support in `LibAFL`:
 
 * Support for grammars specified in python
 * Support for non-context free grammars using python scripts to generate inputs from the structure

--- a/crates/libafl/src/common/nautilus/mod.rs
+++ b/crates/libafl/src/common/nautilus/mod.rs
@@ -1,4 +1,4 @@
-//! LibAFL version of the [`Nautilus`](https://github.com/nautilus-fuzz/nautilus) grammar fuzzer
+//! `LibAFL` version of the [`Nautilus`](https://github.com/nautilus-fuzz/nautilus) grammar fuzzer
 #![doc = include_str!("README.md")]
 
 #[allow(missing_docs)]

--- a/crates/libafl/src/executors/command.rs
+++ b/crates/libafl/src/executors/command.rs
@@ -235,6 +235,7 @@ pub struct PTraceCommandConfigurator {
 }
 
 #[cfg(all(feature = "intel_pt", target_os = "linux"))]
+#[allow(unreachable_code)]
 impl CommandConfigurator<Pid> for PTraceCommandConfigurator {
     fn spawn_child(&mut self, target_bytes: OwnedSlice<'_, u8>) -> Result<Pid, Error> {
         use nix::{

--- a/crates/libafl_bolts/src/rands/mod.rs
+++ b/crates/libafl_bolts/src/rands/mod.rs
@@ -567,9 +567,9 @@ pub mod pybind {
     #[pyclass(unsendable, name = "StdRand")]
     #[expect(clippy::unsafe_derive_deserialize)]
     #[derive(Serialize, Deserialize, Debug, Clone)]
-    /// Python class for StdRand
+    /// Python class for `StdRand`
     pub struct PythonStdRand {
-        /// Rust wrapped StdRand object
+        /// Rust wrapped `StdRand` object
         pub inner: StdRand,
     }
 

--- a/crates/libafl_frida/src/helper.rs
+++ b/crates/libafl_frida/src/helper.rs
@@ -699,26 +699,26 @@ where
                 };
 
                 #[cfg(target_arch = "x86_64")]
-                if let Some(details) = res {
-                    if let Some(rt) = runtimes.match_first_type_mut::<AsanRuntime>() {
-                        let start = output.writer().pc();
-                        rt.emit_shadow_check(
-                            address,
-                            output,
-                            instr.bytes().len(),
-                            details.0,
-                            details.1,
-                            details.2,
-                            details.3,
-                            details.4,
-                        );
-                        log::trace!(
-                            "emitted shadow_check for {:x} at {:x}-{:x}",
-                            address,
-                            start,
-                            output.writer().pc()
-                        );
-                    }
+                if let Some(details) = res
+                    && let Some(rt) = runtimes.match_first_type_mut::<AsanRuntime>()
+                {
+                    let start = output.writer().pc();
+                    rt.emit_shadow_check(
+                        address,
+                        output,
+                        instr.bytes().len(),
+                        details.0,
+                        details.1,
+                        details.2,
+                        details.3,
+                        details.4,
+                    );
+                    log::trace!(
+                        "emitted shadow_check for {:x} at {:x}-{:x}",
+                        address,
+                        start,
+                        output.writer().pc()
+                    );
                 }
 
                 #[cfg(target_arch = "aarch64")]
@@ -740,21 +740,13 @@ where
                     feature = "cmplog",
                     any(target_arch = "aarch64", target_arch = "x86_64")
                 ))]
-                if let Some(rt) = runtimes.match_first_type_mut::<CmpLogRuntime>() {
-                    if let Some((op1, op2, shift, special_case)) =
+                if let Some(rt) = runtimes.match_first_type_mut::<CmpLogRuntime>()
+                    && let Some((op1, op2, shift, special_case)) =
                         CmpLogRuntime::cmplog_is_interesting_instruction(decoder, address, instr)
-                    //change this as well
-                    {
-                        //emit code that saves the relevant data in runtime(passes it to x0, x1)
-                        rt.emit_comparison_handling(
-                            address,
-                            output,
-                            &op1,
-                            &op2,
-                            &shift,
-                            &special_case,
-                        );
-                    }
+                //change this as well
+                {
+                    //emit code that saves the relevant data in runtime(passes it to x0, x1)
+                    rt.emit_comparison_handling(address, output, &op1, &op2, &shift, &special_case);
                 }
 
                 if let Some(rt) = runtimes.match_first_type_mut::<AsanRuntime>() {

--- a/crates/libafl_qemu/src/elf.rs
+++ b/crates/libafl_qemu/src/elf.rs
@@ -49,26 +49,26 @@ impl<'a> EasyElf<'a> {
     #[must_use]
     pub fn resolve_symbol(&self, name: &str, load_addr: GuestAddr) -> Option<GuestAddr> {
         for sym in &self.elf.syms {
-            if let Some(sym_name) = self.elf.strtab.get_at(sym.st_name) {
-                if sym_name == name {
-                    return if sym.st_value == 0 {
-                        None
-                    } else if self.is_pic() {
-                        #[cfg(cpu_target = "arm")]
-                        // Required because of arm interworking addresses aka bit(0) for thumb mode
-                        let addr = (sym.st_value as GuestAddr + load_addr) & !(0x1 as GuestAddr);
-                        #[cfg(not(cpu_target = "arm"))]
-                        let addr = sym.st_value as GuestAddr + load_addr;
-                        Some(addr)
-                    } else {
-                        #[cfg(cpu_target = "arm")]
-                        // Required because of arm interworking addresses aka bit(0) for thumb mode
-                        let addr = (sym.st_value as GuestAddr) & !(0x1 as GuestAddr);
-                        #[cfg(not(cpu_target = "arm"))]
-                        let addr = sym.st_value as GuestAddr;
-                        Some(addr)
-                    };
-                }
+            if let Some(sym_name) = self.elf.strtab.get_at(sym.st_name)
+                && sym_name == name
+            {
+                return if sym.st_value == 0 {
+                    None
+                } else if self.is_pic() {
+                    #[cfg(cpu_target = "arm")]
+                    // Required because of arm interworking addresses aka bit(0) for thumb mode
+                    let addr = (sym.st_value as GuestAddr + load_addr) & !(0x1 as GuestAddr);
+                    #[cfg(not(cpu_target = "arm"))]
+                    let addr = sym.st_value as GuestAddr + load_addr;
+                    Some(addr)
+                } else {
+                    #[cfg(cpu_target = "arm")]
+                    // Required because of arm interworking addresses aka bit(0) for thumb mode
+                    let addr = (sym.st_value as GuestAddr) & !(0x1 as GuestAddr);
+                    #[cfg(not(cpu_target = "arm"))]
+                    let addr = sym.st_value as GuestAddr;
+                    Some(addr)
+                };
             }
         }
         None

--- a/crates/libafl_qemu/src/modules/cmplog.rs
+++ b/crates/libafl_qemu/src/modules/cmplog.rs
@@ -204,11 +204,12 @@ where
     I: Unpin,
     S: Unpin + HasMetadata,
 {
-    if let Some(h) = emulator_modules.get::<CmpLogModule>() {
-        if !h.must_instrument(pc) {
-            return None;
-        }
+    if let Some(h) = emulator_modules.get::<CmpLogModule>()
+        && !h.must_instrument(pc)
+    {
+        return None;
     }
+
     let state = state.expect("The gen_unique_cmp_ids hook works only for in-process fuzzing. Is the Executor initialized?");
     if state.metadata_map().get::<QemuCmpsMapMetadata>().is_none() {
         state.add_metadata(QemuCmpsMapMetadata::new());
@@ -238,11 +239,12 @@ where
     I: Unpin,
     S: HasMetadata + Unpin,
 {
-    if let Some(h) = emulator_modules.get::<CmpLogChildModule>() {
-        if !h.must_instrument(pc) {
-            return None;
-        }
+    if let Some(h) = emulator_modules.get::<CmpLogChildModule>()
+        && !h.must_instrument(pc)
+    {
+        return None;
     }
+
     Some(hash_64_fast(pc.into()) & (CMPLOG_MAP_W as u64 - 1))
 }
 

--- a/crates/libafl_qemu/src/modules/usermode/asan_guest.rs
+++ b/crates/libafl_qemu/src/modules/usermode/asan_guest.rs
@@ -116,13 +116,12 @@ where
     }
 
     /* Don't sanitize the sanitizer! */
-    if let Some(asan_mappings) = &h.asan_mappings {
-        if asan_mappings
+    if let Some(asan_mappings) = &h.asan_mappings
+        && asan_mappings
             .iter()
             .any(|m| m.start() <= pc && pc < m.end())
-        {
-            return None;
-        }
+    {
+        return None;
     }
 
     let size = info.size();

--- a/crates/libafl_qemu/src/modules/usermode/asan_host.rs
+++ b/crates/libafl_qemu/src/modules/usermode/asan_host.rs
@@ -1199,13 +1199,12 @@ where
     }
 
     // Don't sanitize the sanitizer!
-    if let Some(asan_mappings) = &h.asan_mappings {
-        if asan_mappings
+    if let Some(asan_mappings) = &h.asan_mappings
+        && asan_mappings
             .iter()
             .any(|m| m.start() <= pc && pc < m.end())
-        {
-            return None;
-        }
+    {
+        return None;
     }
 
     Some(pc.into())
@@ -1296,13 +1295,12 @@ where
     }
 
     // Don't sanitize the sanitizer!
-    if let Some(asan_mappings) = &h.asan_mappings {
-        if asan_mappings
+    if let Some(asan_mappings) = &h.asan_mappings
+        && asan_mappings
             .iter()
             .any(|m| m.start() <= pc && pc < m.end())
-        {
-            return Some(0);
-        }
+    {
+        return Some(0);
     }
 
     Some(pc.into())

--- a/crates/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/crates/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -1077,17 +1077,17 @@ where
             }
 
             #[cfg(not(any(cpu_target = "arm", cpu_target = "riscv32")))]
-            if sys_const == SYS_mmap {
-                if let Ok(prot) = MmapPerms::try_from(a2 as i32) {
-                    if let Some(h) = emulator_modules.get_mut::<SnapshotModule>() {
-                        h.add_mapped(result, a1 as usize, Some(prot));
-                    } else {
-                        let snap = emulator_modules
-                            .get_mut::<OptionalModule<SnapshotModule>>()
-                            .unwrap();
-                        let h = snap.get_inner_module_mut();
-                        h.add_mapped(result, a1 as usize, Some(prot));
-                    }
+            if sys_const == SYS_mmap
+                && let Ok(prot) = MmapPerms::try_from(a2 as i32)
+            {
+                if let Some(h) = emulator_modules.get_mut::<SnapshotModule>() {
+                    h.add_mapped(result, a1 as usize, Some(prot));
+                } else {
+                    let snap = emulator_modules
+                        .get_mut::<OptionalModule<SnapshotModule>>()
+                        .unwrap();
+                    let h = snap.get_inner_module_mut();
+                    h.add_mapped(result, a1 as usize, Some(prot));
                 }
             }
 

--- a/crates/libafl_qemu/src/modules/utils/logic.rs
+++ b/crates/libafl_qemu/src/modules/utils/logic.rs
@@ -1,0 +1,113 @@
+use std::fmt::Debug;
+
+use crate::modules::{EmulatorModule, EmulatorModuleTuple};
+
+#[derive(Debug)]
+pub struct OptionalModule<MD> {
+    enabled: bool,
+    module: MD,
+}
+
+impl<MD> OptionalModule<MD> {
+    pub fn new(enabled: bool, module: MD) -> Self {
+        Self { enabled, module }
+    }
+
+    pub fn get_inner_module_mut(&mut self) -> &mut MD {
+        &mut self.module
+    }
+}
+
+impl<MD, I, S> EmulatorModule<I, S> for OptionalModule<MD>
+where
+    I: Unpin,
+    S: Unpin,
+    MD: EmulatorModule<I, S>,
+{
+    const HOOKS_DO_SIDE_EFFECTS: bool = true;
+
+    fn pre_qemu_init<ET>(
+        &mut self,
+        emulator_modules: &mut crate::EmulatorModules<ET, I, S>,
+        qemu_params: &mut crate::QemuParams,
+    ) where
+        ET: EmulatorModuleTuple<I, S>,
+    {
+        if self.enabled {
+            self.module.pre_qemu_init(emulator_modules, qemu_params);
+        }
+    }
+
+    fn post_qemu_init<ET>(
+        &mut self,
+        qemu: crate::Qemu,
+        emulator_modules: &mut crate::EmulatorModules<ET, I, S>,
+    ) where
+        ET: EmulatorModuleTuple<I, S>,
+    {
+        if self.enabled {
+            self.module.post_qemu_init(qemu, emulator_modules);
+        }
+    }
+
+    fn first_exec<ET>(
+        &mut self,
+        qemu: crate::Qemu,
+        emulator_modules: &mut crate::EmulatorModules<ET, I, S>,
+        state: &mut S,
+    ) where
+        ET: EmulatorModuleTuple<I, S>,
+    {
+        if self.enabled {
+            self.module.first_exec(qemu, emulator_modules, state);
+        }
+    }
+
+    fn pre_exec<ET>(
+        &mut self,
+        qemu: crate::Qemu,
+        emulator_modules: &mut crate::EmulatorModules<ET, I, S>,
+        state: &mut S,
+        input: &I,
+    ) where
+        ET: EmulatorModuleTuple<I, S>,
+    {
+        if self.enabled {
+            self.module.pre_exec(qemu, emulator_modules, state, input);
+        }
+    }
+
+    fn post_exec<OT, ET>(
+        &mut self,
+        qemu: crate::Qemu,
+        emulator_modules: &mut crate::EmulatorModules<ET, I, S>,
+        state: &mut S,
+        input: &I,
+        observers: &mut OT,
+        exit_kind: &mut libafl::executors::ExitKind,
+    ) where
+        OT: libafl::observers::ObserversTuple<I, S>,
+        ET: EmulatorModuleTuple<I, S>,
+    {
+        if self.enabled {
+            self.module
+                .post_exec(qemu, emulator_modules, state, input, observers, exit_kind);
+        }
+    }
+
+    unsafe fn on_crash(&mut self) {
+        if self.enabled {
+            unsafe {
+                self.module.on_crash();
+            }
+        }
+    }
+
+    unsafe fn on_timeout(&mut self) {
+        if self.enabled {
+            unsafe {
+                self.module.on_timeout();
+            }
+        }
+    }
+}

--- a/crates/libafl_qemu/src/modules/utils/mod.rs
+++ b/crates/libafl_qemu/src/modules/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod filters;
+pub mod logic;
 
 #[cfg(feature = "usermode")]
 pub use addr2line::*;


### PR DESCRIPTION
@tokatoka @rmalmain 

## Description

Trying to add an optional support for snapshot in Qemu Sugar. @domenukk suggested a `IfModule` like the `IfStage` to avoid duplicating a lot of code and pleasing Rust's type system.
I went with a simpler version taking a bool rather than a closure as we probably don't want to dynamically change the list of loaded modules.

I had to fix the `SnapshotModule` because it couldn't retrieve the module wrapped in the `OptionalModule` but:
1) it feels ugly
2) I want to also allow using the AddressFilter, it will require updating it with the same type of logic
3) I need to document the module and 2) if we want to include more modules in the future 

```Rust
if let Some(h) = emulator_modules.get_mut::<SnapshotModule>() {
    h.access(addr, SIZE);
} else {
    let snap = emulator_modules.get_mut::<OptionalModule<SnapshotModule>>().unwrap();
    let h = snap.get_inner_module_mut();
    h.access(addr, SIZE);
}
```
I'm open to any suggestion to improve this and how/where I should document it.

## Checklist

- [] I have run `./scripts/precommit.sh` and addressed all comments

I ran the precommit script but couldn't address all comments.
In this example clippy wants me to merge the two `if` because it can't see the arm specific code.
```
        if let Some(h) = emulator_modules.get_mut::<Self>() {
            if !h.must_instrument(pc) {
                return None;
            }

            #[cfg(cpu_target = "arm")]
            h.cs.set_mode(if pc & 1 == 1 {
                capstone::arch::arm::ArchMode::Thumb.into()
            } else {
                capstone::arch::arm::ArchMode::Arm.into()
            })
            .unwrap();
        }
```

Also when targeting arm so it doesn't complain about this I got a lot of errors
```
error[E0432]: unresolved import `crate::SYS_execve`
  --> crates/libafl_qemu/src/modules/usermode/injections.rs:22:5
   |
22 | use crate::SYS_execve;
   |     ^^^^^^^^^^^^^^^^^ no `SYS_execve` in the root

error[E0432]: unresolved import `crate::SYS_fstatat64`
  --> crates/libafl_qemu/src/modules/usermode/snapshot.rs:10:5
   |
10 | use crate::SYS_fstatat64;
   |     ^^^^^^^^^^^^^^^^^^^^ no `SYS_fstatat64` in the root

error[E0432]: unresolved import `crate::SYS_mmap2`
  --> crates/libafl_qemu/src/modules/usermode/snapshot.rs:14:5
   |
14 | use crate::SYS_mmap2;
   |     ^^^^^^^^^^^^^^^^ no `SYS_mmap2` in the root

```