### PR TITLE
PPC32: avoid stale TBs across snapshot's mprotect swaps

### DIFF
--- a/crates/libafl_qemu/src/modules/usermode/snapshot.rs
+++ b/crates/libafl_qemu/src/modules/usermode/snapshot.rs
@@ -553,6 +553,10 @@ impl SnapshotModule {
         qemu.set_brk(self.brk);
         qemu.set_mmap_start(self.mmap_start);
 
+        // PPC32 TCG keeps stale TBs across the snapshot's mprotect swaps, so flush
+        #[cfg(cpu_target = "ppc")]
+        qemu.flush_jit();
+
         #[cfg(feature = "paranoid_debug")]
         self.check_snapshot(qemu);
 


### PR DESCRIPTION
## Description

PPC32 TCG retains translation blocks past the mprotect()-driven page swaps performed above, so the next dispatch from the snapshotted PC executes stale TBs and SIGILLs even though guest memory and registers have been restored byte-identically. An explicit JIT flush after permission + content restoration fixes it. Gated on ppc to avoid the throughput hit on other targets (unless someone confirms a global flush is harmless).

## Checklist

- [X] I have run `./scripts/precommit.sh` and addressed all comments
