### PR TITLE
Update libafl-libfuzzer build scripts with more options

### DIFF
--- a/crates/libafl_libfuzzer_runtime/build.ps1
+++ b/crates/libafl_libfuzzer_runtime/build.ps1
@@ -1,4 +1,16 @@
 #!/usr/bin/env pwsh
+param (
+    [Parameter(Mandatory = $false, HelpMessage = "The build profile to use, e.g. 'release' or 'dev'. Default is 'release'.")]
+    [string]$Profile = "release",
+    [Parameter(Mandatory = $false, HelpMessage = "The toolchain to use, e.g. 'stable', 'nightly', etc. Default is 'stable'.")]
+    [string]$Toolchain = "stable",
+    [Parameter(Mandatory = $false, HelpMessage = "Additional cargo arguments to pass")]
+    [string]$CargoArgs = "",
+    [Parameter(Mandatory = $false, HelpMessage = "Additional rustc arguments to pass")]
+    [string]$RustcArgs = "",
+    [Parameter(Mandatory = $false, HelpMessage = "Additional flags to set for the C compiler")]
+    [string]$CCFlags = ""
+)
 
 $ErrorActionPreference = "Stop"
 
@@ -6,14 +18,20 @@ $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Set-Location $SCRIPT_DIR
 
-if ($args.Count -eq 0) {
-    $profile = "release"
-} else {
-    $profile = $args[0]
+Write-Host "Building libafl_libfuzzer runtime with profile '$Profile' on toolchain '$Toolchain'" -ForegroundColor Green
+Invoke-Command -ScriptBlock {
+    $env:RUSTFLAGS = $RustcArgs
+    $env:CFLAGS = $CCFlags
+    Write-Host "Using Rust flags: $env:RUSTFLAGS" -ForegroundColor Cyan
+    Write-Host "Using Cargo arguments: $CargoArgs" -ForegroundColor Cyan
+    Write-Host "Using C compiler flags: $env:CFLAGS" -ForegroundColor Cyan
+    if ($CargoArgs) {
+        cargo +$Toolchain build --profile $Profile $CargoArgs
+    } else {
+        cargo +$Toolchain build --profile $Profile
+    }
 }
 
-Write-Host "Building libafl_libfuzzer runtime with profile '$profile'" -ForegroundColor Green
-Invoke-Expression "cargo build --profile $profile"
 
 $tmpdir = Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())
 New-Item -ItemType Directory -Path $tmpdir | Out-Null
@@ -25,13 +43,13 @@ function Cleanup {
 }
 
 try {
-    if ($profile -eq "dev") {
+    if ($Profile -eq "dev") {
         # Set the profile to debug for dev builds, because the path isn't the same
         # as the profile name
-        $profile = "debug"
+        $Profile = "debug"
     }
 
-    $targetPath = Join-Path $SCRIPT_DIR "target\$profile\afl_libfuzzer_runtime.lib"
+    $targetPath = Join-Path $SCRIPT_DIR "target\$Profile\afl_libfuzzer_runtime.lib"
     $outputPath = Join-Path $SCRIPT_DIR "libFuzzer.lib"
     
     Copy-Item -Path $targetPath -Destination $outputPath -Force | Out-Null

--- a/crates/libafl_libfuzzer_runtime/build.rs
+++ b/crates/libafl_libfuzzer_runtime/build.rs
@@ -19,6 +19,11 @@ fn main() {
 
     let mut harness_wrap = cc::Build::new();
 
+    if let Ok(flags) = env::var("CFLAGS") {
+        println!("cargo:rerun-if-env-changed=CFLAGS");
+        harness_wrap.flags(flags.split_whitespace());
+    }
+
     harness_wrap.cpp(true).file("src/harness_wrap.cpp");
 
     harness_wrap.compile("harness_wrap");


### PR DESCRIPTION
## Description

Adds options for profile, toolchain, rust args, cargo args, and c compiler in libafl-libfuzzer build scripts. This allows scenarios where e.g. you want to build std with some
unstable options. For example, to work with CFG you can build like `.\build.ps1 -Toolchain nightly -RustcArgs "-Zunstable-options -Zehcont-guard" -CargoArgs "-Zbuild-std" -CCFlags "/guard:ehcont"`.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
