### PR TITLE
Optimize hash_64_fast for default dev profile

### DIFF
--- a/crates/libafl_bolts/src/lib.rs
+++ b/crates/libafl_bolts/src/lib.rs
@@ -276,13 +276,9 @@ pub fn hash_std(input: &[u8]) -> u64 {
 /// Adapted from <https://xorshift.di.unimi.it/splitmix64.c>
 #[must_use]
 pub fn hash_64_fast(mut x: u64) -> u64 {
-    x = (x ^ (x.overflowing_shr(30).0))
-        .overflowing_mul(0xbf58476d1ce4e5b9)
-        .0;
-    x = (x ^ (x.overflowing_shr(27).0))
-        .overflowing_mul(0x94d049bb133111eb)
-        .0;
-    x ^ (x.overflowing_shr(31).0)
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+    x ^ (x >> 31)
 }
 
 /// Hashes the input with a given hash


### PR DESCRIPTION
## Description

Godbolt link to preview assembly: https://rust.godbolt.org/z/KWb6dxefK

Though in `opt-level>1` produces the same assembly, in the default dev profile, it involves additional unnecessary checks.

This patch makes it conforms to an existing implementation in `rand` crate https://github.com/rust-random/rand/blob/2eb1bbeb1dc0f489c1575f3f5157bd851acdf255/src/rngs/xoshiro128plusplus.rs#L54

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
