### PR TITLE
Update `last_objective_time` with current time when objective size changes

### DIFF
--- a/crates/libafl/src/monitors/stats/mod.rs
+++ b/crates/libafl/src/monitors/stats/mod.rs
@@ -240,6 +240,7 @@ impl ClientStats {
     /// We got a new information about objective corpus size for this client, insert them.
     pub fn update_objective_size(&mut self, objective_size: u64) {
         self.objective_size = objective_size;
+        self.last_objective_time = current_time();
         self.stats_status.basic_stats_updated = true;
     }
 


### PR DESCRIPTION
## Description

There seems to be a bug where ClientStats::last_objective_time is not updated when a new objective is found.

Expectations:
* I am expecting to see `last_objective_time` updated to current time whenever a new objective is discovered by a fuzzer.

Reproducing steps:
1. Modify file `crates/libafl/src/monitors/mod.rs` with the following [inserted here](https://github.com/AFLplusplus/LibAFL/blob/28b53580766f45ae6de0ad4f8ccfdb90516a4264/crates/libafl/src/monitors/mod.rs#L196) in SimpleMonitor::display() so it outputs `last_corpus_time` and `last_objective_time` on the console:
```rust
fmt += format!(
	", last_corpus_time: {}, last_objective_time: {}",
	client.last_corpus_time().as_millis(),
	client.last_objective_time().as_millis()
).as_str();
```
2. Run the fuzzer example `fuzzers/binary_only/fuzzbench_qemu`.
3. Look at the console output:

Before fix:
> [Objective #0] run time: 1m-58s, clients: 1, corpus: 2, objectives: 1315, executions: 880786, exec/sec: 7.439k, edges: 72/72 (100%), stability: 71/71 (100%), last_corpus_time: 1761850964314, last_objective_time: 0

After fix:
> [Objective #0] run time: 2m-29s, clients: 1, corpus: 2, objectives: 1605, executions: 802822, exec/sec: 5.357k, edges: 72/86 (83%), stability: 71/71 (100%), last_corpus_time: 1761851517725, last_objective_time: 1761851667436

You can see that even if the fuzzer has found some 1315 objectives, client stats `last_objective_time` is still 0.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
