### PR TITLE
libafl_nyx: fix stdout cursor position after set_len()

### DIFF
--- a/crates/libafl_nyx/src/executor.rs
+++ b/crates/libafl_nyx/src/executor.rs
@@ -73,7 +73,7 @@ where
             .set_len(0)
             .map_err(|e| Error::illegal_state(format!("Failed to clear Nyx stdout: {e}")))?;
         self.helper.nyx_stdout.rewind()?;
-        
+
         let size = u32::try_from(buffer.len())
             .map_err(|_| Error::unsupported("Inputs larger than 4GB are not supported"))?;
 


### PR DESCRIPTION
## Description

set_len doesn't change the cursor position
so if we don't move cursor back to the position 0. then libafl_nyx will not read the content from stdout into there. (but into a latter position)
that means that everytime we read something the buffer keeps growing and the first part of the buffer is always filled with zero. (because the content is always _appended_ beyond the end of the buffer, rather than read into position 0, and thus the buffer always increase by the size of the newly added bytes

similar issue is described here: https://users.rust-lang.org/t/set-len-appears-to-leave-behind-null-chars/119668/2