### PR TITLE
fix(qemu): typo while cleanup path parameters

### DIFF
--- a/crates/libafl_qemu/src/qemu/config.rs
+++ b/crates/libafl_qemu/src/qemu/config.rs
@@ -228,7 +228,7 @@ impl Display for Bios {
 }
 
 #[cfg(feature = "systemmode")]
-impl<P: Into<Path>> From<P> for Bios {
+impl<P: Into<PathBuf>> From<P> for Bios {
     fn from(path: P) -> Self {
         Self { path: path.into() }
     }


### PR DESCRIPTION
## Description

Fix for typo in #3526.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
