### PR TITLE
Fix incomplete implementation in `HitcountsMapObserver`s observer trait

### DIFF
--- a/crates/libafl/src/observers/map/hitcount_map.rs
+++ b/crates/libafl/src/observers/map/hitcount_map.rs
@@ -120,6 +120,11 @@ where
     M: MapObserver<Entry = u8> + Observer<I, S> + for<'a> AsSliceMut<'a, Entry = u8>,
 {
     #[inline]
+    fn flush(&mut self) -> Result<(), Error> {
+        self.base.flush()
+    }
+
+    #[inline]
     fn pre_exec(&mut self, state: &mut S, input: &I) -> Result<(), Error> {
         self.base.pre_exec(state, input)
     }
@@ -128,6 +133,21 @@ where
     fn post_exec(&mut self, state: &mut S, input: &I, exit_kind: &ExitKind) -> Result<(), Error> {
         classify_counts(&mut self.as_slice_mut());
         self.base.post_exec(state, input, exit_kind)
+    }
+
+    #[inline]
+    fn pre_exec_child(&mut self, state: &mut S, input: &I) -> Result<(), Error> {
+        self.base.pre_exec_child(state, input)
+    }
+
+    #[inline]
+    fn post_exec_child(
+        &mut self,
+        state: &mut S,
+        input: &I,
+        exit_kind: &ExitKind,
+    ) -> Result<(), Error> {
+        self.base.post_exec_child(state, input, exit_kind)
     }
 }
 
@@ -333,6 +353,11 @@ where
     M: MapObserver<Entry = u8> + Observer<I, S> + for<'it> AsIterMut<'it, Item = u8>,
 {
     #[inline]
+    fn flush(&mut self) -> Result<(), Error> {
+        self.base.flush()
+    }
+
+    #[inline]
     fn pre_exec(&mut self, state: &mut S, input: &I) -> Result<(), Error> {
         self.base.pre_exec(state, input)
     }
@@ -344,6 +369,21 @@ where
         }
 
         self.base.post_exec(state, input, exit_kind)
+    }
+
+    #[inline]
+    fn pre_exec_child(&mut self, state: &mut S, input: &I) -> Result<(), Error> {
+        self.base.pre_exec_child(state, input)
+    }
+
+    #[inline]
+    fn post_exec_child(
+        &mut self,
+        state: &mut S,
+        input: &I,
+        exit_kind: &ExitKind,
+    ) -> Result<(), Error> {
+        self.base.post_exec_child(state, input, exit_kind)
     }
 }
 


### PR DESCRIPTION
## Description

This patch fixes that `HitcountsMapObserver`s are not calling their base observers' flush and child functions.
It silently fails the user's expectations if these functions are implemented in the base observer passing to the hitcount map.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
