### PR TITLE
v0 mangling fix for libafl_libfuzzer

### DIFF
--- a/crates/libafl_libfuzzer/build.rs
+++ b/crates/libafl_libfuzzer/build.rs
@@ -142,10 +142,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         "Couldn't build runtime crate! Did you remember to use nightly? (`rustup default nightly` to install)"
     );
 
-    rename_symbols(&custom_lib_target);
+    let redefined_archive_path = rename_symbols(&custom_lib_target);
 
-    #[cfg(feature = "embed-runtime")]
-    {
+    if cfg!(feature = "embed-runtime") {
         // NOTE: lib, .a are added always on unix-like systems as described in:
         // https://gist.github.com/novafacing/1389cbb2f0a362d7eb103e67b4468e2b
         println!(
@@ -170,7 +169,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 /// This function creates a copy of the libfuzzer runtime with all the symbols renamed to avoid
 /// a conflict with whatever we link to. It should be compatible with legacy and v0 mangling.
-fn rename_symbols(custom_lib_target: &Path) {
+fn rename_symbols(custom_lib_target: &Path) -> PathBuf {
     let mut archive_path = custom_lib_target.join(std::env::var_os("TARGET").unwrap());
     archive_path.push("release");
 
@@ -299,4 +298,5 @@ fn rename_symbols(custom_lib_target: &Path) {
         objcopy_command.status().is_ok_and(|s| s.success()),
         "Couldn't rename allocators in the runtime crate! Do you have the llvm-tools component installed? (`rustup component add llvm-tools-preview` to install)"
     );
+    redefined_archive_path
 }


### PR DESCRIPTION
[v0 mangling](https://github.com/rust-lang/rust/issues/60705) was merged, which breaks our assumptions about the shape of the symbols. This PR uses vendor-specific suffixes to remediate.

At this time, it is not complete.