### PR TITLE
Fix : resolve the clippy::collapsible_if warning in dump_covered_lines

### DIFF
--- a/crates/libafl_targets/src/sancov_pcguard_dump_cov.rs
+++ b/crates/libafl_targets/src/sancov_pcguard_dump_cov.rs
@@ -40,9 +40,9 @@ pub struct SrcLoc {
 /// * `Vec<SrcLoc>` - The covered lines, location and symbol
 pub fn dump_covered_lines(clear: bool) -> Vec<SrcLoc> {
     let mut res = Vec::new();
-    #[allow(clippy::collapsible_if)]
-    if let Ok(mut guard) = COVERED_PCS.lock() {
-        if let Some(map) = guard.as_mut() {
+    if let Ok(mut guard) = COVERED_PCS.lock()
+        && let Some(map) = guard.as_mut()
+    {
             for (&pc, &hits) in map.iter() {
                 let mut loc = SrcLoc {
                     pc,


### PR DESCRIPTION
## Description

This Change resolves the warnings by the Clippy linting warnings. by the `sancov_pcguard_dump_cov`, Fixed it by rewriting the if  let statement in `dump_covered_lines` by let chains and keeping the logic same which satisfies Clippy.

## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments

