### PR TITLE
Introduce get_all and get_all_mut on tuple_list using handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,11 +3532,12 @@ dependencies = [
 
 [[package]]
 name = "libipt"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975943706827c4d4f6b22771e71512af9b4cf7144680003600db11ada92f8383"
+checksum = "4c3143c4dae9794d23fa2bbc6315847fdf3ef718caa09a7ba09238bce19fe9d4"
 dependencies = [
  "bitflags 2.9.1",
+ "derive_more",
  "libipt-sys",
  "num_enum",
 ]

--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -621,11 +621,12 @@ where
 
 #[cfg(feature = "alloc")]
 mod seal {
+    use tuple_list::tuple_list;
+
     use crate::{
         Named,
         tuples::{Handle, Merge, type_eq},
     };
-    use tuple_list::tuple_list;
 
     pub trait InnerBorrowMut {
         type Borrowed<'a>

--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -15,14 +15,13 @@ use core::{
 use serde::{Deserialize, Serialize};
 pub use tuple_list::{TupleList, tuple_list, tuple_list_type};
 
+use crate::HasLen;
 #[cfg(feature = "alloc")]
 use crate::Named;
 #[cfg(any(feature = "xxh3", feature = "alloc"))]
 use crate::hash_std;
-use crate::{
-    HasLen,
-    tuples::seal::{InnerBorrowMut, StackedExtract},
-};
+#[cfg(feature = "alloc")]
+use crate::tuples::seal::{InnerBorrowMut, StackedExtract};
 
 /// Returns if the type `T` is equal to `U`, ignoring lifetimes.
 #[must_use]

--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -557,10 +557,6 @@ pub trait MatchNameRef {
 
 /// Get multiple values using a tuple of handles
 ///
-/// This trait allows retrieving multiple values from a collection using a tuple of handles.
-/// The handles are references to `Handle<T>` objects, and the result is a tuple of
-/// `Option<&T>` values corresponding to each handle.
-///
 /// # Example
 /// ```ignore
 /// let tuple = tuple_list!(a, b, c);
@@ -579,16 +575,16 @@ pub trait GetAll<HandleTuple> {
     where
         Self: 'a;
 
-    /// Get all values using a tuple of handles
+    /// Get all values from a tuple of handles, the order is preserved
     fn get_all(&self, handles: HandleTuple) -> Self::GetAllResult<'_>;
 
-    /// Get all mutable values using a tuple of handles
+    /// Get all mutable values from a tuple of handles, the order is preserved
     ///
     /// # Safety
     ///
     /// There is no way to get multiple mutable references to the same collection without using unsafe code.
     ///
-    /// Should be safe if no two handles point to the same Target.
+    /// Safe if no two handles point to the same Target.
     unsafe fn get_all_mut(&mut self, handles: HandleTuple) -> Self::GetAllMutResult<'_>;
 }
 
@@ -607,7 +603,6 @@ where
     }
 }
 
-// Implementation for empty tuple
 #[cfg(feature = "alloc")]
 impl<M> GetAll<()> for M
 where
@@ -628,7 +623,6 @@ where
     unsafe fn get_all_mut(&mut self, _handles: ()) -> Self::GetAllMutResult<'_> {}
 }
 
-// Implementation for non-empty tuple
 #[cfg(feature = "alloc")]
 impl<M, T, Tail> GetAll<(&Handle<T>, Tail)> for M
 where

--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -620,6 +620,7 @@ where
     fn get_all_mut(&mut self, _handles: ()) -> Self::GetAllMutResult<'_> {}
 }
 
+#[cfg(feature = "alloc")]
 mod seal {
     use crate::{
         Named,

--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -15,12 +15,14 @@ use core::{
 use serde::{Deserialize, Serialize};
 pub use tuple_list::{TupleList, tuple_list, tuple_list_type};
 
-use crate::HasLen;
 #[cfg(feature = "alloc")]
 use crate::Named;
 #[cfg(any(feature = "xxh3", feature = "alloc"))]
 use crate::hash_std;
-use crate::tuples::seal::{InnerBorrowMut, StackedExtract};
+use crate::{
+    HasLen,
+    tuples::seal::{InnerBorrowMut, StackedExtract},
+};
 
 /// Returns if the type `T` is equal to `U`, ignoring lifetimes.
 #[must_use]
@@ -619,8 +621,10 @@ where
 }
 
 mod seal {
-    use crate::Named;
-    use crate::tuples::{Handle, Merge, type_eq};
+    use crate::{
+        Named,
+        tuples::{Handle, Merge, type_eq},
+    };
 
     pub trait InnerBorrowMut {
         type Borrowed<'a>


### PR DESCRIPTION
## Description

With handles, it was previously possible to retrieve a single element from a tuple_list. This PR introduces functions to retrieve tuples of elements based on tuples of handles.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
