### PR TITLE
Add `backtrace_full` method to `FullBacktraceCollector` for multi-threaded trace collection

### DIFF
--- a/crates/libafl_qemu/src/modules/calls.rs
+++ b/crates/libafl_qemu/src/modules/calls.rs
@@ -618,6 +618,24 @@ impl FullBacktraceCollector {
             }
         }
     }
+
+    pub fn backtrace_full() -> Option<Vec<&'static Vec<GuestAddr>>> {
+        // # Safety
+        // This accesses the global [`CALLSTACKS`] variable.
+        // However, the actual variable access is behind a `ThreadLocal` class.
+        let callstacks_ptr = &raw mut CALLSTACKS;
+        unsafe {
+            if let Some(c) = (*callstacks_ptr).as_mut() {
+                let mut res = Vec::new();
+                for tls in &mut *c {
+                    res.push(&*tls.get());
+                }
+                Some(res)
+            } else {
+                None
+            }
+        }
+    }
 }
 
 impl CallTraceCollector for FullBacktraceCollector {


### PR DESCRIPTION
## Description

This PR extends the `FullBacktraceCollector` with a new `backtrace_full` method to address limitations in multi-threaded environments. While trace information is collected from all threads, it's stored in the Thread Local Storage of individual threads. The existing `backtrace` method only accesses the current thread's TLS, making it impossible to retrieve traces from threads that have already terminated. The new `backtrace_full` method aggregates trace information from all available thread storage, including data from threads that no longer exist, ensuring complete trace collection across the entire system.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
