### PR TITLE
Fixes in corpus minimizer

### DIFF
--- a/libafl/src/corpus/inmemory_ondisk.rs
+++ b/libafl/src/corpus/inmemory_ondisk.rs
@@ -473,7 +473,7 @@ impl<I> InMemoryOnDiskCorpus<I> {
 
     fn remove_testcase(&self, testcase: &Testcase<I>) -> Result<(), Error> {
         if let Some(filename) = testcase.filename() {
-            let mut ctr = String::new();
+            let mut ctr = 0;
             if self.locking {
                 let lockfile_path = self.dir_path.join(format!(".{filename}"));
                 let mut lockfile = OpenOptions::new()
@@ -481,16 +481,17 @@ impl<I> InMemoryOnDiskCorpus<I> {
                     .read(true)
                     .open(&lockfile_path)?;
 
+                let mut ctr_bytes = [0; 4];
                 lockfile.lock_exclusive()?;
-                lockfile.read_to_string(&mut ctr)?;
-                ctr = ctr.trim().to_string();
+                lockfile.read(&mut ctr_bytes)?;
+                ctr = u32::from_le_bytes(ctr_bytes);
 
-                if ctr == "1" {
+                if ctr == 1 {
                     FileExt::unlock(&lockfile)?;
                     drop(fs::remove_file(lockfile_path));
                 } else {
                     lockfile.seek(SeekFrom::Start(0))?;
-                    lockfile.write_all(&(ctr.parse::<u32>()? - 1).to_le_bytes())?;
+                    lockfile.write_all(&(ctr - 1).to_le_bytes())?;
                     return Ok(());
                 }
             }

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -2,11 +2,11 @@
 //! of your corpus.
 
 use alloc::{borrow::Cow, string::ToString, vec::Vec};
-use core::{hash::Hash, marker::PhantomData};
+use core::{hash::Hash, marker::PhantomData, time::Duration};
 
 use hashbrown::{HashMap, HashSet};
 use libafl_bolts::{
-    AsIter, Named,
+    AsIter, Named, current_time,
     tuples::{Handle, Handled},
 };
 use num_traits::ToPrimitive;
@@ -16,7 +16,7 @@ use crate::{
     Error, HasMetadata, HasScheduler,
     corpus::Corpus,
     events::{Event, EventFirer, EventWithStats, LogSeverity},
-    executors::{Executor, HasObservers},
+    executors::{Executor, ExitKind, HasObservers},
     inputs::Input,
     monitors::stats::{AggregatorOps, UserStats, UserStatsValue},
     observers::{MapObserver, ObserversTuple},
@@ -66,7 +66,7 @@ where
         &self,
         fuzzer: &mut Z,
         executor: &mut E,
-        manager: &mut EM,
+        mgr: &mut EM,
         state: &mut S,
     ) -> Result<(), Error>
     where
@@ -88,7 +88,7 @@ where
 
         let mut cur_id = state.corpus().first();
 
-        manager.log(
+        mgr.log(
             state,
             LogSeverity::Info,
             "Executing each input...".to_string(),
@@ -97,31 +97,53 @@ where
         let total = state.corpus().count() as u64;
         let mut curr = 0;
         while let Some(id) = cur_id {
-            let (weight, input) = {
+            let (weight, executions) = {
+                if state.corpus().get(id)?.borrow().scheduled_count() == 0 {
+                    // Execute the input; we cannot rely on the metadata already being present.
+
+                    let input = state
+                        .corpus()
+                        .get(id)?
+                        .borrow_mut()
+                        .load_input(state.corpus())?
+                        .clone();
+
+                    executor.observers_mut().pre_exec_all(state, &input)?;
+                    let mut start = current_time();
+                    let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
+                    let mut total_time = if exit_kind == ExitKind::Ok {
+                        current_time() - start
+                    } else {
+                        mgr.log(
+                            state,
+                            LogSeverity::Warn,
+                            "Corpus entry errored on execution!".into(),
+                        )?;
+                        // assume one second as default time
+                        Duration::from_secs(1)
+                    };
+                    executor
+                        .observers_mut()
+                        .post_exec_all(state, &input, &exit_kind)?;
+                    state
+                        .corpus()
+                        .get(id)?
+                        .borrow_mut()
+                        .set_exec_time(total_time);
+                }
+
                 let mut testcase = state.corpus().get(id)?.borrow_mut();
-                let weight = TS::compute(state, &mut *testcase)?
-                    .to_u64()
-                    .expect("Weight must be computable.");
-                let input = testcase
-                    .input()
-                    .as_ref()
-                    .expect("Input must be available.")
-                    .clone();
-                (weight, input)
+                (
+                    TS::compute(state, &mut *testcase)?
+                        .to_u64()
+                        .expect("Weight must be computable."),
+                    *state.executions(),
+                )
             };
-
-            // Execute the input; we cannot rely on the metadata already being present.
-            executor.observers_mut().pre_exec_all(state, &input)?;
-            let kind = executor.run_target(fuzzer, state, manager, &input)?;
-            executor
-                .observers_mut()
-                .post_exec_all(state, &input, &kind)?;
-
-            let executions = *state.executions();
 
             curr += 1;
 
-            manager.fire(
+            mgr.fire(
                 state,
                 EventWithStats::with_current_time(
                     Event::UpdateUserStats {
@@ -159,7 +181,7 @@ where
             cur_id = state.corpus().next(id);
         }
 
-        manager.log(
+        mgr.log(
             state,
             LogSeverity::Info,
             "Preparing Z3 assertions...".to_string(),
@@ -186,7 +208,7 @@ where
             opt.assert_soft(&!seed, *weight, None);
         }
 
-        manager.log(state, LogSeverity::Info, "Performing MaxSAT...".to_string())?;
+        mgr.log(state, LogSeverity::Info, "Performing MaxSAT...".to_string())?;
         // Perform the optimization!
         opt.check(&[]);
 

--- a/libafl/src/corpus/minimizer.rs
+++ b/libafl/src/corpus/minimizer.rs
@@ -109,9 +109,9 @@ where
                         .clone();
 
                     executor.observers_mut().pre_exec_all(state, &input)?;
-                    let mut start = current_time();
+                    let start = current_time();
                     let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
-                    let mut total_time = if exit_kind == ExitKind::Ok {
+                    let total_time = if exit_kind == ExitKind::Ok {
                         current_time() - start
                     } else {
                         mgr.log(


### PR DESCRIPTION
## Description

In an attempt to implement the corpus minimizer in https://github.com/TNO-S3/WuppieFuzz/pull/146 I stumbled on some issues with the current implementation. My feeling is that parts of the code were unmaintained for too long.

I made a couple of adjustments to get it operational again.
1. Ensure inputs are loaded. Previously it would fail due to, I assume, lazy loading
2. Ensure `exec_time` is set. In my use case `exec_time` was not set as we want to minimize before starting a fuzzing run. 
3. Removal of corpus entries fails sometimes. Not entirely sure why it happens, but sometimes the read `ctr` String contains null bytes (string has the form `\u{3}000` and therefore can't be cast to u32.

For all these adjustments I am looking forward to your suggestions. In particular,

2. Ideally I would say we reuse the calibration code to calibrate the entries and ensure all required metadata is present. I could not come up with a better solution.
3. Currently the code uses `read` instead of `read_exact` which is not preferred and not allowed by the rules set in the precommit, suggestions are much appreciated. Weirdly sometimes the read buffer contains a single digit, and sometimes it contains four bytes (single digit + three null bytes). I can't get my head around it.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
