### PR TITLE
Fix libafl_qemu build on ARM

### DIFF
--- a/crates/libafl_qemu/runtime/nyx_api.h
+++ b/crates/libafl_qemu/runtime/nyx_api.h
@@ -14,6 +14,7 @@
   // userspace
   #include <stdarg.h>
   #include <stdio.h>
+  #include <stdlib.h>
 
   #ifdef __MINGW64__
     #ifndef uint64_t
@@ -38,6 +39,7 @@
   // Linux kernel
   #include <linux/stdarg.h>
   #include <linux/types.h>
+  #include <linux/kernel.h>
 #endif
 
 #define HYPERCALL_KAFL_RAX_ID 0x01f
@@ -118,6 +120,15 @@ static inline uint64_t kAFL_hypercall(uint64_t p1, uint64_t p2) {
   uint64_t nr = HYPERCALL_KAFL_RAX_ID;
   asm volatile("vmcall" : "=a"(nr) : "a"(nr), "b"(p1), "c"(p2));
   return nr;
+}
+#else
+static inline uint32_t kAFL_hypercall(uint32_t p1, uint32_t p2) {
+  #ifdef __KERNEL__
+  BUG();
+  #else
+  abort();
+  #endif
+  return 0;
 }
 #endif
 

--- a/crates/libafl_qemu/src/qemu/systemmode.rs
+++ b/crates/libafl_qemu/src/qemu/systemmode.rs
@@ -260,7 +260,7 @@ impl Qemu {
                 track,
                 true,
                 device_filter.enum_id(),
-                device_filter.devices(&mut v),
+                device_filter.devices(&mut v) as *mut *mut _,
             )
         }
     }


### PR DESCRIPTION
## Description

libafl_qemu tries to generate nyx bindings even if nyx is not going to be used.  On ARM, this results in a compile error during bindgen because kAFL_hypercall, which is defined inside an #ifdef on x86 platforms, is not defined and is later referenced in the same header file.

This commit adds an #else clause that creates a dummy definition of kAFL_hypercall on non-x86 platforms.  Additionally, a pointer cast is added because the signedness of `libafl_qemu_sys#libafl_qemu_sys`'s last argument appears to be unstable.