### PR TITLE
fix: Pin cc version for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ bindgen = "0.72.1"
 bitbybit = "1.4.0" # bitfields, use this for bit fields and bit enums
 capstone = "0.13.0" # Disassembler used in libafl_unicorn to provide disassembly on crash
 clap = "4.5.49"
-cc = "1.2.40"
+cc = "=1.2.40"
 cmake = "0.1.54"
 document-features = "0.2.11"
 fastbloom = { version = "0.14.0", default-features = false }


### PR DESCRIPTION
## Description

Since the cc crate decided to [deprecate the shared flag](https://github.com/rust-lang/cc-rs/issues/594), pinning the version is probably the best option until [this MR is merged](https://github.com/rust-lang/cc-rs/pull/1444) since LibAFL heavily relies on compiling shared libraries. Currently when trying to download the repository the latest cc version gets chosen, breaking the build of libafl-cc.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
