### PR TITLE
Fix: mismatched braces in libafl_targets dump_cov

### DIFF
--- a/crates/libafl_targets/src/sancov_pcguard_dump_cov.rs
+++ b/crates/libafl_targets/src/sancov_pcguard_dump_cov.rs
@@ -43,33 +43,33 @@ pub fn dump_covered_lines(clear: bool) -> Vec<SrcLoc> {
     if let Ok(mut guard) = COVERED_PCS.lock()
         && let Some(map) = guard.as_mut()
     {
-            for (&pc, &hits) in map.iter() {
-                let mut loc = SrcLoc {
-                    pc,
-                    function: None,
-                    filename: None,
-                    line: None,
-                    hits,
-                };
+        for (&pc, &hits) in map.iter() {
+            let mut loc = SrcLoc {
+                pc,
+                function: None,
+                filename: None,
+                line: None,
+                hits,
+            };
 
-                backtrace::resolve(pc as *mut _, |symbol| {
-                    if let Some(name) = symbol.name() {
-                        loc.function = Some(name.to_string());
-                    }
-                    if let Some(filename) = symbol.filename() {
-                        loc.filename = Some(filename.display().to_string());
-                    }
-                    if let Some(lineno) = symbol.lineno() {
-                        loc.line = Some(lineno);
-                    }
-                });
-                res.push(loc);
-            }
-            if clear {
-                map.clear();
-            }
+            backtrace::resolve(pc as *mut _, |symbol| {
+                if let Some(name) = symbol.name() {
+                    loc.function = Some(name.to_string());
+                }
+                if let Some(filename) = symbol.filename() {
+                    loc.filename = Some(filename.display().to_string());
+                }
+                if let Some(lineno) = symbol.lineno() {
+                    loc.line = Some(lineno);
+                }
+            });
+            res.push(loc);
+        }
+        if clear {
+            map.clear();
         }
     }
+    
     res
 }
 


### PR DESCRIPTION
## Description

Fixes a compile error caused by extra closing braces after a refactor.

This was breaking the dump_covered_lines when the feature is enabled

Tested with:
`cargo build -p libafl_targets --features sancov_pcguard_dump_cov`


## Screenshots
<img width="1380" height="896" alt="Screenshot 2026-03-30 at 1 55 08 PM" src="https://github.com/user-attachments/assets/8db1e618-dd1d-4776-a079-019e94fe88fd" />

Closes #3771


## Checklist

- [x] I have run `./scripts/precommit.sh` and addressed all comments
