### PR TITLE
Add functions to simplify creating sub-RNGs

### DIFF
--- a/crates/fast_rands/src/lib.rs
+++ b/crates/fast_rands/src/lib.rs
@@ -288,6 +288,7 @@ where
 /// Useful when sampling random data while also accessing the state.
 pub trait SubRng {
     /// Creates and returns a sub-RNG.
+    #[must_use]
     fn sub_rng(&mut self) -> Self;
 }
 


### PR DESCRIPTION
Addresses #3774. I updated the `Rand` trait to have a method (`create_sub_rng`) that creates a sub-RNG seeded from the current RNG state and added a simple method (`sub_rand`) to the `HasRand` trait for the sake of convenience when calling this function.

I also made a small update to MIGRATION.md (after reading through CONTRIBUTION.md) and added a function to test my changes. As this is my first attempt at contributing to this repository, I would really appreciate any and all feedback. Thank you!