### PR TITLE
Fix infinite disassembly loop in `CallTracerModule`'s `gen_blocks_calls` function

### DIFF
--- a/crates/libafl_qemu/src/modules/calls.rs
+++ b/crates/libafl_qemu/src/modules/calls.rs
@@ -370,7 +370,7 @@ where
                     if let Err(err) = qemu.read_mem(iaddr, code) {
                         // TODO handle faults
                         log::error!(
-                            "gen_block_calls error 2: Failed to read mem at pc {pc:#x}: {err:?}"
+                            "gen_block_calls error 2: Failed to read mem at pc {iaddr:#x}: {err:?}"
                         );
                         return None;
                     }

--- a/crates/libafl_qemu/src/modules/cmplog.rs
+++ b/crates/libafl_qemu/src/modules/cmplog.rs
@@ -401,9 +401,13 @@ impl CmpLogRoutinesModule {
                 }
                 #[cfg(feature = "systemmode")]
                 {
-                    unsafe {
-                        qemu.read_mem(pc, code);
-                    } // TODO handle faults
+                    if let Err(err) = qemu.read_mem(iaddr, code) {
+                        // TODO handle faults
+                        log::error!(
+                            "gen_block_calls error 2: Failed to read mem at pc {iaddr:#x}: {err:?}"
+                        );
+                        return None;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR fixes a bug in the `CallTracerModule` where the `gen_blocks_calls` function would enter an infinite loop repeatedly disassembling the same code block, which prevented the collection of call traces.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
