### PR TITLE
Observing an empty output is fine

### DIFF
--- a/crates/libafl/src/observers/stdio.rs
+++ b/crates/libafl/src/observers/stdio.rs
@@ -315,14 +315,12 @@ where
         {
             let pos = file.stream_position()?;
 
-            if pos != 0 {
-                file.seek(SeekFrom::Start(0))?;
+            file.seek(SeekFrom::Start(0))?;
 
-                let mut buf = vec![0; pos as usize];
-                file.read_exact(&mut buf)?;
+            let mut buf = vec![0; pos as usize];
+            file.read_exact(&mut buf)?;
 
-                self.observe(buf);
-            }
+            self.observe(buf);
         }
         Ok(())
     }


### PR DESCRIPTION
The stdout/stderr observers run into an error here https://github.com/AFLplusplus/LibAFL/blob/47ca3389f74fbc3d396a213f3b59490b74924bc2/crates/libafl/src/feedbacks/stdio.rs#L137-L143 when the observed stdout/stderr is `None`. This PR is supposed to fix this by allowing empty stdout/stderr to be `Some('')` instead of `None`.