### PR TITLE
Remove lifetime parameter of inprocess executors

### DIFF
--- a/crates/libafl/src/executors/inprocess/mod.rs
+++ b/crates/libafl/src/executors/inprocess/mod.rs
@@ -36,12 +36,12 @@ pub mod inner;
 pub mod stateful;
 
 /// The process executor simply calls a target function, as mutable reference to a closure.
-pub type InProcessExecutor<'a, EM, H, I, OT, S, Z> =
-    GenericInProcessExecutor<EM, H, &'a mut H, (), I, OT, S, Z>;
+pub type InProcessExecutor<EM, H, I, OT, S, Z> =
+    GenericInProcessExecutor<EM, H, H, (), I, OT, S, Z>;
 
 /// The inprocess executor that allows hooks
-pub type HookableInProcessExecutor<'a, EM, H, HT, I, OT, S, Z> =
-    GenericInProcessExecutor<EM, H, &'a mut H, HT, I, OT, S, Z>;
+pub type HookableInProcessExecutor<EM, H, HT, I, OT, S, Z> =
+    GenericInProcessExecutor<EM, H, H, HT, I, OT, S, Z>;
 /// The process executor simply calls a target function, as boxed `FnMut` trait object
 pub type OwnedInProcessExecutor<EM, I, OT, S, Z> = GenericInProcessExecutor<
     EM,
@@ -124,7 +124,7 @@ impl<EM, H, HB, HT, I, OT, S, Z> HasObservers
     }
 }
 
-impl<'a, EM, H, I, OT, S, Z> InProcessExecutor<'a, EM, H, I, OT, S, Z>
+impl<EM, H, I, OT, S, Z> InProcessExecutor<EM, H, I, OT, S, Z>
 where
     H: FnMut(&I) -> ExitKind + Sized,
     OT: ObserversTuple<I, S>,
@@ -133,7 +133,7 @@ where
 {
     /// Create a new in mem executor with the default timeout (5 sec)
     pub fn new<OF>(
-        harness_fn: &'a mut H,
+        harness_fn: H,
         observers: OT,
         fuzzer: &mut Z,
         state: &mut S,
@@ -164,7 +164,7 @@ where
     ///
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout<OF>(
-        harness_fn: &'a mut H,
+        harness_fn: H,
         observers: OT,
         fuzzer: &mut Z,
         state: &mut S,
@@ -262,24 +262,28 @@ where
 
     /// Retrieve the harness function.
     #[inline]
+    #[must_use]
     pub fn harness(&self) -> &H {
         self.harness_fn.borrow()
     }
 
     /// Retrieve the harness function for a mutable reference.
     #[inline]
+    #[must_use]
     pub fn harness_mut(&mut self) -> &mut H {
         self.harness_fn.borrow_mut()
     }
 
     /// The inprocess handlers
     #[inline]
+    #[must_use]
     pub fn hooks(&self) -> &(InProcessHooks<I, S>, HT) {
         self.inner.hooks()
     }
 
     /// The inprocess handlers (mutable)
     #[inline]
+    #[must_use]
     pub fn hooks_mut(&mut self) -> &mut (InProcessHooks<I, S>, HT) {
         self.inner.hooks_mut()
     }

--- a/crates/libafl/src/executors/inprocess/stateful.rs
+++ b/crates/libafl/src/executors/inprocess/stateful.rs
@@ -27,8 +27,8 @@ use crate::{
 
 /// The process executor simply calls a target function, as mutable reference to a closure
 /// The internal state of the executor is made available to the harness.
-pub type StatefulInProcessExecutor<'a, EM, ES, H, I, OT, S, Z> =
-    StatefulGenericInProcessExecutor<EM, ES, H, &'a mut H, (), I, OT, S, Z>;
+pub type StatefulInProcessExecutor<EM, ES, H, I, OT, S, Z> =
+    StatefulGenericInProcessExecutor<EM, ES, H, H, (), I, OT, S, Z>;
 
 /// The process executor simply calls a target function, as boxed `FnMut` trait object
 /// The internal state of the executor is made available to the harness.
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<'a, EM, ES, H, I, OT, S, Z> StatefulInProcessExecutor<'a, EM, ES, H, I, OT, S, Z>
+impl<EM, ES, H, I, OT, S, Z> StatefulInProcessExecutor<EM, ES, H, I, OT, S, Z>
 where
     H: FnMut(&mut ES, &mut S, &I) -> ExitKind + Sized,
     OT: ObserversTuple<I, S>,
@@ -132,7 +132,7 @@ where
 {
     /// Create a new in mem executor with the default timeout (5 sec)
     pub fn new<OF>(
-        harness_fn: &'a mut H,
+        harness_fn: H,
         exposed_executor_state: ES,
         observers: OT,
         fuzzer: &mut Z,
@@ -165,7 +165,7 @@ where
     ///
     /// This may return an error on unix, if signal handler setup fails
     pub fn with_timeout<OF>(
-        harness_fn: &'a mut H,
+        harness_fn: H,
         exposed_executor_state: ES,
         observers: OT,
         fuzzer: &mut Z,

--- a/crates/libafl/src/executors/inprocess_fork/stateful.rs
+++ b/crates/libafl/src/executors/inprocess_fork/stateful.rs
@@ -24,10 +24,10 @@ use crate::{
 };
 
 /// The `StatefulInProcessForkExecutor` with no user hooks
-pub type StatefulInProcessForkExecutor<'a, EM, ES, H, I, OT, S, SP, Z> =
-    StatefulGenericInProcessForkExecutor<'a, EM, ES, H, (), I, OT, S, SP, Z>;
+pub type StatefulInProcessForkExecutor<EM, ES, H, I, OT, S, SP, Z> =
+    StatefulGenericInProcessForkExecutor<EM, ES, H, (), I, OT, S, SP, Z>;
 
-impl<'a, H, I, OT, S, SP, EM, ES, Z> StatefulInProcessForkExecutor<'a, EM, ES, H, I, OT, S, SP, Z>
+impl<H, I, OT, S, SP, EM, ES, Z> StatefulInProcessForkExecutor<EM, ES, H, I, OT, S, SP, Z>
 where
     OT: ObserversTuple<I, S>,
     SP: ShMemProvider,
@@ -35,7 +35,7 @@ where
     #[expect(clippy::too_many_arguments)]
     /// The constructor for `InProcessForkExecutor`
     pub fn new(
-        harness_fn: &'a mut H,
+        harness_fn: H,
         exposed_executor_state: ES,
         observers: OT,
         fuzzer: &mut Z,
@@ -59,9 +59,9 @@ where
 }
 
 /// [`StatefulGenericInProcessForkExecutor`] is an executor that forks the current process before each execution. Harness can access some internal state.
-pub struct StatefulGenericInProcessForkExecutor<'a, EM, ES, H, HT, I, OT, S, SP, Z> {
+pub struct StatefulGenericInProcessForkExecutor<EM, ES, H, HT, I, OT, S, SP, Z> {
     /// The harness function, being executed for each fuzzing loop execution
-    harness_fn: &'a mut H,
+    harness_fn: H,
     /// The state used as argument of the harness
     pub exposed_executor_state: ES,
     /// Inner state of the executor
@@ -69,7 +69,7 @@ pub struct StatefulGenericInProcessForkExecutor<'a, EM, ES, H, HT, I, OT, S, SP,
 }
 
 impl<H, HT, I, OT, S, SP, EM, ES, Z> Debug
-    for StatefulGenericInProcessForkExecutor<'_, EM, ES, H, HT, I, OT, S, SP, Z>
+    for StatefulGenericInProcessForkExecutor<EM, ES, H, HT, I, OT, S, SP, Z>
 where
     HT: Debug,
     OT: Debug,
@@ -93,7 +93,7 @@ where
 }
 
 impl<EM, H, HT, I, OT, S, SP, Z, ES> Executor<EM, I, S, Z>
-    for StatefulGenericInProcessForkExecutor<'_, EM, ES, H, HT, I, OT, S, SP, Z>
+    for StatefulGenericInProcessForkExecutor<EM, ES, H, HT, I, OT, S, SP, Z>
 where
     H: FnMut(&mut ES, &I) -> ExitKind + Sized,
     HT: ExecutorHooksTuple<I, S>,
@@ -134,8 +134,8 @@ where
     }
 }
 
-impl<'a, H, HT, I, OT, S, SP, EM, ES, Z>
-    StatefulGenericInProcessForkExecutor<'a, EM, ES, H, HT, I, OT, S, SP, Z>
+impl<H, HT, I, OT, S, SP, EM, ES, Z>
+    StatefulGenericInProcessForkExecutor<EM, ES, H, HT, I, OT, S, SP, Z>
 where
     HT: ExecutorHooksTuple<I, S>,
     OT: ObserversTuple<I, S>,
@@ -144,7 +144,7 @@ where
     #[expect(clippy::too_many_arguments)]
     pub fn with_hooks(
         userhooks: HT,
-        harness_fn: &'a mut H,
+        harness_fn: H,
         exposed_executor_state: ES,
         observers: OT,
         fuzzer: &mut Z,
@@ -170,19 +170,21 @@ where
 
     /// Retrieve the harness function.
     #[inline]
+    #[must_use]
     pub fn harness(&self) -> &H {
-        self.harness_fn
+        &self.harness_fn
     }
 
     /// Retrieve the harness function for a mutable reference.
     #[inline]
+    #[must_use]
     pub fn harness_mut(&mut self) -> &mut H {
-        self.harness_fn
+        &mut self.harness_fn
     }
 }
 
 impl<H, HT, I, OT, S, SP, EM, ES, Z> HasObservers
-    for StatefulGenericInProcessForkExecutor<'_, EM, ES, H, HT, I, OT, S, SP, Z>
+    for StatefulGenericInProcessForkExecutor<EM, ES, H, HT, I, OT, S, SP, Z>
 {
     type Observers = OT;
 

--- a/crates/libafl_qemu/src/executor.rs
+++ b/crates/libafl_qemu/src/executor.rs
@@ -42,14 +42,14 @@ use crate::{Emulator, EmulatorDriver, command::CommandManager, modules::Emulator
 #[cfg(feature = "usermode")]
 use crate::{EmulatorModules, Qemu, QemuSignalContext, run_target_crash_hooks};
 
-type EmulatorInProcessExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z> =
-    StatefulInProcessExecutor<'a, EM, Emulator<C, CM, ED, ET, I, S, SM>, H, I, OT, S, Z>;
+type EmulatorInProcessExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> =
+    StatefulInProcessExecutor<EM, Emulator<C, CM, ED, ET, I, S, SM>, H, I, OT, S, Z>;
 
 #[cfg(feature = "systemmode")]
 pub(crate) static BREAK_ON_TMOUT: AtomicBool = AtomicBool::new(false);
 
-pub struct QemuExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z> {
-    inner: EmulatorInProcessExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>,
+pub struct QemuExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> {
+    inner: EmulatorInProcessExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z>,
     first_exec: bool,
 }
 
@@ -214,7 +214,7 @@ pub unsafe fn inproc_qemu_timeout_handler<E, EM, ET, I, OF, S, Z>(
 }
 
 impl<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> Debug
-    for QemuExecutor<'_, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
+    for QemuExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
 where
     OT: Debug,
 {
@@ -225,8 +225,7 @@ where
     }
 }
 
-impl<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
-    QemuExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
+impl<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> QemuExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
 where
     ET: EmulatorModuleTuple<I, S>,
     H: FnMut(&mut Emulator<C, CM, ED, ET, I, S, SM>, &mut S, &I) -> ExitKind,
@@ -236,7 +235,7 @@ where
 {
     pub fn new<OF>(
         emulator: Emulator<C, CM, ED, ET, I, S, SM>,
-        harness_fn: &'a mut H,
+        harness_fn: H,
         observers: OT,
         fuzzer: &mut Z,
         state: &mut S,
@@ -264,7 +263,7 @@ where
 
         // rewrite the timeout handler pointer
         inner.inprocess_hooks_mut().timeout_handler = inproc_qemu_timeout_handler::<
-            StatefulInProcessExecutor<'a, EM, Emulator<C, CM, ED, ET, I, S, SM>, H, I, OT, S, Z>,
+            StatefulInProcessExecutor<EM, Emulator<C, CM, ED, ET, I, S, SM>, H, I, OT, S, Z>,
             EM,
             ET,
             I,
@@ -279,7 +278,7 @@ where
         })
     }
 
-    pub fn inner(&self) -> &EmulatorInProcessExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z> {
+    pub fn inner(&self) -> &EmulatorInProcessExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> {
         &self.inner
     }
 
@@ -290,13 +289,13 @@ where
 
     pub fn inner_mut(
         &mut self,
-    ) -> &mut EmulatorInProcessExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z> {
+    ) -> &mut EmulatorInProcessExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> {
         &mut self.inner
     }
 }
 
 impl<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> Executor<EM, I, S, Z>
-    for QemuExecutor<'_, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
+    for QemuExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
 where
     C: Clone,
     CM: CommandManager<C, ED, ET, I, S, SM, Commands = C>,
@@ -337,7 +336,7 @@ where
 }
 
 impl<C, CM, ED, EM, ET, H, I, OT, S, SM, Z> HasObservers
-    for QemuExecutor<'_, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
+    for QemuExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, Z>
 where
     ET: EmulatorModuleTuple<I, S>,
     H: FnMut(&mut Emulator<C, CM, ED, ET, I, S, SM>, &mut S, &I) -> ExitKind,
@@ -355,18 +354,18 @@ where
     }
 }
 
-pub type QemuInProcessForkExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> =
-    StatefulInProcessForkExecutor<'a, EM, Emulator<C, CM, ED, ET, I, S, SM>, H, I, OT, S, SP, Z>;
+pub type QemuInProcessForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> =
+    StatefulInProcessForkExecutor<EM, Emulator<C, CM, ED, ET, I, S, SM>, H, I, OT, S, SP, Z>;
 
 #[cfg(feature = "fork")]
-pub struct QemuForkExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> {
-    inner: QemuInProcessForkExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>,
+pub struct QemuForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> {
+    inner: QemuInProcessForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>,
     first_exec: bool,
 }
 
 #[cfg(feature = "fork")]
 impl<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> Debug
-    for QemuForkExecutor<'_, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
+    for QemuForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
 where
     C: Debug,
     CM: Debug,
@@ -388,8 +387,8 @@ where
 }
 
 #[cfg(feature = "fork")]
-impl<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
-    QemuForkExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
+impl<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
+    QemuForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
 where
     EM: EventFirer<I, S> + EventRestarter<S>,
     ET: EmulatorModuleTuple<I, S>,
@@ -402,7 +401,7 @@ where
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         emulator: Emulator<C, CM, ED, ET, I, S, SM>,
-        harness_fn: &'a mut H,
+        harness_fn: H,
         observers: OT,
         fuzzer: &mut Z,
         state: &mut S,
@@ -431,16 +430,14 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn inner(
-        &self,
-    ) -> &QemuInProcessForkExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> {
+    pub fn inner(&self) -> &QemuInProcessForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> {
         &self.inner
     }
 
     #[allow(clippy::type_complexity)]
     pub fn inner_mut(
         &mut self,
-    ) -> &mut QemuInProcessForkExecutor<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> {
+    ) -> &mut QemuInProcessForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> {
         &mut self.inner
     }
 
@@ -455,7 +452,7 @@ where
 
 #[cfg(feature = "fork")]
 impl<C, CM, ED, EM, ET, H, I, OF, OT, S, SM, SP, Z> Executor<EM, I, S, Z>
-    for QemuForkExecutor<'_, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
+    for QemuForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
 where
     C: Clone,
     CM: CommandManager<C, ED, ET, I, S, SM, Commands = C>,
@@ -499,7 +496,7 @@ where
 
 #[cfg(feature = "fork")]
 impl<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z> HasObservers
-    for QemuForkExecutor<'_, C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
+    for QemuForkExecutor<C, CM, ED, EM, ET, H, I, OT, S, SM, SP, Z>
 where
     ET: EmulatorModuleTuple<I, S>,
     OT: ObserversTuple<I, S>,

--- a/fuzzers/binary_only/qemu_launcher/src/instance.rs
+++ b/fuzzers/binary_only/qemu_launcher/src/instance.rs
@@ -368,8 +368,8 @@ where
     }
 
     #[allow(clippy::type_complexity)] // TODO: make less complex
-    fn reset_executor_snapshot_module<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, Z>(
-        executor: &mut QemuExecutor<'a, C, CM, ED, EM, (SnapshotModule, ET), H, I, OT, S, SM, Z>,
+    fn reset_executor_snapshot_module<C, CM, ED, EM, ET, H, I, OT, S, SM, Z>(
+        executor: &mut QemuExecutor<C, CM, ED, EM, (SnapshotModule, ET), H, I, OT, S, SM, Z>,
         qemu: Qemu,
     ) where
         ET: EmulatorModuleTuple<I, S>,
@@ -392,9 +392,9 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    fn reset_shadow_executor_snapshot_module<'a, C, CM, ED, EM, ET, H, I, OT, S, SM, SOT, Z>(
+    fn reset_shadow_executor_snapshot_module<C, CM, ED, EM, ET, H, I, OT, S, SM, SOT, Z>(
         executor: &mut ShadowExecutor<
-            QemuExecutor<'a, C, CM, ED, EM, (SnapshotModule, ET), H, I, OT, S, SM, Z>,
+            QemuExecutor<C, CM, ED, EM, (SnapshotModule, ET), H, I, OT, S, SM, Z>,
             I,
             S,
             SOT,


### PR DESCRIPTION
For any `H: FnMut(...) -> T`, it is also the case that `&mut H: FnMut(...) -> T`. Thus, changing from `&mut H` to just `H` gives API clients more flexibility. They can still pass a `&mut` reference if they want to (as evidenced by not needing any changes in the example fuzzers), but they can also now pass an owned `H`. A client might want to do this  to pass a `Box<dyn FnMut(...) -> T>` they just allocated and don't want to hold onto.

This also allows for removing some ubiquitous lifetime parameters, which is a nice simplification.

Also, sprinkle a few `#[must_use]`s around while I'm in the area.