### PR TITLE
Change out println! for log::debug! in libafl_qemu crate - usermode module

### DIFF
--- a/crates/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/crates/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -239,7 +239,7 @@ impl SnapshotModule {
         self.mmap_start = qemu.get_mmap_start();
         self.pages.clear();
         for map in qemu.mappings() {
-            log::debug!("mapping: {:?}", map);
+            log::debug!("mapping: {map:?}");
 
             let mut addr = map.start();
             while addr < map.end() {


### PR DESCRIPTION
Closes #3581

"A library should not unconditionally and directly print to the terminal."
Therefore, the println! statement was replaced by logging it with the debug 'indicator'.