### PR TITLE
Add constructor for UnicodeIdentificationMetadata

### DIFF
--- a/crates/libafl/src/mutators/unicode/mod.rs
+++ b/crates/libafl/src/mutators/unicode/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     mutators::{MutationResult, Mutator, Tokens, rand_range},
     nonzero,
     stages::{
-        UnicodeIdentificationMetadata, extract_metadata,
+        UnicodeIdentificationMetadata,
         mutational::{MutatedTransform, MutatedTransformPost},
     },
     state::{HasCorpus, HasMaxSize, HasRand},
@@ -268,7 +268,7 @@ fn rand_replace_range<S: HasRand + HasMaxSize, F: Fn(&mut S) -> char>(
     }
 
     input.0.splice(range, replacement);
-    input.1 = extract_metadata(input.0.mutator_bytes());
+    input.1 = UnicodeIdentificationMetadata::new(input.0.mutator_bytes());
 
     MutationResult::Mutated
 }
@@ -445,7 +445,7 @@ where
             }
 
             input.0.splice(range, token.iter().copied());
-            input.1 = extract_metadata(input.0.mutator_bytes());
+            input.1 = UnicodeIdentificationMetadata::new(input.0.mutator_bytes());
             return Ok(MutationResult::Mutated);
         }
 
@@ -508,7 +508,7 @@ where
             }
 
             input.0.splice(range, token.iter().copied());
-            input.1 = extract_metadata(input.0.mutator_bytes());
+            input.1 = UnicodeIdentificationMetadata::new(input.0.mutator_bytes());
             return Ok(MutationResult::Mutated);
         }
 
@@ -528,7 +528,7 @@ mod test {
         corpus::NopCorpus,
         inputs::{BytesInput, HasMutatorBytes},
         mutators::{Mutator, UnicodeCategoryRandMutator, UnicodeSubcategoryRandMutator},
-        stages::extract_metadata,
+        stages::UnicodeIdentificationMetadata,
         state::StdState,
     };
 
@@ -550,7 +550,7 @@ mod test {
             )?;
 
             for _ in 0..(1 << 12) {
-                let metadata = extract_metadata(bytes.mutator_bytes());
+                let metadata = UnicodeIdentificationMetadata::new(bytes.mutator_bytes());
                 let mut input = (bytes, metadata);
                 let _ = mutator.mutate(&mut state, &mut input);
                 println!(
@@ -585,7 +585,7 @@ mod test {
             )?;
 
             for _ in 0..(1 << 12) {
-                let metadata = extract_metadata(bytes.mutator_bytes());
+                let metadata = UnicodeIdentificationMetadata::new(bytes.mutator_bytes());
                 let mut input = (bytes, metadata);
                 let _ = mutator.mutate(&mut state, &mut input);
                 println!(

--- a/crates/libafl/src/stages/unicode.rs
+++ b/crates/libafl/src/stages/unicode.rs
@@ -23,6 +23,14 @@ pub struct UnicodeIdentificationMetadata {
 impl_serdeany!(UnicodeIdentificationMetadata);
 
 impl UnicodeIdentificationMetadata {
+    /// Creates a new [`struct@UnicodeIdentificationMetadata`].
+    #[must_use]
+    pub fn new(bytes: &[u8]) -> Self {
+        Self {
+            ranges: Rc::new(extract_ranges(bytes))
+        }
+    }
+
     /// The list of pre-computed string-like ranges in the input
     #[must_use]
     pub fn ranges(&self) -> &Vec<(usize, BitVec)> {
@@ -30,7 +38,7 @@ impl UnicodeIdentificationMetadata {
     }
 }
 
-pub(crate) fn extract_metadata(bytes: &[u8]) -> UnicodeIdentificationMetadata {
+fn extract_ranges(bytes: &[u8]) -> Vec<(usize, BitVec)> {
     let mut ranges = Vec::new();
 
     if !bytes.is_empty() {
@@ -63,9 +71,7 @@ pub(crate) fn extract_metadata(bytes: &[u8]) -> UnicodeIdentificationMetadata {
         }
     }
 
-    UnicodeIdentificationMetadata {
-        ranges: Rc::new(ranges),
-    }
+    ranges
 }
 
 /// Stage which identifies potential strings in the provided input
@@ -101,7 +107,7 @@ impl<I, S> UnicodeIdentificationStage<I, S> {
         let input = tc.load_input(state.corpus())?;
 
         let bytes = input.target_bytes();
-        let metadata = extract_metadata(&bytes);
+        let metadata = UnicodeIdentificationMetadata::new(&bytes);
         tc.add_metadata(metadata);
 
         Ok(())

--- a/crates/libafl/src/stages/unicode.rs
+++ b/crates/libafl/src/stages/unicode.rs
@@ -27,7 +27,7 @@ impl UnicodeIdentificationMetadata {
     #[must_use]
     pub fn new(bytes: &[u8]) -> Self {
         Self {
-            ranges: Rc::new(extract_ranges(bytes))
+            ranges: Rc::new(extract_ranges(bytes)),
         }
     }
 


### PR DESCRIPTION
## Description

The four provided Unicode mutators are public, but are effectively unusable outside of the libafl crate due to `extract_metadata` being `pub(crate)` and `UnicodeIdentificationMetadata` not having a public constructor. This makes it convoluted/impossible (outside of a deserialize hack) to construct a non-empty `UnicodeIdentificationMetadata` which short-circuits the mutations.

This PR adds `UnicodeIdentificationMetadata::new` as a constructor wrapping the `extract_metadata` functionality (moved to a private `extract_ranges` helper), and updates internal callers to use the public constructor.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
