### PR TITLE
Reset runs_in_current_cycle when the current cycle is done

### DIFF
--- a/crates/libafl/src/schedulers/queue.rs
+++ b/crates/libafl/src/schedulers/queue.rs
@@ -53,6 +53,7 @@ where
             // TODO deal with corpus_counts decreasing due to removals
             if self.runs_in_current_cycle >= state.corpus().count() as u64 {
                 self.queue_cycles += 1;
+                self.runs_in_current_cycle = 0;
             }
             <Self as Scheduler<I, S>>::set_current_scheduled(self, state, Some(id))?;
             Ok(id)


### PR DESCRIPTION
Spotted this while working on a similar scheduler. Looks like we don't reset `runs_in_current_cycle` anywhere, which is almost certainly wrong.