### PR TITLE
fix(afl_stats):Add TrimTime reporting to AflStatsStage

### DIFF
--- a/crates/libafl/src/stages/afl_stats.rs
+++ b/crates/libafl/src/stages/afl_stats.rs
@@ -83,6 +83,18 @@ impl From<Duration> for FuzzTime {
 
 libafl_bolts::impl_serdeany!(FuzzTime);
 
+/// `TrimTime` - Use to report time spent in queue trimming/minimization
+/// (AFL++ `trim` concept).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TrimTime(pub Duration);
+impl From<Duration> for TrimTime {
+    fn from(value: Duration) -> Self {
+        Self(value)
+    }
+}
+
+libafl_bolts::impl_serdeany!(TrimTime);
+
 /// The [`AflStatsStage`] is a Stage that calculates and writes
 /// AFL++'s `fuzzer_stats` and `plot_data` information.
 #[derive(Debug, Clone)]
@@ -357,7 +369,10 @@ where
                 .metadata::<SyncTime>()
                 .map_or(Duration::from_secs(0), |d| d.0)
                 .as_secs(),
-            trim_time: 0, // TODO
+            trim_time: state
+                .metadata::<TrimTime>()
+                .map_or(Duration::from_secs(0), |d| d.0)
+                .as_secs(),
             execs_done: total_executions,
             execs_per_sec: *state.executions(),     // TODO
             execs_ps_last_min: *state.executions(), // TODO
@@ -913,5 +928,81 @@ where
             autotokens_enabled: self.uses_autotokens,
             phantom: PhantomData,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::HasMetadata;
+    use crate::Error;
+    use crate::stages::{time_tracker::TimeTrackingStageWrapper, Stage};
+    use libafl_bolts::serdeany::SerdeAnyMap;
+
+    struct DummyState {
+        metadata: SerdeAnyMap,
+    }
+
+    impl DummyState {
+        fn new() -> Self {
+            Self {
+                metadata: SerdeAnyMap::new(),
+            }
+        }
+    }
+
+    impl HasMetadata for DummyState {
+        fn metadata_map(&self) -> &SerdeAnyMap {
+            &self.metadata
+        }
+
+        fn metadata_map_mut(&mut self) -> &mut SerdeAnyMap {
+            &mut self.metadata
+        }
+    }
+
+    struct NoopStage;
+
+    impl<E, EM, S, Z> Stage<E, EM, S, Z> for NoopStage {
+        fn perform(
+            &mut self,
+            _fuzzer: &mut Z,
+            _executor: &mut E,
+            _state: &mut S,
+            _manager: &mut EM,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn trim_time_is_read_from_metadata() {
+        let mut state = DummyState::new();
+        state.add_metadata(TrimTime(Duration::from_secs(7)));
+
+        let seconds = state
+            .metadata::<TrimTime>()
+            .map_or(Duration::from_secs(0), |d| d.0)
+            .as_secs();
+
+        assert_eq!(seconds, 7);
+    }
+
+    #[test]
+    fn time_tracking_wrapper_updates_trim_time_metadata() {
+        let mut state = DummyState::new();
+
+        let mut wrapper: TimeTrackingStageWrapper<TrimTime, _, NoopStage> =
+            TimeTrackingStageWrapper::new(NoopStage);
+        let mut fuzzer = ();
+        let mut executor = ();
+        let mut manager = ();
+
+        wrapper
+            .perform(&mut fuzzer, &mut executor, &mut state, &mut manager)
+            .unwrap();
+
+        let stored = state.metadata::<TrimTime>().unwrap().0;
+        assert!(stored >= Duration::from_secs(0));
     }
 }

--- a/crates/libafl/src/stages/mod.rs
+++ b/crates/libafl/src/stages/mod.rs
@@ -13,7 +13,7 @@ use alloc::{
 use core::{fmt, marker::PhantomData};
 
 #[cfg(feature = "std")]
-pub use afl_stats::{AflStatsStage, CalibrationTime, FuzzTime, SyncTime};
+pub use afl_stats::{AflStatsStage, CalibrationTime, FuzzTime, SyncTime, TrimTime};
 pub use calibrate::{CalibrationStage, run_target_with_timing};
 pub use colorization::*;
 #[cfg(all(feature = "std", unix))]


### PR DESCRIPTION
## Description

Added a new *TrimTime(Duration) SerdeAny metadata type*,basically wired `AflStatsStage` to read it from `state` metadata, and reexported it from `stages/mod.rs`. 
To verify , I added unit tests that confirm `TrimTime` is readable and that `TimeTrackingStageWrapper::<TrimTime>` updates the metadata correctly. Then I ran an fuzzer example(`fuzzers/inprocess/libfuzzer_libpng_launcher`) updated `libfuzzer_libpng_launcher` to include `StdTMinMutationalStage (tmin)` wrapped with `TimeTrackingStageWrapper::<TrimTime>` so  stats writer can report trimming time, then built and ran to confirm `trim_time` can change.Got the following stats after running for 120 sec:
<img width="503" height="545" alt="Screenshot 2026-03-20 152814" src="https://github.com/user-attachments/assets/e8d17cf5-19ae-47cb-8317-06f5e9deb7a4" />

in afl++ we go with micro sec time convention,but here kept it (ns) as it goes with convention across codebase,the out will be in sec anyways.
If approved I can also push `libfuzzer_libpng_launcher/src/lib.rs` which updates `trim_time` for that example.

## Checklist
- [x] I have run new unit test locally
- [x] I have run [updated libfuzzer_libpng_launcher](https://github.com/0xmuon/xtra/tree/main/libfuzzer_libpng_launcher)
- [ ] I have run `./scripts/precommit.sh` and addressed all comments
