### PR TITLE
Explicitly invoke nightly toolchain in *Nix LibAFL-LibFuzzer build script

### DIFF
--- a/crates/libafl_libfuzzer_runtime/build.sh
+++ b/crates/libafl_libfuzzer_runtime/build.sh
@@ -12,12 +12,12 @@ else
   profile="$1"
 fi
 
-if ! cargo --version >& /dev/null; then
+if ! cargo +nightly --version >& /dev/null; then
   echo -e "You must install a recent Rust to build the libafl_libfuzzer runtime!"
   exit 1
 fi
 
-cargo build --profile "$profile"
+cargo +nightly build --profile "$profile"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # MacOS and iOS
@@ -26,7 +26,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     -o libafl_libfuzzer_runtime.dylib
 else
   # Linux and *BSD
-  RUSTC_BIN="$(cargo rustc -Zunstable-options --print target-libdir)/../bin"
+  RUSTC_BIN="$(cargo +nightly rustc -Zunstable-options --print target-libdir)/../bin"
   RUST_LLD="${RUSTC_BIN}/rust-lld"
   RUST_AR="${RUSTC_BIN}/llvm-ar"
 


### PR DESCRIPTION
## Description

LibAFL-LibFuzzer's `build.sh` currently assumes your Rust toolchain is set to use `nightly` by default. This change explicitly invokes `+nightly` so that users who default to stable are not required to change their default toolchain with `rustup toolchain default nightly` before running the script.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
