### PR TITLE
Add missing mode to LibAFL

### DIFF
--- a/crates/libafl/src/monitors/mod.rs
+++ b/crates/libafl/src/monitors/mod.rs
@@ -48,10 +48,10 @@ pub use statsd::StatsdMonitor;
 /// Returns if we're cooking.
 #[cfg(feature = "std")]
 #[must_use]
-pub(crate) fn is_pizza_mode() -> bool {
-    static IS_PIZZA_MODE: OnceLock<bool> = OnceLock::new();
-    *IS_PIZZA_MODE.get_or_init(|| {
-        std::env::var_os("AFL_PIZZA_MODE").is_some() || {
+pub(crate) fn pizza_is_served() -> bool {
+    static PIZZA_IS_SERVED: OnceLock<bool> = OnceLock::new();
+    *PIZZA_IS_SERVED.get_or_init(|| {
+        std::env::var("AFL_PIZZA_MODE").map_or(false, |v| v != "0") || {
             #[cfg(unix)]
             // SAFETY: `localtime` and `time` are standard libc functions. `t` is initialized.
             unsafe {
@@ -75,7 +75,7 @@ pub(crate) fn is_pizza_mode() -> bool {
 #[cfg(not(feature = "std"))]
 /// Returns `true` if it is currently pizza mode.
 #[must_use]
-pub fn is_pizza_mode() -> bool {
+pub fn pizza_is_served() -> bool {
     false
 }
 
@@ -153,7 +153,7 @@ impl Monitor for SimplePrintingMonitor {
             .collect::<Vec<_>>();
         userstats.sort();
         let global_stats = client_stats_manager.global_stats();
-        let (run, customers, corpus, objectives, executions, speed) = if is_pizza_mode() {
+        let (run, customers, corpus, objectives, executions, speed) = if pizza_is_served() {
             (
                 "time to bake",
                 "customers",
@@ -236,7 +236,7 @@ where
         sender_id: ClientId,
     ) -> Result<(), Error> {
         let global_stats = client_stats_manager.global_stats();
-        let (run, customers, corpus, objectives, executions, speed) = if is_pizza_mode() {
+        let (run, customers, corpus, objectives, executions, speed) = if pizza_is_served() {
             (
                 "time to bake",
                 "customers",
@@ -399,7 +399,7 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn test_pizza_mode() {
-        let _ = super::is_pizza_mode();
+        let _ = super::pizza_is_served();
     }
 
     #[test]

--- a/crates/libafl/src/monitors/multi.rs
+++ b/crates/libafl/src/monitors/multi.rs
@@ -149,7 +149,7 @@ where
     pub fn new(print_fn: F) -> Self {
         Self {
             print_fn,
-            pizza_mode: crate::monitors::is_pizza_mode(),
+            pizza_mode: crate::monitors::pizza_is_served(),
         }
     }
 

--- a/crates/libafl/src/monitors/tui/ui.rs
+++ b/crates/libafl/src/monitors/tui/ui.rs
@@ -143,7 +143,11 @@ impl TuiUi {
 
     /// create a new [`TuiUi`] with a given `version` string.
     #[must_use]
-    pub fn with_version(title: String, version: String, enhanced_graphics: bool) -> Self {
+    pub fn with_version(mut title: String, version: String, enhanced_graphics: bool) -> Self {
+        let pizza_mode = crate::monitors::pizza_is_served();
+        if pizza_mode {
+            title = "Mozzarbella Pizzeria management system".into();
+        }
         Self {
             title,
             version,
@@ -168,7 +172,7 @@ impl TuiUi {
             show_geometry: false,
             item_geometry_scroll: 0,
             item_geometry_page_size: 10,
-            pizza_mode: crate::monitors::is_pizza_mode(),
+            pizza_mode: crate::monitors::pizza_is_served(),
         }
     }
 
@@ -230,7 +234,7 @@ impl TuiUi {
 
     fn prepare_overall_stats(&self, ctx: &TuiContext) -> GenericStats {
         let (corpus, objectives, executions) = if self.pizza_mode {
-            ("pizzas", "deliveries", "doughs")
+            ("pizzas on the menu", "deliveries", "doughs")
         } else {
             ("corpus count", "solutions", "total execs")
         };
@@ -379,8 +383,13 @@ impl TuiUi {
                     let colors = [Color::Green, Color::Blue, Color::Magenta, Color::Cyan];
                     let style = Style::default().fg(colors[color_idx]);
 
+                    // Map keys if pizza mode is active
                     let key_str = if self.pizza_mode {
                         match k.as_ref() {
+                            "cycles done" => "seasons done",
+                            "unique crashes" => "at table",
+                            "unique hangs" => "number of Peroni",
+                            "map density" => "Baking progress",
                             "edges" => "toppings",
                             "stability" => "dough consistency",
                             "havoc_inc" => "spice level",
@@ -934,7 +943,13 @@ impl TuiUi {
             );
 
             self.draw_overall_ui(f, top_body, has_charts, &prepared);
-            draw_logs(f, logs_area, &prepared.logs, self.logs_wrap, prepared.pizza_mode);
+            draw_logs(
+                f,
+                logs_area,
+                &prepared.logs,
+                self.logs_wrap,
+                prepared.pizza_mode,
+            );
         } else {
             let body = split_main(area, self.show_logs, introspection, has_charts);
             let top_body = body[0];
@@ -944,7 +959,13 @@ impl TuiUi {
             self.draw_client_ui(f, mid_body, self.show_logs, &prepared);
 
             if self.show_logs && body.len() > 2 {
-                draw_logs(f, body[2], &prepared.logs, self.logs_wrap, prepared.pizza_mode);
+                draw_logs(
+                    f,
+                    body[2],
+                    &prepared.logs,
+                    self.logs_wrap,
+                    prepared.pizza_mode,
+                );
             }
         }
     }

--- a/crates/libafl/src/monitors/tui/widgets.rs
+++ b/crates/libafl/src/monitors/tui/widgets.rs
@@ -451,9 +451,9 @@ pub fn draw_process_timing_text(
 ) {
     let (run, speed, entry, solution) = if pizza_mode {
         (
-            "time to bake",
+            "open time",
             "baking speed",
-            "last pizza recipe",
+            "last pizza baked",
             "last delivery",
         )
     } else {


### PR DESCRIPTION
## Description

This adds support of a missing mode available in AFL++, see https://github.com/AFLplusplus/AFLplusplus/pull/1374 for details.

<img width="908" height="440" alt="image" src="https://github.com/user-attachments/assets/6449c76e-7f5d-4ea5-84bc-a50d9772f6f9" />