### PR TITLE
fix(fast_rands): prevent overflow and UB in Rand::between for maximum bounds

### DIFF
--- a/crates/fast_rands/src/lib.rs
+++ b/crates/fast_rands/src/lib.rs
@@ -195,6 +195,11 @@ pub trait Rand {
     #[inline]
     fn between(&mut self, lower_bound_incl: usize, upper_bound_incl: usize) -> usize {
         debug_assert!(lower_bound_incl <= upper_bound_incl);
+
+        if upper_bound_incl == usize::MAX && lower_bound_incl == 0 {
+            return self.next() as usize;
+        }
+
         // # Safety
         // We check that the upper_bound_incl <= lower_bound_incl above (alas only in debug), so the below is fine.
         // Even if we encounter a 0 in release here, the worst-case scenario should be an invalid return value.


### PR DESCRIPTION
## Description
Attempting to request a number between `0` and `usize::MAX` for `Rand::between` results in an 
"attempt to add with overflow" panic in **debug mode** due to the bounds size 
calculation `upper_bound_incl - lower_bound_incl + 1`. 

In **release mode**, this overflow would silently wrap to 0 and trigger 
Undefined Behavior when passed into `NonZero::new_unchecked`.

This PR performs an early return when the full `usize` range is requested.

## Checklist

- [X] I have run `./scripts/precommit.sh` and addressed all comments
