### PR TITLE
RestartingMgr: Fix SIGNAL_RECURSION_EXIT mismatch

### DIFF
--- a/crates/libafl/src/events/restarting.rs
+++ b/crates/libafl/src/events/restarting.rs
@@ -272,8 +272,7 @@ where
                 }
 
                 #[cfg(all(unix, feature = "std", not(miri)))]
-                if child_status == 139 {
-                    // SIGNAL_RECURSION_EXIT
+                if child_status == libafl_bolts::os::SIGNAL_RECURSION_EXIT {
                     return Err(Error::illegal_state(
                         "The fuzzer crashed inside a crash handler, this is likely a bug in fuzzer or libafl.",
                     ));


### PR DESCRIPTION
`SIGNAL_RECURSION_EXIT` has always been 101.
Exit code 139 is the standard SIGSEGV one.

This somehow changed during a refactor commit (#3612), not sure what happened there. Using the actual `SIGNAL_RECURSION_EXIT` constant instead of 139 allows `RestartingMgr` to handle cases where the PUT crashes with a SIGSEGV. Without the patch the fuzzer errors out instead of continuing to fuzz.

FWIW: The CI results are lots of noise but `inprocess/libfuzzer_libpng_launcher` seems like a real change. It looks like the fuzz job was broken previously and now finds inputs that OOM? I'll investigate after fixing CI noise.