### PR TITLE
ListDumpFeedback: Add modified ListFeedback that will dump newly observed addresses

### DIFF
--- a/crates/libafl/src/feedbacks/list.rs
+++ b/crates/libafl/src/feedbacks/list.rs
@@ -13,9 +13,11 @@ use crate::{
     executors::ExitKind,
     feedbacks::{Feedback, StateInitializer},
     observers::ListObserver,
+    std::fmt::LowerHex,
     std::fs::File,
     std::io::Write,
     std::path::Path,
+    std::string::ToString,
 };
 
 /// The metadata to remember past observed value
@@ -62,10 +64,11 @@ impl<T> HasRefCnt for ListFeedbackMetadata<T> {
 }
 
 /// Consider interesting a testcase if the list in `ListObserver` is not empty.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ListFeedback<T> {
     observer_handle: Handle<ListObserver<T>>,
     novelty: HashSet<T>,
+    file: Option<File>,
 }
 
 libafl_bolts::impl_serdeany!(
@@ -75,7 +78,15 @@ libafl_bolts::impl_serdeany!(
 
 impl<T> ListFeedback<T>
 where
-    T: Debug + Eq + Hash + for<'a> Deserialize<'a> + Serialize + 'static + Copy,
+    T: Debug
+        + Eq
+        + Hash
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + 'static
+        + Copy
+        + ToString
+        + LowerHex,
 {
     fn has_interesting_list_observer_feedback<OT, S>(
         &mut self,
@@ -99,7 +110,15 @@ where
                 self.novelty.insert(*v);
             }
         }
-        !self.novelty.is_empty()
+        if !self.novelty.is_empty() {
+            if let Some(mut file) = self.file.as_ref() {
+                for line in &self.novelty {
+                    file.write_all(format!("0x{line:x}\n").as_bytes()).unwrap();
+                }
+            }
+            return true;
+        }
+        false
     }
 
     fn append_list_observer_metadata<S: HasNamedMetadata>(&mut self, state: &mut S) {
@@ -129,7 +148,16 @@ impl<EM, I, OT, S, T> Feedback<EM, I, OT, S> for ListFeedback<T>
 where
     OT: MatchName,
     S: HasNamedMetadata,
-    T: Debug + Eq + Hash + for<'a> Deserialize<'a> + Serialize + Default + Copy + 'static,
+    T: Debug
+        + Eq
+        + Hash
+        + for<'a> Deserialize<'a>
+        + Serialize
+        + Default
+        + Copy
+        + 'static
+        + ToString
+        + LowerHex,
 {
     fn is_interesting(
         &mut self,
@@ -173,123 +201,14 @@ impl<T> ListFeedback<T> {
         Self {
             observer_handle: observer.handle(),
             novelty: HashSet::new(),
+            file: None,
         }
     }
-}
 
-/// Consider interesting a testcase if the list in `ListObserver` is not empty.
-/// Modified version of [[`ListFeedback`]] that expects a [[`ListObserver`]]
-/// containing addresses and will write any newly observed address to
-/// a file (see [[`ListDumpFeedback::new`]])
-#[derive(Debug)]
-pub struct ListDumpFeedback {
-    observer_handle: Handle<ListObserver<u64>>,
-    novelty: HashSet<u64>,
-    file: File,
-}
-
-impl ListDumpFeedback {
-    fn has_interesting_list_observer_feedback<OT, S>(
-        &mut self,
-        state: &mut S,
-        observers: &OT,
-    ) -> bool
-    where
-        OT: MatchName,
-        S: HasNamedMetadata,
-    {
-        let observer = observers.get(&self.observer_handle).unwrap();
-        // TODO register the list content in a testcase metadata
-        self.novelty.clear();
-        // can't fail
-        let history_set = state
-            .named_metadata_map_mut()
-            .get_mut::<ListFeedbackMetadata<u64>>(self.name())
-            .unwrap();
-        for v in observer.list() {
-            if !history_set.set.contains(v) {
-                self.novelty.insert(*v);
-            }
-        }
-        if !self.novelty.is_empty() {
-            for line in &self.novelty {
-                self.file
-                    .write_all(format!("0x{line:x}\n").as_bytes())
-                    .unwrap();
-            }
-            return true;
-        }
-        false
-    }
-
-    fn append_list_observer_metadata<S: HasNamedMetadata>(&mut self, state: &mut S) {
-        let history_set = state
-            .named_metadata_map_mut()
-            .get_mut::<ListFeedbackMetadata<u64>>(self.name())
-            .unwrap();
-
-        for v in &self.novelty {
-            history_set.set.insert(*v);
-        }
-    }
-}
-
-impl<S> StateInitializer<S> for ListDumpFeedback
-where
-    S: HasNamedMetadata,
-{
-    fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
-        state.add_named_metadata_checked(self.name(), ListFeedbackMetadata::<u64>::default())?;
-        Ok(())
-    }
-}
-
-impl<EM, I, OT, S> Feedback<EM, I, OT, S> for ListDumpFeedback
-where
-    OT: MatchName,
-    S: HasNamedMetadata,
-{
-    fn is_interesting(
-        &mut self,
-        state: &mut S,
-        _manager: &mut EM,
-        _input: &I,
-        observers: &OT,
-        _exit_kind: &ExitKind,
-    ) -> Result<bool, Error> {
-        Ok(self.has_interesting_list_observer_feedback(state, observers))
-    }
-
-    #[cfg(feature = "track_hit_feedbacks")]
-    fn last_result(&self) -> Result<bool, Error> {
-        Ok(!self.novelty.is_empty())
-    }
-
-    fn append_metadata(
-        &mut self,
-        state: &mut S,
-        _manager: &mut EM,
-        _observers: &OT,
-        _testcase: &mut crate::corpus::Testcase<I>,
-    ) -> Result<(), Error> {
-        self.append_list_observer_metadata(state);
-        Ok(())
-    }
-}
-
-impl Named for ListDumpFeedback {
-    #[inline]
-    fn name(&self) -> &Cow<'static, str> {
-        self.observer_handle.name()
-    }
-}
-
-impl ListDumpFeedback {
-    /// Creates a new [`ListDumpFeedback`], deciding if the given [`ListObserver`] value of a run is interesting.
-    /// Dump newly observed addresses to `path`
-    #[must_use]
-    pub fn new<P: AsRef<Path>>(observer: &ListObserver<u64>, path: P) -> Self {
-        let file = File::create(path).unwrap();
+    /// Creates a new [`ListFeedback`], deciding if the given [`ListObserver`] value of a run is interesting.
+    /// Will dump newly observed addresses to `path`. If `path` exists, the file will be truncated.
+    pub fn with_coverage_dump<P: AsRef<Path>>(observer: &ListObserver<T>, path: P) -> Self {
+        let file = Some(File::create(path).unwrap());
 
         Self {
             observer_handle: observer.handle(),

--- a/crates/libafl/src/feedbacks/list.rs
+++ b/crates/libafl/src/feedbacks/list.rs
@@ -110,15 +110,7 @@ where
                 self.novelty.insert(*v);
             }
         }
-        if !self.novelty.is_empty() {
-            if let Some(mut file) = self.file.as_ref() {
-                for line in &self.novelty {
-                    file.write_all(format!("0x{line:x}\n").as_bytes()).unwrap();
-                }
-            }
-            return true;
-        }
-        false
+        !self.novelty.is_empty()
     }
 
     fn append_list_observer_metadata<S: HasNamedMetadata>(&mut self, state: &mut S) {
@@ -129,6 +121,12 @@ where
 
         for v in &self.novelty {
             history_set.set.insert(*v);
+        }
+
+        if let Some(mut file) = self.file.as_ref() {
+            for line in &self.novelty {
+                file.write_all(format!("0x{line:x}\n").as_bytes()).unwrap();
+            }
         }
     }
 }

--- a/crates/libafl/src/feedbacks/list.rs
+++ b/crates/libafl/src/feedbacks/list.rs
@@ -116,6 +116,7 @@ where
     }
 
     #[cfg(not(feature = "std"))]
+    #[allow(clippy::unused_self)]
     #[inline]
     fn dump_coverage(&self) {}
 

--- a/crates/libafl/src/feedbacks/list.rs
+++ b/crates/libafl/src/feedbacks/list.rs
@@ -13,6 +13,9 @@ use crate::{
     executors::ExitKind,
     feedbacks::{Feedback, StateInitializer},
     observers::ListObserver,
+    std::fs::File,
+    std::io::Write,
+    std::path::Path,
 };
 
 /// The metadata to remember past observed value
@@ -170,6 +173,128 @@ impl<T> ListFeedback<T> {
         Self {
             observer_handle: observer.handle(),
             novelty: HashSet::new(),
+        }
+    }
+}
+
+/// Consider interesting a testcase if the list in `ListObserver` is not empty.
+/// Modified version of [[`ListFeedback`]] that expects a [[`ListObserver`]]
+/// containing addresses and will write any newly observed address to
+/// a file (see [[`ListDumpFeedback::new`]])
+#[derive(Debug)]
+pub struct ListDumpFeedback {
+    observer_handle: Handle<ListObserver<u64>>,
+    novelty: HashSet<u64>,
+    file: File,
+}
+
+impl ListDumpFeedback {
+    fn has_interesting_list_observer_feedback<OT, S>(
+        &mut self,
+        state: &mut S,
+        observers: &OT,
+    ) -> bool
+    where
+        OT: MatchName,
+        S: HasNamedMetadata,
+    {
+        let observer = observers.get(&self.observer_handle).unwrap();
+        // TODO register the list content in a testcase metadata
+        self.novelty.clear();
+        // can't fail
+        let history_set = state
+            .named_metadata_map_mut()
+            .get_mut::<ListFeedbackMetadata<u64>>(self.name())
+            .unwrap();
+        for v in observer.list() {
+            if !history_set.set.contains(v) {
+                self.novelty.insert(*v);
+            }
+        }
+        if !self.novelty.is_empty() {
+            for line in &self.novelty {
+                self.file
+                    .write_all(format!("0x{line:x}\n").as_bytes())
+                    .unwrap();
+            }
+            return true;
+        }
+        false
+    }
+
+    fn append_list_observer_metadata<S: HasNamedMetadata>(&mut self, state: &mut S) {
+        let history_set = state
+            .named_metadata_map_mut()
+            .get_mut::<ListFeedbackMetadata<u64>>(self.name())
+            .unwrap();
+
+        for v in &self.novelty {
+            history_set.set.insert(*v);
+        }
+    }
+}
+
+impl<S> StateInitializer<S> for ListDumpFeedback
+where
+    S: HasNamedMetadata,
+{
+    fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
+        state.add_named_metadata_checked(self.name(), ListFeedbackMetadata::<u64>::default())?;
+        Ok(())
+    }
+}
+
+impl<EM, I, OT, S> Feedback<EM, I, OT, S> for ListDumpFeedback
+where
+    OT: MatchName,
+    S: HasNamedMetadata,
+{
+    fn is_interesting(
+        &mut self,
+        state: &mut S,
+        _manager: &mut EM,
+        _input: &I,
+        observers: &OT,
+        _exit_kind: &ExitKind,
+    ) -> Result<bool, Error> {
+        Ok(self.has_interesting_list_observer_feedback(state, observers))
+    }
+
+    #[cfg(feature = "track_hit_feedbacks")]
+    fn last_result(&self) -> Result<bool, Error> {
+        Ok(!self.novelty.is_empty())
+    }
+
+    fn append_metadata(
+        &mut self,
+        state: &mut S,
+        _manager: &mut EM,
+        _observers: &OT,
+        _testcase: &mut crate::corpus::Testcase<I>,
+    ) -> Result<(), Error> {
+        self.append_list_observer_metadata(state);
+        Ok(())
+    }
+}
+
+impl Named for ListDumpFeedback {
+    #[inline]
+    fn name(&self) -> &Cow<'static, str> {
+        self.observer_handle.name()
+    }
+}
+
+impl ListDumpFeedback {
+    /// Creates a new [`ListDumpFeedback`], deciding if the given [`ListObserver`] value of a run is interesting.
+    /// Dump newly observed addresses to `path`
+    #[must_use]
+    pub fn new<P: AsRef<Path>>(observer: &ListObserver<u64>, path: P) -> Self {
+        let file = File::create(path).unwrap();
+
+        Self {
+            observer_handle: observer.handle(),
+            novelty: HashSet::new(),
+            file,
         }
     }
 }

--- a/crates/libafl/src/feedbacks/list.rs
+++ b/crates/libafl/src/feedbacks/list.rs
@@ -115,11 +115,6 @@ where
         }
     }
 
-    #[cfg(not(feature = "std"))]
-    #[allow(clippy::unused_self)]
-    #[inline]
-    fn dump_coverage(&self) {}
-
     fn append_list_observer_metadata<S: HasNamedMetadata>(&mut self, state: &mut S) {
         let history_set = state
             .named_metadata_map_mut()
@@ -130,6 +125,7 @@ where
             history_set.set.insert(*v);
         }
 
+        #[cfg(feature = "std")]
         self.dump_coverage();
     }
 }

--- a/crates/libafl/src/feedbacks/list.rs
+++ b/crates/libafl/src/feedbacks/list.rs
@@ -3,6 +3,8 @@ use core::{
     fmt::{Debug, LowerHex},
     hash::Hash,
 };
+#[cfg(feature = "std")]
+use std::{fs::File, io::Write, path::Path};
 
 use hashbrown::HashSet;
 use libafl_bolts::{
@@ -17,9 +19,6 @@ use crate::{
     feedbacks::{Feedback, StateInitializer},
     observers::ListObserver,
 };
-
-#[cfg(feature = "std")]
-use std::{fs::File, io::Write, path::Path};
 
 /// The metadata to remember past observed value
 #[derive(Debug, Serialize, Deserialize)]
@@ -69,6 +68,7 @@ impl<T> HasRefCnt for ListFeedbackMetadata<T> {
 pub struct ListFeedback<T> {
     observer_handle: Handle<ListObserver<T>>,
     novelty: HashSet<T>,
+    #[cfg(feature = "std")]
     file: Option<File>,
 }
 
@@ -200,6 +200,7 @@ impl<T> ListFeedback<T> {
         Self {
             observer_handle: observer.handle(),
             novelty: HashSet::new(),
+            #[cfg(feature = "std")]
             file: None,
         }
     }


### PR DESCRIPTION
## Description

This PR will create a modified ListFeedback that expects a ListObserver<u64>, e.g., containing addresses, and dump
any newly observed addresses to a file that is specified by `path` when creating ListDumpFeedback. This can be useful
to get live coverage for other tools. 

## Checklist

- [x ] I have run `./scripts/precommit.sh` and addressed all comments

(at least for my changes)

