### PR TITLE
Update header method to add newline character

### DIFF
--- a/crates/libafl/src/stages/afl_stats.rs
+++ b/crates/libafl/src/stages/afl_stats.rs
@@ -669,7 +669,7 @@ impl Display for AFLPlotData<'_> {
 }
 impl AFLPlotData<'_> {
     fn header() -> &'static str {
-        "# relative_time, cycles_done, cur_item, corpus_count, pending_total, pending_favs, total_edges, saved_crashes, saved_hangs, max_depth, execs_per_sec, execs_done, edges_found"
+        "# relative_time, cycles_done, cur_item, corpus_count, pending_total, pending_favs, total_edges, saved_crashes, saved_hangs, max_depth, execs_per_sec, execs_done, edges_found\n"
     }
 }
 impl Display for AflFuzzerStats<'_> {


### PR DESCRIPTION
Fix header formatting in AFLPlotData to include newline.