### PR TITLE
Fix: Gate test_type_eq with alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4815,11 +4815,12 @@ dependencies = [
 
 [[package]]
 name = "ptcov"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc3038cb5032affe0f1ef9b1891f9ebf902c1a076a8dd8bedab77885c392d6"
+checksum = "bb9ec054af0cc5cb654bdcd5ee7b1798258875830c2a4ee9341a0f448b468951"
 dependencies = [
  "iced-x86",
+ "num-traits",
 ]
 
 [[package]]

--- a/crates/tuple_list_ex/src/lib.rs
+++ b/crates/tuple_list_ex/src/lib.rs
@@ -1125,6 +1125,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn test_type_eq() {
         // An alias for equality testing
         type OwnedMutSliceAlias<'a> = OwnedMutSlice<'a, u8>;


### PR DESCRIPTION
Resolves #3697 

## Description

Gated test_type_eq. 
The test was using OwnedMutSlice that was gated by "alloc".


## Checklist

- [*] I have run `./scripts/precommit.sh` and addressed all comments
