### PR TITLE
Fix TCP message handling panics and oversized allocations

### DIFF
--- a/crates/libafl/src/events/tcp.rs
+++ b/crates/libafl/src/events/tcp.rs
@@ -45,6 +45,12 @@ use crate::{
     },
 };
 
+/// Maximum size, in bytes, we are willing to allocate for a single incoming
+/// framed TCP message. Guards against a peer sending a bogus/huge size
+/// prefix and forcing an oversized allocation before any real data has been
+/// validated.
+const TCP_MAX_MSG_LEN: u32 = 128 * 1024 * 1024;
+
 /// Tries to create (synchronously) a [`TcpListener`] that is `nonblocking` (for later use in tokio).
 /// Will error if the port is already in use (or other errors occur)
 fn create_nonblocking_listener<A: ToSocketAddrs>(addr: A) -> Result<TcpListener, Error> {
@@ -131,14 +137,23 @@ where
                 }
 
                 // Asynchronously wait for an inbound socket.
-                let (socket, _) = listener.accept().await.expect("Accept failed");
+                let (socket, _) = match listener.accept().await {
+                    Ok(accepted) => accepted,
+                    Err(e) => {
+                        log::error!("Error accepting tcp connection: {e:?}");
+                        continue;
+                    }
+                };
                 let (mut read, mut write) = tokio::io::split(socket);
 
                 // Protocol: the new client communicate its old ClientId or -1 if new
                 let mut this_client_id = [0; 4];
-                read.read_exact(&mut this_client_id)
-                    .await
-                    .expect("Socket closed?");
+                if read.read_exact(&mut this_client_id).await.is_err() {
+                    // The peer disconnected before sending its client id - ignore and
+                    // keep accepting other connections instead of tearing down the broker.
+                    log::info!("Client disconnected before sending its client id");
+                    continue;
+                }
                 let this_client_id = ClientId(u32::from_le_bytes(this_client_id));
 
                 let (this_client_id, is_old) = if this_client_id == UNDEFINED_CLIENT_ID {
@@ -155,7 +170,10 @@ where
                 let this_client_id_bytes = this_client_id.0.to_le_bytes();
 
                 // Protocol: Send the client id for this node;
-                write.write_all(&this_client_id_bytes).await.unwrap();
+                if let Err(e) = write.write_all(&this_client_id_bytes).await {
+                    log::error!("Error sending client id back to client: {e:?}");
+                    continue;
+                }
 
                 if !is_old && reached_max {
                     continue;
@@ -178,6 +196,13 @@ where
                         // we forward the sender id as well, so we add 4 bytes to the message length
                         len += 4;
                         log::debug!("TCP Manager - len = {len:?}");
+
+                        if len > TCP_MAX_MSG_LEN {
+                            log::error!(
+                                "Refusing to allocate {len} bytes for an incoming tcp message (max {TCP_MAX_MSG_LEN})"
+                            );
+                            return;
+                        }
 
                         let mut buf = vec![0; len as usize];
 

--- a/crates/libafl/src/events/tcp.rs
+++ b/crates/libafl/src/events/tcp.rs
@@ -192,9 +192,12 @@ where
                             return;
                         }
 
-                        let mut len = u32::from_le_bytes(len_buf);
+                        let len = u32::from_le_bytes(len_buf);
                         // we forward the sender id as well, so we add 4 bytes to the message length
-                        len += 4;
+                        let Some(len) = len.checked_add(4) else {
+                            log::error!("TCP message length overflow");
+                            return;
+                        };
                         log::debug!("TCP Manager - len = {len:?}");
 
                         if len > TCP_MAX_MSG_LEN {

--- a/crates/ll_mp/src/lib.rs
+++ b/crates/ll_mp/src/lib.rs
@@ -546,6 +546,11 @@ where
     Ok(())
 }
 
+/// Maximum size, in bytes, we are willing to allocate for a single incoming
+/// TCP message. Guards against a peer sending a bogus/huge size prefix and
+/// forcing an oversized allocation before any real data has been validated.
+const LLMP_TCP_MAX_MSG_LEN: u32 = 128 * 1024 * 1024;
+
 /// Receive one message of `u32` len and `[u8; len]` bytes
 #[cfg(feature = "std")]
 pub fn recv_tcp_msg(stream: &mut TcpStream) -> Result<Vec<u8>, Error> {
@@ -560,14 +565,19 @@ pub fn recv_tcp_msg(stream: &mut TcpStream) -> Result<Vec<u8>, Error> {
     let mut size_bytes = [0_u8; 4];
     stream.read_exact(&mut size_bytes)?;
     let size = u32::from_be_bytes(size_bytes);
-    let mut bytes = vec![0; size.try_into().unwrap()];
+
+    if size > LLMP_TCP_MAX_MSG_LEN {
+        return Err(Error::illegal_state(format!(
+            "Refusing to allocate {size} bytes for an incoming TCP message (max {LLMP_TCP_MAX_MSG_LEN})"
+        )));
+    }
+
+    let mut bytes = vec![0; size as usize];
 
     #[cfg(feature = "llmp_debug")]
     log::trace!("LLMP TCP: Receiving payload of size {size}");
 
-    stream
-        .read_exact(&mut bytes)
-        .expect("Failed to read message body");
+    stream.read_exact(&mut bytes)?;
     Ok(bytes)
 }
 
@@ -4035,7 +4045,65 @@ mod tests {
         // We want at least the tcp and sender clients.
         assert_eq!(broker.inner.llmp_clients.len(), 2);
     }
+    #[test]
+    fn test_recv_tcp_msg_truncated_does_not_panic() {
+        use std::{
+            io::Write,
+            net::{TcpListener, TcpStream},
+        };
 
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+
+            let result = super::recv_tcp_msg(&mut stream);
+
+            assert!(
+                result.is_err(),
+                "expected an Err, not a panic, on a truncated message"
+            );
+        });
+
+        let mut client = TcpStream::connect(addr).unwrap();
+
+        // Claim a 100-byte body...
+        client.write_all(&100u32.to_be_bytes()).unwrap();
+
+        // ...but disconnect before sending it.
+        drop(client);
+
+        handle
+            .join()
+            .expect("recv_tcp_msg must not panic on a truncated message");
+    }
+
+    #[test]
+    fn test_recv_tcp_msg_rejects_oversized_len() {
+        use std::{
+            io::Write,
+            net::{TcpListener, TcpStream},
+        };
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let result = super::recv_tcp_msg(&mut stream);
+            assert!(
+                result.is_err(),
+                "a bogus u32::MAX length prefix must be rejected before allocating"
+            );
+        });
+
+        let mut client = TcpStream::connect(addr).unwrap();
+        client.write_all(&u32::MAX.to_be_bytes()).unwrap();
+        // No body sent at all - the size cap should reject before trying to read it.
+
+        handle.join().unwrap();
+    }
     #[test]
     #[serial]
     #[should_panic(expected = "Map was not priviously initialized at")]

--- a/crates/ll_mp/src/lib.rs
+++ b/crates/ll_mp/src/lib.rs
@@ -549,6 +549,7 @@ where
 /// Maximum size, in bytes, we are willing to allocate for a single incoming
 /// TCP message. Guards against a peer sending a bogus/huge size prefix and
 /// forcing an oversized allocation before any real data has been validated.
+#[cfg(feature = "std")]
 const LLMP_TCP_MAX_MSG_LEN: u32 = 128 * 1024 * 1024;
 
 /// Receive one message of `u32` len and `[u8; len]` bytes

--- a/crates/shmem_providers/src/unix_shmem_server.rs
+++ b/crates/shmem_providers/src/unix_shmem_server.rs
@@ -597,17 +597,27 @@ where
     }
 
     fn read_request(&mut self, client_id: RawFd) -> Result<ServedShMemRequest, Error> {
+        // Maximum size, in bytes, we are willing to allocate for a single
+        // incoming request. Guards against a peer sending a bogus/huge size
+        // prefix and forcing an oversized allocation before any real data
+        // has been validated.
+        const MAX_REQUEST_LEN: u32 = 128 * 1024 * 1024;
+
         let client = self.clients.get_mut(&client_id).unwrap();
 
         // Always receive one be u32 of size, then the command.
         let mut size_bytes = [0_u8; 4];
         client.stream.read_exact(&mut size_bytes)?;
         let size = u32::from_be_bytes(size_bytes);
-        let mut bytes = vec![0; size.try_into().unwrap()];
-        client
-            .stream
-            .read_exact(&mut bytes)
-            .expect("Failed to read message body");
+
+        if size > MAX_REQUEST_LEN {
+            return Err(Error::illegal_state(format!(
+                "Refusing to allocate {size} bytes for an incoming shmem service request (max {MAX_REQUEST_LEN})"
+            )));
+        }
+
+        let mut bytes = vec![0; size as usize];
+        client.stream.read_exact(&mut bytes)?;
         let request: ServedShMemRequest = postcard::from_bytes(&bytes)?;
 
         Ok(request)


### PR DESCRIPTION
## Summary

This PR improves robustness of TCP message handling by preventing panics and unsafe allocations when receiving malformed input.

## Changes

- Replace TCP receive `expect()`/panic paths with proper error propagation.
- Add maximum message size checks before allocating buffers.
- Reject oversized length prefixes from untrusted peers.
- Add regression tests for:
  - Truncated TCP messages causing incomplete reads.
  - Oversized message length prefixes.

Previously, malformed TCP input could:
- Trigger a panic when the peer disconnected before sending the full message.
- Cause excessive memory allocation attempts by sending a very large length prefix.

These changes ensure invalid input results in an error instead of crashing the process.

## Testing

Tested with:

```bash
cargo test -p ll_mp test_recv_tcp_msg
cargo clippy -p ll_mp --tests

#3888 