### PR TITLE
Fix qemu systemmode: Add nyx feature to gate nyx commands

### DIFF
--- a/crates/libafl_qemu/Cargo.toml
+++ b/crates/libafl_qemu/Cargo.toml
@@ -92,6 +92,8 @@ slirp = [
 intel_pt = ["systemmode", "x86_64", "dep:libafl_intelpt"]
 intel_pt_export_raw = ["intel_pt", "libafl_intelpt/export_raw"]
 
+nyx = ["systemmode", "x86_64"]
+
 # Requires the binary's build.rs to call `build_libafl_qemu`
 shared = ["libafl_qemu_sys/shared"]
 

--- a/crates/libafl_qemu/src/command/mod.rs
+++ b/crates/libafl_qemu/src/command/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     sync_exit::ExitArgs,
 };
 
-#[cfg(all(cpu_target = "x86_64", feature = "systemmode"))]
+#[cfg(feature = "nyx")]
 pub mod nyx;
 pub mod parser;
 

--- a/crates/libafl_qemu/src/command/parser/mod.rs
+++ b/crates/libafl_qemu/src/command/parser/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     sync_exit::ExitArgs,
 };
 
-#[cfg(all(cpu_target = "x86_64", feature = "systemmode"))]
+#[cfg(feature = "nyx")]
 pub mod nyx;
 
 pub static EMU_EXIT_KIND_MAP: OnceLock<EnumMap<NativeExitKind, Option<ExitKind>>> = OnceLock::new();

--- a/crates/libafl_qemu/src/emu/drivers/mod.rs
+++ b/crates/libafl_qemu/src/emu/drivers/mod.rs
@@ -14,9 +14,9 @@ use crate::{
     modules::EmulatorModuleTuple,
 };
 
-#[cfg(all(cpu_target = "x86_64", feature = "systemmode"))]
+#[cfg(feature = "nyx")]
 pub mod nyx;
-#[cfg(all(cpu_target = "x86_64", feature = "systemmode"))]
+#[cfg(feature = "nyx")]
 pub use nyx::{NyxEmulatorDriver, NyxEmulatorDriverBuilder};
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Description

at the moment qemu in systemmode does not compile.
Extract the creation of the nyx feature from #3366 so that it can compile again

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
