### PR TITLE
Work around setsid addition to nightly in 1.90

### DIFF
--- a/crates/libafl/src/executors/forkserver.rs
+++ b/crates/libafl/src/executors/forkserver.rs
@@ -513,18 +513,20 @@ impl Forkserver {
         // # Saftey
         // The pipe file descriptors used for `setpipe` are valid at this point.
         let fsrv_handle = unsafe {
-            match ConfigTarget::setsid(command
-                .env("LD_BIND_NOW", "1")
-                .envs(envs)
-                .setlimit(memlimit)
-                .set_coredump(afl_debug))
-                .setpipe(
-                    st_pipe.read_end().unwrap(),
-                    st_pipe.write_end().unwrap(),
-                    ctl_pipe.read_end().unwrap(),
-                    ctl_pipe.write_end().unwrap(),
-                )
-                .spawn()
+            match ConfigTarget::setsid(
+                command
+                    .env("LD_BIND_NOW", "1")
+                    .envs(envs)
+                    .setlimit(memlimit)
+                    .set_coredump(afl_debug),
+            )
+            .setpipe(
+                st_pipe.read_end().unwrap(),
+                st_pipe.write_end().unwrap(),
+                ctl_pipe.read_end().unwrap(),
+                ctl_pipe.write_end().unwrap(),
+            )
+            .spawn()
             {
                 Ok(fsrv_handle) => fsrv_handle,
                 Err(err) => {


### PR DESCRIPTION
## Description

Explicitly calls `setsid` to avoid new error in 1.90. Solves #3345.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
