### PR TITLE
Add non-cellared llvm-config detection on macos

### DIFF
--- a/crates/libafl_cc/build.rs
+++ b/crates/libafl_cc/build.rs
@@ -72,7 +72,7 @@ fn find_llvm_config_brew() -> Result<PathBuf, String> {
                 return Ok(path.unwrap());
             }
         }
-        Err(err) => return Err(format!("Could not execute brew --cellar: {err:?}")),
+        Err(err) => return Err(format!("Could not execute brew --prefix: {err:?}")),
     }
     match Command::new("brew").arg("--cellar").output() {
         Ok(output) => {


### PR DESCRIPTION
## Description

On Macos LibAFL was failing detect non cellared installations of llvm-config which is now the default when running brew install llvm. I've added a check that will look for llvm-config in `/opt/homebrew/opt/llvm/bin/llvm-config` in such a way that it will check for cellared installation after checking for non cellared

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
