### PR TITLE
Fix deprecation warnings in trait libafl_bolts::tuples::MatchName

### DIFF
--- a/crates/libafl_bolts/src/tuples.rs
+++ b/crates/libafl_bolts/src/tuples.rs
@@ -440,10 +440,10 @@ where
 #[cfg(feature = "alloc")]
 pub trait MatchName {
     /// Match for a name and return the borrowed value
-    #[deprecated = "Use `.reference` and either `.get` (fallible access) or `[]` (infallible access) instead"]
+    #[deprecated = "Use `.handle` and either `.get` (fallible access) or `[]` (infallible access) instead"]
     fn match_name<T>(&self, name: &str) -> Option<&T>;
     /// Match for a name and return the mut borrowed value
-    #[deprecated = "Use `.reference` and either `.get` (fallible access) or `[]` (infallible access) instead"]
+    #[deprecated = "Use `.handle` and either `.get` (fallible access) or `[]` (infallible access) instead"]
     fn match_name_mut<T>(&mut self, name: &str) -> Option<&mut T>;
 }
 


### PR DESCRIPTION
## Description

fix deprecated `match_name` and `match_name_ref` suggesting non-exsiting `.reference`, which already renamed to `.handle`

Resolves https://github.com/AFLplusplus/LibAFL/issues/3444

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
