### PR TITLE
Potential fix for code scanning alert no. 29: Likely overrunning write

### DIFF
--- a/crates/libafl_qemu/libqasan/patch.c
+++ b/crates/libafl_qemu/libqasan/patch.c
@@ -132,7 +132,7 @@ static void find_libc(void) {
     int      fields, dev_maj, dev_min, inode;
     uint64_t min, max, offset;
     char     flag_r, flag_w, flag_x, flag_p;
-    char     path[512] = "";
+    char     path[513] = "";
     fields = sscanf(line,
                     "%" PRIx64 "-%" PRIx64 " %c%c%c%c %" PRIx64
                     " %x:%x %d"


### PR DESCRIPTION
Potential fix for [https://github.com/AFLplusplus/LibAFL/security/code-scanning/29](https://github.com/AFLplusplus/LibAFL/security/code-scanning/29)

The most direct way to fix the problem is to increase the size of the `path` buffer by one, from `char path[512]` to `char path[513]`. This ensures that the `%512s` conversion in `sscanf` always writes into a buffer large enough to hold 512 characters plus a null terminator. Make this change only where `path` is declared, leaving the rest of the code and the format string unchanged, so as not to affect parsing logic or functionality. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
