### PR TITLE
Remove Clone from ShMem

### DIFF
--- a/crates/ll_mp/src/lib.rs
+++ b/crates/ll_mp/src/lib.rs
@@ -3638,13 +3638,10 @@ where
     }
 
     /// Create a point-to-point channel instead of using a broker-client channel
-    pub fn new_p2p(shmem_provider: SP, sender_id: ClientId) -> Result<Self, Error> {
+    pub fn new_p2p(mut shmem_provider: SP, sender_id: ClientId) -> Result<Self, Error> {
         let sender = LlmpSender::new(shmem_provider.clone(), sender_id, false)?;
-        let receiver = LlmpReceiver::on_existing_shmem(
-            shmem_provider,
-            sender.out_shmems[0].shmem.clone(),
-            None,
-        )?;
+        let shmem = shmem_provider.clone_ref(&sender.out_shmems[0].shmem)?;
+        let receiver = LlmpReceiver::on_existing_shmem(shmem_provider, shmem, None)?;
         Ok(Self { sender, receiver })
     }
 
@@ -3653,7 +3650,7 @@ where
     /// else reattach will get a new, empty page, from the OS, or fail
     #[allow(clippy::needless_pass_by_value)] // no longer necessary on nightly
     pub fn on_existing_shmem(
-        shmem_provider: SP,
+        mut shmem_provider: SP,
         _current_out_shmem: SHM,
         _last_msg_sent_offset: Option<u64>,
         current_broker_shmem: SHM,
@@ -3662,7 +3659,7 @@ where
         Ok(Self {
             receiver: LlmpReceiver::on_existing_shmem(
                 shmem_provider.clone(),
-                current_broker_shmem.clone(),
+                shmem_provider.clone_ref(&current_broker_shmem)?,
                 last_msg_recvd_offset,
             )?,
             sender: LlmpSender::on_existing_shmem(

--- a/crates/shmem_providers/src/lib.rs
+++ b/crates/shmem_providers/src/lib.rs
@@ -282,7 +282,7 @@ impl Display for ShMemId {
 ///
 /// They are the backbone of `llmp` for inter-process communication.
 /// All you need for scaling on a new target is to implement this interface, as well as the respective [`ShMemProvider`].
-pub trait ShMem: Sized + Debug + Clone + DerefMut<Target = [u8]> {
+pub trait ShMem: Sized + Debug + DerefMut<Target = [u8]> {
     /// Get the id of this shared memory mapping
     fn id(&self) -> ShMemId;
 
@@ -757,7 +757,7 @@ pub mod unix_shmem {
         /// Mmap-based The sharedmap impl for unix using [`shm_open`] and [`mmap`].
         /// Default on `MacOS` and `iOS`, where we need a central point to unmap
         /// shared mem segments for dubious Mach kernel reasons.
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct MmapShMem {
             /// The path of this shared memory segment.
             /// None in case we didn't [`shm_open`] this ourselves, but someone sent us the FD.
@@ -1098,7 +1098,7 @@ pub mod unix_shmem {
         }
 
         /// The default sharedmap impl for unix using shmctl & shmget
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct CommonUnixShMem {
             id: ShMemId,
             map: *mut u8,
@@ -1250,7 +1250,7 @@ pub mod unix_shmem {
         use crate::{Error, ShMem, ShMemId, ShMemProvider};
 
         /// An ashmem based impl for linux/android
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct AshmemShMem {
             id: ShMemId,
             map: *mut u8,
@@ -1469,7 +1469,7 @@ pub mod unix_shmem {
 
         /// An memfd based impl for linux/android
         #[cfg(unix)]
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct MemfdShMem {
             id: ShMemId,
             map: *mut u8,
@@ -1667,7 +1667,6 @@ pub mod win32_shmem {
     const INVALID_HANDLE_VALUE: *mut c_void = -1isize as *mut c_void;
 
     /// The default [`ShMem`] impl for Windows using `shmctl` & `shmget`
-    #[derive(Clone)]
     pub struct Win32ShMem {
         id: ShMemId,
         handle: HANDLE,


### PR DESCRIPTION
The ShMem implementations were never actually Clone, and Drop'ing them unmaps memory eventually causing havoc. This is a breaking change as the public API changes, let's see what the CI things about this one. 

Fixes #3768 
