### PR TITLE
Add `DynamicCorpus`

### DIFF
--- a/crates/libafl/src/corpus/dynamic.rs
+++ b/crates/libafl/src/corpus/dynamic.rs
@@ -17,16 +17,6 @@ pub enum DynamicCorpus<C1, C2, I> {
     Corpus2(C2, PhantomData<I>),
 }
 
-/// A helper macro to avoid too many duplicates.
-macro_rules! select_corpus {
-    ($sf: tt, $it: tt, $( $args: tt), *) => {
-        match $sf {
-            Self::Corpus1(c1, _) => c1.$it( $($args),* ),
-            Self::Corpus2(c2, _) => c2.$it( $($args),* ),
-        }
-    };
-}
-
 impl<C1, C2, I> DynamicCorpus<C1, C2, I>
 where
     C1: Corpus<I>,
@@ -49,93 +39,159 @@ where
     C2: Corpus<I>,
 {
     fn peek_free_id(&self) -> CorpusId {
-        select_corpus!(self, peek_free_id,)
+        match self {
+            Self::Corpus1(c1, _) => c1.peek_free_id(),
+            Self::Corpus2(c2, _) => c2.peek_free_id(),
+        }
     }
 
     fn add(&mut self, testcase: Testcase<I>) -> Result<CorpusId, Error> {
-        select_corpus!(self, add, testcase)
+        match self {
+            Self::Corpus1(c1, _) => c1.add(testcase),
+            Self::Corpus2(c2, _) => c2.add(testcase),
+        }
     }
 
     fn add_disabled(&mut self, testcase: Testcase<I>) -> Result<CorpusId, Error> {
-        select_corpus!(self, add_disabled, testcase)
+        match self {
+            Self::Corpus1(c1, _) => c1.add_disabled(testcase),
+            Self::Corpus2(c2, _) => c2.add_disabled(testcase),
+        }
     }
 
     fn cloned_input_for_id(&self, idx: CorpusId) -> Result<I, Error>
     where
         I: Clone,
     {
-        select_corpus!(self, cloned_input_for_id, idx)
+        match self {
+            Self::Corpus1(c1, _) => c1.cloned_input_for_id(idx),
+            Self::Corpus2(c2, _) => c2.cloned_input_for_id(idx),
+        }
     }
 
     fn count(&self) -> usize {
-        select_corpus!(self, count,)
+        match self {
+            Self::Corpus1(c1, _) => c1.count(),
+            Self::Corpus2(c2, _) => c2.count(),
+        }
     }
 
     fn count_all(&self) -> usize {
-        select_corpus!(self, count_all,)
+        match self {
+            Self::Corpus1(c1, _) => c1.count_all(),
+            Self::Corpus2(c2, _) => c2.count_all(),
+        }
     }
 
     fn count_disabled(&self) -> usize {
-        select_corpus!(self, count_disabled,)
+        match self {
+            Self::Corpus1(c1, _) => c1.count_disabled(),
+            Self::Corpus2(c2, _) => c2.count_disabled(),
+        }
     }
 
     fn current(&self) -> &Option<CorpusId> {
-        select_corpus!(self, current,)
+        match self {
+            Self::Corpus1(c1, _) => c1.current(),
+            Self::Corpus2(c2, _) => c2.current(),
+        }
     }
 
     fn current_mut(&mut self) -> &mut Option<CorpusId> {
-        select_corpus!(self, current_mut,)
+        match self {
+            Self::Corpus1(c1, _) => c1.current_mut(),
+            Self::Corpus2(c2, _) => c2.current_mut(),
+        }
     }
 
     fn first(&self) -> Option<CorpusId> {
-        select_corpus!(self, first,)
+        match self {
+            Self::Corpus1(c1, _) => c1.first(),
+            Self::Corpus2(c2, _) => c2.first(),
+        }
     }
 
     fn get(&self, id: CorpusId) -> Result<&RefCell<Testcase<I>>, Error> {
-        select_corpus!(self, get, id)
+        match self {
+            Self::Corpus1(c1, _) => c1.get(id),
+            Self::Corpus2(c2, _) => c2.get(id),
+        }
     }
 
     fn get_from_all(&self, id: CorpusId) -> Result<&RefCell<Testcase<I>>, Error> {
-        select_corpus!(self, get_from_all, id)
+        match self {
+            Self::Corpus1(c1, _) => c1.get_from_all(id),
+            Self::Corpus2(c2, _) => c2.get_from_all(id),
+        }
     }
 
     fn is_empty(&self) -> bool {
-        select_corpus!(self, is_empty,)
+        match self {
+            Self::Corpus1(c1, _) => c1.is_empty(),
+            Self::Corpus2(c2, _) => c2.is_empty(),
+        }
     }
 
     fn last(&self) -> Option<CorpusId> {
-        select_corpus!(self, last,)
+        match self {
+            Self::Corpus1(c1, _) => c1.last(),
+            Self::Corpus2(c2, _) => c2.last(),
+        }
     }
 
     fn load_input_into(&self, testcase: &mut Testcase<I>) -> Result<(), Error> {
-        select_corpus!(self, load_input_into, testcase)
+        match self {
+            Self::Corpus1(c1, _) => c1.load_input_into(testcase),
+            Self::Corpus2(c2, _) => c2.load_input_into(testcase),
+        }
     }
 
     fn next(&self, id: CorpusId) -> Option<CorpusId> {
-        select_corpus!(self, next, id)
+        match self {
+            Self::Corpus1(c1, _) => c1.next(id),
+            Self::Corpus2(c2, _) => c2.next(id),
+        }
     }
 
     fn nth(&self, nth: usize) -> CorpusId {
-        select_corpus!(self, nth, nth)
+        match self {
+            Self::Corpus1(c1, _) => c1.nth(nth),
+            Self::Corpus2(c2, _) => c2.nth(nth),
+        }
     }
 
     fn nth_from_all(&self, nth: usize) -> CorpusId {
-        select_corpus!(self, nth_from_all, nth)
+        match self {
+            Self::Corpus1(c1, _) => c1.nth_from_all(nth),
+            Self::Corpus2(c2, _) => c2.nth_from_all(nth),
+        }
     }
 
     fn prev(&self, id: CorpusId) -> Option<CorpusId> {
-        select_corpus!(self, prev, id)
+        match self {
+            Self::Corpus1(c1, _) => c1.prev(id),
+            Self::Corpus2(c2, _) => c2.prev(id),
+        }
     }
 
     fn remove(&mut self, id: CorpusId) -> Result<Testcase<I>, Error> {
-        select_corpus!(self, remove, id)
+        match self {
+            Self::Corpus1(c1, _) => c1.remove(id),
+            Self::Corpus2(c2, _) => c2.remove(id),
+        }
     }
 
     fn replace(&mut self, idx: CorpusId, testcase: Testcase<I>) -> Result<Testcase<I>, Error> {
-        select_corpus!(self, replace, idx, testcase)
+        match self {
+            Self::Corpus1(c1, _) => c1.replace(idx, testcase),
+            Self::Corpus2(c2, _) => c2.replace(idx, testcase),
+        }
     }
 
     fn store_input_from(&self, testcase: &Testcase<I>) -> Result<(), Error> {
-        select_corpus!(self, store_input_from, testcase)
+        match self {
+            Self::Corpus1(c1, _) => c1.store_input_from(testcase),
+            Self::Corpus2(c2, _) => c2.store_input_from(testcase),
+        }
     }
 }

--- a/crates/libafl/src/corpus/dynamic.rs
+++ b/crates/libafl/src/corpus/dynamic.rs
@@ -1,0 +1,135 @@
+//! Dynamic corpus that allows users to switch corpus types at runtime.
+use std::{cell::RefCell, marker::PhantomData};
+
+use libafl_bolts::Error;
+
+use crate::corpus::{Corpus, CorpusId, Testcase};
+
+/// An dynamic corpus type accepting two types of corpus at runtime. This helps rustc better
+/// reason about the bounds compared to dyn objects.
+#[derive(Debug)]
+pub enum DynamicCorpus<C1, C2, I> {
+    /// Corpus1 implementation
+    Corpus1(C1, PhantomData<I>),
+    /// Corpus2 implementation
+    Corpus2(C2, PhantomData<I>),
+}
+
+/// A helper macro to avoid too many duplicates.
+macro_rules! select_corpus {
+    ($sf: tt, $it: tt, $( $args: tt), *) => {
+        match $sf {
+            Self::Corpus1(c1, _) => c1.$it( $($args),* ),
+            Self::Corpus2(c2, _) => c2.$it( $($args),* ),
+        }
+    };
+}
+
+impl<C1, C2, I> DynamicCorpus<C1, C2, I> {
+    /// Create a `DynamicCorpus` with Corpus1 variant.
+    pub fn corpus1(c: C1) -> Self {
+        Self::Corpus1(c, PhantomData)
+    }
+
+    /// Create a `DynamicCorpus` with Corpus2 variant.
+    pub fn corpus2(c: C2) -> Self {
+        Self::Corpus2(c, PhantomData)
+    }
+}
+
+impl<C1, C2, I> Corpus<I> for DynamicCorpus<C1, C2, I>
+where
+    C1: Corpus<I>,
+    C2: Corpus<I>,
+{
+    fn peek_free_id(&self) -> CorpusId {
+        select_corpus!(self, peek_free_id,)
+    }
+
+    fn add(&mut self, testcase: Testcase<I>) -> Result<CorpusId, Error> {
+        select_corpus!(self, add, testcase)
+    }
+
+    fn add_disabled(&mut self, testcase: Testcase<I>) -> Result<CorpusId, Error> {
+        select_corpus!(self, add_disabled, testcase)
+    }
+
+    fn cloned_input_for_id(&self, idx: CorpusId) -> Result<I, Error>
+    where
+        I: Clone,
+    {
+        select_corpus!(self, cloned_input_for_id, idx)
+    }
+
+    fn count(&self) -> usize {
+        select_corpus!(self, count,)
+    }
+
+    fn count_all(&self) -> usize {
+        select_corpus!(self, count_all,)
+    }
+
+    fn count_disabled(&self) -> usize {
+        select_corpus!(self, count_disabled,)
+    }
+
+    fn current(&self) -> &Option<CorpusId> {
+        select_corpus!(self, current,)
+    }
+
+    fn current_mut(&mut self) -> &mut Option<CorpusId> {
+        select_corpus!(self, current_mut,)
+    }
+
+    fn first(&self) -> Option<CorpusId> {
+        select_corpus!(self, first,)
+    }
+
+    fn get(&self, id: CorpusId) -> Result<&RefCell<Testcase<I>>, Error> {
+        select_corpus!(self, get, id)
+    }
+
+    fn get_from_all(&self, id: CorpusId) -> Result<&RefCell<Testcase<I>>, Error> {
+        select_corpus!(self, get_from_all, id)
+    }
+
+    fn is_empty(&self) -> bool {
+        select_corpus!(self, is_empty,)
+    }
+
+    fn last(&self) -> Option<CorpusId> {
+        select_corpus!(self, last,)
+    }
+
+    fn load_input_into(&self, testcase: &mut Testcase<I>) -> Result<(), Error> {
+        select_corpus!(self, load_input_into, testcase)
+    }
+
+    fn next(&self, id: CorpusId) -> Option<CorpusId> {
+        select_corpus!(self, next, id)
+    }
+
+    fn nth(&self, nth: usize) -> CorpusId {
+        select_corpus!(self, nth, nth)
+    }
+
+    fn nth_from_all(&self, nth: usize) -> CorpusId {
+        select_corpus!(self, nth_from_all, nth)
+    }
+
+    fn prev(&self, id: CorpusId) -> Option<CorpusId> {
+        select_corpus!(self, prev, id)
+    }
+
+    fn remove(&mut self, id: CorpusId) -> Result<Testcase<I>, Error> {
+        select_corpus!(self, remove, id)
+    }
+
+    fn replace(&mut self, idx: CorpusId, testcase: Testcase<I>) -> Result<Testcase<I>, Error> {
+        select_corpus!(self, replace, idx, testcase)
+    }
+
+    fn store_input_from(&self, testcase: &Testcase<I>) -> Result<(), Error> {
+        select_corpus!(self, store_input_from, testcase)
+    }
+}

--- a/crates/libafl/src/corpus/dynamic.rs
+++ b/crates/libafl/src/corpus/dynamic.rs
@@ -3,12 +3,13 @@
 use core::{cell::RefCell, marker::PhantomData};
 
 use libafl_bolts::Error;
+use serde::{Deserialize, Serialize};
 
 use crate::corpus::{Corpus, CorpusId, Testcase};
 
 /// An dynamic corpus type accepting two types of corpus at runtime. This helps rustc better
 /// reason about the bounds compared to dyn objects.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DynamicCorpus<C1, C2, I> {
     /// Corpus1 implementation
     Corpus1(C1, PhantomData<I>),
@@ -26,7 +27,11 @@ macro_rules! select_corpus {
     };
 }
 
-impl<C1, C2, I> DynamicCorpus<C1, C2, I> {
+impl<C1, C2, I> DynamicCorpus<C1, C2, I>
+where
+    C1: Corpus<I>,
+    C2: Corpus<I>,
+{
     /// Create a `DynamicCorpus` with Corpus1 variant.
     pub fn corpus1(c: C1) -> Self {
         Self::Corpus1(c, PhantomData)

--- a/crates/libafl/src/corpus/dynamic.rs
+++ b/crates/libafl/src/corpus/dynamic.rs
@@ -1,5 +1,6 @@
 //! Dynamic corpus that allows users to switch corpus types at runtime.
-use std::{cell::RefCell, marker::PhantomData};
+
+use core::{cell::RefCell, marker::PhantomData};
 
 use libafl_bolts::Error;
 

--- a/crates/libafl/src/corpus/mod.rs
+++ b/crates/libafl/src/corpus/mod.rs
@@ -12,6 +12,9 @@ pub use testcase::{HasTestcase, SchedulerTestcaseMetadata, Testcase};
 pub mod inmemory;
 pub use inmemory::InMemoryCorpus;
 
+pub mod dynamic;
+pub use dynamic::DynamicCorpus;
+
 #[cfg(feature = "std")]
 pub mod inmemory_ondisk;
 #[cfg(feature = "std")]


### PR DESCRIPTION
## Description

A follow up of #3124 like `DynamicStage`. No idea why it was missing then.

The typical use case of this type is debugging. To be specific, when I'm developing fuzzers, I will save seeds or so to disks via `InMemoryOnDiskCorpus` while I will use `InMemoryCorpus` for production, writing nothing to disks so that it is easy to be orchestrated.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
