### PR TITLE
Fix caching logic for CachedOnDiskCorpus

### DIFF
--- a/crates/libafl/src/corpus/inmemory.rs
+++ b/crates/libafl/src/corpus/inmemory.rs
@@ -257,6 +257,7 @@ impl<I> TestcaseStorage<I> {
     #[cfg(not(feature = "corpus_btreemap"))]
     fn insert_inner(&mut self, testcase: RefCell<Testcase<I>>, is_disabled: bool) -> CorpusId {
         let id = CorpusId::from(self.progressive_id);
+        testcase.borrow_mut().set_corpus_id(Some(id));
         self.progressive_id += 1;
         let corpus = if is_disabled {
             &mut self.disabled

--- a/crates/libafl/src/corpus/testcase.rs
+++ b/crates/libafl/src/corpus/testcase.rs
@@ -52,6 +52,8 @@ pub struct Testcase<I> {
     scheduled_count: usize,
     /// Number of executions done at discovery time
     executions: u64,
+    /// The [`CorpusId`], if added to a corpus
+    corpus_id: Option<CorpusId>,
     /// Parent [`CorpusId`], if known
     parent_id: Option<CorpusId>,
     /// If the testcase is "disabled"
@@ -207,6 +209,18 @@ impl<I> Testcase<I> {
         self.disabled = disabled;
     }
 
+    /// Get the corpus id of the testcase
+    #[inline]
+    pub fn corpus_id(&self) -> Option<CorpusId> {
+        self.corpus_id
+    }
+
+    /// Set the corpus id of the testcase
+    #[inline]
+    pub fn set_corpus_id(&mut self, id: Option<CorpusId>) {
+        self.corpus_id = id;
+    }
+
     /// Get the hit feedbacks
     #[inline]
     #[cfg(feature = "track_hit_feedbacks")]
@@ -250,6 +264,7 @@ impl<I> Testcase<I> {
             cached_len: None,
             executions: 0,
             scheduled_count: 0,
+            corpus_id: None,
             parent_id: None,
             disabled: false,
             objectives_found: 0,
@@ -275,6 +290,7 @@ impl<I> Testcase<I> {
             cached_len: None,
             executions: 0,
             scheduled_count: 0,
+            corpus_id: None,
             parent_id: Some(parent_id),
             disabled: false,
             objectives_found: 0,
@@ -302,6 +318,7 @@ impl<I> Testcase<I> {
             cached_len: None,
             executions: 0,
             scheduled_count: 0,
+            corpus_id: None,
             parent_id: None,
             disabled: false,
             objectives_found: 0,
@@ -350,6 +367,7 @@ impl<I> Default for Testcase<I> {
             exec_time: None,
             cached_len: None,
             scheduled_count: 0,
+            corpus_id: None,
             parent_id: None,
             #[cfg(feature = "std")]
             file_path: None,


### PR DESCRIPTION
## Description

Prior to this fix, the `CachedOnDiskCorpus` will load the input to the test case when it was `get` from the corpus. However, this is not the correct timing to load the input for the test case, as there is another function `load_input_into` for that. 

Some schedulers (e.g., `WeightedScheduler`) will traverse all the test cases in the corpus to compute the score (using only their metadata). This will made all the input being loaded from the disk even though they are not needed. In this case, the fuzzer will be bounded by the disk I/O for loading the inputs from the disk.

https://github.com/AFLplusplus/LibAFL/blob/8dd5118ef03710671aa1664ff00524834f36ed33/crates/libafl/src/schedulers/weighted.rs#L192-L200

In this PR, `CachedOnDiskCorpus` is made to cache the input only when `load_input_into` is called.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments

`./scripts/precommit.sh` reported errors in the crates I didn't touch.
