### PR TITLE
Fix asan issue with transmuting invalid syscall number

### DIFF
--- a/crates/libafl_asan/Justfile
+++ b/crates/libafl_asan/Justfile
@@ -47,7 +47,7 @@ test: test_asan
 
 pretty_rust:
   #!/bin/sh
-  MAIN_LLVM_VERSION=$LLVM_VERSION cargo run --manifest-path ../utils/libafl_repo_tools/Cargo.toml --release -- -v
+  MAIN_LLVM_VERSION=$LLVM_VERSION cargo run --manifest-path ../../utils/libafl_repo_tools/Cargo.toml --release -- -v
 
 pretty_toml:
   #!/bin/sh

--- a/crates/libafl_asan/src/host/linux.rs
+++ b/crates/libafl_asan/src/host/linux.rs
@@ -1,7 +1,6 @@
 //! # linux
 //! The `LinuxHost` supports the established means of interacting with the QEMU
 //! emulator on Linux by means of issuing a bespoke syscall.
-use core::mem::transmute;
 
 use syscalls::{Errno, Sysno, syscall2, syscall3, syscall4};
 
@@ -83,6 +82,9 @@ impl LinuxHost {
     const SYSCALL_NO: u32 = 0xa2a4;
 
     pub fn sysno() -> Sysno {
-        unsafe { transmute(Self::SYSCALL_NO) }
+        let mut ret = Sysno::read;
+        let ptr = &mut ret as *mut Sysno as *mut u32;
+        unsafe { *ptr = Self::SYSCALL_NO };
+        ret
     }
 }


### PR DESCRIPTION
## Description

Fix asan issue with transmuting invalid syscall number

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
