### PR TITLE
Fix relative path error for compiler wrappers in fuzzer Justfiles

### DIFF
--- a/fuzzers/inprocess/libfuzzer_libmozjpeg/Justfile
+++ b/fuzzers/inprocess/libfuzzer_libmozjpeg/Justfile
@@ -2,7 +2,7 @@ FUZZER_NAME := 'fuzzer_mozjpeg'
 PROJECT_DIR := absolute_path(".")
 PROFILE := env("PROFILE", "release")
 PROFILE_DIR := if PROFILE == "release" { "release" } else if PROFILE == "dev" { "debug" } else { "debug" }
-CARGO_TARGET_DIR := env("CARGO_TARGET_DIR", "target")
+CARGO_TARGET_DIR := absolute_path(env("CARGO_TARGET_DIR", "target"))
 FUZZER := CARGO_TARGET_DIR / PROFILE_DIR / FUZZER_NAME
 LIBAFL_CC := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"
 LIBAFL_CXX := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cxx"

--- a/fuzzers/inprocess/libfuzzer_libpng_accounting/Justfile
+++ b/fuzzers/inprocess/libfuzzer_libpng_accounting/Justfile
@@ -2,7 +2,7 @@ FUZZER_NAME := 'fuzzer_libpng_accounting'
 PROJECT_DIR := absolute_path(".")
 PROFILE := env("PROFILE", "release")
 PROFILE_DIR := if PROFILE == "release" { "release" } else if PROFILE == "dev" { "debug" } else { "debug" }
-CARGO_TARGET_DIR := env("CARGO_TARGET_DIR", "target")
+CARGO_TARGET_DIR := absolute_path(env("CARGO_TARGET_DIR", "target"))
 FUZZER := CARGO_TARGET_DIR / PROFILE_DIR / FUZZER_NAME
 LIBAFL_CC := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"
 LIBAFL_CXX := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cxx"

--- a/fuzzers/inprocess/libfuzzer_libpng_norestart/Justfile
+++ b/fuzzers/inprocess/libfuzzer_libpng_norestart/Justfile
@@ -2,7 +2,7 @@ FUZZER_NAME := 'fuzzer_libpng_norestart'
 PROJECT_DIR := absolute_path(".")
 PROFILE := env("PROFILE", "release")
 PROFILE_DIR := if PROFILE == "release" { "release" } else if PROFILE == "dev" { "debug" } else { "debug" }
-CARGO_TARGET_DIR := env("CARGO_TARGET_DIR", "target")
+CARGO_TARGET_DIR := absolute_path(env("CARGO_TARGET_DIR", "target"))
 FUZZER := CARGO_TARGET_DIR / PROFILE_DIR / FUZZER_NAME
 LIBAFL_CC := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"
 LIBAFL_CXX := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cxx"

--- a/fuzzers/inprocess/libfuzzer_libpng_tcp_manager/Justfile
+++ b/fuzzers/inprocess/libfuzzer_libpng_tcp_manager/Justfile
@@ -2,7 +2,7 @@ FUZZER_NAME := 'fuzzer_libpng_tcp_manager'
 PROJECT_DIR := absolute_path(".")
 PROFILE := env("PROFILE", "release")
 PROFILE_DIR := if PROFILE == "release" { "release" } else if PROFILE == "dev" { "debug" } else { "debug" }
-CARGO_TARGET_DIR := env("CARGO_TARGET_DIR", "target")
+CARGO_TARGET_DIR := absolute_path(env("CARGO_TARGET_DIR", "target"))
 FUZZER := CARGO_TARGET_DIR / PROFILE_DIR / FUZZER_NAME
 LIBAFL_CC := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"
 LIBAFL_CXX := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cxx"

--- a/fuzzers/structure_aware/nautilus_sync/Justfile
+++ b/fuzzers/structure_aware/nautilus_sync/Justfile
@@ -2,7 +2,7 @@ FUZZER_NAME := 'fuzzer_libpng_nautilus'
 PROJECT_DIR := absolute_path(".")
 PROFILE := env("PROFILE", "release")
 PROFILE_DIR := if PROFILE == "release" { "release" } else if PROFILE == "dev" { "debug" } else { "debug" }
-CARGO_TARGET_DIR := env("CARGO_TARGET_DIR", "target")
+CARGO_TARGET_DIR := absolute_path(env("CARGO_TARGET_DIR", "target"))
 FUZZER := CARGO_TARGET_DIR / PROFILE_DIR / FUZZER_NAME
 LIBAFL_CC := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"
 LIBAFL_CXX := CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cxx"


### PR DESCRIPTION
### Problem
Multiple fuzzer `Justfile` recipes fail during the `lib` task while running `just run`:
```
/bin/bash: line 2: target/release/libafl_cc: No such file or directory
make[1]: *** [Makefile:1196: contrib/tools/pngfix.o] Error 127
```

### Root Cause
`LIBAFL_CC` and `LIBAFL_CXX` were defined as relative paths (e.g., `CARGO_TARGET_DIR / PROFILE_DIR / "libafl_cc"`). Invoking `make -C <subdir>` later in the recipe resolves the relative path from the target subdirectory instead of the project root, resulting in an invalid compiler path.

### Solution
Wrap compiler wrapper definition with `absolute_path()` so the path remains valid regardless of working directory change:

```just
CARGO_TARGET_DIR := absolute_path(env("CARGO_TARGET_DIR", "target"))
```

This ensures that when `make -C` changes into other directory, the compiler path is still correct.

### Affected Fuzzers
- `inprocess/libfuzzer_libmozjpeg`
- `inprocess/libfuzzer_libpng_accounting`
- `inprocess/libfuzzer_libpng_norestart`
- `inprocess/libfuzzer_libpng_tcp_manager`
- `structure_aware/nautilus_sync`

### Testing
After the fix, `just run` completes successfully on all affected fuzzers without path resolution errors.