### PR TITLE
Intel PT: Avoid crashing on tracing errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "ptcov"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fd9f341fcafdbf0b585bcb9617e5a8e3759c6277955b37c3e44dbc91528d8c"
+checksum = "49fc3038cb5032affe0f1ef9b1891f9ebf902c1a076a8dd8bedab77885c392d6"
 dependencies = [
  "iced-x86",
 ]

--- a/crates/libafl/src/executors/hooks/intel_pt.rs
+++ b/crates/libafl/src/executors/hooks/intel_pt.rs
@@ -17,7 +17,7 @@ pub struct IntelPTHook<T> {
 impl<I, S, T> ExecutorHook<I, S> for IntelPTHook<T>
 where
     S: Serialize,
-    T: AddAssign + From<u8> + Debug,
+    T: AddAssign + Copy + Debug + From<u8>,
 {
     fn init(&mut self, _state: &mut S) {}
 

--- a/crates/libafl_intelpt/Cargo.toml
+++ b/crates/libafl_intelpt/Cargo.toml
@@ -32,7 +32,7 @@ libc = { workspace = true }
 log = { workspace = true }
 num_enum = { workspace = true, default-features = false }
 num-traits = { workspace = true, default-features = false }
-ptcov = { version = "0.0.4" }
+ptcov = { version = "0.0.5" }
 raw-cpuid = { version = "11.1.0" }
 
 [target.'cfg(target_os = "linux" )'.dependencies]

--- a/crates/libafl_intelpt/src/linux.rs
+++ b/crates/libafl_intelpt/src/linux.rs
@@ -191,7 +191,7 @@ impl IntelPT {
         map_len: usize,
     ) -> Result<(), Error>
     where
-        T: AddAssign + From<u8> + Debug,
+        T: AddAssign + Copy + Debug + From<u8>,
     {
         let head = unsafe { self.aux_head.read_volatile() };
         let tail = unsafe { self.aux_tail.read_volatile() };
@@ -243,7 +243,12 @@ impl IntelPT {
 
         let pt_trace = unsafe { &*slice_from_raw_parts(data_ptr, len) };
         let coverage = unsafe { &mut *slice_from_raw_parts_mut(map_ptr, map_len) };
-        self.ptcov_decoder.coverage(pt_trace, coverage).unwrap();
+        // todo: trace collection might fail for microarchitectural reasons, introduce in LibAFL a
+        // way to mark an execution as to be ignored and repeated.
+        if let Err(e) = self.ptcov_decoder.coverage(pt_trace, coverage) {
+            log::warn!("PT trace decoding to coverage failed: {e:?}");
+            coverage.fill(0.into());
+        }
 
         // Advance the trace pointer up to the latest sync point, otherwise next execution's trace
         // might not contain a PSB packet.


### PR DESCRIPTION
## Description

Due to microarchitectural reasons, Intel PT data might be incomplete and contain overflow packets.
At the moment the library crashes on such events.
Avoid crashing and produce an empty coverage map instead.

As a future development, a mechanism to mark an execution as to be ignored and repeated should be introduced.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
