### PR TITLE
Add coverage file path configuration and rename `filename` to `path` in `DrCovModule` of QEMU

### DIFF
--- a/crates/libafl_qemu/src/modules/drcov.rs
+++ b/crates/libafl_qemu/src/modules/drcov.rs
@@ -95,11 +95,11 @@ where
     }
 
     #[must_use]
-    pub fn path(self, path: PathBuf) -> Self {
+    pub fn path<P: Into<PathBuf>>(self, path: P) -> Self {
         Self {
             filter: self.filter,
             module_mapping: self.module_mapping,
-            path: Some(path),
+            path: Some(path.into()),
             full_trace: self.full_trace,
         }
     }
@@ -386,9 +386,9 @@ impl DrCovModule<NopAddressFilter> {
 
 impl<F> DrCovModule<F> {
     #[must_use]
-    pub fn new(
+    pub fn new<P: Into<PathBuf>>(
         filter: F,
-        path: PathBuf,
+        path: P,
         module_mapping: Option<RangeMap<u64, (u16, String)>>,
         full_trace: bool,
     ) -> Self {
@@ -402,14 +402,14 @@ impl<F> DrCovModule<F> {
         Self {
             filter,
             module_mapping,
-            path,
+            path: path.into(),
             full_trace,
             drcov_len: 0,
         }
     }
 
-    pub fn set_path(&mut self, path: PathBuf) {
-        self.path = path;
+    pub fn set_path<P: Into<PathBuf>>(&mut self, path: P) {
+        self.path = path.into();
     }
 
     pub fn path(&self) -> &Path {


### PR DESCRIPTION
## Description

This PR extends the `DrCovModule` for QEMU to support configuring output path for coverage file. I needed to collect coverage for each individual testcase. For this purpose, it is necessary to set a path for each generated coverage file. In connection with this, I needed additional methods with which to set the path for the generated coverage file and to get this path.

Besides this, I renamed the field `filename` to `path`. I think it fits the meaning better. If you disagree with me, then let me know, and I will revert the changes.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
