### PR TITLE
fix(libafl_cc): expand @file response files before configuration rewr…

### DIFF
--- a/crates/libafl_cc/src/ar.rs
+++ b/crates/libafl_cc/src/ar.rs
@@ -50,13 +50,23 @@ impl ToolWrapper for ArWrapper {
             ));
         }
 
-        self.name = args[0].as_ref().to_string();
+        // Expand any `@file` response-file arguments up front so the
+        // per-`Configuration` filename rewriting below sees the real
+        // arguments instead of an opaque `@file` token. The wrapper's own
+        // name (args[0]) is passed through untouched.
+        let expanded_tail = crate::response_file::expand_response_files(&args[1..])?;
+        let mut expanded: Vec<String> = Vec::with_capacity(1 + expanded_tail.len());
+        expanded.push(args[0].as_ref().to_string());
+        expanded.extend(expanded_tail);
+        let args = expanded;
+
+        self.name.clone_from(&args[0]);
 
         let mut linking = true;
         // Detect stray -v calls from ./configure scripts.
-        if args.len() > 1 && args[1].as_ref() == "-v" {
+        if args.len() > 1 && args[1].as_str() == "-v" {
             if args.len() == 2 {
-                self.base_args.push(args[1].as_ref().into());
+                self.base_args.push(args[1].clone());
                 return Ok(self);
             }
             linking = false;
@@ -93,7 +103,6 @@ impl ToolWrapper for ArWrapper {
                 "--libafl-configurations" if i + 1 < args.len() => {
                     self.configurations.extend(
                         args[i + 1]
-                            .as_ref()
                             .split(',')
                             .map(|x| crate::Configuration::from_str(x).unwrap()),
                     );
@@ -102,7 +111,7 @@ impl ToolWrapper for ArWrapper {
                 }
                 _ => (),
             }
-            new_args.push(args[i].as_ref().to_string());
+            new_args.push(args[i].clone());
             i += 1;
         }
         if linking

--- a/crates/libafl_cc/src/clang.rs
+++ b/crates/libafl_cc/src/clang.rs
@@ -127,7 +127,17 @@ impl ToolWrapper for ClangWrapper {
             ));
         }
 
-        self.name = args[0].as_ref().to_string();
+        // Expand any `@file` response-file arguments up front so the
+        // per-`Configuration` filename rewriting below sees the real
+        // arguments instead of an opaque `@file` token. The wrapper's own
+        // name (args[0]) is passed through untouched.
+        let expanded_tail = crate::response_file::expand_response_files(&args[1..])?;
+        let mut expanded: Vec<String> = Vec::with_capacity(1 + expanded_tail.len());
+        expanded.push(args[0].as_ref().to_string());
+        expanded.extend(expanded_tail);
+        let args = expanded;
+
+        self.name.clone_from(&args[0]);
         // Detect C++ compiler looking at the wrapper name
         self.is_cpp = if cfg!(windows) {
             self.is_cpp || self.name.ends_with("++.exe")
@@ -141,9 +151,9 @@ impl ToolWrapper for ClangWrapper {
         let mut linking = true;
         let mut shared = false;
         // Detect stray -v calls from ./configure scripts.
-        if args.len() > 1 && args[1].as_ref() == "-v" {
+        if args.len() > 1 && args[1].as_str() == "-v" {
             if args.len() == 2 {
-                self.base_args.push(args[1].as_ref().into());
+                self.base_args.push(args[1].clone());
                 return Ok(self);
             }
             linking = false;
@@ -152,7 +162,7 @@ impl ToolWrapper for ClangWrapper {
         let mut suppress_linking = 0;
         let mut i = 1;
         while i < args.len() {
-            let arg_as_path = Path::new(args[i].as_ref());
+            let arg_as_path = Path::new(args[i].as_str());
 
             if arg_as_path
                 .extension()
@@ -192,8 +202,8 @@ impl ToolWrapper for ClangWrapper {
                 }
                 "-z" | "-Wl,-z"
                     if i + 1 < args.len()
-                        && (args[i + 1].as_ref() == "defs"
-                            || args[i + 1].as_ref() == "-Wl,defs") =>
+                        && (args[i + 1].as_str() == "defs"
+                            || args[i + 1].as_str() == "-Wl,defs") =>
                 {
                     i += 2;
                     continue;
@@ -206,7 +216,6 @@ impl ToolWrapper for ClangWrapper {
                 "--libafl-configurations" if i + 1 < args.len() => {
                     self.configurations.extend(
                         args[i + 1]
-                            .as_ref()
                             .split(',')
                             .map(|x| crate::Configuration::from_str(x).unwrap()),
                     );
@@ -214,7 +223,7 @@ impl ToolWrapper for ClangWrapper {
                     continue;
                 }
                 "-o" if i + 1 < args.len() => {
-                    self.output = Some(PathBuf::from(args[i + 1].as_ref()));
+                    self.output = Some(PathBuf::from(args[i + 1].as_str()));
                     i += 2;
                     continue;
                 }
@@ -228,7 +237,7 @@ impl ToolWrapper for ClangWrapper {
                 } // TODO dynamic list?
                 _ => (),
             }
-            new_args.push(args[i].as_ref().to_string());
+            new_args.push(args[i].clone());
             i += 1;
         }
         if linking

--- a/crates/libafl_cc/src/lib.rs
+++ b/crates/libafl_cc/src/lib.rs
@@ -52,6 +52,8 @@ pub mod clang;
 pub use clang::{ClangWrapper, LLVMPasses};
 pub mod libtool;
 pub use libtool::LibtoolWrapper;
+pub mod response_file;
+pub use response_file::expand_response_files;
 
 /// `LibAFL` CC Error Type
 #[derive(Debug)]

--- a/crates/libafl_cc/src/libtool.rs
+++ b/crates/libafl_cc/src/libtool.rs
@@ -49,13 +49,23 @@ impl ToolWrapper for LibtoolWrapper {
             ));
         }
 
-        self.name = args[0].as_ref().to_string();
+        // Expand any `@file` response-file arguments up front so the
+        // per-`Configuration` filename rewriting below sees the real
+        // arguments instead of an opaque `@file` token. The wrapper's own
+        // name (args[0]) is passed through untouched.
+        let expanded_tail = crate::response_file::expand_response_files(&args[1..])?;
+        let mut expanded: Vec<String> = Vec::with_capacity(1 + expanded_tail.len());
+        expanded.push(args[0].as_ref().to_string());
+        expanded.extend(expanded_tail);
+        let args = expanded;
+
+        self.name.clone_from(&args[0]);
 
         let mut linking = true;
         // Detect stray -v calls from ./configure scripts.
-        if args.len() > 1 && args[1].as_ref() == "-v" {
+        if args.len() > 1 && args[1].as_str() == "-v" {
             if args.len() == 2 {
-                self.base_args.push(args[1].as_ref().into());
+                self.base_args.push(args[1].clone());
                 return Ok(self);
             }
             linking = false;
@@ -92,7 +102,6 @@ impl ToolWrapper for LibtoolWrapper {
                 "--libafl-configurations" if i + 1 < args.len() => {
                     self.configurations.extend(
                         args[i + 1]
-                            .as_ref()
                             .split(',')
                             .map(|x| crate::Configuration::from_str(x).unwrap()),
                     );
@@ -100,13 +109,13 @@ impl ToolWrapper for LibtoolWrapper {
                     continue;
                 }
                 "-o" if i + 1 < args.len() => {
-                    self.output = Some(PathBuf::from(args[i + 1].as_ref()));
+                    self.output = Some(PathBuf::from(args[i + 1].as_str()));
                     i += 2;
                     continue;
                 }
                 _ => (),
             }
-            new_args.push(args[i].as_ref().to_string());
+            new_args.push(args[i].clone());
             i += 1;
         }
         if linking

--- a/crates/libafl_cc/src/response_file.rs
+++ b/crates/libafl_cc/src/response_file.rs
@@ -1,0 +1,207 @@
+//! Response file (`@file`) expansion for compiler/archiver command lines.
+//!
+//! Many toolchains (MSVC, GNU `ld`/`ar`, and Clang/GCC) support passing extra
+//! command-line arguments via a "response file": an argument of the form
+//! `@path/to/file` whose contents are read and tokenized into additional
+//! arguments, spliced in place of the `@file` token. Build systems that emit
+//! very long argument lists (for example, one object file per line) commonly
+//! rely on this to avoid hitting OS command-line length limits.
+//!
+//! `libafl_cc`'s per-[`crate::Configuration`] argument rewriting (renaming
+//! `foo.o` to `foo.coverage.o`, for example) walks the argument list
+//! directly, so any filenames hidden behind an `@file` token were invisible
+//! to it and never got rewritten. This module expands `@file` tokens before
+//! that rewriting happens, so the rest of the pipeline only ever sees
+//! literal arguments.
+
+use std::{fs, path::Path};
+
+use crate::Error;
+
+/// Maximum recursion depth for nested `@file` references, guarding against
+/// cycles (`a.rsp` containing `@a.rsp`) or pathological chains.
+const MAX_RESPONSE_FILE_DEPTH: usize = 16;
+
+/// Expand any `@file` (response file) arguments in `args`, returning a
+/// flattened argument list with no response-file tokens remaining.
+///
+/// A bare `@` (no filename following it) and any token starting with `@`
+/// that does not point at a readable file are passed through unchanged --
+/// this matches Clang/GCC/`ar`'s behavior of only treating `@` specially
+/// when it resolves to an existing file, and avoids misinterpreting other
+/// arguments that happen to start with `@`.
+pub fn expand_response_files<S: AsRef<str>>(args: &[S]) -> Result<Vec<String>, Error> {
+    let mut out = Vec::with_capacity(args.len());
+    for arg in args {
+        expand_one(arg.as_ref(), &mut out, 0)?;
+    }
+    Ok(out)
+}
+
+fn expand_one(arg: &str, out: &mut Vec<String>, depth: usize) -> Result<(), Error> {
+    let Some(file_path) = arg.strip_prefix('@') else {
+        out.push(arg.to_string());
+        return Ok(());
+    };
+
+    if file_path.is_empty() || !Path::new(file_path).is_file() {
+        // Not a real response file reference -- leave it alone.
+        out.push(arg.to_string());
+        return Ok(());
+    }
+
+    if depth >= MAX_RESPONSE_FILE_DEPTH {
+        return Err(Error::InvalidArguments(format!(
+            "Response file nesting exceeded {MAX_RESPONSE_FILE_DEPTH} levels while expanding \
+             '{arg}' -- possible cyclic @file reference"
+        )));
+    }
+
+    let contents = fs::read_to_string(file_path).map_err(Error::Io)?;
+    for token in tokenize(&contents) {
+        expand_one(&token, out, depth + 1)?;
+    }
+    Ok(())
+}
+
+/// Tokenize the contents of a response file into individual arguments.
+///
+/// Response files are whitespace-separated (including newlines), support
+/// both single- and double-quoted segments (so paths containing spaces
+/// survive), and support backslash-escaping of the following character --
+/// the common subset of GNU and MSVC response file conventions.
+fn tokenize(contents: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_token = false;
+    let mut quote: Option<char> = None;
+    let mut chars = contents.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(q) => {
+                if c == '\\' && chars.peek().is_some_and(|&n| n == q || n == '\\') {
+                    current.push(chars.next().unwrap());
+                } else if c == q {
+                    quote = None;
+                } else {
+                    current.push(c);
+                }
+            }
+            None => match c {
+                '\'' | '"' => {
+                    quote = Some(c);
+                    in_token = true;
+                }
+                '\\' if chars.peek().is_some() => {
+                    current.push(chars.next().unwrap());
+                    in_token = true;
+                }
+                c if c.is_whitespace() => {
+                    if in_token {
+                        tokens.push(core::mem::take(&mut current));
+                        in_token = false;
+                    }
+                }
+                c => {
+                    current.push(c);
+                    in_token = true;
+                }
+            },
+        }
+    }
+    if in_token || !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    /// Minimal scoped temp-file helper so these tests don't need an extra
+    /// dev-dependency. Writes `contents` to a fresh path under the OS temp
+    /// dir and removes it on drop.
+    struct ScratchFile {
+        path: std::path::PathBuf,
+    }
+
+    impl ScratchFile {
+        fn new(contents: &str) -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "libafl_cc_response_file_test_{}_{unique}.rsp",
+                std::process::id()
+            ));
+            fs::write(&path, contents).unwrap();
+            Self { path }
+        }
+
+        fn at_arg(&self) -> String {
+            format!("@{}", self.path.display())
+        }
+    }
+
+    impl Drop for ScratchFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    #[test]
+    fn tokenize_basic() {
+        assert_eq!(
+            tokenize("-o foo.o -c bar.c"),
+            vec!["-o", "foo.o", "-c", "bar.c"]
+        );
+    }
+
+    #[test]
+    fn tokenize_quoted_with_space() {
+        assert_eq!(
+            tokenize(r#"-o "my file.o" -c bar.c"#),
+            vec!["-o", "my file.o", "-c", "bar.c"]
+        );
+    }
+
+    #[test]
+    fn tokenize_escaped_space() {
+        assert_eq!(tokenize(r"-o my\ file.o"), vec!["-o", "my file.o"]);
+    }
+
+    #[test]
+    fn tokenize_multiline() {
+        assert_eq!(
+            tokenize("-o foo.o\n-c bar.c\n"),
+            vec!["-o", "foo.o", "-c", "bar.c"]
+        );
+    }
+
+    #[test]
+    fn non_response_file_arg_untouched() {
+        let args = vec!["@this-file-does-not-exist.rsp".to_string()];
+        let expanded = expand_response_files(&args).unwrap();
+        assert_eq!(expanded, args);
+    }
+
+    #[test]
+    fn expands_real_response_file() {
+        let file = ScratchFile::new("-o foo.o -c bar.c\n");
+        let args = vec!["-c".to_string(), file.at_arg()];
+        let expanded = expand_response_files(&args).unwrap();
+        assert_eq!(expanded, vec!["-c", "-o", "foo.o", "-c", "bar.c"]);
+    }
+
+    #[test]
+    fn rejects_cyclic_response_file() {
+        let file = ScratchFile::new(""); // placeholder path, filled in below
+        fs::write(&file.path, file.at_arg()).unwrap();
+
+        let args = vec![file.at_arg()];
+        assert!(expand_response_files(&args).is_err());
+    }
+}


### PR DESCRIPTION
## Description

Modern toolchains (Clang/GCC, `ar`, `libtool`) support response files `@path/to/file` arguments whose contents are read and tokenized into additional command-line arguments. Build systems that emit very long argument lists (e.g. one object file per line) commonly rely on these to avoid OS command-line length limits.

`libafl_cc`'s per-`Configuration` filename rewriting (e.g. `foo.o` -> `foo.coverage.o`) walks the argument list directly, so any filenames passed via an `@file` token were invisible to it and never got rewritten — producing incorrect compilation results for projects whose build systems use response files.

This PR adds a `response_file` module to `libafl_cc` with `expand_response_files()`, and wires it into `ArWrapper`, `ClangWrapper`, and `LibtoolWrapper`'s `parse_args` so response files are expanded *before* the existing rewrite logic runs. The wrapper's own name (`args[0]`) is left untouched; expansion only applies to the rest of the argument list.

Design notes:
- An `@token` is only treated as a response file if it resolves to a real, readable file — anything else (including args that just happen to start with `@`) passes through unchanged, matching Clang/GCC/`ar` behavior.
- Response file contents are tokenized on whitespace (including newlines), with support for single/double-quoted segments and backslash-escaping - the common subset of GNU and MSVC response-file conventions.
- Nested `@file` references are expanded recursively, with a depth cap (16) to guard against cyclic references.
- No new dependencies - the tests use a small scoped temp-file helper instead of pulling in `tempfile`.

## Testing

Added unit tests for the tokenizer (basic, quoted, escaped, multiline) and for `expand_response_files` (untouched non-file `@` args, real expansion, cyclic-reference rejection). `cargo test -p libafl_cc` and `cargo clippy -p libafl_cc --all-targets` both pass locally (LLVM passes weren't built due to no local `llvm-config`, so pure-LLVM-pass code paths weren't exercised).

I wasn't able to run `./scripts/precommit.sh` end-to-end locally it builds the full workspace, and `unicorn-engine-sys` (a dependency of `libafl_qemu`/`libafl_unicorn`, unrelated to this change) fails to build on my macOS setup due to missing `pkg-config` and some Apple-clang/QEMU header incompatibilities. `cargo clippy -p libafl_cc --all-targets` (which picks up the same workspace lint config via `[lints] workspace = true`) is clean.

I also haven't yet tested this against a real build system that actually emits response files (e.g. an MSVC-style toolchain or a large CMake/Ninja project) happy to do that if it'd help review, or if anyone has a quick repro handy.