### PR TITLE
Use upstream wide crate instead of fork

### DIFF
--- a/crates/libafl_bolts/Cargo.toml
+++ b/crates/libafl_bolts/Cargo.toml
@@ -178,8 +178,8 @@ serial_test = { workspace = true, optional = true, default-features = false, fea
   "logging",
 ] }
 
-# optional stable simd, pin to a commit due to `u8x32` not released yet. Switch to `wide` as long as next release is out!
-wide = { version = "0.7.33", optional = true, package = "libafl_wide" }
+# optional stable simd
+wide = { version = "0.7.33", optional = true }
 rustversion = { workspace = true }
 
 # Document all features of this crate (for `cargo doc`)


### PR DESCRIPTION
## Description

u8x32 got released upstream a while back :)

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
