### PR TITLE
fix: clang-format issue

### DIFF
--- a/fuzzers/binary_only/tinyinst_simple/test/test.cpp
+++ b/fuzzers/binary_only/tinyinst_simple/test/test.cpp
@@ -119,7 +119,7 @@ char *crash = NULL;
 #ifdef __cplusplus
 extern "C"
 #endif  // __cplusplus
-    void FUZZ_TARGET_MODIFIERS fuzz(char *name) {
+void FUZZ_TARGET_MODIFIERS fuzz(char *name) {
   // clang-format on
   char    *sample_bytes = NULL;
   uint32_t sample_size = 0;


### PR DESCRIPTION
## Description

added `// clang-format off`  & `// clang-format on` which protects around `extern c` + macro function declaration 
in `fuzzers/binary_only/tinyinst_simple/test/test.cpp`

## Why

The `extern C`  prefix before the marco function  is formatted differently and due to that it's failing and resulting in CI failure.

disabled it for some section of the code only which had the formatting issues

## Tested

tested it with clang format command and the file `fuzzers/binary_only/tinyinst_simple/test/test.cpp`

<img width="794" height="116" alt="Screenshot 2026-03-20 at 3 38 12 PM" src="https://github.com/user-attachments/assets/43921c16-3c28-487d-a58f-1bc87416a437" />

fix-ci-again is the branch which is part of ongoing CI fixes