### PR TITLE
Fix CI on MacOS

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,6 +14,7 @@ env:
   AFL_PIZZA_MODE: "-1" # this is sad, I know, but it breaks on a certain spring day otherwise :(
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  # FIXME: please unpin macos rust stable toolchain once LLVM is bumped to version 22
   MAIN_LLVM_VERSION: 21
 
 concurrency:
@@ -973,7 +974,7 @@ jobs:
   macos:
     runs-on: macOS-latest
     steps:
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: clippy
       - name: Install nightly

--- a/Justfile
+++ b/Justfile
@@ -130,7 +130,7 @@ clippy:
 # Run clippy on.. some things?
 [macos]
 clippy:
-    cargo +nightly clippy --tests --all --exclude libafl_nyx --exclude symcc_runtime --exclude runtime_test
+    cargo clippy --tests --all --exclude libafl_nyx --exclude symcc_runtime --exclude runtime_test
     just clippy-excluded
 
 # Run clippy powershell script

--- a/crates/libafl_frida/src/asan/asan_rt.rs
+++ b/crates/libafl_frida/src/asan/asan_rt.rs
@@ -2666,31 +2666,35 @@ impl AsanRuntime {
         //abuse the fact that the last operand is always the mem operand
         match instr.operands[operands_len - 1] {
             Operand::RegRegOffset(reg1, reg2, size, shift, shift_size) => {
-                let ret = Some((
+                // let ret =
+                Some((
                     reg1,
                     Some((reg2, size)),
                     0,
                     instruction_width(&instr),
                     Some((shift, shift_size)),
-                ));
+                ))
                 // log::trace!("Interesting instruction: {}, {:?}", instr.to_string(), ret);
-                ret
+                // ret
             }
             Operand::RegPreIndex(reg, disp, _) => {
-                let ret = Some((reg, None, disp, instruction_width(&instr), None));
+                // let ret =
+                Some((reg, None, disp, instruction_width(&instr), None))
                 // log::trace!("Interesting instruction: {}, {:?}", instr.to_string(), ret);
-                ret
+                // ret
             }
             Operand::RegPostIndex(reg, _) => {
                 //in post index the disp is applied after so it doesn't matter for this memory access
-                let ret = Some((reg, None, 0, instruction_width(&instr), None));
+                // let ret =
+                Some((reg, None, 0, instruction_width(&instr), None))
                 // log::trace!("Interesting instruction: {}, {:?}", instr.to_string(), ret);
-                ret
+                // ret
             }
             Operand::RegPostIndexReg(reg, _) => {
-                let ret = Some((reg, None, 0, instruction_width(&instr), None));
+                // let ret =
+                Some((reg, None, 0, instruction_width(&instr), None))
                 //  log::trace!("Interesting instruction: {}, {:?}", instr.to_string(), ret);
-                ret
+                // ret
             }
             _ => None,
         }


### PR DESCRIPTION
## Description

Lock MacOS stable toolchain to 1.94.1 until LLVM gets bumped to 22.
Use stable for clippy as it is done on Ubuntu.

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
