### PR TITLE
fix(testcase_score): typo in documentation of TestcasePenalty

### DIFF
--- a/crates/libafl/src/schedulers/testcase_score.rs
+++ b/crates/libafl/src/schedulers/testcase_score.rs
@@ -21,9 +21,9 @@ pub trait TestcaseScore<I, S> {
     fn compute(state: &S, entry: &mut Testcase<I>) -> Result<f64, Error>;
 }
 
-/// Compute the favor factor of a [`Testcase`]. Lower  is better.
+/// Compute the favor factor of a [`Testcase`]. Lower is better.
 pub trait TestcasePenalty<I, S> {
-    /// Computes the favor factor of a [`Testcase`]. Higher is better.
+    /// Computes the favor factor of a [`Testcase`]. Lower is better.
     fn compute(state: &S, entry: &mut Testcase<I>) -> Result<f64, Error>;
 }
 


### PR DESCRIPTION
## Description
Minor typo fix that confused me for a split second :P 

## Checklist

- [ ] I have run `./scripts/precommit.sh` and addressed all comments
