### PR TITLE
Remove `HasConstLen` super trait from `NamedTuple`

### DIFF
--- a/crates/libafl/src/mutators/mopt_mutator.rs
+++ b/crates/libafl/src/mutators/mopt_mutator.rs
@@ -8,7 +8,7 @@ use core::fmt::{self, Debug};
 use libafl_bolts::{
     Named,
     rands::{Rand, StdRand},
-    tuples::NamedTuple,
+    tuples::{HasConstLen, NamedTuple},
 };
 use serde::{Deserialize, Serialize};
 
@@ -502,7 +502,7 @@ impl<MT> StdMOptMutator<MT> {
     ) -> Result<Self, Error>
     where
         S: HasMetadata + HasRand,
-        MT: NamedTuple,
+        MT: NamedTuple + HasConstLen,
     {
         if !state.has_metadata::<MOpt>() {
             let rand_seed = state.rand_mut().next();

--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -386,7 +386,7 @@ where
 
 #[cfg(feature = "alloc")]
 /// A named tuple
-pub trait NamedTuple: HasConstLen {
+pub trait NamedTuple {
     /// Gets the name of this tuple
     fn name(&self, index: usize) -> Option<&Cow<'static, str>>;
 


### PR DESCRIPTION
## Description

None of the implementations of `NamedTuple` rely on `HasConstLen`. Removing this super trait enables `NamedTuple` to be used in more contexts.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments

The script complained about qemu on macOS, which I didn't touch.
