### PR TITLE
refactor(tinyinst): spring-clean TinyInstExecutor

### DIFF
--- a/crates/libafl_tinyinst/src/executor.rs
+++ b/crates/libafl_tinyinst/src/executor.rs
@@ -19,9 +19,18 @@ use libafl_bolts::{
 };
 use tinyinst::tinyinst::{TinyInst, litecov::RunResult};
 
-/// [`TinyInst`](https://github.com/googleprojectzero/TinyInst) executor
+const MAX_FILE: usize = 1024 * 1024;
+const SHMEM_FUZZ_HDR_SIZE: usize = 4;
+
+/// Executor wrapping [TinyInst](https://github.com/googleprojectzero/TinyInst)
+/// for binary-only coverage-guided fuzzing.
+///
+/// Supports file-based and shared memory testcase delivery, as well as persistent
+/// mode. Construct via [`TinyInstExecutor::builder`] -> [`TinyInstExecutorBuilder`].
 pub struct TinyInstExecutor<S, SHM, OT> {
     tinyinst: TinyInst,
+    // Invariant: non-null, points to a valid Vec<u64>, valid for the executor's
+    // lifetime, not accessed concurrently during execution.
     coverage_ptr: *mut Vec<u64>,
     timeout: Duration,
     observers: OT,
@@ -31,7 +40,10 @@ pub struct TinyInstExecutor<S, SHM, OT> {
 }
 
 impl TinyInstExecutor<(), NopShMem, ()> {
-    /// Create a builder for [`TinyInstExecutor`]
+    /// Returns a builder for [`TinyInstExecutor`].
+    ///
+    /// Configure instrumentation args, program args, timeout, and coverage pointer
+    /// before calling [`TinyInstExecutorBuilder::build`].
     #[must_use]
     pub fn builder<'a>() -> TinyInstExecutorBuilder<'a, NopShMemProvider> {
         TinyInstExecutorBuilder::new()
@@ -39,7 +51,7 @@ impl TinyInstExecutor<(), NopShMem, ()> {
 }
 
 impl<S, SHM, OT> Debug for TinyInstExecutor<S, SHM, OT> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TinyInstExecutor")
             .field("timeout", &self.timeout)
             .finish_non_exhaustive()
@@ -52,7 +64,6 @@ where
     I: HasTargetBytes,
     SHM: ShMem,
 {
-    #[inline]
     fn run_target(
         &mut self,
         _fuzzer: &mut Z,
@@ -61,44 +72,68 @@ where
         input: &I,
     ) -> Result<ExitKind, Error> {
         *state.executions_mut() += 1;
-        match &self.map {
-            Some(_) => {
-                // use shmem to pass testcase
-                let shmem = unsafe { self.map.as_mut().unwrap_unchecked() };
-                let target_bytes = input.target_bytes();
-                let size = target_bytes.as_slice().len();
-                let size_in_bytes = size.to_ne_bytes();
-                // The first four bytes tells the size of the shmem.
-                shmem.as_slice_mut()[..SHMEM_FUZZ_HDR_SIZE]
-                    .copy_from_slice(&size_in_bytes[..SHMEM_FUZZ_HDR_SIZE]);
-                shmem.as_slice_mut()[SHMEM_FUZZ_HDR_SIZE..(SHMEM_FUZZ_HDR_SIZE + size)]
-                    .copy_from_slice(target_bytes.as_slice());
-            }
-            None => {
-                self.cur_input.write_buf(input.target_bytes().as_slice())?;
-            }
+
+        if let Some(shmem) = &mut self.map {
+            let target_bytes = input.target_bytes();
+            let size = target_bytes.as_slice().len();
+            let size_in_bytes = size.to_ne_bytes();
+            shmem.as_slice_mut()[..SHMEM_FUZZ_HDR_SIZE]
+                .copy_from_slice(&size_in_bytes[..SHMEM_FUZZ_HDR_SIZE]);
+            shmem.as_slice_mut()[SHMEM_FUZZ_HDR_SIZE..(SHMEM_FUZZ_HDR_SIZE + size)]
+                .copy_from_slice(target_bytes.as_slice());
+        } else {
+            self.cur_input.write_buf(input.target_bytes().as_slice())?;
         }
 
-        #[expect(unused_assignments)]
-        let mut status = RunResult::OK;
-        unsafe {
-            status = self.tinyinst.run();
-            self.tinyinst
-                .vec_coverage(self.coverage_ptr.as_mut().unwrap(), false);
-        }
+        // SAFETY: coverage_ptr is validated as non-null in the builder.
+        let status = unsafe {
+            let s = self.tinyinst.run();
+            self.tinyinst.vec_coverage(&mut *self.coverage_ptr, false);
+            s
+        };
 
         match status {
             RunResult::CRASH | RunResult::HANG => Ok(ExitKind::Crash),
             RunResult::OK => Ok(ExitKind::Ok),
-            RunResult::OTHER_ERROR => Err(Error::unknown(
-                "Tinyinst RunResult is other error".to_string(),
-            )),
+            RunResult::OTHER_ERROR => Err(Error::unknown("Tinyinst RunResult is other error")),
             _ => Err(Error::unknown("Tinyinst RunResult is unknown")),
         }
     }
 }
 
-/// Builder for `TinyInstExecutor`
+impl<S, SHM, OT> HasObservers for TinyInstExecutor<S, SHM, OT> {
+    type Observers = OT;
+
+    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
+        RefIndexable::from(&self.observers)
+    }
+
+    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
+        RefIndexable::from(&mut self.observers)
+    }
+}
+
+/// Builder for [`TinyInstExecutor`].
+///
+/// # Example
+/// ```no_run
+/// # use std::time::Duration;
+/// # use libafl_tinyinst::executor::TinyInstExecutor;
+/// # use libafl::observers::ListObserver;
+/// # use libafl_bolts::{ownedref::OwnedMutPtr, tuples::tuple_list};
+/// # fn main() -> Result<(), libafl::Error> {
+/// static mut COVERAGE: Vec<u64> = Vec::new();
+///
+/// let observer = ListObserver::new("cov", OwnedMutPtr::Ptr(&raw mut COVERAGE));
+/// let mut executor = TinyInstExecutor::builder()
+///     .instrument_module(["target.dll"])
+///     .program_args(["./target", "@@"])
+///     .timeout(Duration::from_secs(5))
+///     .coverage_ptr(&raw mut COVERAGE)
+///     .build::<_, ()>(tuple_list!(observer))?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct TinyInstExecutorBuilder<'a, SP> {
     tinyinst_args: Vec<String>,
@@ -108,9 +143,6 @@ pub struct TinyInstExecutorBuilder<'a, SP> {
     shmem_provider: Option<&'a mut SP>,
 }
 
-const MAX_FILE: usize = 1024 * 1024;
-const SHMEM_FUZZ_HDR_SIZE: usize = 4;
-
 impl Default for TinyInstExecutorBuilder<'_, NopShMemProvider> {
     fn default() -> Self {
         Self::new()
@@ -118,9 +150,11 @@ impl Default for TinyInstExecutorBuilder<'_, NopShMemProvider> {
 }
 
 impl<'a> TinyInstExecutorBuilder<'a, NopShMemProvider> {
-    /// Creates a new `TinyInstExecutorBuilder`
+    /// Creates a new builder without shared memory support.
+    ///
+    /// Use [`Self::shmem_provider`] to enable shmem-based testcase delivery.
     #[must_use]
-    pub fn new() -> TinyInstExecutorBuilder<'a, NopShMemProvider> {
+    pub fn new() -> Self {
         Self {
             tinyinst_args: vec![],
             program_args: vec![],
@@ -130,7 +164,7 @@ impl<'a> TinyInstExecutorBuilder<'a, NopShMemProvider> {
         }
     }
 
-    /// Use this to enable shmem testcase passing.
+    /// Enables shared memory testcase delivery using the given provider.
     #[must_use]
     pub fn shmem_provider<SP>(self, shmem_provider: &'a mut SP) -> TinyInstExecutorBuilder<'a, SP> {
         TinyInstExecutorBuilder {
@@ -143,37 +177,35 @@ impl<'a> TinyInstExecutorBuilder<'a, NopShMemProvider> {
     }
 }
 
-impl<SP> TinyInstExecutorBuilder<'_, SP>
-where
-    SP: ShMemProvider,
-{
-    /// Argument for tinyinst instrumentation
+impl<SP: ShMemProvider> TinyInstExecutorBuilder<'_, SP> {
+    /// Appends a single argument to the `TinyInst` instrumentation command line.
     #[must_use]
-    pub fn tinyinst_arg(mut self, arg: String) -> Self {
-        self.tinyinst_args.push(arg);
+    pub fn tinyinst_arg(mut self, arg: impl Into<String>) -> Self {
+        self.tinyinst_args.push(arg.into());
         self
     }
 
-    /// Arguments for tinyinst instrumentation
+    /// Appends multiple arguments to the `TinyInst` instrumentation command line.
     #[must_use]
-    pub fn tinyinst_args(mut self, args: Vec<String>) -> Self {
-        for arg in args {
-            self.tinyinst_args.push(arg);
-        }
+    pub fn tinyinst_args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.tinyinst_args.extend(args.into_iter().map(Into::into));
         self
     }
 
-    /// The module to instrument.
+    /// Registers one or more modules for instrumentation (`-instrument_module <name>`).
     #[must_use]
-    pub fn instrument_module(mut self, module: Vec<String>) -> Self {
-        for modname in module {
+    pub fn instrument_module(
+        mut self,
+        modules: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        for name in modules {
             self.tinyinst_args.push("-instrument_module".to_string());
-            self.tinyinst_args.push(modname);
+            self.tinyinst_args.push(name.into());
         }
         self
     }
 
-    /// Use shmem
+    /// Configures testcase delivery over shared memory (`-delivery shmem`).
     #[must_use]
     pub fn use_shmem(mut self) -> Self {
         self.tinyinst_args.push("-delivery".to_string());
@@ -181,67 +213,72 @@ where
         self
     }
 
-    /// Persistent mode
+    /// Enables persistent fuzzing mode, looping over `target_method` in `target_module`
+    /// for `iterations` rounds with `nargs` arguments per call.
     #[must_use]
     pub fn persistent(
         mut self,
-        target_module: String,
-        target_method: String,
+        target_module: impl Into<String>,
+        target_method: impl Into<String>,
         nargs: usize,
         iterations: usize,
     ) -> Self {
-        self.tinyinst_args.push("-target_module".to_string());
-        self.tinyinst_args.push(target_module);
-
-        self.tinyinst_args.push("-target_method".to_string());
-        self.tinyinst_args.push(target_method);
-
-        self.tinyinst_args.push("-nargs".to_string());
-        self.tinyinst_args.push(nargs.to_string());
-
-        self.tinyinst_args.push("-iterations".to_string());
-        self.tinyinst_args.push(iterations.to_string());
-
-        self.tinyinst_args.push("-persist".to_string());
-        self.tinyinst_args.push("-loop".to_string());
+        self.tinyinst_args.extend([
+            "-target_module".to_string(),
+            target_module.into(),
+            "-target_method".to_string(),
+            target_method.into(),
+            "-nargs".to_string(),
+            nargs.to_string(),
+            "-iterations".to_string(),
+            iterations.to_string(),
+            "-persist".to_string(),
+            "-loop".to_string(),
+        ]);
         self
     }
 
-    /// Program arg
+    /// Appends a single argument to the target program's command line.
     #[must_use]
-    pub fn program_arg(mut self, arg: String) -> Self {
-        self.program_args.push(arg);
+    pub fn program_arg(mut self, arg: impl Into<String>) -> Self {
+        self.program_args.push(arg.into());
         self
     }
 
-    /// Program args
+    /// Appends multiple arguments to the target program's command line.
+    ///
+    /// Use `"@@"` as a placeholder for the input.
     #[must_use]
-    pub fn program_args(mut self, args: Vec<String>) -> Self {
-        for arg in args {
-            self.program_args.push(arg);
-        }
+    pub fn program_args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.program_args.extend(args.into_iter().map(Into::into));
         self
     }
 
-    /// Set timeout
+    /// Sets the per-execution timeout. Defaults to 3 seconds.
     #[must_use]
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
     }
 
-    /// Set the pointer to the coverage vec used to observer the execution.
+    /// Sets the pointer to the coverage vector populated after each execution.
     ///
-    /// # Safety
-    /// The coverage vec pointer must point to a valid vec and outlive the time the [`TinyInstExecutor`] is alive.
-    /// The map will be dereferenced and borrowed mutably during execution. This may not happen concurrently.
+    /// The pointer must be non-null, point to a valid `Vec<u64>`, and remain
+    /// valid for the entire lifetime of the resulting [`TinyInstExecutor`].
+    /// The vector must not be accessed concurrently with execution.
+    ///
+    /// Nullness is checked at [`build`](Self::build) time; all other invariants
+    /// are the caller's responsibility.
     #[must_use]
     pub fn coverage_ptr(mut self, coverage_ptr: *mut Vec<u64>) -> Self {
         self.coverage_ptr = coverage_ptr;
         self
     }
 
-    /// Build [`TinyInst`](https://github.com/googleprojectzero/TinyInst) executor
+    /// Builds the [`TinyInstExecutor`].
+    ///
+    /// Fails if `coverage_ptr` is null or `"@@"` does not appear in the
+    /// program arguments.
     pub fn build<OT, S>(
         &mut self,
         observers: OT,
@@ -249,17 +286,13 @@ where
         if self.coverage_ptr.is_null() {
             return Err(Error::illegal_argument("Coverage pointer may not be null."));
         }
+
         let (map, shmem_id) = match &mut self.shmem_provider {
             Some(provider) => {
-                // setup shared memory
                 let mut shmem = provider.new_shmem(MAX_FILE + SHMEM_FUZZ_HDR_SIZE)?;
                 let shmem_id = shmem.id();
-                // log::trace!("{:#?}", shmem.id());
-                // shmem.write_to_env("__TINY_SHM_FUZZ_ID")?;
-
                 let size_in_bytes = (MAX_FILE + SHMEM_FUZZ_HDR_SIZE).to_ne_bytes();
-                shmem.as_slice_mut()[..4].clone_from_slice(&size_in_bytes[..4]);
-
+                shmem.as_slice_mut()[..4].copy_from_slice(&size_in_bytes[..4]);
                 (Some(shmem), Some(shmem_id))
             }
             None => (None, None),
@@ -273,10 +306,9 @@ where
             .map(|arg| {
                 if arg == "@@" {
                     has_input = true;
-                    match shmem_id {
-                        Some(shmem_name) => shmem_name.to_string(),
-                        None => INPUTFILE_STD.to_string(),
-                    }
+                    shmem_id
+                        .as_ref()
+                        .map_or_else(|| INPUTFILE_STD.to_string(), ToString::to_string)
                 } else {
                     arg
                 }
@@ -284,14 +316,12 @@ where
             .collect();
 
         if !has_input {
-            return Err(Error::unknown(
-                "No input file or shmem provided".to_string(),
-            ));
+            return Err(Error::unknown("No input file or shmem provided"));
         }
+
         log::info!("tinyinst args: {:#?}", &self.tinyinst_args);
 
-        let cur_input = InputFile::create(INPUTFILE_STD).expect("Unable to create cur_file");
-
+        let cur_input = InputFile::create(INPUTFILE_STD)?;
         let tinyinst = TinyInst::new(
             &self.tinyinst_args,
             &program_args,
@@ -307,17 +337,5 @@ where
             cur_input,
             map,
         })
-    }
-}
-
-impl<S, SHM, OT> HasObservers for TinyInstExecutor<S, SHM, OT> {
-    type Observers = OT;
-
-    fn observers(&self) -> RefIndexable<&Self::Observers, Self::Observers> {
-        RefIndexable::from(&self.observers)
-    }
-
-    fn observers_mut(&mut self) -> RefIndexable<&mut Self::Observers, Self::Observers> {
-        RefIndexable::from(&mut self.observers)
     }
 }


### PR DESCRIPTION
- Remove unnecessary unsafe (unwrap_unchecked -> if let Some)
- Remove `#[expect(unused_assignments)] `by restructuring control flow
- Replace `.expect()` with ? in Result-returning `build()`
- Use `impl Into<String>` / impl IntoIterator on builder APIs
- Drop redundant `.to_string()` on error messages
- Improve documentation with usage notes, safety invariants
- Use `core::fmt::Result`, Self return type, lifetime elision
- Move constants to top, reorder trait impls for readability
- Replace `clone_from_slice` with `copy_from_slice`
- Remove commented-out code

Related to #2068