### PR TITLE
Ffix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,6 @@
 name: build and test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AFLplusplus/LibAFL/security/code-scanning/28](https://github.com/AFLplusplus/LibAFL/security/code-scanning/28)

To fix the issue, you should add a `permissions` block to the workflow to explicitly restrict the default permissions granted to GITHUB_TOKEN. This is best applied at the workflow root level (above `jobs:` or immediately under the workflow name / triggers) to enforce least privilege for all jobs, unless specific jobs require greater permissions and override it. In this case, setting `permissions: contents: read` is safest and matches the recommended minimal base. You only need to edit the `.github/workflows/build_and_test.yml` file, adding the following block directly after the `name: build and test` line and before the `on:` block (i.e., as the first keys in the YAML after the name).

No additional imports, methods, or definitions are needed for YAML workflows—just a one-line addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
