### PR TITLE
feat: add prefix to file_name in InMemoryOnDiskCorpus

### DIFF
--- a/crates/libafl/src/corpus/inmemory_ondisk.rs
+++ b/crates/libafl/src/corpus/inmemory_ondisk.rs
@@ -380,10 +380,15 @@ impl<I> InMemoryOnDiskCorpus<I> {
     where
         I: Input,
     {
-        let file_name = testcase.filename_mut().take().unwrap_or_else(|| {
+        let base = testcase.filename_mut().take().unwrap_or_else(|| {
             // TODO walk entry metadata to ask for pieces of filename (e.g. :havoc in AFL)
             testcase.input().as_ref().unwrap().generate_name(id)
         });
+
+        let file_name = match &self.prefix {
+            Some(pref) => format!("{pref}{base}"),
+            None => base,
+        };
 
         let mut ctr = 1;
         if self.locking {


### PR DESCRIPTION
Regarding #3404, the change I made was to `save_testcase()`, where I set the non-prefixed file name to "base" and then set "file_name" to prefix + base if prefix has Some value, otherwise it is just base. The issue mentions that the function will disappear after refactor, but I'd like to implement the prefix feature before the refactor so that the prefix field does not remain unused.