### PR TITLE
UPDATE set_coverage_hook to accept generic Unicorn

### DIFF
--- a/crates/libafl_unicorn/src/hooks.rs
+++ b/crates/libafl_unicorn/src/hooks.rs
@@ -3,7 +3,7 @@ use libafl_targets::{EDGES_MAP_DEFAULT_SIZE, EDGES_MAP_PTR};
 use unicorn_engine::Unicorn;
 
 /// Hook that is called for every basic block
-fn coverage_hook(_emu: &mut unicorn_engine::Unicorn<()>, pc: u64, _: u32) {
+fn coverage_hook<D>(_emu: &mut Unicorn<D>, pc: u64, _: u32) {
     unsafe {
         let id = pc % EDGES_MAP_DEFAULT_SIZE as u64;
 
@@ -14,6 +14,6 @@ fn coverage_hook(_emu: &mut unicorn_engine::Unicorn<()>, pc: u64, _: u32) {
 }
 
 /// Sets the `coverage_hook` for the emulator
-pub fn set_coverage_hook(emu: &mut Unicorn<()>) {
+pub fn set_coverage_hook<D>(emu: &mut Unicorn<D>) {
     emu.add_block_hook(0x0, !0x0_u64, coverage_hook).unwrap();
 }


### PR DESCRIPTION
## Description

The current implementation of `set_coverage_hook` only accepts `Unicorn` instances with the data type as `()`. This PR adds a generic data type `D` to the definition of `set_coverage_hook` and underlying `coverage_hook`.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
