### PR TITLE
Move to feedback_not in example

### DIFF
--- a/fuzzers/structure_aware/forkserver_simple_nautilus/src/main.rs
+++ b/fuzzers/structure_aware/forkserver_simple_nautilus/src/main.rs
@@ -6,7 +6,7 @@ use libafl::{
     corpus::{InMemoryCorpus, OnDiskCorpus},
     events::SimpleEventManager,
     executors::{forkserver::ForkserverExecutor, HasObservers, StdChildArgs},
-    feedback_and_fast, feedback_not,
+    feedback_and_fast, feedback_not, feedback_or,
     feedbacks::{
         CrashFeedback, MaxMapFeedback, NautilusChunksMetadata, NautilusFeedback,
         NautilusUnparseToMetadataFeedback, TimeFeedback,


### PR DESCRIPTION
## Description

@domenukk guess what — there already is a `NotFeedback` and a `feedback_not!` macro. I was on my phone last night so didn't check, sorry.

So here's a tiny PR that uses it in the example.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
