### PR TITLE
Fix mismatched_lifetime_syntaxes lint

### DIFF
--- a/crates/libafl_libfuzzer/runtime/src/options.rs
+++ b/crates/libafl_libfuzzer/runtime/src/options.rs
@@ -11,7 +11,7 @@ enum RawOption<'a> {
     Flag { name: &'a str, value: &'a str },
 }
 
-fn parse_option(arg: &str) -> Option<RawOption> {
+fn parse_option(arg: &str) -> Option<RawOption<'_>> {
     if arg.starts_with("--") {
         None
     } else if arg.starts_with('-') {


### PR DESCRIPTION
## Description

libafl_libfuzzer_runtime has a new lint warning:

```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src\options.rs:14:22
   |
14 | fn parse_option(arg: &str) -> Option<RawOption> {
   |                      ^^^^            --------- the same lifetime is hidden here
   |                      |
   |                      the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
14 | fn parse_option(arg: &str) -> Option<RawOption<'_>> {
   |                                               ++++
 
warning: `libafl_libfuzzer_runtime` (lib) generated 1 warning
```

This just fixes using the suggestion to banish the warning.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
